### PR TITLE
feat: add AIM Secrets TypeScript SDK (Phase 3)

### DIFF
--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -20,6 +20,7 @@ import {
   NetworkError,
   parseAPIError,
 } from '../exceptions';
+import type { SecretsClient } from '../secrets';
 
 const DEFAULT_BASE_URL = 'http://localhost:8080';
 const DEFAULT_TIMEOUT = 30000;
@@ -55,6 +56,7 @@ export class AIMClient {
   private tokenManager: OAuthTokenManager | null = null;
   private credentials: AgentCredentials | null = null;
   private agent: Agent | null = null;
+  private _secrets: SecretsClient | null = null;
 
   constructor(config: AIMClientConfig = {}) {
     this.config = {
@@ -72,6 +74,24 @@ export class AIMClient {
     if (this.credentials) {
       this.tokenManager = new OAuthTokenManager(this.config.baseUrl, this.credentials);
     }
+  }
+
+  /**
+   * Lazy-initialized secrets client for identity-native credential management.
+   */
+  get secrets(): SecretsClient {
+    if (!this._secrets) {
+      // Dynamic import to avoid circular dependency and keep secrets optional
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { SecretsClient: SC } = require('../secrets') as { SecretsClient: typeof SecretsClient };
+      this._secrets = new SC({
+        request: <T>(method: string, path: string, body?: unknown, useApiKey?: boolean) =>
+          this.request<T>(method, path, body, useApiKey),
+        getPrivateKey: () => this.credentials?.privateKey ?? null,
+        getPublicKey: () => this.credentials?.publicKey ?? null,
+      });
+    }
+    return this._secrets;
   }
 
   /**

--- a/sdk/typescript/src/exceptions.ts
+++ b/sdk/typescript/src/exceptions.ts
@@ -137,6 +137,16 @@ export class RateLimitError extends AIMError {
 }
 
 /**
+ * Secrets operation failed
+ */
+export class SecretsError extends AIMError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 'SECRETS_ERROR', undefined, details);
+    this.name = 'SecretsError';
+  }
+}
+
+/**
  * Parse API error response
  */
 export function parseAPIError(statusCode: number, body: unknown): AIMError {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -98,6 +98,7 @@ export {
   NetworkError,
   NotFoundError,
   RateLimitError,
+  SecretsError,
 } from './exceptions';
 
 // Auth utilities
@@ -197,6 +198,17 @@ export {
   type EncodedHybridSignature,
   type EncodedHybridPublicKey,
 } from './crypto/pqc';
+
+// Secrets (identity-native credential management)
+export {
+  SecretsClient,
+  edwardsToMontgomeryPrivate,
+  type SecretsClientHost,
+  type ResolvedCredential,
+  type CreateNamespaceOptions,
+  type StoreCredentialOptions,
+  type AuditLogOptions,
+} from './secrets';
 
 // Version
 export const VERSION = '1.0.0';

--- a/sdk/typescript/src/secrets/SecretsClient.test.ts
+++ b/sdk/typescript/src/secrets/SecretsClient.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Tests for SecretsClient - Identity-native secrets management
+ *
+ * Coverage:
+ * - Ed25519 -> X25519 key conversion
+ * - Round-trip ECDH + ChaCha20-Poly1305 encryption/decryption
+ * - Tampered ciphertext detection
+ * - Wrong key rejection
+ * - Namespace CRUD delegation
+ * - Credential store/rotate delegation
+ * - Audit log delegation
+ * - Error handling (missing keys, short blobs, incomplete responses)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as nodeCrypto from 'crypto';
+import { SecretsClient, edwardsToMontgomeryPrivate } from './SecretsClient';
+import type { SecretsClientHost } from './SecretsClient';
+import { SecretsError } from '../exceptions';
+
+// ---------------------------------------------------------------------------
+// Test helpers: simulate server-side encryption
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate what the Go server does when resolving a credential:
+ * 1. Generate ephemeral X25519 key pair
+ * 2. Convert agent's Ed25519 pub -> X25519 pub
+ * 3. ECDH(ephemeral_priv, agent_x25519_pub) -> shared secret
+ * 4. SHA-256(shared_secret) -> 256-bit key
+ * 5. ChaCha20-Poly1305 encrypt: nonce || ciphertext || tag
+ */
+function serverEncrypt(
+  plaintext: Uint8Array,
+  agentEd25519PubKey: Uint8Array,
+): { encryptedBlob: Buffer; ephemeralPubKey: Buffer } {
+  // Convert agent Ed25519 public key -> X25519 public key
+  // Use the birational map: u = (1 + y) / (1 - y) mod p
+  const agentX25519Pub = edwardsToMontgomeryPublic(agentEd25519PubKey);
+
+  // Generate ephemeral X25519 key pair
+  const ephemeralKeyPair = nodeCrypto.generateKeyPairSync('x25519');
+
+  // Get raw ephemeral public key bytes
+  const ephemeralPubDer = ephemeralKeyPair.publicKey.export({ format: 'der', type: 'spki' });
+  const ephemeralPubBytes = ephemeralPubDer.slice(-32); // Last 32 bytes of SPKI
+
+  // Build agent X25519 public key object
+  const agentX25519PubObj = nodeCrypto.createPublicKey({
+    key: Buffer.concat([
+      Buffer.from('302a300506032b656e032100', 'hex'),
+      Buffer.from(agentX25519Pub),
+    ]),
+    format: 'der',
+    type: 'spki',
+  });
+
+  // ECDH
+  const sharedSecret = nodeCrypto.diffieHellman({
+    privateKey: ephemeralKeyPair.privateKey,
+    publicKey: agentX25519PubObj,
+  });
+
+  // Derive key
+  const encKey = nodeCrypto.createHash('sha256').update(sharedSecret).digest();
+
+  // ChaCha20-Poly1305 encrypt
+  const nonce = nodeCrypto.randomBytes(12);
+  const cipher = nodeCrypto.createCipheriv('chacha20-poly1305' as string, encKey, nonce, {
+    authTagLength: 16,
+  });
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  // Format: nonce || ciphertext || tag
+  const encryptedBlob = Buffer.concat([nonce, encrypted, tag]);
+
+  return { encryptedBlob, ephemeralPubKey: ephemeralPubBytes };
+}
+
+/**
+ * Convert Ed25519 public key (compressed Edwards y-coordinate) to X25519 public key
+ * (Montgomery u-coordinate). Uses the birational map: u = (1 + y) / (1 - y) mod p.
+ *
+ * This is a simplified version for testing. The server uses Go's crypto/ecdh which
+ * does this conversion internally.
+ */
+function edwardsToMontgomeryPublic(ed25519Pub: Uint8Array): Uint8Array {
+  // Use Node.js crypto to do the conversion via key import/export
+  // Import as Ed25519 public key, the conversion happens via the math
+  // Actually, Node doesn't have a direct conversion API. We'll use the
+  // mathematical conversion ourselves.
+
+  // Ed25519 public key is 32 bytes: the y-coordinate with sign bit in high bit of last byte
+  // p = 2^255 - 19
+  const p = 2n ** 255n - 19n;
+
+  // Read y coordinate (little-endian, clear top bit)
+  let y = 0n;
+  for (let i = 0; i < 32; i++) {
+    y |= BigInt(ed25519Pub[i]) << BigInt(8 * i);
+  }
+  y &= (1n << 255n) - 1n; // Clear sign bit
+
+  // u = (1 + y) / (1 - y) mod p
+  const one = 1n;
+  const numerator = modP(one + y, p);
+  const denominator = modP(one - y, p);
+  const denominatorInv = modPow(denominator, p - 2n, p); // Fermat's little theorem
+  const u = modP(numerator * denominatorInv, p);
+
+  // Write u as 32-byte little-endian
+  const result = new Uint8Array(32);
+  let val = u;
+  for (let i = 0; i < 32; i++) {
+    result[i] = Number(val & 0xffn);
+    val >>= 8n;
+  }
+
+  return result;
+}
+
+function modP(a: bigint, p: bigint): bigint {
+  return ((a % p) + p) % p;
+}
+
+function modPow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = 1n;
+  base = modP(base, mod);
+  while (exp > 0n) {
+    if (exp & 1n) {
+      result = modP(result * base, mod);
+    }
+    exp >>= 1n;
+    base = modP(base * base, mod);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Generate a test Ed25519 key pair using @noble/ed25519
+// ---------------------------------------------------------------------------
+
+async function generateTestKeyPair(): Promise<{ privateKey: Uint8Array; publicKey: Uint8Array }> {
+  const ed = await import('@noble/ed25519');
+  const privateKey = ed.utils.randomPrivateKey();
+  const publicKey = await ed.getPublicKeyAsync(privateKey);
+  return { privateKey, publicKey };
+}
+
+// ---------------------------------------------------------------------------
+// Mock host factory
+// ---------------------------------------------------------------------------
+
+function createMockHost(overrides: Partial<SecretsClientHost> = {}): SecretsClientHost & {
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn();
+  return {
+    request,
+    getPrivateKey: () => null,
+    getPublicKey: () => null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SecretsClient', () => {
+  describe('edwardsToMontgomeryPrivate', () => {
+    it('should produce a 32-byte clamped scalar from a 32-byte seed', () => {
+      const seed = nodeCrypto.randomBytes(32);
+      const x25519Key = edwardsToMontgomeryPrivate(new Uint8Array(seed));
+
+      expect(x25519Key).toHaveLength(32);
+      // Check clamping: low 3 bits of first byte must be 0
+      expect(x25519Key[0] & 7).toBe(0);
+      // High bit of last byte must be 0, second-highest must be 1
+      expect(x25519Key[31] & 128).toBe(0);
+      expect(x25519Key[31] & 64).toBe(64);
+    });
+
+    it('should extract seed from 64-byte key and produce same result', () => {
+      const seed = nodeCrypto.randomBytes(32);
+      const extended = new Uint8Array(64);
+      extended.set(seed, 0);
+      extended.set(nodeCrypto.randomBytes(32), 32); // pub key part
+
+      const from32 = edwardsToMontgomeryPrivate(new Uint8Array(seed));
+      const from64 = edwardsToMontgomeryPrivate(extended);
+
+      expect(from32).toEqual(from64);
+    });
+
+    it('should be deterministic', () => {
+      const seed = nodeCrypto.randomBytes(32);
+      const a = edwardsToMontgomeryPrivate(new Uint8Array(seed));
+      const b = edwardsToMontgomeryPrivate(new Uint8Array(seed));
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe('resolve — round-trip decrypt', () => {
+    it('should decrypt a server-encrypted credential', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const plaintext = new TextEncoder().encode('ghp_secrettoken123');
+
+      // Simulate server encryption
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(plaintext, publicKey);
+
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      const result = await client.resolve('github-creds', 'read');
+
+      expect(result.credential).toEqual(plaintext);
+      expect(result.encryptionAlg).toBe('X25519-ChaCha20-Poly1305');
+      expect(result.namespace).toBe('github-creds');
+
+      // Verify the request was signed correctly
+      expect(host.request).toHaveBeenCalledWith(
+        'POST',
+        '/api/v1/secrets/resolve',
+        expect.objectContaining({
+          namespace: 'github-creds',
+          operation: 'read',
+          agentPublicKey: Buffer.from(publicKey).toString('base64'),
+        }),
+      );
+    });
+
+    it('should decrypt empty credential', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const plaintext = new Uint8Array(0);
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(plaintext, publicKey);
+
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      const result = await client.resolve('ns', 'read');
+      expect(result.credential).toEqual(plaintext);
+    });
+
+    it('should decrypt large credential (4KB)', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const plaintext = nodeCrypto.randomBytes(4096);
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(new Uint8Array(plaintext), publicKey);
+
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      const result = await client.resolve('ns', 'read');
+      expect(result.credential).toEqual(new Uint8Array(plaintext));
+    });
+  });
+
+  describe('resolve — tamper detection', () => {
+    it('should reject tampered ciphertext', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const plaintext = new TextEncoder().encode('secret');
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(plaintext, publicKey);
+
+      // Tamper with a byte in the middle of the ciphertext
+      encryptedBlob[15] ^= 0xff;
+
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns', 'read')).rejects.toThrow(SecretsError);
+      await expect(client.resolve('ns', 'read')).rejects.toThrow('Failed to decrypt');
+    });
+
+    it('should reject tampered auth tag', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const plaintext = new TextEncoder().encode('secret');
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(plaintext, publicKey);
+
+      // Tamper with the last byte (auth tag)
+      encryptedBlob[encryptedBlob.length - 1] ^= 0xff;
+
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns', 'read')).rejects.toThrow(SecretsError);
+    });
+  });
+
+  describe('resolve — wrong key rejection', () => {
+    it('should fail to decrypt with a different agent key', async () => {
+      const agentA = await generateTestKeyPair();
+      const agentB = await generateTestKeyPair();
+
+      const plaintext = new TextEncoder().encode('secret-for-A');
+      // Encrypted for agent A's public key
+      const { encryptedBlob, ephemeralPubKey } = serverEncrypt(plaintext, agentA.publicKey);
+
+      // Try to decrypt with agent B's private key
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(agentB.privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(agentB.publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        encryptedBlob: encryptedBlob.toString('base64'),
+        ephemeralPubKey: ephemeralPubKey.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns', 'read')).rejects.toThrow(SecretsError);
+    });
+  });
+
+  describe('resolve — error handling', () => {
+    it('should throw if no private key', async () => {
+      const host = createMockHost({
+        getPrivateKey: () => null,
+        getPublicKey: () => 'some-key',
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns')).rejects.toThrow('Ed25519 private key required');
+    });
+
+    it('should throw if no public key', async () => {
+      const host = createMockHost({
+        getPrivateKey: () => 'some-key',
+        getPublicKey: () => null,
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns')).rejects.toThrow('Public key required');
+    });
+
+    it('should throw on incomplete server response (no blob)', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      host.request.mockResolvedValue({
+        ephemeralPubKey: 'abc',
+        // Missing encryptedBlob
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns')).rejects.toThrow('incomplete resolution response');
+    });
+
+    it('should throw on blob too short', async () => {
+      const { privateKey, publicKey } = await generateTestKeyPair();
+      const host = createMockHost({
+        getPrivateKey: () => Buffer.from(privateKey).toString('base64'),
+        getPublicKey: () => Buffer.from(publicKey).toString('base64'),
+      });
+      // Use a real ephemeral key so ECDH succeeds, but blob is too short
+      const nodeCryptoLocal = require('crypto');
+      const ephKp = nodeCryptoLocal.generateKeyPairSync('x25519');
+      const ephPubDer = ephKp.publicKey.export({ format: 'der', type: 'spki' });
+      const ephPubBytes = ephPubDer.slice(-32);
+
+      // 20 bytes < 12 (nonce) + 16 (tag) = 28 minimum
+      const shortBlob = Buffer.alloc(20).toString('base64');
+      host.request.mockResolvedValue({
+        encryptedBlob: shortBlob,
+        ephemeralPubKey: ephPubBytes.toString('base64'),
+        encryptionAlg: 'X25519-ChaCha20-Poly1305',
+      });
+
+      const client = new SecretsClient(host);
+      await expect(client.resolve('ns')).rejects.toThrow('too short');
+    });
+  });
+
+  describe('namespace CRUD', () => {
+    let host: ReturnType<typeof createMockHost>;
+    let client: SecretsClient;
+
+    beforeEach(() => {
+      host = createMockHost();
+      client = new SecretsClient(host);
+    });
+
+    it('should create a namespace', async () => {
+      host.request.mockResolvedValue({ id: 'ns-123', status: 'active' });
+
+      const result = await client.createNamespace('agent-1', 'github-creds', ['read'], [
+        'https://api.github.com/*',
+      ]);
+
+      expect(host.request).toHaveBeenCalledWith('POST', '/api/v1/secrets/namespaces', {
+        agentId: 'agent-1',
+        namespace: 'github-creds',
+        operations: ['read'],
+        urlPatterns: ['https://api.github.com/*'],
+      });
+      expect(result).toEqual({ id: 'ns-123', status: 'active' });
+    });
+
+    it('should list namespaces', async () => {
+      host.request.mockResolvedValue({
+        namespaces: [{ id: 'ns-1' }, { id: 'ns-2' }],
+      });
+
+      const result = await client.listNamespaces('agent-1');
+      expect(host.request).toHaveBeenCalledWith(
+        'GET',
+        '/api/v1/secrets/namespaces?agentId=agent-1',
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when no namespaces', async () => {
+      host.request.mockResolvedValue({});
+      const result = await client.listNamespaces('agent-1');
+      expect(result).toEqual([]);
+    });
+
+    it('should get a namespace', async () => {
+      host.request.mockResolvedValue({ id: 'ns-123', namespace: 'github-creds' });
+      const result = await client.getNamespace('ns-123');
+      expect(host.request).toHaveBeenCalledWith('GET', '/api/v1/secrets/namespaces/ns-123');
+      expect(result).toEqual({ id: 'ns-123', namespace: 'github-creds' });
+    });
+
+    it('should delete a namespace', async () => {
+      host.request.mockResolvedValue({ deleted: true });
+      const result = await client.deleteNamespace('ns-123');
+      expect(host.request).toHaveBeenCalledWith('DELETE', '/api/v1/secrets/namespaces/ns-123');
+      expect(result).toEqual({ deleted: true });
+    });
+  });
+
+  describe('credential storage', () => {
+    let host: ReturnType<typeof createMockHost>;
+    let client: SecretsClient;
+
+    beforeEach(() => {
+      host = createMockHost();
+      client = new SecretsClient(host);
+    });
+
+    it('should store a credential', async () => {
+      host.request.mockResolvedValue({ version: 1 });
+      const blob = new Uint8Array([1, 2, 3, 4]);
+
+      await client.storeCredential({ namespaceId: 'ns-1', encryptedBlob: blob });
+
+      expect(host.request).toHaveBeenCalledWith(
+        'POST',
+        '/api/v1/secrets/namespaces/ns-1/credentials',
+        expect.objectContaining({
+          encryptionAlgorithm: 'X25519-ChaCha20-Poly1305',
+        }),
+      );
+    });
+
+    it('should rotate a credential', async () => {
+      host.request.mockResolvedValue({ version: 2 });
+      const blob = new Uint8Array([5, 6, 7, 8]);
+
+      await client.rotateCredential({ namespaceId: 'ns-1', encryptedBlob: blob });
+
+      expect(host.request).toHaveBeenCalledWith(
+        'POST',
+        '/api/v1/secrets/namespaces/ns-1/rotate',
+        expect.objectContaining({
+          encryptionAlgorithm: 'X25519-ChaCha20-Poly1305',
+        }),
+      );
+    });
+
+    it('should include ephemeral public key when provided', async () => {
+      host.request.mockResolvedValue({ version: 1 });
+      const blob = new Uint8Array([1, 2, 3]);
+      const epk = new Uint8Array([10, 20, 30]);
+
+      await client.storeCredential({
+        namespaceId: 'ns-1',
+        encryptedBlob: blob,
+        ephemeralPublicKey: epk,
+      });
+
+      expect(host.request).toHaveBeenCalledWith(
+        'POST',
+        '/api/v1/secrets/namespaces/ns-1/credentials',
+        expect.objectContaining({
+          ephemeralPublicKey: expect.any(String),
+        }),
+      );
+    });
+  });
+
+  describe('audit log', () => {
+    it('should query audit log with defaults', async () => {
+      const host = createMockHost();
+      host.request.mockResolvedValue({
+        entries: [{ operation: 'resolve', result: 'granted' }],
+      });
+
+      const client = new SecretsClient(host);
+      const result = await client.getAuditLog({ agentId: 'agent-1' });
+
+      expect(host.request).toHaveBeenCalledWith(
+        'GET',
+        '/api/v1/secrets/audit?agentId=agent-1&limit=50&offset=0',
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('should pass since/limit/offset parameters', async () => {
+      const host = createMockHost();
+      host.request.mockResolvedValue({ entries: [] });
+
+      const client = new SecretsClient(host);
+      await client.getAuditLog({
+        agentId: 'a1',
+        since: '2026-01-01T00:00:00Z',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(host.request).toHaveBeenCalledWith(
+        'GET',
+        '/api/v1/secrets/audit?agentId=a1&limit=10&offset=5&since=2026-01-01T00:00:00Z',
+      );
+    });
+
+    it('should return empty array when no entries', async () => {
+      const host = createMockHost();
+      host.request.mockResolvedValue({});
+      const client = new SecretsClient(host);
+      const result = await client.getAuditLog({ agentId: 'a1' });
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/sdk/typescript/src/secrets/SecretsClient.ts
+++ b/sdk/typescript/src/secrets/SecretsClient.ts
@@ -1,0 +1,353 @@
+/**
+ * AIM Secrets Client - Identity-native secrets management for AI agents.
+ *
+ * Credentials never enter agent process memory. The SDK signs a resolution
+ * request with the agent's Ed25519 key, the server performs ECDH + ChaCha20-Poly1305
+ * encryption, and the SDK decrypts the response locally.
+ *
+ * @example
+ * ```typescript
+ * import { AIMClient } from '@opena2a/aim-sdk';
+ *
+ * const client = new AIMClient({ baseUrl: '...', apiKey: '...' });
+ * await client.registerAgent({ name: 'my-agent' });
+ *
+ * // Resolve a credential (agent auth via Ed25519 signature)
+ * const result = await client.secrets.resolve('github-creds', 'read');
+ * const token = result.credential; // decrypted credential bytes
+ *
+ * // Namespace management (JWT/API key auth)
+ * await client.secrets.createNamespace(agentId, 'github-creds', ['read']);
+ * const namespaces = await client.secrets.listNamespaces(agentId);
+ * ```
+ */
+
+import * as nodeCrypto from 'crypto';
+import { sign, toBase64, fromBase64 } from '../crypto/ed25519';
+import { SecretsError } from '../exceptions';
+
+/** Result of a credential resolution. */
+export interface ResolvedCredential {
+  credential: Uint8Array;
+  encryptionAlg: string;
+  namespace: string;
+}
+
+/** Options for creating a namespace. */
+export interface CreateNamespaceOptions {
+  agentId: string;
+  namespace: string;
+  operations: string[];
+  urlPatterns?: string[];
+}
+
+/** Options for storing/rotating a credential. */
+export interface StoreCredentialOptions {
+  namespaceId: string;
+  encryptedBlob: Uint8Array;
+  encryptionAlgorithm?: string;
+  ephemeralPublicKey?: Uint8Array;
+}
+
+/** Options for querying audit logs. */
+export interface AuditLogOptions {
+  agentId: string;
+  since?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Interface for the parent client that SecretsClient depends on.
+ * Keeps SecretsClient decoupled from the full AIMClient type.
+ */
+export interface SecretsClientHost {
+  /** Make an authenticated HTTP request. */
+  request<T>(method: string, path: string, body?: unknown, useApiKey?: boolean): Promise<T>;
+  /** Agent's Ed25519 private key (base64). */
+  getPrivateKey(): string | null;
+  /** Agent's Ed25519 public key (base64). */
+  getPublicKey(): string | null;
+}
+
+/**
+ * Identity-native secrets client.
+ *
+ * Handles the cryptographic resolution flow:
+ * 1. Sign request with agent's Ed25519 key
+ * 2. Server performs X25519 ECDH + ChaCha20-Poly1305 encryption
+ * 3. Client decrypts response using Ed25519->X25519 converted private key
+ */
+export class SecretsClient {
+  constructor(private readonly host: SecretsClientHost) {}
+
+  // ---------------------------------------------------------------------------
+  // Resolve (agent auth — Ed25519 signature)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve a credential from a namespace.
+   *
+   * The server encrypts the credential with an ephemeral X25519 key via ECDH.
+   * This method decrypts the response locally. The raw credential exists only
+   * in the SDK's memory, never in the agent's application memory if consumed
+   * immediately and discarded.
+   */
+  async resolve(namespace: string, operation = 'read'): Promise<ResolvedCredential> {
+    const privateKeyB64 = this.host.getPrivateKey();
+    const publicKeyB64 = this.host.getPublicKey();
+
+    if (!privateKeyB64) {
+      throw new SecretsError('Ed25519 private key required for secrets resolution');
+    }
+    if (!publicKeyB64) {
+      throw new SecretsError('Public key required for secrets resolution');
+    }
+
+    // Build nonce: RFC3339Nano:UUID (server rejects nonces older than 30s)
+    const now = new Date().toISOString().replace(/\.\d{3}Z$/, '.000000000Z');
+    const uuid = nodeCrypto.randomUUID();
+    const nonce = `${now}:${uuid}`;
+
+    // Sign: namespace|operation|nonce
+    const message = `${namespace}|${operation}|${nonce}`;
+    const encoder = new TextEncoder();
+    const messageBytes = encoder.encode(message);
+    const privateKey = fromBase64(privateKeyB64);
+    const signatureBytes = await sign(messageBytes, privateKey);
+    const signatureB64 = toBase64(signatureBytes);
+
+    // Build request
+    const payload = {
+      namespace,
+      operation,
+      nonce,
+      signature: signatureB64,
+      agentPublicKey: publicKeyB64,
+    };
+
+    // POST /api/v1/secrets/resolve uses PQCAgentMiddleware (agent auth)
+    const result = await this.host.request<Record<string, string>>(
+      'POST',
+      '/api/v1/secrets/resolve',
+      payload,
+    );
+
+    // Decrypt the response
+    const encryptedBlobB64 = result.encryptedBlob ?? '';
+    const ephemeralPubB64 = result.ephemeralPubKey ?? '';
+
+    if (!encryptedBlobB64 || !ephemeralPubB64) {
+      throw new SecretsError('Server returned incomplete resolution response');
+    }
+
+    const encryptedBlob = fromBase64(encryptedBlobB64);
+    const ephemeralPubBytes = fromBase64(ephemeralPubB64);
+
+    const credential = this.decryptResolved(privateKey, encryptedBlob, ephemeralPubBytes);
+
+    return {
+      credential,
+      encryptionAlg: result.encryptionAlg ?? '',
+      namespace,
+    };
+  }
+
+  /**
+   * Decrypt a resolved credential using X25519 ECDH + ChaCha20-Poly1305.
+   *
+   * The server used:
+   *   1. Generate ephemeral X25519 key pair
+   *   2. Convert agent's Ed25519 pub -> X25519 pub
+   *   3. ECDH(ephemeral_priv, agent_x25519_pub) -> shared_secret
+   *   4. SHA-256(shared_secret) -> 256-bit key
+   *   5. ChaCha20-Poly1305 encrypt: nonce (12) || ciphertext || tag (16)
+   *
+   * We mirror steps 1-4 but use agent's private key:
+   *   1. Convert agent's Ed25519 priv -> X25519 priv
+   *   2. Load ephemeral X25519 pub from response
+   *   3. ECDH(agent_x25519_priv, ephemeral_pub) -> same shared_secret
+   *   4. SHA-256(shared_secret) -> same 256-bit key
+   *   5. ChaCha20-Poly1305 decrypt
+   */
+  private decryptResolved(
+    ed25519PrivateKey: Uint8Array,
+    ciphertext: Uint8Array,
+    ephemeralPubBytes: Uint8Array,
+  ): Uint8Array {
+    // Convert Ed25519 private key to X25519 private key
+    const x25519PrivateKey = edwardsToMontgomeryPrivate(ed25519PrivateKey);
+
+    // Build Node.js key objects via DER encoding
+    const agentX25519Priv = nodeCrypto.createPrivateKey({
+      key: Buffer.concat([
+        // PKCS#8 DER wrapper for X25519 private key (48 bytes total)
+        Buffer.from('302e020100300506032b656e04220420', 'hex'),
+        Buffer.from(x25519PrivateKey),
+      ]),
+      format: 'der',
+      type: 'pkcs8',
+    });
+
+    const ephemeralX25519Pub = nodeCrypto.createPublicKey({
+      key: Buffer.concat([
+        // SubjectPublicKeyInfo DER wrapper for X25519 public key (44 bytes total)
+        Buffer.from('302a300506032b656e032100', 'hex'),
+        Buffer.from(ephemeralPubBytes),
+      ]),
+      format: 'der',
+      type: 'spki',
+    });
+
+    // ECDH shared secret
+    const sharedSecret = nodeCrypto.diffieHellman({
+      privateKey: agentX25519Priv,
+      publicKey: ephemeralX25519Pub,
+    });
+
+    // Derive key: SHA-256(shared_secret)
+    const encKey = nodeCrypto.createHash('sha256').update(sharedSecret).digest();
+
+    // ChaCha20-Poly1305 decrypt
+    // Format: nonce (12 bytes) || ciphertext || tag (16 bytes)
+    const NONCE_SIZE = 12;
+    const TAG_SIZE = 16;
+
+    if (ciphertext.length < NONCE_SIZE + TAG_SIZE) {
+      throw new SecretsError('Encrypted blob too short to contain nonce and authentication tag');
+    }
+
+    const nonce = ciphertext.slice(0, NONCE_SIZE);
+    const encryptedData = ciphertext.slice(NONCE_SIZE, ciphertext.length - TAG_SIZE);
+    const authTag = ciphertext.slice(ciphertext.length - TAG_SIZE);
+
+    try {
+      const decipher = (nodeCrypto.createDecipheriv as Function)(
+        'chacha20-poly1305',
+        encKey,
+        nonce,
+        { authTagLength: TAG_SIZE },
+      ) as nodeCrypto.DecipherGCM;
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([decipher.update(encryptedData), decipher.final()]);
+      return new Uint8Array(decrypted);
+    } catch (e) {
+      throw new SecretsError(`Failed to decrypt credential: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Namespace CRUD (JWT/API key auth)
+  // ---------------------------------------------------------------------------
+
+  async createNamespace(
+    agentId: string,
+    namespace: string,
+    operations: string[],
+    urlPatterns: string[] = [],
+  ): Promise<Record<string, unknown>> {
+    return this.host.request('POST', '/api/v1/secrets/namespaces', {
+      agentId,
+      namespace,
+      operations,
+      urlPatterns,
+    });
+  }
+
+  async listNamespaces(agentId: string): Promise<Record<string, unknown>[]> {
+    const result = await this.host.request<{ namespaces?: Record<string, unknown>[] }>(
+      'GET',
+      `/api/v1/secrets/namespaces?agentId=${agentId}`,
+    );
+    return result.namespaces ?? [];
+  }
+
+  async getNamespace(namespaceId: string): Promise<Record<string, unknown>> {
+    return this.host.request('GET', `/api/v1/secrets/namespaces/${namespaceId}`);
+  }
+
+  async deleteNamespace(namespaceId: string): Promise<Record<string, unknown>> {
+    return this.host.request('DELETE', `/api/v1/secrets/namespaces/${namespaceId}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Credential storage (JWT/API key auth)
+  // ---------------------------------------------------------------------------
+
+  async storeCredential(options: StoreCredentialOptions): Promise<Record<string, unknown>> {
+    const payload: Record<string, string> = {
+      encryptedBlob: toBase64(options.encryptedBlob),
+      encryptionAlgorithm: options.encryptionAlgorithm ?? 'X25519-ChaCha20-Poly1305',
+    };
+    if (options.ephemeralPublicKey) {
+      payload.ephemeralPublicKey = toBase64(options.ephemeralPublicKey);
+    }
+    return this.host.request(
+      'POST',
+      `/api/v1/secrets/namespaces/${options.namespaceId}/credentials`,
+      payload,
+    );
+  }
+
+  async rotateCredential(options: StoreCredentialOptions): Promise<Record<string, unknown>> {
+    const payload: Record<string, string> = {
+      encryptedBlob: toBase64(options.encryptedBlob),
+      encryptionAlgorithm: options.encryptionAlgorithm ?? 'X25519-ChaCha20-Poly1305',
+    };
+    if (options.ephemeralPublicKey) {
+      payload.ephemeralPublicKey = toBase64(options.ephemeralPublicKey);
+    }
+    return this.host.request(
+      'POST',
+      `/api/v1/secrets/namespaces/${options.namespaceId}/rotate`,
+      payload,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audit (JWT/API key auth)
+  // ---------------------------------------------------------------------------
+
+  async getAuditLog(options: AuditLogOptions): Promise<Record<string, unknown>[]> {
+    const { agentId, since, limit = 50, offset = 0 } = options;
+    let params = `agentId=${agentId}&limit=${limit}&offset=${offset}`;
+    if (since) {
+      params += `&since=${since}`;
+    }
+    const result = await this.host.request<{ entries?: Record<string, unknown>[] }>(
+      'GET',
+      `/api/v1/secrets/audit?${params}`,
+    );
+    return result.entries ?? [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ed25519 -> X25519 private key conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an Ed25519 private key (seed) to an X25519 private key.
+ *
+ * The Ed25519 seed is hashed with SHA-512, and the first 32 bytes are clamped
+ * per RFC 7748 to produce the X25519 scalar. This matches Go's crypto/ecdh
+ * and PyNaCl's crypto_sign_ed25519_sk_to_curve25519.
+ *
+ * @param ed25519Key - 32-byte Ed25519 seed OR 64-byte Ed25519 secret key (seed+pub)
+ * @returns 32-byte X25519 private key (clamped scalar)
+ */
+export function edwardsToMontgomeryPrivate(ed25519Key: Uint8Array): Uint8Array {
+  // Extract the 32-byte seed from either format
+  const seed = ed25519Key.length === 64 ? ed25519Key.slice(0, 32) : ed25519Key;
+
+  // SHA-512 hash of the seed, take first 32 bytes
+  const hash = nodeCrypto.createHash('sha512').update(seed).digest();
+
+  // Clamp per RFC 7748 section 5
+  const scalar = new Uint8Array(hash.slice(0, 32));
+  scalar[0] &= 248;
+  scalar[31] &= 127;
+  scalar[31] |= 64;
+
+  return scalar;
+}

--- a/sdk/typescript/src/secrets/index.ts
+++ b/sdk/typescript/src/secrets/index.ts
@@ -1,0 +1,9 @@
+export {
+  SecretsClient,
+  edwardsToMontgomeryPrivate,
+  type SecretsClientHost,
+  type ResolvedCredential,
+  type CreateNamespaceOptions,
+  type StoreCredentialOptions,
+  type AuditLogOptions,
+} from './SecretsClient';


### PR DESCRIPTION
## Summary

- Add `SecretsClient` class to the TypeScript SDK with full API parity to the Python SDK (Phase 2, PR #97)
- Implements identity-native credential resolution: Ed25519 signed request -> X25519 ECDH + ChaCha20-Poly1305 decryption
- Adds namespace CRUD, credential store/rotate, and audit log methods
- Wires `SecretsClient` into `AIMClient` via lazy `secrets` getter
- 24 tests covering round-trip decrypt, tamper detection, wrong-key rejection, CRUD, and error handling

## Files changed

- `sdk/typescript/src/secrets/SecretsClient.ts` — SecretsClient class (~280 lines)
- `sdk/typescript/src/secrets/SecretsClient.test.ts` — 24 tests
- `sdk/typescript/src/secrets/index.ts` — barrel exports
- `sdk/typescript/src/exceptions.ts` — add `SecretsError`
- `sdk/typescript/src/client/AIMClient.ts` — lazy `secrets` getter
- `sdk/typescript/src/index.ts` — export SecretsClient types

## Crypto details

- Ed25519 -> X25519 key conversion via SHA-512 + RFC 7748 clamping (matches Go server + PyNaCl)
- X25519 ECDH via Node.js `crypto.diffieHellman()`
- ChaCha20-Poly1305 AEAD via Node.js `crypto.createDecipheriv()`
- No new dependencies — uses Node.js built-in crypto (engine requirement: Node >= 18)

## Test plan

- [x] Round-trip decrypt with server-simulated encryption (ECDH + ChaCha20-Poly1305)
- [x] Empty and large (4KB) credential decryption
- [x] Tampered ciphertext and auth tag rejection
- [x] Wrong agent key fails to decrypt
- [x] Missing keys, incomplete responses, short blobs throw SecretsError
- [x] Namespace CRUD delegates to correct API endpoints
- [x] Credential store/rotate with optional ephemeral public key
- [x] Audit log with default and custom parameters
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Full test suite: 391 passed, 0 failed
- [x] Build succeeds (`tsup`)