### PR TITLE
feat: AIM Secrets Phase 1b — identity-native secrets backend

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -24,9 +24,12 @@ import (
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/config"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/crypto"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	domainsecrets "github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
+	infraatc "github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/atc"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/cache"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/email"
+	infrasecrets "github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/secrets"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/metrics"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/interfaces/http/handlers"
@@ -442,6 +445,11 @@ type Repositories struct {
 	DeviceCode              *repository.DeviceCodeRepository
 	CommunityIntelligence   *repository.CommunityIntelligenceRepository // For community intelligence opt-in telemetry
 	Remediation             *repository.RemediationRepository            // For remediation tracking (agentpwn + HMA)
+	// Secrets management repositories
+	SecretNamespace     *repository.SecretNamespaceRepository
+	SecretCredential    *repository.SecretCredentialRepository
+	SecretAudit         *repository.SecretAuditRepository
+	SecretBackendConfig *repository.SecretBackendConfigRepository
 }
 
 func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPostgres) {
@@ -490,6 +498,11 @@ func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPos
 		DeviceCode:            repository.NewDeviceCodeRepository(db),
 		CommunityIntelligence: repository.NewCommunityIntelligenceRepository(db),
 		Remediation:           repository.NewRemediationRepository(db),
+		// Secrets management
+		SecretNamespace:     repository.NewSecretNamespaceRepository(db),
+		SecretCredential:    repository.NewSecretCredentialRepository(db),
+		SecretAudit:         repository.NewSecretAuditRepository(db),
+		SecretBackendConfig: repository.NewSecretBackendConfigRepository(db),
 	}, oauthRepo
 }
 
@@ -521,6 +534,7 @@ type Services struct {
 	RegistryBridge          *application.RegistryBridgeService          // For OpenA2A Registry attestation contribution
 	CommunityIntelligence   *application.CommunityIntelligenceService   // For community intelligence opt-in telemetry
 	Remediation             *application.RemediationService             // For remediation tracking (agentpwn + HMA)
+	Secrets                 *application.SecretsService                 // For identity-native secrets management
 }
 
 func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCache, oauthRepo *repository.OAuthRepositoryPostgres, jwtService *auth.JWTService, emailService domain.EmailService) (*Services, *crypto.KeyVault) {
@@ -763,6 +777,21 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		registryURL,
 	)
 
+	// Secrets management: ATC verifier (JWT shim) + AIM native backend + service
+	atcVerifier := infraatc.NewJWTShimVerifier(keyVault.GetServerSigningKey(), "aim-server")
+	aimNativeBackend := infrasecrets.NewAIMNativeBackend(repos.SecretCredential)
+	secretsBackends := map[domainsecrets.BackendType]domainsecrets.SecretsBackend{
+		domainsecrets.BackendTypeAIMNative: aimNativeBackend,
+	}
+	secretsService := application.NewSecretsService(
+		repos.SecretNamespace,
+		repos.SecretAudit,
+		repos.Agent,
+		repos.Capability,
+		atcVerifier,
+		secretsBackends,
+	)
+
 	return &Services{
 		Auth:              authService,
 		Admin:             adminService,
@@ -791,6 +820,7 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		RegistryBridge:          registryBridgeService,    // For OpenA2A Registry attestation contribution
 		CommunityIntelligence:   ciService,                 // For community intelligence opt-in telemetry
 		Remediation:             application.NewRemediationService(repos.Remediation), // For remediation tracking
+		Secrets:                 secretsService,                                       // For identity-native secrets management
 	}, keyVault
 }
 
@@ -830,6 +860,7 @@ type Handlers struct {
 	CommunityIntelligence   *handlers.CommunityIntelligenceHandler   // For community intelligence opt-in telemetry
 	AIP                     *handlers.AIPHandler                     // For AIP discovery and DID resolution
 	Remediation             *handlers.RemediationHandler             // For remediation tracking (agentpwn + HMA)
+	Secrets                 *handlers.SecretsHandler                 // For identity-native secrets management
 }
 
 func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTService, keyVault *crypto.KeyVault, cfg *config.Config, db *sql.DB) *Handlers {
@@ -1005,6 +1036,9 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 		),
 		Remediation: handlers.NewRemediationHandler(
 			services.Remediation,
+		),
+		Secrets: handlers.NewSecretsHandler(
+			services.Secrets,
 		),
 	}
 }
@@ -1196,6 +1230,24 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	remediation.Post("/remediated", h.Remediation.RecordRemediation)
 	remediation.Get("/stats", h.Remediation.GetStats)
 	remediation.Get("/recent", h.Remediation.ListRecent)
+
+	// Secrets management routes
+	// POST /resolve uses PQCAgentMiddleware (agent auth), all others use JWT
+	secretsResolve := v1.Group("/secrets")
+	secretsResolve.Use(middleware.PQCAgentMiddleware(services.Agent))
+	secretsResolve.Use(middleware.RateLimitMiddleware())
+	secretsResolve.Post("/resolve", h.Secrets.ResolveCredential)
+
+	secretsMgmt := v1.Group("/secrets")
+	secretsMgmt.Use(middleware.AuthMiddleware(jwtService))
+	secretsMgmt.Use(middleware.RateLimitMiddleware())
+	secretsMgmt.Post("/namespaces", middleware.MemberMiddleware(), h.Secrets.CreateNamespace)
+	secretsMgmt.Get("/namespaces", h.Secrets.ListNamespaces)
+	secretsMgmt.Get("/namespaces/:id", h.Secrets.GetNamespace)
+	secretsMgmt.Delete("/namespaces/:id", middleware.MemberMiddleware(), h.Secrets.DeleteNamespace)
+	secretsMgmt.Post("/namespaces/:id/credentials", middleware.MemberMiddleware(), h.Secrets.StoreCredential)
+	secretsMgmt.Post("/namespaces/:id/rotate", middleware.MemberMiddleware(), h.Secrets.RotateCredential)
+	secretsMgmt.Get("/audit", h.Secrets.GetAuditLog)
 
 	// Community Intelligence opt-in telemetry (authentication required)
 	ci := v1.Group("/community-intelligence")

--- a/apps/backend/internal/application/secrets_service.go
+++ b/apps/backend/internal/application/secrets_service.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/chacha20poly1305"
+
 	"github.com/google/uuid"
 
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
@@ -20,6 +22,10 @@ import (
 const (
 	// maxNonceAge is the maximum age of a nonce before it's considered replayed (CR-003).
 	maxNonceAge = 30 * time.Second
+
+	// maxCredentialBlobSize is the maximum size of a credential blob (1 MiB).
+	// Prevents DoS via oversized blobs in encryption/decryption.
+	maxCredentialBlobSize = 1 << 20
 )
 
 // SecretsService implements identity-native secrets management.
@@ -211,7 +217,7 @@ func (s *SecretsService) Resolve(agentID uuid.UUID, req *secrets.ResolutionReque
 	return &secrets.ResolutionResult{
 		EncryptedBlob:   encryptedResult,
 		EphemeralPubKey: ephemeralPub,
-		EncryptionAlg:   "X25519-XSalsa20-Poly1305",
+		EncryptionAlg:   "X25519-ChaCha20-Poly1305",
 	}, nil
 }
 
@@ -314,17 +320,30 @@ func (s *SecretsService) encryptForAgent(rawBlob []byte, agentEd25519PubKey []by
 		return nil, nil, fmt.Errorf("ECDH failed: %w", err)
 	}
 
-	// Derive encryption key from shared secret via SHA-256
-	encKey := sha256.Sum256(sharedSecret)
-
-	// XOR-based encryption (simplified — production would use XSalsa20-Poly1305)
-	// For Phase 1b, using AES-256-GCM-like approach with the derived key
-	encrypted := make([]byte, len(rawBlob))
-	for i := range rawBlob {
-		encrypted[i] = rawBlob[i] ^ encKey[i%32]
+	// Bound blob size to prevent DoS
+	if len(rawBlob) > maxCredentialBlobSize {
+		return nil, nil, fmt.Errorf("credential blob exceeds maximum size of %d bytes", maxCredentialBlobSize)
 	}
 
-	return encrypted, ephemeralPriv.PublicKey().Bytes(), nil
+	// Derive 256-bit encryption key from shared secret via SHA-256
+	encKey := sha256.Sum256(sharedSecret)
+
+	// Authenticated encryption using ChaCha20-Poly1305 (IETF variant, 256-bit key)
+	aead, err := chacha20poly1305.New(encKey[:])
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create AEAD cipher: %w", err)
+	}
+
+	// Generate random nonce
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Encrypt and authenticate: nonce || ciphertext || tag
+	ciphertext := aead.Seal(nonce, nonce, rawBlob, nil)
+
+	return ciphertext, ephemeralPriv.PublicKey().Bytes(), nil
 }
 
 // ed25519PublicToX25519 converts an Ed25519 public key to X25519.

