### PR TITLE
fix: proxy API routes to backend via Next.js rewrites

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,13 +11,50 @@ const nextConfig = {
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME || 'Agent Identity Management',
   },
   async rewrites() {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
-    return [
-      {
-        source: '/api/:path*',
-        destination: `${apiUrl}/api/:path*`,
-      },
-    ];
+    // AIM_BACKEND_URL is the canonical backend URL for Vercel deployments.
+    // Falls back to NEXT_PUBLIC_API_URL for local dev, then localhost.
+    const backendUrl = process.env.AIM_BACKEND_URL
+      || process.env.NEXT_PUBLIC_API_URL
+      || 'http://localhost:8080';
+
+    return {
+      // afterFiles: runs after Next.js pages/static files, so the SPA still works
+      afterFiles: [
+        // Core API routes
+        {
+          source: '/api/v1/:path*',
+          destination: `${backendUrl}/api/v1/:path*`,
+        },
+        // Legacy /api catch-all (preserves existing behavior)
+        {
+          source: '/api/:path*',
+          destination: `${backendUrl}/api/:path*`,
+        },
+        // Health endpoints
+        {
+          source: '/health',
+          destination: `${backendUrl}/health`,
+        },
+        {
+          source: '/health/:path*',
+          destination: `${backendUrl}/health/:path*`,
+        },
+        // Well-known discovery endpoints
+        {
+          source: '/.well-known/agent.json',
+          destination: `${backendUrl}/.well-known/agent.json`,
+        },
+        {
+          source: '/.well-known/aip',
+          destination: `${backendUrl}/.well-known/aip`,
+        },
+        // Metrics endpoint
+        {
+          source: '/metrics',
+          destination: `${backendUrl}/metrics`,
+        },
+      ],
+    };
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `afterFiles` rewrites in `next.config.js` to proxy API calls to the Go backend
- Routes proxied: `/api/v1/*`, `/health`, `/.well-known/agent.json`, `/.well-known/aip`, `/metrics`
- Backend URL configurable via `AIM_BACKEND_URL` env var (falls back to `NEXT_PUBLIC_API_URL` then `localhost:8080`)
- Fixes aim.opena2a.org returning 307 redirects for all API calls (AIM Cloud was completely non-functional for API access)

## Test plan
- [ ] Set `AIM_BACKEND_URL` in Vercel project env vars
- [ ] Verify `curl https://aim.opena2a.org/health` returns JSON health check
- [ ] Verify `curl https://aim.opena2a.org/api/v1/status` returns platform status
- [ ] Verify `curl https://aim.opena2a.org/.well-known/aip` returns AIP discovery
- [ ] Verify frontend SPA still loads at `https://aim.opena2a.org/`
- [ ] Verify local dev (`npm run dev`) still proxies to `localhost:8080`