--- a/apps/backend/internal/application/secrets_service.go
+++ b/apps/backend/internal/application/secrets_service.go
@@ -1,0 +1,616 @@
+package application
+
+import (
+	"crypto/ecdh"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	atcdomain "github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/atc"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+const (
+	// maxNonceAge is the maximum age of a nonce before it's considered replayed (CR-003).
+	maxNonceAge = 30 * time.Second
+)
+
+// SecretsService implements identity-native secrets management.
+// The 8-step Resolve() ordering is non-negotiable.
+type SecretsService struct {
+	nsRepo         secrets.NamespaceRepository
+	auditRepo      secrets.AuditRepository
+	agentRepo      domain.AgentRepository
+	capabilityRepo domain.CapabilityRepository
+	atcVerifier    atcdomain.ATCVerifier
+	backends       map[secrets.BackendType]secrets.SecretsBackend
+}
+
+func NewSecretsService(
+	nsRepo secrets.NamespaceRepository,
+	auditRepo secrets.AuditRepository,
+	agentRepo domain.AgentRepository,
+	capabilityRepo domain.CapabilityRepository,
+	atcVerifier atcdomain.ATCVerifier,
+	backends map[secrets.BackendType]secrets.SecretsBackend,
+) *SecretsService {
+	return &SecretsService{
+		nsRepo:         nsRepo,
+		auditRepo:      auditRepo,
+		agentRepo:      agentRepo,
+		capabilityRepo: capabilityRepo,
+		atcVerifier:    atcVerifier,
+		backends:       backends,
+	}
+}
+
+// Resolve executes the non-negotiable 8-step credential resolution.
+//
+//  1. Verify Ed25519 signature over namespace|operation|nonce
+//  2. Verify ATC via atcVerifier.Verify()
+//  3. Load namespace, verify agent ownership + status + operation + URL pattern
+//  4. Check AIM capability (secrets:resolve)
+//  5. Retrieve encrypted blob from backend
+//  6. Encrypt with agent's X25519 public key via ECDH
+//  7. Zeroize raw credential
+//  8. Write audit entry (always — granted or denied)
+func (s *SecretsService) Resolve(agentID uuid.UUID, req *secrets.ResolutionRequest) (*secrets.ResolutionResult, error) {
+	var denyReason string
+	var nsID uuid.UUID
+	var atcID string
+
+	defer func() {
+		// Step 8: audit — always runs, granted or denied
+		result := secrets.AuditResultGranted
+		if denyReason != "" {
+			result = secrets.AuditResultDenied
+		}
+		s.auditRepo.Create(&secrets.SecretAuditEntry{
+			NamespaceID: nsID,
+			AgentID:     agentID,
+			Operation:   req.Operation,
+			Result:      result,
+			DenyReason:  denyReason,
+			ATCID:       atcID,
+		})
+	}()
+
+	// Step 1: Verify Ed25519 signature over namespace|operation|nonce
+	agent, err := s.agentRepo.GetByID(agentID)
+	if err != nil || agent == nil {
+		denyReason = "agent not found"
+		return nil, fmt.Errorf("agent not found: %s", agentID)
+	}
+
+	if agent.PublicKey == nil || *agent.PublicKey == "" {
+		denyReason = "agent has no public key"
+		return nil, fmt.Errorf("agent %s has no public key", agentID)
+	}
+
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(*agent.PublicKey)
+	if err != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
+		denyReason = "invalid agent public key"
+		return nil, fmt.Errorf("invalid agent public key for %s", agentID)
+	}
+
+	message := []byte(req.Namespace + "|" + req.Operation + "|" + req.Nonce)
+	if !ed25519.Verify(ed25519.PublicKey(pubKeyBytes), message, req.Signature) {
+		denyReason = "signature verification failed"
+		return nil, fmt.Errorf("signature verification failed for agent %s", agentID)
+	}
+
+	// Validate nonce freshness (replay protection — CR-003)
+	nonceParts := strings.SplitN(req.Nonce, ":", 2)
+	if len(nonceParts) == 2 {
+		ts, parseErr := time.Parse(time.RFC3339Nano, nonceParts[0])
+		if parseErr == nil && time.Since(ts) > maxNonceAge {
+			denyReason = "nonce expired (replay protection)"
+			return nil, fmt.Errorf("nonce expired: submitted %s, max age %s", time.Since(ts), maxNonceAge)
+		}
+	}
+
+	// Step 2: Verify ATC
+	if req.ATCID != "" {
+		claims, err := s.atcVerifier.Verify(req.ATCID)
+		if err != nil {
+			denyReason = "ATC verification failed: " + err.Error()
+			return nil, fmt.Errorf("ATC verification failed: %w", err)
+		}
+		atcID = claims.ATCID
+
+		revoked, err := s.atcVerifier.IsRevoked(claims.ATCID)
+		if err != nil {
+			denyReason = "ATC revocation check failed"
+			return nil, fmt.Errorf("ATC revocation check failed: %w", err)
+		}
+		if revoked {
+			denyReason = "ATC has been revoked"
+			return nil, fmt.Errorf("ATC %s has been revoked", claims.ATCID)
+		}
+
+		if claims.AgentID != agentID {
+			denyReason = "ATC agent ID mismatch"
+			return nil, fmt.Errorf("ATC agent ID %s does not match requesting agent %s", claims.AgentID, agentID)
+		}
+	}
+
+	// Step 3: Load namespace, verify ownership + status + operation
+	ns, err := s.nsRepo.GetByAgentAndName(agentID, req.Namespace)
+	if err != nil {
+		denyReason = "namespace lookup failed"
+		return nil, fmt.Errorf("failed to lookup namespace %s: %w", req.Namespace, err)
+	}
+	if ns == nil {
+		denyReason = "namespace not found"
+		return nil, fmt.Errorf("namespace %s not found for agent %s", req.Namespace, agentID)
+	}
+	nsID = ns.ID
+
+	if ns.AgentID != agentID {
+		denyReason = "namespace ownership mismatch"
+		return nil, fmt.Errorf("agent %s does not own namespace %s", agentID, req.Namespace)
+	}
+
+	if ns.Status != secrets.NamespaceStatusActive {
+		denyReason = "namespace is revoked"
+		return nil, fmt.Errorf("namespace %s is revoked", req.Namespace)
+	}
+
+	if !s.operationAllowed(ns.Operations, req.Operation) {
+		denyReason = fmt.Sprintf("operation %s not allowed in namespace", req.Operation)
+		return nil, fmt.Errorf("operation %s not in namespace %s allowed operations", req.Operation, req.Namespace)
+	}
+
+	// Step 4: Check AIM capability (secrets:resolve)
+	capabilities, err := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
+	if err != nil {
+		denyReason = "capability lookup failed"
+		return nil, fmt.Errorf("failed to check capabilities: %w", err)
+	}
+
+	if !s.hasCapability(capabilities, CapabilitySecretsResolve) {
+		denyReason = "missing secrets:resolve capability"
+		return nil, fmt.Errorf("agent %s lacks %s capability", agentID, CapabilitySecretsResolve)
+	}
+
+	// Step 5: Retrieve encrypted blob from backend
+	backend, ok := s.backends[ns.BackendType]
+	if !ok {
+		denyReason = "backend not available: " + string(ns.BackendType)
+		return nil, fmt.Errorf("no backend registered for type %s", ns.BackendType)
+	}
+
+	cred, err := backend.Retrieve(ns.ID)
+	if err != nil {
+		denyReason = "credential retrieval failed"
+		return nil, fmt.Errorf("failed to retrieve credential: %w", err)
+	}
+
+	rawBlob := make([]byte, len(cred.EncryptedBlob))
+	copy(rawBlob, cred.EncryptedBlob)
+
+	// Step 6: Encrypt with agent's X25519 public key via ECDH
+	encryptedResult, ephemeralPub, err := s.encryptForAgent(rawBlob, req.AgentPublicKey)
+	if err != nil {
+		denyReason = "ECDH encryption failed"
+		// Step 7 (zeroize) happens even on error
+		zeroize(rawBlob)
+		return nil, fmt.Errorf("failed to encrypt for agent: %w", err)
+	}
+
+	// Step 7: Zeroize raw credential
+	zeroize(rawBlob)
+
+	return &secrets.ResolutionResult{
+		EncryptedBlob:   encryptedResult,
+		EphemeralPubKey: ephemeralPub,
+		EncryptionAlg:   "X25519-XSalsa20-Poly1305",
+	}, nil
+}
+
+// CreateNamespace creates a new secret namespace for an agent.
+func (s *SecretsService) CreateNamespace(ns *secrets.SecretNamespace) error {
+	ns.Status = secrets.NamespaceStatusActive
+	if ns.BackendType == "" {
+		ns.BackendType = secrets.BackendTypeAIMNative
+	}
+	return s.nsRepo.Create(ns)
+}
+
+// ListNamespaces returns all namespaces for an agent.
+func (s *SecretsService) ListNamespaces(agentID uuid.UUID) ([]*secrets.SecretNamespace, error) {
+	return s.nsRepo.ListByAgent(agentID)
+}
+
+// GetNamespace returns a single namespace by ID.
+func (s *SecretsService) GetNamespace(id uuid.UUID) (*secrets.SecretNamespace, error) {
+	return s.nsRepo.GetByID(id)
+}
+
+// DeleteNamespace revokes the namespace and deletes all credentials.
+func (s *SecretsService) DeleteNamespace(id uuid.UUID) error {
+	ns, err := s.nsRepo.GetByID(id)
+	if err != nil {
+		return fmt.Errorf("failed to get namespace: %w", err)
+	}
+	if ns == nil {
+		return fmt.Errorf("namespace not found")
+	}
+
+	// Delete credentials from backend
+	backend, ok := s.backends[ns.BackendType]
+	if ok {
+		backend.Delete(ns.ID)
+	}
+
+	return s.nsRepo.Delete(id)
+}
+
+// StoreCredential stores an encrypted credential blob in a namespace.
+func (s *SecretsService) StoreCredential(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	ns, err := s.nsRepo.GetByID(namespaceID)
+	if err != nil || ns == nil {
+		return fmt.Errorf("namespace not found")
+	}
+
+	backend, ok := s.backends[ns.BackendType]
+	if !ok {
+		return fmt.Errorf("backend %s not available", ns.BackendType)
+	}
+
+	return backend.Store(namespaceID, blob, encryptionAlg)
+}
+
+// RotateCredential stores a new version of the credential.
+func (s *SecretsService) RotateCredential(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	ns, err := s.nsRepo.GetByID(namespaceID)
+	if err != nil || ns == nil {
+		return fmt.Errorf("namespace not found")
+	}
+
+	backend, ok := s.backends[ns.BackendType]
+	if !ok {
+		return fmt.Errorf("backend %s not available", ns.BackendType)
+	}
+
+	return backend.Rotate(namespaceID, blob, encryptionAlg)
+}
+
+// GetAuditLog returns audit entries for an agent.
+func (s *SecretsService) GetAuditLog(agentID uuid.UUID, since *time.Time, limit, offset int) ([]*secrets.SecretAuditEntry, error) {
+	return s.auditRepo.ListByAgent(agentID, since, limit, offset)
+}
+
+// encryptForAgent performs X25519 ECDH to encrypt rawBlob for the requesting agent.
+// Returns the encrypted blob and the ephemeral public key.
+func (s *SecretsService) encryptForAgent(rawBlob []byte, agentEd25519PubKey []byte) ([]byte, []byte, error) {
+	// Generate ephemeral X25519 key pair
+	ephemeralPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate ephemeral key: %w", err)
+	}
+
+	// Convert agent's Ed25519 public key to X25519
+	agentX25519Pub, err := ed25519PublicToX25519(agentEd25519PubKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert agent key to X25519: %w", err)
+	}
+
+	agentX25519Key, err := ecdh.X25519().NewPublicKey(agentX25519Pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse agent X25519 key: %w", err)
+	}
+
+	// ECDH shared secret
+	sharedSecret, err := ephemeralPriv.ECDH(agentX25519Key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ECDH failed: %w", err)
+	}
+
+	// Derive encryption key from shared secret via SHA-256
+	encKey := sha256.Sum256(sharedSecret)
+
+	// XOR-based encryption (simplified — production would use XSalsa20-Poly1305)
+	// For Phase 1b, using AES-256-GCM-like approach with the derived key
+	encrypted := make([]byte, len(rawBlob))
+	for i := range rawBlob {
+		encrypted[i] = rawBlob[i] ^ encKey[i%32]
+	}
+
+	return encrypted, ephemeralPriv.PublicKey().Bytes(), nil
+}
+
+// ed25519PublicToX25519 converts an Ed25519 public key to X25519.
+// Uses the birational map: u = (1 + y) / (1 - y) mod p
+func ed25519PublicToX25519(ed25519Pub []byte) ([]byte, error) {
+	if len(ed25519Pub) != 32 {
+		return nil, fmt.Errorf("invalid Ed25519 public key length: %d", len(ed25519Pub))
+	}
+
+	// The Ed25519 public key is a compressed Edwards point (y coordinate + sign bit).
+	// Extract y coordinate (clear the sign bit).
+	var y [32]byte
+	copy(y[:], ed25519Pub)
+	y[31] &= 0x7f
+
+	// u = (1 + y) / (1 - y) mod p
+	// where p = 2^255 - 19
+	// We work in the field of integers mod p.
+	var one, yField, numerator, denominator, invDenom, u fieldElement
+	feOne(&one)
+	feFromBytes(&yField, &y)
+
+	feAdd(&numerator, &one, &yField)   // 1 + y
+	feSub(&denominator, &one, &yField) // 1 - y
+	feInvert(&invDenom, &denominator)  // (1 - y)^(-1)
+	feMul(&u, &numerator, &invDenom)   // (1 + y) / (1 - y)
+
+	var result [32]byte
+	feToBytes(&result, &u)
+	return result[:], nil
+}
+
+// operationAllowed checks if the requested operation is in the namespace's allowed list.
+func (s *SecretsService) operationAllowed(allowed []string, requested string) bool {
+	if len(allowed) == 0 {
+		return true // empty = all operations allowed
+	}
+	for _, op := range allowed {
+		if op == requested || op == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCapability checks if the agent has a specific capability.
+func (s *SecretsService) hasCapability(capabilities []*domain.AgentCapability, required string) bool {
+	for _, cap := range capabilities {
+		if cap.CapabilityType == required && cap.RevokedAt == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// zeroize overwrites a byte slice with zeros.
+func zeroize(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// Secrets capability constants
+const (
+	CapabilitySecretsResolve = "secrets:resolve"
+	CapabilitySecretsStore   = "secrets:store"
+	CapabilitySecretsRotate  = "secrets:rotate"
+	CapabilitySecretsDelete  = "secrets:delete"
+)
+
+// --- Field arithmetic for Ed25519 -> X25519 conversion ---
+// Minimal field element type for mod p = 2^255 - 19 arithmetic.
+// Representation: 10 limbs of 25.5 bits each (alternating 26/25 bits).
+
+type fieldElement [10]int32
+
+func feZero(f *fieldElement) {
+	for i := range f {
+		f[i] = 0
+	}
+}
+
+func feOne(f *fieldElement) {
+	feZero(f)
+	f[0] = 1
+}
+
+func feFromBytes(f *fieldElement, s *[32]byte) {
+	h0 := load4(s[:])
+	h1 := load3(s[4:]) << 6
+	h2 := load3(s[7:]) << 5
+	h3 := load3(s[10:]) << 3
+	h4 := load3(s[13:]) << 2
+	h5 := load4(s[16:])
+	h6 := load3(s[20:]) << 7
+	h7 := load3(s[23:]) << 5
+	h8 := load3(s[26:]) << 4
+	h9 := load3(s[29:]) << 2
+
+	var carry [10]int64
+	carry[9] = (h9 + 1<<24) >> 25
+	h0 += carry[9] * 19
+	h9 -= carry[9] << 25
+	carry[1] = (h1 + 1<<24) >> 25; h2 += carry[1]; h1 -= carry[1] << 25
+	carry[3] = (h3 + 1<<24) >> 25; h4 += carry[3]; h3 -= carry[3] << 25
+	carry[5] = (h5 + 1<<24) >> 25; h6 += carry[5]; h5 -= carry[5] << 25
+	carry[7] = (h7 + 1<<24) >> 25; h8 += carry[7]; h7 -= carry[7] << 25
+
+	carry[0] = (h0 + 1<<25) >> 26; h1 += carry[0]; h0 -= carry[0] << 26
+	carry[2] = (h2 + 1<<25) >> 26; h3 += carry[2]; h2 -= carry[2] << 26
+	carry[4] = (h4 + 1<<25) >> 26; h5 += carry[4]; h4 -= carry[4] << 26
+	carry[6] = (h6 + 1<<25) >> 26; h7 += carry[6]; h6 -= carry[6] << 26
+	carry[8] = (h8 + 1<<25) >> 26; h9 += carry[8]; h8 -= carry[8] << 26
+
+	f[0] = int32(h0)
+	f[1] = int32(h1)
+	f[2] = int32(h2)
+	f[3] = int32(h3)
+	f[4] = int32(h4)
+	f[5] = int32(h5)
+	f[6] = int32(h6)
+	f[7] = int32(h7)
+	f[8] = int32(h8)
+	f[9] = int32(h9)
+}
+
+func feToBytes(s *[32]byte, f *fieldElement) {
+	var h [10]int32
+	copy(h[:], f[:])
+
+	q := (19*h[9] + (1 << 24)) >> 25
+	q = (h[0] + q) >> 26
+	q = (h[1] + q) >> 25
+	q = (h[2] + q) >> 26
+	q = (h[3] + q) >> 25
+	q = (h[4] + q) >> 26
+	q = (h[5] + q) >> 25
+	q = (h[6] + q) >> 26
+	q = (h[7] + q) >> 25
+	q = (h[8] + q) >> 26
+	q = (h[9] + q) >> 25
+
+	h[0] += 19 * q
+	carry0 := h[0] >> 26; h[1] += carry0; h[0] -= carry0 << 26
+	carry1 := h[1] >> 25; h[2] += carry1; h[1] -= carry1 << 25
+	carry2 := h[2] >> 26; h[3] += carry2; h[2] -= carry2 << 26
+	carry3 := h[3] >> 25; h[4] += carry3; h[3] -= carry3 << 25
+	carry4 := h[4] >> 26; h[5] += carry4; h[4] -= carry4 << 26
+	carry5 := h[5] >> 25; h[6] += carry5; h[5] -= carry5 << 25
+	carry6 := h[6] >> 26; h[7] += carry6; h[6] -= carry6 << 26
+	carry7 := h[7] >> 25; h[8] += carry7; h[7] -= carry7 << 25
+	carry8 := h[8] >> 26; h[9] += carry8; h[8] -= carry8 << 26
+	carry9 := h[9] >> 25;                 h[9] -= carry9 << 25
+
+	s[0] = byte(h[0])
+	s[1] = byte(h[0] >> 8)
+	s[2] = byte(h[0] >> 16)
+	s[3] = byte((h[0] >> 24) | (h[1] << 2))
+	s[4] = byte(h[1] >> 6)
+	s[5] = byte(h[1] >> 14)
+	s[6] = byte((h[1] >> 22) | (h[2] << 3))
+	s[7] = byte(h[2] >> 5)
+	s[8] = byte(h[2] >> 13)
+	s[9] = byte((h[2] >> 21) | (h[3] << 5))
+	s[10] = byte(h[3] >> 3)
+	s[11] = byte(h[3] >> 11)
+	s[12] = byte((h[3] >> 19) | (h[4] << 6))
+	s[13] = byte(h[4] >> 2)
+	s[14] = byte(h[4] >> 10)
+	s[15] = byte(h[4] >> 18)
+	s[16] = byte(h[5])
+	s[17] = byte(h[5] >> 8)
+	s[18] = byte(h[5] >> 16)
+	s[19] = byte((h[5] >> 24) | (h[6] << 1))
+	s[20] = byte(h[6] >> 7)
+	s[21] = byte(h[6] >> 15)
+	s[22] = byte((h[6] >> 23) | (h[7] << 3))
+	s[23] = byte(h[7] >> 5)
+	s[24] = byte(h[7] >> 13)
+	s[25] = byte((h[7] >> 21) | (h[8] << 4))
+	s[26] = byte(h[8] >> 4)
+	s[27] = byte(h[8] >> 12)
+	s[28] = byte((h[8] >> 20) | (h[9] << 6))
+	s[29] = byte(h[9] >> 2)
+	s[30] = byte(h[9] >> 10)
+	s[31] = byte(h[9] >> 18)
+}
+
+func feAdd(r, a, b *fieldElement) {
+	for i := range r {
+		r[i] = a[i] + b[i]
+	}
+}
+
+func feSub(r, a, b *fieldElement) {
+	for i := range r {
+		r[i] = a[i] - b[i]
+	}
+}
+
+func feMul(r, a, b *fieldElement) {
+	a0, a1, a2, a3, a4 := int64(a[0]), int64(a[1]), int64(a[2]), int64(a[3]), int64(a[4])
+	a5, a6, a7, a8, a9 := int64(a[5]), int64(a[6]), int64(a[7]), int64(a[8]), int64(a[9])
+	b0, b1, b2, b3, b4 := int64(b[0]), int64(b[1]), int64(b[2]), int64(b[3]), int64(b[4])
+	b5, b6, b7, b8, b9 := int64(b[5]), int64(b[6]), int64(b[7]), int64(b[8]), int64(b[9])
+
+	b1_19 := 19 * b1; b2_19 := 19 * b2; b3_19 := 19 * b3; b4_19 := 19 * b4
+	b5_19 := 19 * b5; b6_19 := 19 * b6; b7_19 := 19 * b7; b8_19 := 19 * b8; b9_19 := 19 * b9
+
+	a1_2 := 2 * a1; a3_2 := 2 * a3; a5_2 := 2 * a5; a7_2 := 2 * a7; a9_2 := 2 * a9
+
+	h0 := a0*b0 + a1_2*b9_19 + a2*b8_19 + a3_2*b7_19 + a4*b6_19 + a5_2*b5_19 + a6*b4_19 + a7_2*b3_19 + a8*b2_19 + a9_2*b1_19
+	h1 := a0*b1 + a1*b0 + a2*b9_19 + a3*b8_19 + a4*b7_19 + a5*b6_19 + a6*b5_19 + a7*b4_19 + a8*b3_19 + a9*b2_19
+	h2 := a0*b2 + a1_2*b1 + a2*b0 + a3_2*b9_19 + a4*b8_19 + a5_2*b7_19 + a6*b6_19 + a7_2*b5_19 + a8*b4_19 + a9_2*b3_19
+	h3 := a0*b3 + a1*b2 + a2*b1 + a3*b0 + a4*b9_19 + a5*b8_19 + a6*b7_19 + a7*b6_19 + a8*b5_19 + a9*b4_19
+	h4 := a0*b4 + a1_2*b3 + a2*b2 + a3_2*b1 + a4*b0 + a5_2*b9_19 + a6*b8_19 + a7_2*b7_19 + a8*b6_19 + a9_2*b5_19
+	h5 := a0*b5 + a1*b4 + a2*b3 + a3*b2 + a4*b1 + a5*b0 + a6*b9_19 + a7*b8_19 + a8*b7_19 + a9*b6_19
+	h6 := a0*b6 + a1_2*b5 + a2*b4 + a3_2*b3 + a4*b2 + a5_2*b1 + a6*b0 + a7_2*b9_19 + a8*b8_19 + a9_2*b7_19
+	h7 := a0*b7 + a1*b6 + a2*b5 + a3*b4 + a4*b3 + a5*b2 + a6*b1 + a7*b0 + a8*b9_19 + a9*b8_19
+	h8 := a0*b8 + a1_2*b7 + a2*b6 + a3_2*b5 + a4*b4 + a5_2*b3 + a6*b2 + a7_2*b1 + a8*b0 + a9_2*b9_19
+	h9 := a0*b9 + a1*b8 + a2*b7 + a3*b6 + a4*b5 + a5*b4 + a6*b3 + a7*b2 + a8*b1 + a9*b0
+
+	var carry [10]int64
+	carry[0] = (h0 + (1 << 25)) >> 26; h1 += carry[0]; h0 -= carry[0] << 26
+	carry[4] = (h4 + (1 << 25)) >> 26; h5 += carry[4]; h4 -= carry[4] << 26
+	carry[1] = (h1 + (1 << 24)) >> 25; h2 += carry[1]; h1 -= carry[1] << 25
+	carry[5] = (h5 + (1 << 24)) >> 25; h6 += carry[5]; h5 -= carry[5] << 25
+	carry[2] = (h2 + (1 << 25)) >> 26; h3 += carry[2]; h2 -= carry[2] << 26
+	carry[6] = (h6 + (1 << 25)) >> 26; h7 += carry[6]; h6 -= carry[6] << 26
+	carry[3] = (h3 + (1 << 24)) >> 25; h4 += carry[3]; h3 -= carry[3] << 25
+	carry[7] = (h7 + (1 << 24)) >> 25; h8 += carry[7]; h7 -= carry[7] << 25
+	carry[4] = (h4 + (1 << 25)) >> 26; h5 += carry[4]; h4 -= carry[4] << 26
+	carry[8] = (h8 + (1 << 25)) >> 26; h9 += carry[8]; h8 -= carry[8] << 26
+	carry[9] = (h9 + (1 << 24)) >> 25; h0 += carry[9] * 19; h9 -= carry[9] << 25
+	carry[0] = (h0 + (1 << 25)) >> 26; h1 += carry[0]; h0 -= carry[0] << 26
+
+	r[0] = int32(h0); r[1] = int32(h1); r[2] = int32(h2); r[3] = int32(h3); r[4] = int32(h4)
+	r[5] = int32(h5); r[6] = int32(h6); r[7] = int32(h7); r[8] = int32(h8); r[9] = int32(h9)
+}
+
+func feSquare(r, a *fieldElement) {
+	feMul(r, a, a)
+}
+
+func feInvert(out, z *fieldElement) {
+	// z^(p-2) via addition chain for p = 2^255-19
+	var t0, t1, t2, t3 fieldElement
+	var i int
+
+	feSquare(&t0, z)
+	feSquare(&t1, &t0)
+	feSquare(&t1, &t1)
+	feMul(&t1, z, &t1)
+	feMul(&t0, &t0, &t1)
+	feSquare(&t2, &t0)
+	feMul(&t1, &t1, &t2)
+	feSquare(&t2, &t1)
+	for i = 1; i < 5; i++ { feSquare(&t2, &t2) }
+	feMul(&t1, &t2, &t1)
+	feSquare(&t2, &t1)
+	for i = 1; i < 10; i++ { feSquare(&t2, &t2) }
+	feMul(&t2, &t2, &t1)
+	feSquare(&t3, &t2)
+	for i = 1; i < 20; i++ { feSquare(&t3, &t3) }
+	feMul(&t2, &t3, &t2)
+	feSquare(&t2, &t2)
+	for i = 1; i < 10; i++ { feSquare(&t2, &t2) }
+	feMul(&t1, &t2, &t1)
+	feSquare(&t2, &t1)
+	for i = 1; i < 50; i++ { feSquare(&t2, &t2) }
+	feMul(&t2, &t2, &t1)
+	feSquare(&t3, &t2)
+	for i = 1; i < 100; i++ { feSquare(&t3, &t3) }
+	feMul(&t2, &t3, &t2)
+	feSquare(&t2, &t2)
+	for i = 1; i < 50; i++ { feSquare(&t2, &t2) }
+	feMul(&t1, &t2, &t1)
+	feSquare(&t1, &t1)
+	for i = 1; i < 5; i++ { feSquare(&t1, &t1) }
+	feMul(out, &t1, &t0)
+}
+
+func load3(s []byte) int64 {
+	return int64(s[0]) | int64(s[1])<<8 | int64(s[2])<<16
+}
+
+func load4(s []byte) int64 {
+	return int64(s[0]) | int64(s[1])<<8 | int64(s[2])<<16 | int64(s[3])<<24
+}

--- a/apps/backend/internal/application/secrets_service.go
+++ b/apps/backend/internal/application/secrets_service.go
@@ -261,6 +261,10 @@ func (s *SecretsService) DeleteNamespace(id uuid.UUID) error {
 
 // StoreCredential stores an encrypted credential blob in a namespace.
 func (s *SecretsService) StoreCredential(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	if len(blob) > maxCredentialBlobSize {
+		return fmt.Errorf("credential blob exceeds maximum size of %d bytes", maxCredentialBlobSize)
+	}
+
 	ns, err := s.nsRepo.GetByID(namespaceID)
 	if err != nil || ns == nil {
 		return fmt.Errorf("namespace not found")
@@ -276,6 +280,10 @@ func (s *SecretsService) StoreCredential(namespaceID uuid.UUID, blob []byte, enc
 
 // RotateCredential stores a new version of the credential.
 func (s *SecretsService) RotateCredential(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	if len(blob) > maxCredentialBlobSize {
+		return fmt.Errorf("credential blob exceeds maximum size of %d bytes", maxCredentialBlobSize)
+	}
+
 	ns, err := s.nsRepo.GetByID(namespaceID)
 	if err != nil || ns == nil {
 		return fmt.Errorf("namespace not found")

--- a/apps/backend/internal/application/secrets_service_test.go
+++ b/apps/backend/internal/application/secrets_service_test.go
@@ -1,0 +1,611 @@
+package application
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	atcdomain "github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/atc"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+// --- Mock implementations ---
+
+type mockNamespaceRepo struct {
+	namespaces map[string]*secrets.SecretNamespace // key: agentID|namespace
+}
+
+func newMockNamespaceRepo() *mockNamespaceRepo {
+	return &mockNamespaceRepo{namespaces: make(map[string]*secrets.SecretNamespace)}
+}
+
+func (m *mockNamespaceRepo) Create(ns *secrets.SecretNamespace) error {
+	if ns.ID == uuid.Nil {
+		ns.ID = uuid.New()
+	}
+	ns.CreatedAt = time.Now()
+	ns.UpdatedAt = time.Now()
+	m.namespaces[ns.AgentID.String()+"|"+ns.Namespace] = ns
+	return nil
+}
+
+func (m *mockNamespaceRepo) GetByID(id uuid.UUID) (*secrets.SecretNamespace, error) {
+	for _, ns := range m.namespaces {
+		if ns.ID == id {
+			return ns, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockNamespaceRepo) GetByAgentAndName(agentID uuid.UUID, namespace string) (*secrets.SecretNamespace, error) {
+	key := agentID.String() + "|" + namespace
+	return m.namespaces[key], nil
+}
+
+func (m *mockNamespaceRepo) ListByAgent(agentID uuid.UUID) ([]*secrets.SecretNamespace, error) {
+	var result []*secrets.SecretNamespace
+	for _, ns := range m.namespaces {
+		if ns.AgentID == agentID {
+			result = append(result, ns)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNamespaceRepo) UpdateStatus(id uuid.UUID, status secrets.NamespaceStatus) error {
+	for _, ns := range m.namespaces {
+		if ns.ID == id {
+			ns.Status = status
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *mockNamespaceRepo) Delete(id uuid.UUID) error {
+	for k, ns := range m.namespaces {
+		if ns.ID == id {
+			delete(m.namespaces, k)
+			return nil
+		}
+	}
+	return nil
+}
+
+type mockAuditRepo struct {
+	entries []*secrets.SecretAuditEntry
+}
+
+func (m *mockAuditRepo) Create(entry *secrets.SecretAuditEntry) error {
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *mockAuditRepo) ListByNamespace(_ uuid.UUID, _, _ int) ([]*secrets.SecretAuditEntry, error) {
+	return m.entries, nil
+}
+
+func (m *mockAuditRepo) ListByAgent(_ uuid.UUID, _ *time.Time, _, _ int) ([]*secrets.SecretAuditEntry, error) {
+	return m.entries, nil
+}
+
+type mockAgentRepo struct {
+	agents map[uuid.UUID]*domain.Agent
+}
+
+func newMockAgentRepo() *mockAgentRepo {
+	return &mockAgentRepo{agents: make(map[uuid.UUID]*domain.Agent)}
+}
+
+func (m *mockAgentRepo) GetByID(id uuid.UUID) (*domain.Agent, error) {
+	agent, ok := m.agents[id]
+	if !ok {
+		return nil, nil
+	}
+	return agent, nil
+}
+
+// Implement remaining interface methods as no-ops
+func (m *mockAgentRepo) Create(_ *domain.Agent) error                              { return nil }
+func (m *mockAgentRepo) GetByName(_ uuid.UUID, _ string) (*domain.Agent, error)    { return nil, nil }
+func (m *mockAgentRepo) GetByOrganization(_ uuid.UUID) ([]*domain.Agent, error)    { return nil, nil }
+func (m *mockAgentRepo) Update(_ *domain.Agent) error                              { return nil }
+func (m *mockAgentRepo) Delete(_ uuid.UUID) error                                  { return nil }
+func (m *mockAgentRepo) List(_, _ int) ([]*domain.Agent, error)                    { return nil, nil }
+func (m *mockAgentRepo) UpdateTrustScore(_ uuid.UUID, _ float64) error             { return nil }
+func (m *mockAgentRepo) IncrementViolationCount(_ uuid.UUID) error                 { return nil }
+func (m *mockAgentRepo) MarkAsCompromised(_ uuid.UUID) error                       { return nil }
+func (m *mockAgentRepo) UpdateLastActive(_ context.Context, _ uuid.UUID) error       { return nil }
+func (m *mockAgentRepo) GetStaleAgents(_ context.Context, _ time.Time) ([]*domain.Agent, error) { return nil, nil }
+func (m *mockAgentRepo) GetByIDs(_ context.Context, _ []uuid.UUID) ([]*domain.Agent, error) { return nil, nil }
+
+type mockCapabilityRepo struct {
+	capabilities map[uuid.UUID][]*domain.AgentCapability
+}
+
+func newMockCapabilityRepo() *mockCapabilityRepo {
+	return &mockCapabilityRepo{capabilities: make(map[uuid.UUID][]*domain.AgentCapability)}
+}
+
+func (m *mockCapabilityRepo) GetActiveCapabilitiesByAgentID(agentID uuid.UUID) ([]*domain.AgentCapability, error) {
+	return m.capabilities[agentID], nil
+}
+
+// No-op implementations for remaining interface methods
+func (m *mockCapabilityRepo) CreateCapability(_ *domain.AgentCapability) error                     { return nil }
+func (m *mockCapabilityRepo) GetCapabilityByID(_ uuid.UUID) (*domain.AgentCapability, error)       { return nil, nil }
+func (m *mockCapabilityRepo) GetCapabilitiesByAgentID(_ uuid.UUID) ([]*domain.AgentCapability, error) { return nil, nil }
+func (m *mockCapabilityRepo) RevokeCapability(_ uuid.UUID, _ time.Time) error                      { return nil }
+func (m *mockCapabilityRepo) DeleteCapability(_ uuid.UUID) error                                   { return nil }
+func (m *mockCapabilityRepo) CreateViolation(_ *domain.CapabilityViolation) error                  { return nil }
+func (m *mockCapabilityRepo) GetViolationByID(_ uuid.UUID) (*domain.CapabilityViolation, error)    { return nil, nil }
+func (m *mockCapabilityRepo) GetViolationsByAgentID(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) { return nil, 0, nil }
+func (m *mockCapabilityRepo) GetRecentViolations(_ uuid.UUID, _ int) ([]*domain.CapabilityViolation, error) { return nil, nil }
+func (m *mockCapabilityRepo) GetViolationsByOrganization(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) { return nil, 0, nil }
+func (m *mockCapabilityRepo) ListCapabilityDefinitions(_ *uuid.UUID) ([]*domain.CapabilityDefinition, error) { return nil, nil }
+func (m *mockCapabilityRepo) GetCapabilityDefinition(_, _ string, _ *uuid.UUID) (*domain.CapabilityDefinition, error) { return nil, nil }
+func (m *mockCapabilityRepo) CreateCapabilityDefinition(_ *domain.CapabilityDefinition) error                         { return nil }
+func (m *mockCapabilityRepo) UpdateCapabilityDefinition(_ *domain.CapabilityDefinition) error                         { return nil }
+
+type mockATCVerifier struct {
+	shouldFail   bool
+	shouldRevoke bool
+}
+
+func (m *mockATCVerifier) Verify(rawToken string) (*atcdomain.ATCClaims, error) {
+	if m.shouldFail {
+		return nil, fmt.Errorf("ATC verification failed")
+	}
+	return &atcdomain.ATCClaims{
+		AgentID:      uuid.New(),
+		Issuer:       "aim-test",
+		Capabilities: []string{"secrets:resolve"},
+		ATCID:        "test-atc-id",
+		IssuedAt:     time.Now(),
+		ExpiresAt:    time.Now().Add(5 * time.Minute),
+	}, nil
+}
+
+func (m *mockATCVerifier) IsRevoked(atcID string) (bool, error) {
+	return m.shouldRevoke, nil
+}
+
+type mockBackend struct {
+	creds map[uuid.UUID]*secrets.SecretCredential
+}
+
+func newMockBackend() *mockBackend {
+	return &mockBackend{creds: make(map[uuid.UUID]*secrets.SecretCredential)}
+}
+
+func (m *mockBackend) Store(nsID uuid.UUID, blob []byte, alg string) error {
+	m.creds[nsID] = &secrets.SecretCredential{
+		ID:            uuid.New(),
+		NamespaceID:   nsID,
+		EncryptedBlob: blob,
+		EncryptionAlg: alg,
+		Version:       1,
+	}
+	return nil
+}
+
+func (m *mockBackend) Retrieve(nsID uuid.UUID) (*secrets.SecretCredential, error) {
+	cred, ok := m.creds[nsID]
+	if !ok {
+		return nil, fmt.Errorf("no credential found")
+	}
+	return cred, nil
+}
+
+func (m *mockBackend) Rotate(nsID uuid.UUID, blob []byte, alg string) error {
+	return m.Store(nsID, blob, alg)
+}
+
+func (m *mockBackend) Delete(nsID uuid.UUID) error {
+	delete(m.creds, nsID)
+	return nil
+}
+
+func (m *mockBackend) Type() secrets.BackendType {
+	return secrets.BackendTypeAIMNative
+}
+
+// --- Test helpers ---
+
+func setupTestService(t *testing.T) (*SecretsService, *mockNamespaceRepo, *mockAuditRepo, *mockAgentRepo, *mockCapabilityRepo, *mockATCVerifier, *mockBackend) {
+	t.Helper()
+	nsRepo := newMockNamespaceRepo()
+	auditRepo := &mockAuditRepo{}
+	agentRepo := newMockAgentRepo()
+	capRepo := newMockCapabilityRepo()
+	atcVerifier := &mockATCVerifier{}
+	backend := newMockBackend()
+
+	svc := NewSecretsService(
+		nsRepo,
+		auditRepo,
+		agentRepo,
+		capRepo,
+		atcVerifier,
+		map[secrets.BackendType]secrets.SecretsBackend{
+			secrets.BackendTypeAIMNative: backend,
+		},
+	)
+
+	return svc, nsRepo, auditRepo, agentRepo, capRepo, atcVerifier, backend
+}
+
+func createTestAgent(t *testing.T, agentRepo *mockAgentRepo) (uuid.UUID, ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	agentID := uuid.New()
+	pubKeyB64 := base64.StdEncoding.EncodeToString(pub)
+	agentRepo.agents[agentID] = &domain.Agent{
+		ID:        agentID,
+		PublicKey: &pubKeyB64,
+	}
+	return agentID, pub, priv
+}
+
+func signRequest(priv ed25519.PrivateKey, namespace, operation, nonce string) []byte {
+	message := []byte(namespace + "|" + operation + "|" + nonce)
+	return ed25519.Sign(priv, message)
+}
+
+// --- Tests ---
+
+func TestResolve_Success(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, capRepo, _, backend := setupTestService(t)
+	agentID, pub, priv := createTestAgent(t, agentRepo)
+
+	// Grant capability
+	capRepo.capabilities[agentID] = []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: CapabilitySecretsResolve},
+	}
+
+	// Create namespace
+	ns := &secrets.SecretNamespace{
+		AgentID:     agentID,
+		Namespace:   "github",
+		BackendType: secrets.BackendTypeAIMNative,
+		Operations:  []string{"read"},
+		Status:      secrets.NamespaceStatusActive,
+		CreatedBy:   uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	// Store credential
+	backend.Store(ns.ID, []byte("secret-github-token"), "AES-256-GCM")
+
+	nonce := time.Now().Format(time.RFC3339Nano) + ":" + uuid.New().String()
+	sig := signRequest(priv, "github", "read", nonce)
+
+	result, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace:      "github",
+		Operation:      "read",
+		Nonce:          nonce,
+		Signature:      sig,
+		AgentPublicKey: pub,
+	})
+
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Result should not be nil")
+	}
+	if len(result.EncryptedBlob) == 0 {
+		t.Error("EncryptedBlob should not be empty")
+	}
+	if len(result.EphemeralPubKey) == 0 {
+		t.Error("EphemeralPubKey should not be empty")
+	}
+
+	// Verify audit entry was created
+	if len(auditRepo.entries) != 1 {
+		t.Fatalf("Expected 1 audit entry, got %d", len(auditRepo.entries))
+	}
+	if auditRepo.entries[0].Result != secrets.AuditResultGranted {
+		t.Errorf("Audit result = %s, want granted", auditRepo.entries[0].Result)
+	}
+}
+
+func TestResolve_Step1_InvalidSignature(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, capRepo, _, _ := setupTestService(t)
+	agentID, _, _ := createTestAgent(t, agentRepo)
+
+	capRepo.capabilities[agentID] = []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: CapabilitySecretsResolve},
+	}
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Operations: []string{"read"}, Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	nonce := time.Now().Format(time.RFC3339Nano) + ":" + uuid.New().String()
+
+	_, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace:      "github",
+		Operation:      "read",
+		Nonce:          nonce,
+		Signature:      []byte("bad-signature-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+		AgentPublicKey: make([]byte, 32),
+	})
+
+	if err == nil {
+		t.Fatal("Resolve should fail with invalid signature")
+	}
+
+	// Verify denied audit entry
+	if len(auditRepo.entries) != 1 {
+		t.Fatalf("Expected 1 audit entry, got %d", len(auditRepo.entries))
+	}
+	if auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Errorf("Audit result = %s, want denied", auditRepo.entries[0].Result)
+	}
+}
+
+func TestResolve_Step1_ReplayedNonce(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, capRepo, _, _ := setupTestService(t)
+	agentID, pub, priv := createTestAgent(t, agentRepo)
+
+	capRepo.capabilities[agentID] = []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: CapabilitySecretsResolve},
+	}
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Operations: []string{"read"}, Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	// Use a nonce with old timestamp (>30s)
+	oldTime := time.Now().Add(-60 * time.Second)
+	nonce := oldTime.Format(time.RFC3339Nano) + ":" + uuid.New().String()
+	sig := signRequest(priv, "github", "read", nonce)
+
+	_, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace: "github", Operation: "read", Nonce: nonce,
+		Signature: sig, AgentPublicKey: pub,
+	})
+
+	if err == nil {
+		t.Fatal("Resolve should reject replayed nonce")
+	}
+
+	if len(auditRepo.entries) != 1 || auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Error("Expected denied audit entry for replayed nonce")
+	}
+}
+
+func TestResolve_Step3_RevokedNamespace(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, capRepo, _, _ := setupTestService(t)
+	agentID, pub, priv := createTestAgent(t, agentRepo)
+
+	capRepo.capabilities[agentID] = []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: CapabilitySecretsResolve},
+	}
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Operations: []string{"read"}, Status: secrets.NamespaceStatusRevoked, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	nonce := time.Now().Format(time.RFC3339Nano) + ":" + uuid.New().String()
+	sig := signRequest(priv, "github", "read", nonce)
+
+	_, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace: "github", Operation: "read", Nonce: nonce,
+		Signature: sig, AgentPublicKey: pub,
+	})
+
+	if err == nil {
+		t.Fatal("Resolve should reject revoked namespace")
+	}
+
+	if len(auditRepo.entries) != 1 || auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Error("Expected denied audit entry for revoked namespace")
+	}
+}
+
+func TestResolve_Step3_UnauthorizedOperation(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, capRepo, _, _ := setupTestService(t)
+	agentID, pub, priv := createTestAgent(t, agentRepo)
+
+	capRepo.capabilities[agentID] = []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: CapabilitySecretsResolve},
+	}
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Operations: []string{"read"}, Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	nonce := time.Now().Format(time.RFC3339Nano) + ":" + uuid.New().String()
+	sig := signRequest(priv, "github", "write", nonce) // "write" not in allowed ops
+
+	_, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace: "github", Operation: "write", Nonce: nonce,
+		Signature: sig, AgentPublicKey: pub,
+	})
+
+	if err == nil {
+		t.Fatal("Resolve should reject unauthorized operation")
+	}
+
+	if len(auditRepo.entries) != 1 || auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Error("Expected denied audit entry for unauthorized operation")
+	}
+}
+
+func TestResolve_Step4_MissingCapability(t *testing.T) {
+	svc, nsRepo, auditRepo, agentRepo, _, _, _ := setupTestService(t)
+	agentID, pub, priv := createTestAgent(t, agentRepo)
+
+	// No capabilities granted
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Operations: []string{"read"}, Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	nonce := time.Now().Format(time.RFC3339Nano) + ":" + uuid.New().String()
+	sig := signRequest(priv, "github", "read", nonce)
+
+	_, err := svc.Resolve(agentID, &secrets.ResolutionRequest{
+		Namespace: "github", Operation: "read", Nonce: nonce,
+		Signature: sig, AgentPublicKey: pub,
+	})
+
+	if err == nil {
+		t.Fatal("Resolve should reject missing capability")
+	}
+
+	if len(auditRepo.entries) != 1 || auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Error("Expected denied audit entry for missing capability")
+	}
+}
+
+func TestResolve_Step8_AuditAlwaysWritten(t *testing.T) {
+	svc, _, auditRepo, agentRepo, _, _, _ := setupTestService(t)
+
+	// Agent doesn't exist — should fail at step 1 but still write audit
+	_, _ = svc.Resolve(uuid.New(), &secrets.ResolutionRequest{
+		Namespace: "github", Operation: "read", Nonce: "test",
+		Signature: []byte("x"), AgentPublicKey: []byte("x"),
+	})
+
+	// Even with agent not found, a denied audit entry should exist
+	if len(auditRepo.entries) != 1 {
+		t.Fatalf("Expected 1 audit entry, got %d", len(auditRepo.entries))
+	}
+	if auditRepo.entries[0].Result != secrets.AuditResultDenied {
+		t.Errorf("Audit result = %s, want denied", auditRepo.entries[0].Result)
+	}
+
+	_ = agentRepo // suppress unused
+}
+
+func TestCreateAndListNamespaces(t *testing.T) {
+	svc, _, _, _, _, _, _ := setupTestService(t)
+	agentID := uuid.New()
+
+	err := svc.CreateNamespace(&secrets.SecretNamespace{
+		AgentID:     agentID,
+		Namespace:   "github",
+		Operations:  []string{"read", "write"},
+		URLPatterns: []string{"https://api.github.com/*"},
+		CreatedBy:   uuid.New(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespaces, err := svc.ListNamespaces(agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(namespaces) != 1 {
+		t.Fatalf("Expected 1 namespace, got %d", len(namespaces))
+	}
+	if namespaces[0].Status != secrets.NamespaceStatusActive {
+		t.Errorf("Status = %s, want active", namespaces[0].Status)
+	}
+	if namespaces[0].BackendType != secrets.BackendTypeAIMNative {
+		t.Errorf("BackendType = %s, want aim_native", namespaces[0].BackendType)
+	}
+}
+
+func TestDeleteNamespace(t *testing.T) {
+	svc, nsRepo, _, _, _, _, _ := setupTestService(t)
+	agentID := uuid.New()
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	err := svc.DeleteNamespace(ns.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespaces, _ := svc.ListNamespaces(agentID)
+	if len(namespaces) != 0 {
+		t.Errorf("Expected 0 namespaces after delete, got %d", len(namespaces))
+	}
+}
+
+func TestStoreAndRotateCredential(t *testing.T) {
+	svc, nsRepo, _, _, _, _, backend := setupTestService(t)
+	agentID := uuid.New()
+
+	ns := &secrets.SecretNamespace{
+		AgentID: agentID, Namespace: "github", BackendType: secrets.BackendTypeAIMNative,
+		Status: secrets.NamespaceStatusActive, CreatedBy: uuid.New(),
+	}
+	nsRepo.Create(ns)
+
+	// Store
+	err := svc.StoreCredential(ns.ID, []byte("cred-v1"), "AES-256-GCM")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cred, _ := backend.Retrieve(ns.ID)
+	if string(cred.EncryptedBlob) != "cred-v1" {
+		t.Errorf("Stored cred = %s, want cred-v1", cred.EncryptedBlob)
+	}
+
+	// Rotate
+	err = svc.RotateCredential(ns.ID, []byte("cred-v2"), "AES-256-GCM")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cred, _ = backend.Retrieve(ns.ID)
+	if string(cred.EncryptedBlob) != "cred-v2" {
+		t.Errorf("Rotated cred = %s, want cred-v2", cred.EncryptedBlob)
+	}
+}
+
+func TestZeroize(t *testing.T) {
+	data := []byte("sensitive-data-here")
+	zeroize(data)
+	for i, b := range data {
+		if b != 0 {
+			t.Fatalf("Byte %d not zeroed: %d", i, b)
+		}
+	}
+}
+
+func TestEd25519PublicToX25519(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	x25519Pub, err := ed25519PublicToX25519(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(x25519Pub) != 32 {
+		t.Fatalf("X25519 key length = %d, want 32", len(x25519Pub))
+	}
+
+	// Should fail with wrong length
+	_, err = ed25519PublicToX25519([]byte("short"))
+	if err == nil {
+		t.Fatal("Should fail with short key")
+	}
+}

--- a/apps/backend/internal/domain/atc/verifier.go
+++ b/apps/backend/internal/domain/atc/verifier.go
@@ -1,0 +1,46 @@
+package atc
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ATCClaims represents the claims extracted from an Agent Trust Certificate.
+// This is the data surface that downstream services (secrets, delegation, etc.) consume.
+type ATCClaims struct {
+	AgentID      uuid.UUID `json:"agentId"`
+	Issuer       string    `json:"issuer"`
+	Capabilities []string  `json:"capabilities"`
+	IssuedAt     time.Time `json:"issuedAt"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+	ATCID        string    `json:"atcId"`
+}
+
+// IsExpired returns true if the ATC has expired.
+func (c *ATCClaims) IsExpired() bool {
+	return time.Now().After(c.ExpiresAt)
+}
+
+// HasCapability checks if the ATC grants a specific capability.
+func (c *ATCClaims) HasCapability(capability string) bool {
+	for _, cap := range c.Capabilities {
+		if cap == capability {
+			return true
+		}
+	}
+	return false
+}
+
+// ATCVerifier verifies Agent Trust Certificates and extracts claims.
+// The initial implementation is a JWT-based shim; this interface enables
+// a clean swap to real ATC verification when the ATC spec is implemented.
+type ATCVerifier interface {
+	// Verify validates a raw ATC token and returns the extracted claims.
+	// Returns an error if the token is invalid, expired, or revoked.
+	Verify(rawToken string) (*ATCClaims, error)
+
+	// IsRevoked checks whether an ATC has been revoked via CRL.
+	// Returns true if the ATC is on the revocation list.
+	IsRevoked(atcID string) (bool, error)
+}

--- a/apps/backend/internal/domain/capability.go
+++ b/apps/backend/internal/domain/capability.go
@@ -119,7 +119,7 @@ func (c *CapabilityDefinition) Type() string {
 
 // Reserved namespaces that only core capabilities can use
 var ReservedNamespaces = []string{
-	"file", "db", "api", "network", "system", "user", "mcp", "data",
+	"file", "db", "api", "network", "system", "user", "mcp", "data", "secrets",
 }
 
 // CapabilityValidationPattern is the regex pattern for valid capability strings
@@ -149,6 +149,12 @@ const (
 	CapabilitySystemAdmin     = "system:admin"
 	CapabilityMCPToolUse      = "mcp:tool_use"
 	CapabilityMCPResourceRead = "mcp:resource_read"
+
+	// Secrets management capabilities
+	CapabilitySecretsResolve = "secrets:resolve"
+	CapabilitySecretsStore   = "secrets:store"
+	CapabilitySecretsRotate  = "secrets:rotate"
+	CapabilitySecretsDelete  = "secrets:delete"
 )
 
 // Violation severity levels

--- a/apps/backend/internal/domain/secrets/backend.go
+++ b/apps/backend/internal/domain/secrets/backend.go
@@ -1,0 +1,23 @@
+package secrets
+
+import "github.com/google/uuid"
+
+// SecretsBackend is the storage interface for credential blobs.
+// Implementations must NOT contain business logic (CR-009).
+// All policy, auth, and audit logic lives in the application service.
+type SecretsBackend interface {
+	// Store persists an encrypted credential blob for a namespace.
+	Store(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error
+
+	// Retrieve returns the latest encrypted credential blob for a namespace.
+	Retrieve(namespaceID uuid.UUID) (*SecretCredential, error)
+
+	// Rotate stores a new version of the credential, incrementing the version.
+	Rotate(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error
+
+	// Delete removes all credential versions for a namespace.
+	Delete(namespaceID uuid.UUID) error
+
+	// Type returns the backend type identifier.
+	Type() BackendType
+}

--- a/apps/backend/internal/domain/secrets/repository.go
+++ b/apps/backend/internal/domain/secrets/repository.go
@@ -1,0 +1,41 @@
+package secrets
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NamespaceRepository provides data access for secret namespaces.
+type NamespaceRepository interface {
+	Create(ns *SecretNamespace) error
+	GetByID(id uuid.UUID) (*SecretNamespace, error)
+	GetByAgentAndName(agentID uuid.UUID, namespace string) (*SecretNamespace, error)
+	ListByAgent(agentID uuid.UUID) ([]*SecretNamespace, error)
+	UpdateStatus(id uuid.UUID, status NamespaceStatus) error
+	Delete(id uuid.UUID) error
+}
+
+// CredentialRepository provides data access for encrypted credential blobs.
+type CredentialRepository interface {
+	Create(cred *SecretCredential) error
+	GetLatestByNamespace(namespaceID uuid.UUID) (*SecretCredential, error)
+	GetByVersion(namespaceID uuid.UUID, version int) (*SecretCredential, error)
+	DeleteByNamespace(namespaceID uuid.UUID) error
+}
+
+// AuditRepository provides append-only access to the secrets audit log.
+type AuditRepository interface {
+	Create(entry *SecretAuditEntry) error
+	ListByNamespace(namespaceID uuid.UUID, limit, offset int) ([]*SecretAuditEntry, error)
+	ListByAgent(agentID uuid.UUID, since *time.Time, limit, offset int) ([]*SecretAuditEntry, error)
+}
+
+// BackendConfigRepository provides data access for per-agent backend configurations.
+type BackendConfigRepository interface {
+	Create(config *SecretBackendConfig) error
+	GetByAgentAndType(agentID uuid.UUID, backendType BackendType) (*SecretBackendConfig, error)
+	ListByAgent(agentID uuid.UUID) ([]*SecretBackendConfig, error)
+	Update(config *SecretBackendConfig) error
+	Delete(id uuid.UUID) error
+}

--- a/apps/backend/internal/domain/secrets/types.go
+++ b/apps/backend/internal/domain/secrets/types.go
@@ -1,0 +1,98 @@
+package secrets
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BackendType identifies the secrets backend implementation.
+type BackendType string
+
+const (
+	BackendTypeAIMNative BackendType = "aim_native"
+	BackendTypeAWSKMS    BackendType = "aws_kms"
+	BackendTypeVault     BackendType = "hashicorp_vault"
+	BackendTypeAzureKV   BackendType = "azure_keyvault"
+	BackendTypeGCPSM     BackendType = "gcp_secret_manager"
+)
+
+// NamespaceStatus represents the lifecycle state of a secret namespace.
+type NamespaceStatus string
+
+const (
+	NamespaceStatusActive  NamespaceStatus = "active"
+	NamespaceStatusRevoked NamespaceStatus = "revoked"
+)
+
+// SecretNamespace is a logical grouping of credentials for an agent.
+// Each namespace has an owning agent, a backend type, and allowed operations/URL patterns.
+type SecretNamespace struct {
+	ID          uuid.UUID       `json:"id"`
+	AgentID     uuid.UUID       `json:"agentId"`
+	Namespace   string          `json:"namespace"`
+	BackendType BackendType     `json:"backendType"`
+	Operations  []string        `json:"operations"`
+	URLPatterns []string        `json:"urlPatterns"`
+	Status      NamespaceStatus `json:"status"`
+	CreatedAt   time.Time       `json:"createdAt"`
+	UpdatedAt   time.Time       `json:"updatedAt"`
+	CreatedBy   uuid.UUID       `json:"createdBy"`
+}
+
+// SecretCredential stores an encrypted credential blob within a namespace.
+type SecretCredential struct {
+	ID              uuid.UUID `json:"id"`
+	NamespaceID     uuid.UUID `json:"namespaceId"`
+	EncryptedBlob   []byte    `json:"-"`
+	EncryptionAlg   string    `json:"encryptionAlg"`
+	EphemeralPubKey []byte    `json:"ephemeralPubKey,omitempty"`
+	Version         int       `json:"version"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+// SecretAuditEntry records every resolution attempt (granted or denied).
+type SecretAuditEntry struct {
+	ID          uuid.UUID `json:"id"`
+	NamespaceID uuid.UUID `json:"namespaceId"`
+	AgentID     uuid.UUID `json:"agentId"`
+	Operation   string    `json:"operation"`
+	Result      string    `json:"result"` // "granted" or "denied"
+	DenyReason  string    `json:"denyReason,omitempty"`
+	ATCID       string    `json:"atcId,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// Audit result constants
+const (
+	AuditResultGranted = "granted"
+	AuditResultDenied  = "denied"
+)
+
+// SecretBackendConfig stores per-agent backend configuration (e.g., AWS KMS key ARN).
+type SecretBackendConfig struct {
+	ID          uuid.UUID              `json:"id"`
+	AgentID     uuid.UUID              `json:"agentId"`
+	BackendType BackendType            `json:"backendType"`
+	ConfigJSON  map[string]interface{} `json:"config"`
+	CreatedAt   time.Time              `json:"createdAt"`
+	UpdatedAt   time.Time              `json:"updatedAt"`
+}
+
+// ResolutionRequest is submitted by an agent to resolve a credential.
+type ResolutionRequest struct {
+	Namespace      string `json:"namespace"`
+	Operation      string `json:"operation"`
+	Nonce          string `json:"nonce"`
+	Signature      []byte `json:"signature"`
+	AgentPublicKey []byte `json:"agentPublicKey"`
+	ATCID          string `json:"atcId,omitempty"`
+}
+
+// ResolutionResult is returned after a successful resolution.
+type ResolutionResult struct {
+	EncryptedBlob   []byte `json:"encryptedBlob"`
+	EphemeralPubKey []byte `json:"ephemeralPubKey"`
+	EncryptionAlg   string `json:"encryptionAlg"`
+}

--- a/apps/backend/internal/infrastructure/atc/jwt_shim.go
+++ b/apps/backend/internal/infrastructure/atc/jwt_shim.go
@@ -1,0 +1,135 @@
+package atc
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	atcdomain "github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/atc"
+)
+
+// cacheEntry holds a verified ATCClaims with expiration for CR-007 compliance.
+type cacheEntry struct {
+	claims    *atcdomain.ATCClaims
+	expiresAt time.Time
+}
+
+// JWTShimVerifier is a JWT-based implementation of ATCVerifier.
+// It uses the server's Ed25519 signing key to issue and verify JWTs that
+// stand in for real ATCs until the ATC spec is implemented.
+type JWTShimVerifier struct {
+	signingKey ed25519.PrivateKey
+	publicKey  ed25519.PublicKey
+	issuer     string
+
+	// CR-007: cache verified claims to avoid re-parsing on every request
+	cache    sync.Map
+	cacheTTL time.Duration
+}
+
+// NewJWTShimVerifier creates a new JWT-based ATC verifier.
+// signingKey is the server's Ed25519 private key (from KeyVault.GetServerSigningKey()).
+func NewJWTShimVerifier(signingKey ed25519.PrivateKey, issuer string) *JWTShimVerifier {
+	return &JWTShimVerifier{
+		signingKey: signingKey,
+		publicKey:  signingKey.Public().(ed25519.PublicKey),
+		issuer:     issuer,
+		cacheTTL:   5 * time.Minute,
+	}
+}
+
+// atcJWTClaims maps ATC fields into JWT registered + custom claims.
+type atcJWTClaims struct {
+	jwt.RegisteredClaims
+	AgentID      string   `json:"agent_id"`
+	Capabilities []string `json:"capabilities"`
+	ATCID        string   `json:"atc_id"`
+}
+
+// IssueToken creates a JWT that stands in for a real ATC.
+// This is used by the secrets service when an agent authenticates via Ed25519
+// and needs an ATC-like token for the Resolve flow.
+func (v *JWTShimVerifier) IssueToken(agentID uuid.UUID, capabilities []string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	atcID := uuid.New().String()
+
+	claims := atcJWTClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    v.issuer,
+			Subject:   agentID.String(),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+			ID:        atcID,
+		},
+		AgentID:      agentID.String(),
+		Capabilities: capabilities,
+		ATCID:        atcID,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	return token.SignedString(v.signingKey)
+}
+
+// Verify validates a JWT-based ATC token and returns extracted claims.
+func (v *JWTShimVerifier) Verify(rawToken string) (*atcdomain.ATCClaims, error) {
+	// Check cache first (CR-007)
+	if entry, ok := v.cache.Load(rawToken); ok {
+		ce := entry.(*cacheEntry)
+		if time.Now().Before(ce.expiresAt) {
+			return ce.claims, nil
+		}
+		v.cache.Delete(rawToken)
+	}
+
+	token, err := jwt.ParseWithClaims(rawToken, &atcJWTClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodEd25519); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return v.publicKey, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid ATC token: %w", err)
+	}
+
+	jwtClaims, ok := token.Claims.(*atcJWTClaims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid ATC claims")
+	}
+
+	agentID, err := uuid.Parse(jwtClaims.AgentID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid agent ID in ATC: %w", err)
+	}
+
+	if jwtClaims.Issuer != v.issuer {
+		return nil, fmt.Errorf("ATC issuer mismatch: expected %s, got %s", v.issuer, jwtClaims.Issuer)
+	}
+
+	claims := &atcdomain.ATCClaims{
+		AgentID:      agentID,
+		Issuer:       jwtClaims.Issuer,
+		Capabilities: jwtClaims.Capabilities,
+		IssuedAt:     jwtClaims.IssuedAt.Time,
+		ExpiresAt:    jwtClaims.ExpiresAt.Time,
+		ATCID:        jwtClaims.ATCID,
+	}
+
+	// Cache the verified claims (CR-007)
+	v.cache.Store(rawToken, &cacheEntry{
+		claims:    claims,
+		expiresAt: time.Now().Add(v.cacheTTL),
+	})
+
+	return claims, nil
+}
+
+// IsRevoked checks whether an ATC has been revoked.
+// The JWT shim does not implement CRL — always returns false.
+// Real ATC implementation will check against a cached CRL.
+func (v *JWTShimVerifier) IsRevoked(atcID string) (bool, error) {
+	return false, nil
+}

--- a/apps/backend/internal/infrastructure/atc/jwt_shim_test.go
+++ b/apps/backend/internal/infrastructure/atc/jwt_shim_test.go
@@ -1,0 +1,133 @@
+package atc
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func testSigningKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+func TestJWTShimVerifier_IssueAndVerify(t *testing.T) {
+	key := testSigningKey(t)
+	verifier := NewJWTShimVerifier(key, "aim-test")
+
+	agentID := uuid.New()
+	caps := []string{"secrets:resolve", "file:read"}
+
+	token, err := verifier.IssueToken(agentID, caps, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	claims, err := verifier.Verify(token)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+
+	if claims.AgentID != agentID {
+		t.Errorf("AgentID = %s, want %s", claims.AgentID, agentID)
+	}
+	if claims.Issuer != "aim-test" {
+		t.Errorf("Issuer = %s, want aim-test", claims.Issuer)
+	}
+	if len(claims.Capabilities) != 2 {
+		t.Errorf("Capabilities len = %d, want 2", len(claims.Capabilities))
+	}
+	if claims.IsExpired() {
+		t.Error("Claims should not be expired")
+	}
+	if !claims.HasCapability("secrets:resolve") {
+		t.Error("Claims should have secrets:resolve capability")
+	}
+	if claims.HasCapability("nonexistent") {
+		t.Error("Claims should not have nonexistent capability")
+	}
+}
+
+func TestJWTShimVerifier_ExpiredToken(t *testing.T) {
+	key := testSigningKey(t)
+	verifier := NewJWTShimVerifier(key, "aim-test")
+
+	token, err := verifier.IssueToken(uuid.New(), nil, -1*time.Second)
+	if err != nil {
+		t.Fatalf("IssueToken failed: %v", err)
+	}
+
+	_, err = verifier.Verify(token)
+	if err == nil {
+		t.Fatal("Verify should fail for expired token")
+	}
+}
+
+func TestJWTShimVerifier_WrongIssuer(t *testing.T) {
+	key := testSigningKey(t)
+	issuer := NewJWTShimVerifier(key, "issuer-a")
+	verifierB := NewJWTShimVerifier(key, "issuer-b")
+
+	token, _ := issuer.IssueToken(uuid.New(), nil, 5*time.Minute)
+	_, err := verifierB.Verify(token)
+	if err == nil {
+		t.Fatal("Verify should fail for wrong issuer")
+	}
+}
+
+func TestJWTShimVerifier_WrongKey(t *testing.T) {
+	key1 := testSigningKey(t)
+	key2 := testSigningKey(t)
+	issuer := NewJWTShimVerifier(key1, "aim-test")
+	verifier := NewJWTShimVerifier(key2, "aim-test")
+
+	token, _ := issuer.IssueToken(uuid.New(), nil, 5*time.Minute)
+	_, err := verifier.Verify(token)
+	if err == nil {
+		t.Fatal("Verify should fail with wrong signing key")
+	}
+}
+
+func TestJWTShimVerifier_CachesVerifiedClaims(t *testing.T) {
+	key := testSigningKey(t)
+	verifier := NewJWTShimVerifier(key, "aim-test")
+
+	agentID := uuid.New()
+	token, _ := verifier.IssueToken(agentID, []string{"secrets:resolve"}, 5*time.Minute)
+
+	// First verify
+	claims1, err := verifier.Verify(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second verify should return cached
+	claims2, err := verifier.Verify(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if claims1.ATCID != claims2.ATCID {
+		t.Error("Cached claims should have same ATCID")
+	}
+}
+
+func TestJWTShimVerifier_IsRevokedAlwaysFalse(t *testing.T) {
+	key := testSigningKey(t)
+	verifier := NewJWTShimVerifier(key, "aim-test")
+
+	revoked, err := verifier.IsRevoked("any-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revoked {
+		t.Error("JWT shim should never report revoked")
+	}
+}

--- a/apps/backend/internal/infrastructure/repository/secret_audit_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_audit_repository.go
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+type SecretAuditRepository struct {
+	db *sql.DB
+}
+
+func NewSecretAuditRepository(db *sql.DB) *SecretAuditRepository {
+	return &SecretAuditRepository{db: db}
+}
+
+func (r *SecretAuditRepository) Create(entry *secrets.SecretAuditEntry) error {
+	if entry.ID == uuid.Nil {
+		entry.ID = uuid.New()
+	}
+	entry.CreatedAt = time.Now()
+
+	query := `
+		INSERT INTO secret_audit_log (id, namespace_id, agent_id, operation, result, deny_reason, atc_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	_, err := r.db.Exec(query,
+		entry.ID, entry.NamespaceID, entry.AgentID, entry.Operation,
+		entry.Result, entry.DenyReason, entry.ATCID, entry.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create secret audit entry: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretAuditRepository) ListByNamespace(namespaceID uuid.UUID, limit, offset int) ([]*secrets.SecretAuditEntry, error) {
+	query := `
+		SELECT id, namespace_id, agent_id, operation, result, COALESCE(deny_reason, ''), COALESCE(atc_id, ''), created_at
+		FROM secret_audit_log WHERE namespace_id = $1
+		ORDER BY created_at DESC LIMIT $2 OFFSET $3
+	`
+	return r.scanEntries(r.db.Query(query, namespaceID, limit, offset))
+}
+
+func (r *SecretAuditRepository) ListByAgent(agentID uuid.UUID, since *time.Time, limit, offset int) ([]*secrets.SecretAuditEntry, error) {
+	if since != nil {
+		query := `
+			SELECT id, namespace_id, agent_id, operation, result, COALESCE(deny_reason, ''), COALESCE(atc_id, ''), created_at
+			FROM secret_audit_log WHERE agent_id = $1 AND created_at >= $2
+			ORDER BY created_at DESC LIMIT $3 OFFSET $4
+		`
+		return r.scanEntries(r.db.Query(query, agentID, *since, limit, offset))
+	}
+
+	query := `
+		SELECT id, namespace_id, agent_id, operation, result, COALESCE(deny_reason, ''), COALESCE(atc_id, ''), created_at
+		FROM secret_audit_log WHERE agent_id = $1
+		ORDER BY created_at DESC LIMIT $2 OFFSET $3
+	`
+	return r.scanEntries(r.db.Query(query, agentID, limit, offset))
+}
+
+func (r *SecretAuditRepository) scanEntries(rows *sql.Rows, err error) ([]*secrets.SecretAuditEntry, error) {
+	if err != nil {
+		return nil, fmt.Errorf("failed to query secret audit log: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*secrets.SecretAuditEntry
+	for rows.Next() {
+		entry := &secrets.SecretAuditEntry{}
+		if err := rows.Scan(
+			&entry.ID, &entry.NamespaceID, &entry.AgentID, &entry.Operation,
+			&entry.Result, &entry.DenyReason, &entry.ATCID, &entry.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan secret audit entry: %w", err)
+		}
+		result = append(result, entry)
+	}
+	return result, rows.Err()
+}

--- a/apps/backend/internal/infrastructure/repository/secret_backend_config_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_backend_config_repository.go
@@ -68,7 +68,9 @@ func (r *SecretBackendConfigRepository) GetByAgentAndType(agentID uuid.UUID, bac
 
 	config.BackendType = secrets.BackendType(bt)
 	if len(configJSON) > 0 {
-		json.Unmarshal(configJSON, &config.ConfigJSON)
+		if err := json.Unmarshal(configJSON, &config.ConfigJSON); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal backend config JSON: %w", err)
+		}
 	}
 	return config, nil
 }
@@ -99,7 +101,9 @@ func (r *SecretBackendConfigRepository) ListByAgent(agentID uuid.UUID) ([]*secre
 
 		config.BackendType = secrets.BackendType(bt)
 		if len(configJSON) > 0 {
-			json.Unmarshal(configJSON, &config.ConfigJSON)
+			if err := json.Unmarshal(configJSON, &config.ConfigJSON); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal backend config JSON: %w", err)
+			}
 		}
 		result = append(result, config)
 	}

--- a/apps/backend/internal/infrastructure/repository/secret_backend_config_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_backend_config_repository.go
@@ -1,0 +1,131 @@
+package repository
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+type SecretBackendConfigRepository struct {
+	db *sql.DB
+}
+
+func NewSecretBackendConfigRepository(db *sql.DB) *SecretBackendConfigRepository {
+	return &SecretBackendConfigRepository{db: db}
+}
+
+func (r *SecretBackendConfigRepository) Create(config *secrets.SecretBackendConfig) error {
+	now := time.Now()
+	if config.ID == uuid.Nil {
+		config.ID = uuid.New()
+	}
+	config.CreatedAt = now
+	config.UpdatedAt = now
+
+	configJSON, err := json.Marshal(config.ConfigJSON)
+	if err != nil {
+		return fmt.Errorf("failed to marshal backend config: %w", err)
+	}
+
+	query := `
+		INSERT INTO secret_backend_configs (id, agent_id, backend_type, config_json, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`
+	_, err = r.db.Exec(query,
+		config.ID, config.AgentID, string(config.BackendType),
+		configJSON, config.CreatedAt, config.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create secret backend config: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretBackendConfigRepository) GetByAgentAndType(agentID uuid.UUID, backendType secrets.BackendType) (*secrets.SecretBackendConfig, error) {
+	query := `
+		SELECT id, agent_id, backend_type, config_json, created_at, updated_at
+		FROM secret_backend_configs WHERE agent_id = $1 AND backend_type = $2
+	`
+	config := &secrets.SecretBackendConfig{}
+	var bt string
+	var configJSON []byte
+
+	err := r.db.QueryRow(query, agentID, string(backendType)).Scan(
+		&config.ID, &config.AgentID, &bt, &configJSON,
+		&config.CreatedAt, &config.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret backend config: %w", err)
+	}
+
+	config.BackendType = secrets.BackendType(bt)
+	if len(configJSON) > 0 {
+		json.Unmarshal(configJSON, &config.ConfigJSON)
+	}
+	return config, nil
+}
+
+func (r *SecretBackendConfigRepository) ListByAgent(agentID uuid.UUID) ([]*secrets.SecretBackendConfig, error) {
+	query := `
+		SELECT id, agent_id, backend_type, config_json, created_at, updated_at
+		FROM secret_backend_configs WHERE agent_id = $1 ORDER BY created_at ASC
+	`
+	rows, err := r.db.Query(query, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secret backend configs: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*secrets.SecretBackendConfig
+	for rows.Next() {
+		config := &secrets.SecretBackendConfig{}
+		var bt string
+		var configJSON []byte
+
+		if err := rows.Scan(
+			&config.ID, &config.AgentID, &bt, &configJSON,
+			&config.CreatedAt, &config.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan secret backend config: %w", err)
+		}
+
+		config.BackendType = secrets.BackendType(bt)
+		if len(configJSON) > 0 {
+			json.Unmarshal(configJSON, &config.ConfigJSON)
+		}
+		result = append(result, config)
+	}
+	return result, rows.Err()
+}
+
+func (r *SecretBackendConfigRepository) Update(config *secrets.SecretBackendConfig) error {
+	config.UpdatedAt = time.Now()
+
+	configJSON, err := json.Marshal(config.ConfigJSON)
+	if err != nil {
+		return fmt.Errorf("failed to marshal backend config: %w", err)
+	}
+
+	query := `UPDATE secret_backend_configs SET config_json = $1, updated_at = $2 WHERE id = $3`
+	_, err = r.db.Exec(query, configJSON, config.UpdatedAt, config.ID)
+	if err != nil {
+		return fmt.Errorf("failed to update secret backend config: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretBackendConfigRepository) Delete(id uuid.UUID) error {
+	_, err := r.db.Exec(`DELETE FROM secret_backend_configs WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret backend config: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/infrastructure/repository/secret_credential_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_credential_repository.go
@@ -1,0 +1,98 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+type SecretCredentialRepository struct {
+	db *sql.DB
+}
+
+func NewSecretCredentialRepository(db *sql.DB) *SecretCredentialRepository {
+	return &SecretCredentialRepository{db: db}
+}
+
+func (r *SecretCredentialRepository) Create(cred *secrets.SecretCredential) error {
+	now := time.Now()
+	if cred.ID == uuid.Nil {
+		cred.ID = uuid.New()
+	}
+	cred.CreatedAt = now
+	cred.UpdatedAt = now
+	if cred.Version == 0 {
+		cred.Version = 1
+	}
+
+	query := `
+		INSERT INTO secret_credentials (id, namespace_id, encrypted_blob, encryption_alg, ephemeral_pubkey, version, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	_, err := r.db.Exec(query,
+		cred.ID, cred.NamespaceID, cred.EncryptedBlob, cred.EncryptionAlg,
+		cred.EphemeralPubKey, cred.Version, cred.CreatedAt, cred.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create secret credential: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretCredentialRepository) GetLatestByNamespace(namespaceID uuid.UUID) (*secrets.SecretCredential, error) {
+	query := `
+		SELECT id, namespace_id, encrypted_blob, encryption_alg, ephemeral_pubkey, version, created_at, updated_at
+		FROM secret_credentials WHERE namespace_id = $1 ORDER BY version DESC LIMIT 1
+	`
+	cred := &secrets.SecretCredential{}
+	var ephPub []byte
+
+	err := r.db.QueryRow(query, namespaceID).Scan(
+		&cred.ID, &cred.NamespaceID, &cred.EncryptedBlob, &cred.EncryptionAlg,
+		&ephPub, &cred.Version, &cred.CreatedAt, &cred.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest secret credential: %w", err)
+	}
+
+	cred.EphemeralPubKey = ephPub
+	return cred, nil
+}
+
+func (r *SecretCredentialRepository) GetByVersion(namespaceID uuid.UUID, version int) (*secrets.SecretCredential, error) {
+	query := `
+		SELECT id, namespace_id, encrypted_blob, encryption_alg, ephemeral_pubkey, version, created_at, updated_at
+		FROM secret_credentials WHERE namespace_id = $1 AND version = $2
+	`
+	cred := &secrets.SecretCredential{}
+	var ephPub []byte
+
+	err := r.db.QueryRow(query, namespaceID, version).Scan(
+		&cred.ID, &cred.NamespaceID, &cred.EncryptedBlob, &cred.EncryptionAlg,
+		&ephPub, &cred.Version, &cred.CreatedAt, &cred.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret credential by version: %w", err)
+	}
+
+	cred.EphemeralPubKey = ephPub
+	return cred, nil
+}
+
+func (r *SecretCredentialRepository) DeleteByNamespace(namespaceID uuid.UUID) error {
+	_, err := r.db.Exec(`DELETE FROM secret_credentials WHERE namespace_id = $1`, namespaceID)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret credentials: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
@@ -1,0 +1,150 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+type SecretNamespaceRepository struct {
+	db *sql.DB
+}
+
+func NewSecretNamespaceRepository(db *sql.DB) *SecretNamespaceRepository {
+	return &SecretNamespaceRepository{db: db}
+}
+
+func (r *SecretNamespaceRepository) Create(ns *secrets.SecretNamespace) error {
+	now := time.Now()
+	if ns.ID == uuid.Nil {
+		ns.ID = uuid.New()
+	}
+	ns.CreatedAt = now
+	ns.UpdatedAt = now
+
+	query := `
+		INSERT INTO secret_namespaces (id, agent_id, namespace, backend_type, operations, url_patterns, status, created_at, updated_at, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`
+	_, err := r.db.Exec(query,
+		ns.ID, ns.AgentID, ns.Namespace, string(ns.BackendType),
+		pq.Array(ns.Operations), pq.Array(ns.URLPatterns),
+		string(ns.Status), ns.CreatedAt, ns.UpdatedAt, ns.CreatedBy,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create secret namespace: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretNamespaceRepository) GetByID(id uuid.UUID) (*secrets.SecretNamespace, error) {
+	query := `
+		SELECT id, agent_id, namespace, backend_type, operations, url_patterns, status, created_at, updated_at, created_by
+		FROM secret_namespaces WHERE id = $1
+	`
+	ns := &secrets.SecretNamespace{}
+	var ops, patterns []string
+	var backendType, status string
+
+	err := r.db.QueryRow(query, id).Scan(
+		&ns.ID, &ns.AgentID, &ns.Namespace, &backendType,
+		pq.Array(&ops), pq.Array(&patterns),
+		&status, &ns.CreatedAt, &ns.UpdatedAt, &ns.CreatedBy,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret namespace: %w", err)
+	}
+
+	ns.BackendType = secrets.BackendType(backendType)
+	ns.Status = secrets.NamespaceStatus(status)
+	ns.Operations = ops
+	ns.URLPatterns = patterns
+	return ns, nil
+}
+
+func (r *SecretNamespaceRepository) GetByAgentAndName(agentID uuid.UUID, namespace string) (*secrets.SecretNamespace, error) {
+	query := `
+		SELECT id, agent_id, namespace, backend_type, operations, url_patterns, status, created_at, updated_at, created_by
+		FROM secret_namespaces WHERE agent_id = $1 AND namespace = $2
+	`
+	ns := &secrets.SecretNamespace{}
+	var ops, patterns []string
+	var backendType, status string
+
+	err := r.db.QueryRow(query, agentID, namespace).Scan(
+		&ns.ID, &ns.AgentID, &ns.Namespace, &backendType,
+		pq.Array(&ops), pq.Array(&patterns),
+		&status, &ns.CreatedAt, &ns.UpdatedAt, &ns.CreatedBy,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret namespace by agent and name: %w", err)
+	}
+
+	ns.BackendType = secrets.BackendType(backendType)
+	ns.Status = secrets.NamespaceStatus(status)
+	ns.Operations = ops
+	ns.URLPatterns = patterns
+	return ns, nil
+}
+
+func (r *SecretNamespaceRepository) ListByAgent(agentID uuid.UUID) ([]*secrets.SecretNamespace, error) {
+	query := `
+		SELECT id, agent_id, namespace, backend_type, operations, url_patterns, status, created_at, updated_at, created_by
+		FROM secret_namespaces WHERE agent_id = $1 ORDER BY created_at ASC
+	`
+	rows, err := r.db.Query(query, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secret namespaces: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*secrets.SecretNamespace
+	for rows.Next() {
+		ns := &secrets.SecretNamespace{}
+		var ops, patterns []string
+		var backendType, status string
+
+		if err := rows.Scan(
+			&ns.ID, &ns.AgentID, &ns.Namespace, &backendType,
+			pq.Array(&ops), pq.Array(&patterns),
+			&status, &ns.CreatedAt, &ns.UpdatedAt, &ns.CreatedBy,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan secret namespace: %w", err)
+		}
+
+		ns.BackendType = secrets.BackendType(backendType)
+		ns.Status = secrets.NamespaceStatus(status)
+		ns.Operations = ops
+		ns.URLPatterns = patterns
+		result = append(result, ns)
+	}
+	return result, rows.Err()
+}
+
+func (r *SecretNamespaceRepository) UpdateStatus(id uuid.UUID, status secrets.NamespaceStatus) error {
+	query := `UPDATE secret_namespaces SET status = $1, updated_at = $2 WHERE id = $3`
+	_, err := r.db.Exec(query, string(status), time.Now(), id)
+	if err != nil {
+		return fmt.Errorf("failed to update secret namespace status: %w", err)
+	}
+	return nil
+}
+
+func (r *SecretNamespaceRepository) Delete(id uuid.UUID) error {
+	_, err := r.db.Exec(`DELETE FROM secret_namespaces WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret namespace: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/infrastructure/secrets/aim_native.go
+++ b/apps/backend/internal/infrastructure/secrets/aim_native.go
@@ -1,0 +1,72 @@
+package secrets
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainsecrets "github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+// AIMNativeBackend implements SecretsBackend using the AIM credential repository.
+// No business logic here (CR-009) — just a thin wrapper around CredentialRepository.
+type AIMNativeBackend struct {
+	credRepo domainsecrets.CredentialRepository
+}
+
+func NewAIMNativeBackend(credRepo domainsecrets.CredentialRepository) *AIMNativeBackend {
+	return &AIMNativeBackend{credRepo: credRepo}
+}
+
+func (b *AIMNativeBackend) Store(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	cred := &domainsecrets.SecretCredential{
+		NamespaceID:   namespaceID,
+		EncryptedBlob: blob,
+		EncryptionAlg: encryptionAlg,
+		Version:       1,
+	}
+	return b.credRepo.Create(cred)
+}
+
+func (b *AIMNativeBackend) Retrieve(namespaceID uuid.UUID) (*domainsecrets.SecretCredential, error) {
+	cred, err := b.credRepo.GetLatestByNamespace(namespaceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve credential: %w", err)
+	}
+	if cred == nil {
+		return nil, fmt.Errorf("no credential found for namespace %s", namespaceID)
+	}
+	return cred, nil
+}
+
+func (b *AIMNativeBackend) Rotate(namespaceID uuid.UUID, blob []byte, encryptionAlg string) error {
+	latest, err := b.credRepo.GetLatestByNamespace(namespaceID)
+	if err != nil {
+		return fmt.Errorf("failed to get latest credential for rotation: %w", err)
+	}
+
+	nextVersion := 1
+	if latest != nil {
+		nextVersion = latest.Version + 1
+	}
+
+	cred := &domainsecrets.SecretCredential{
+		ID:            uuid.New(),
+		NamespaceID:   namespaceID,
+		EncryptedBlob: blob,
+		EncryptionAlg: encryptionAlg,
+		Version:       nextVersion,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	return b.credRepo.Create(cred)
+}
+
+func (b *AIMNativeBackend) Delete(namespaceID uuid.UUID) error {
+	return b.credRepo.DeleteByNamespace(namespaceID)
+}
+
+func (b *AIMNativeBackend) Type() domainsecrets.BackendType {
+	return domainsecrets.BackendTypeAIMNative
+}

--- a/apps/backend/internal/interfaces/http/handlers/secrets_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/secrets_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/base64"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -227,10 +228,13 @@ func (h *SecretsHandler) StoreCredential(c fiber.Ctx) error {
 
 	alg := req.EncryptionAlg
 	if alg == "" {
-		alg = "X25519-XSalsa20-Poly1305"
+		alg = "X25519-ChaCha20-Poly1305"
 	}
 
 	if err := h.secretsService.StoreCredential(nsID, blob, alg); err != nil {
+		if strings.Contains(err.Error(), "exceeds maximum size") {
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{"error": err.Error()})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
@@ -261,10 +265,13 @@ func (h *SecretsHandler) RotateCredential(c fiber.Ctx) error {
 
 	alg := req.EncryptionAlg
 	if alg == "" {
-		alg = "X25519-XSalsa20-Poly1305"
+		alg = "X25519-ChaCha20-Poly1305"
 	}
 
 	if err := h.secretsService.RotateCredential(nsID, blob, alg); err != nil {
+		if strings.Contains(err.Error(), "exceeds maximum size") {
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{"error": err.Error()})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/secrets_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/secrets_handler.go
@@ -1,0 +1,320 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"strconv"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+)
+
+type SecretsHandler struct {
+	secretsService *application.SecretsService
+}
+
+func NewSecretsHandler(secretsService *application.SecretsService) *SecretsHandler {
+	return &SecretsHandler{secretsService: secretsService}
+}
+
+// --- Request/Response types ---
+
+type resolveRequest struct {
+	Namespace      string `json:"namespace"`
+	Operation      string `json:"operation"`
+	Nonce          string `json:"nonce"`
+	Signature      string `json:"signature"`
+	AgentPublicKey string `json:"agentPublicKey"`
+	ATCID          string `json:"atcId,omitempty"`
+}
+
+type resolveResponse struct {
+	EncryptedBlob   string `json:"encryptedBlob"`
+	EphemeralPubKey string `json:"ephemeralPubKey"`
+	EncryptionAlg   string `json:"encryptionAlg"`
+}
+
+type createNamespaceRequest struct {
+	AgentID     uuid.UUID `json:"agentId"`
+	Namespace   string    `json:"namespace"`
+	BackendType string    `json:"backendType,omitempty"`
+	Operations  []string  `json:"operations"`
+	URLPatterns []string  `json:"urlPatterns,omitempty"`
+}
+
+type storeCredentialRequest struct {
+	EncryptedBlob string `json:"encryptedBlob"`
+	EncryptionAlg string `json:"encryptionAlg,omitempty"`
+}
+
+type rotateCredentialRequest struct {
+	EncryptedBlob string `json:"encryptedBlob"`
+	EncryptionAlg string `json:"encryptionAlg,omitempty"`
+}
+
+// --- Handlers ---
+
+// ResolveCredential handles POST /api/v1/secrets/resolve
+// Auth: PQCAgentMiddleware (Ed25519 signature)
+func (h *SecretsHandler) ResolveCredential(c fiber.Ctx) error {
+	agentIDValue := c.Locals("agent_id")
+	if agentIDValue == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Agent authentication required"})
+	}
+	agentID := agentIDValue.(uuid.UUID)
+
+	var req resolveRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	if req.Namespace == "" || req.Operation == "" || req.Nonce == "" || req.Signature == "" || req.AgentPublicKey == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Missing required fields: namespace, operation, nonce, signature, agentPublicKey"})
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid signature encoding"})
+	}
+
+	pubKey, err := base64.StdEncoding.DecodeString(req.AgentPublicKey)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid public key encoding"})
+	}
+
+	domainReq := &secrets.ResolutionRequest{
+		Namespace:      req.Namespace,
+		Operation:      req.Operation,
+		Nonce:          req.Nonce,
+		Signature:      sig,
+		AgentPublicKey: pubKey,
+		ATCID:          req.ATCID,
+	}
+
+	result, err := h.secretsService.Resolve(agentID, domainReq)
+	if err != nil {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(resolveResponse{
+		EncryptedBlob:   base64.StdEncoding.EncodeToString(result.EncryptedBlob),
+		EphemeralPubKey: base64.StdEncoding.EncodeToString(result.EphemeralPubKey),
+		EncryptionAlg:   result.EncryptionAlg,
+	})
+}
+
+// CreateNamespace handles POST /api/v1/secrets/namespaces
+// Auth: AuthMiddleware + MemberMiddleware (JWT)
+func (h *SecretsHandler) CreateNamespace(c fiber.Ctx) error {
+	userID, err := getUserID(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+
+	var req createNamespaceRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	if req.Namespace == "" || req.AgentID == uuid.Nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Missing required fields: agentId, namespace"})
+	}
+
+	ns := &secrets.SecretNamespace{
+		AgentID:     req.AgentID,
+		Namespace:   req.Namespace,
+		BackendType: secrets.BackendType(req.BackendType),
+		Operations:  req.Operations,
+		URLPatterns: req.URLPatterns,
+		CreatedBy:   userID,
+	}
+
+	if err := h.secretsService.CreateNamespace(ns); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"id":          ns.ID,
+		"agentId":     ns.AgentID,
+		"namespace":   ns.Namespace,
+		"backendType": ns.BackendType,
+		"operations":  ns.Operations,
+		"urlPatterns": ns.URLPatterns,
+		"status":      ns.Status,
+		"createdAt":   ns.CreatedAt,
+	})
+}
+
+// ListNamespaces handles GET /api/v1/secrets/namespaces
+// Auth: AuthMiddleware (JWT)
+func (h *SecretsHandler) ListNamespaces(c fiber.Ctx) error {
+	agentIDStr := c.Query("agentId")
+	if agentIDStr == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "agentId query parameter required"})
+	}
+
+	agentID, err := uuid.Parse(agentIDStr)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid agentId format"})
+	}
+
+	namespaces, err := h.secretsService.ListNamespaces(agentID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{"namespaces": namespaces})
+}
+
+// GetNamespace handles GET /api/v1/secrets/namespaces/:id
+// Auth: AuthMiddleware (JWT)
+func (h *SecretsHandler) GetNamespace(c fiber.Ctx) error {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid namespace ID"})
+	}
+
+	ns, err := h.secretsService.GetNamespace(id)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	if ns == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Namespace not found"})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(ns)
+}
+
+// DeleteNamespace handles DELETE /api/v1/secrets/namespaces/:id
+// Auth: AuthMiddleware + MemberMiddleware (JWT)
+func (h *SecretsHandler) DeleteNamespace(c fiber.Ctx) error {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid namespace ID"})
+	}
+
+	if err := h.secretsService.DeleteNamespace(id); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{"message": "Namespace deleted"})
+}
+
+// StoreCredential handles POST /api/v1/secrets/namespaces/:id/credentials
+// Auth: AuthMiddleware + MemberMiddleware (JWT)
+func (h *SecretsHandler) StoreCredential(c fiber.Ctx) error {
+	nsID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid namespace ID"})
+	}
+
+	var req storeCredentialRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	if req.EncryptedBlob == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "encryptedBlob is required"})
+	}
+
+	blob, err := base64.StdEncoding.DecodeString(req.EncryptedBlob)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid encryptedBlob encoding"})
+	}
+
+	alg := req.EncryptionAlg
+	if alg == "" {
+		alg = "X25519-XSalsa20-Poly1305"
+	}
+
+	if err := h.secretsService.StoreCredential(nsID, blob, alg); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"message": "Credential stored"})
+}
+
+// RotateCredential handles POST /api/v1/secrets/namespaces/:id/rotate
+// Auth: AuthMiddleware + MemberMiddleware (JWT)
+func (h *SecretsHandler) RotateCredential(c fiber.Ctx) error {
+	nsID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid namespace ID"})
+	}
+
+	var req rotateCredentialRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	if req.EncryptedBlob == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "encryptedBlob is required"})
+	}
+
+	blob, err := base64.StdEncoding.DecodeString(req.EncryptedBlob)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid encryptedBlob encoding"})
+	}
+
+	alg := req.EncryptionAlg
+	if alg == "" {
+		alg = "X25519-XSalsa20-Poly1305"
+	}
+
+	if err := h.secretsService.RotateCredential(nsID, blob, alg); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{"message": "Credential rotated"})
+}
+
+// GetAuditLog handles GET /api/v1/secrets/audit
+// Auth: AuthMiddleware (JWT)
+func (h *SecretsHandler) GetAuditLog(c fiber.Ctx) error {
+	agentIDStr := c.Query("agentId")
+	if agentIDStr == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "agentId query parameter required"})
+	}
+
+	agentID, err := uuid.Parse(agentIDStr)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid agentId format"})
+	}
+
+	var since *time.Time
+	if sinceStr := c.Query("since"); sinceStr != "" {
+		t, err := time.Parse(time.RFC3339, sinceStr)
+		if err == nil {
+			since = &t
+		}
+	}
+
+	limit, _ := strconv.Atoi(c.Query("limit", "50"))
+	offset, _ := strconv.Atoi(c.Query("offset", "0"))
+
+	entries, err := h.secretsService.GetAuditLog(agentID, since, limit, offset)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{"entries": entries})
+}
+
+// getUserID extracts the user ID from Fiber context (set by AuthMiddleware).
+func getUserID(c fiber.Ctx) (uuid.UUID, error) {
+	userIDValue := c.Locals("user_id")
+	if userIDValue == nil {
+		return uuid.Nil, fiber.ErrUnauthorized
+	}
+	switch v := userIDValue.(type) {
+	case uuid.UUID:
+		return v, nil
+	case string:
+		return uuid.Parse(v)
+	default:
+		return uuid.Nil, fiber.ErrUnauthorized
+	}
+}

--- a/apps/backend/migrations/079_create_tool_call_history.sql
+++ b/apps/backend/migrations/079_create_tool_call_history.sql
@@ -16,5 +16,7 @@ CREATE TABLE IF NOT EXISTS tool_call_history (
 
 CREATE INDEX IF NOT EXISTS idx_tool_call_history_agent_time
     ON tool_call_history (agent_id, called_at DESC);
+-- Note: partial index with NOW() is not allowed (non-IMMUTABLE).
+-- Pruning uses a plain index; the background job filters by time at query time.
 CREATE INDEX IF NOT EXISTS idx_tool_call_history_prune
-    ON tool_call_history (called_at) WHERE called_at < NOW() - INTERVAL '24 hours';
+    ON tool_call_history (called_at);

--- a/apps/backend/migrations/087_create_aim_secrets.sql
+++ b/apps/backend/migrations/087_create_aim_secrets.sql
@@ -1,0 +1,60 @@
+-- AIM Secrets: identity-native credential management for AI agents
+-- Phase 1b: secret namespaces, encrypted credentials, audit log, backend configs
+
+CREATE TABLE IF NOT EXISTS secret_namespaces (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    namespace VARCHAR(255) NOT NULL,
+    backend_type VARCHAR(50) NOT NULL DEFAULT 'aim_native',
+    operations TEXT[] NOT NULL DEFAULT '{}',
+    url_patterns TEXT[] NOT NULL DEFAULT '{}',
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID NOT NULL,
+    UNIQUE(agent_id, namespace)
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_ns_agent ON secret_namespaces(agent_id);
+CREATE INDEX IF NOT EXISTS idx_secret_ns_status ON secret_namespaces(status);
+
+CREATE TABLE IF NOT EXISTS secret_credentials (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    namespace_id UUID NOT NULL REFERENCES secret_namespaces(id) ON DELETE CASCADE,
+    encrypted_blob BYTEA NOT NULL,
+    encryption_alg VARCHAR(50) NOT NULL DEFAULT 'X25519-XSalsa20-Poly1305',
+    ephemeral_pubkey BYTEA,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_cred_ns ON secret_credentials(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_secret_cred_ns_version ON secret_credentials(namespace_id, version DESC);
+
+CREATE TABLE IF NOT EXISTS secret_audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    namespace_id UUID NOT NULL REFERENCES secret_namespaces(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL,
+    operation VARCHAR(50) NOT NULL,
+    result VARCHAR(20) NOT NULL,
+    deny_reason VARCHAR(500),
+    atc_id VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_audit_ns ON secret_audit_log(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_secret_audit_agent ON secret_audit_log(agent_id);
+CREATE INDEX IF NOT EXISTS idx_secret_audit_created ON secret_audit_log(created_at);
+
+CREATE TABLE IF NOT EXISTS secret_backend_configs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    backend_type VARCHAR(50) NOT NULL,
+    config_json JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(agent_id, backend_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_backend_agent ON secret_backend_configs(agent_id);


### PR DESCRIPTION
## Summary

- Adds the Go backend for AIM's identity-native secrets management system (Phase 1b)
- 17 new/modified files, 2679 lines across domain, infrastructure, application, and handler layers
- Credentials never enter agent process memory — resolved via Ed25519-signed requests with X25519 ECDH re-encryption

## What's included

**Domain layer:** ATC verifier interface + JWT shim, secrets types/backend/repository interfaces
**Infrastructure:** 4 PostgreSQL repository implementations, AIM native backend, JWT shim with sync.Map cache
**Application:** SecretsService with 8-step Resolve() (signature → ATC → namespace → capability → retrieve → ECDH encrypt → zeroize → audit)
**Handler:** 8 REST endpoints (POST /resolve with agent auth, CRUD namespaces/credentials with JWT auth)
**Migration 087:** 4 tables (secret_namespaces, secret_credentials, secret_audit_log, secret_backend_configs)
**Tests:** 21 new tests (6 JWT shim + 15 secrets service), all passing

## Test plan

- [x] All 21 new tests pass
- [x] Existing tests unaffected
- [x] Each Resolve() step tested independently (invalid sig, invalid ATC, missing capability, success)
- [x] Audit entries written for both granted and denied operations