### PR TITLE
fix: make public agent registration truly public

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1187,6 +1187,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 
 	// Public routes (NO authentication required) - Self-registration API
 	public := v1.Group("/public")
+	public.Use(middleware.StrictRateLimitMiddleware())                                       // SECURITY: Strict rate limiting on public endpoints
 	public.Use(middleware.OptionalAuthMiddleware(jwtService))                               // Try to extract user from JWT if present
 	public.Post("/agents/register", h.PublicAgent.Register)                                 // 🚀 ONE-LINE agent registration
 	public.Post("/register", h.PublicRegistration.RegisterUser)                             // 🚀 User registration

--- a/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/crypto"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
@@ -49,7 +50,7 @@ type PublicRegisterResponse struct {
 	Name        string  `json:"name"`
 	DisplayName string  `json:"displayName"`
 	PublicKey   string  `json:"publicKey"`
-	PrivateKey  string  `json:"privateKey"` // ⚠️ ONLY returned on registration
+	PrivateKey  string  `json:"privateKey"` // ONLY returned on registration
 	AIMURL      string  `json:"aimUrl"`
 	Status      string  `json:"status"`
 	TrustScore  float64 `json:"trustScore"`
@@ -109,9 +110,9 @@ func (h *PublicAgentHandler) Register(c fiber.Ctx) error {
 	}
 
 	// Validate required fields
-	if req.Name == "" || req.DisplayName == "" || req.Description == "" {
+	if req.Name == "" || req.DisplayName == "" || req.Description == "" || req.AgentType == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "name, displayName, and description are required",
+			"error": "name, displayName, description, and agentType are required",
 		})
 	}
 
@@ -121,31 +122,24 @@ func (h *PublicAgentHandler) Register(c fiber.Ctx) error {
 		})
 	}
 
-	// Extract API key from header
-	apiKey := c.Get("X-AIM-API-Key")
-	if apiKey == "" {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": "X-AIM-API-Key header is required for agent registration",
-		})
-	}
+	// Use authenticated user/org if available (set by OptionalAuthMiddleware),
+	// otherwise use zero UUIDs for truly public (unauthenticated) registration.
+	var userID, orgID uuid.UUID
+	var userEmail string
 
-	// Validate API key and extract user identity
-	validation, err := h.authService.ValidateAPIKey(c.Context(), apiKey)
-	if err != nil {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": fmt.Sprintf("Invalid API key: %v", err),
-		})
+	if uid, ok := c.Locals("user_id").(uuid.UUID); ok {
+		userID = uid
 	}
-
-	// Use real user and organization from API key
-	userID := validation.User.ID
-	orgID := validation.Organization.ID
-	userEmail := validation.User.Email
+	if oid, ok := c.Locals("organization_id").(uuid.UUID); ok {
+		orgID = oid
+	}
+	if req.UserEmail != "" {
+		userEmail = req.UserEmail
+	}
 
 	// Create agent (keys generated automatically by AgentService)
-	// Note: Public registration validates API key manually above but doesn't track the key ID
-	// Since validation happens inline (not via middleware), we don't have the API key ID here
-	// Both sdkTokenID and apiKeyID are nil for this flow
+	// Public registration has no API key or SDK token to track.
+	// Both sdkTokenID and apiKeyID are nil for this flow.
 	agent, err := h.agentService.CreateAgent(c.Context(), &application.CreateAgentRequest{
 		Name:             req.Name,
 		DisplayName:      req.DisplayName,
@@ -178,7 +172,7 @@ func (h *PublicAgentHandler) Register(c fiber.Ctx) error {
 		Name:        agent.Name,
 		DisplayName: agent.DisplayName,
 		PublicKey:   publicKey,
-		PrivateKey:  privateKey, // ⚠️ CRITICAL: Only returned ONCE
+		PrivateKey:  privateKey, // CRITICAL: Only returned ONCE
 		AIMURL:      c.BaseURL(),
 		Status:      string(agent.Status),
 		TrustScore:  trustScore,
@@ -211,11 +205,6 @@ func (h *PublicAgentHandler) calculateInitialTrustScore(req *PublicRegisterReque
 	if strings.Contains(req.RepositoryURL, "github.com") || strings.Contains(req.RepositoryURL, "gitlab.com") {
 		score += 10.0
 	}
-
-	// TODO: Add more sophisticated trust scoring
-	// - Organization reputation
-	// - Email domain verification
-	// - Code signing verification
 
 	if score > 100.0 {
 		score = 100.0

--- a/apps/backend/internal/interfaces/http/handlers/public_agent_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_agent_handler_test.go
@@ -72,21 +72,52 @@ func TestPublicAgentHandler_Register_InvalidAgentType(t *testing.T) {
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
-func TestPublicAgentHandler_Register_MissingAPIKey(t *testing.T) {
+func TestPublicAgentHandler_Register_NoAuthRequired(t *testing.T) {
 	handler := &PublicAgentHandler{}
 	app := fiber.New()
+	// Add recover middleware so nil agentService panic returns 500 instead of crashing
+	app.Use(func(c fiber.Ctx) error {
+		defer func() {
+			if r := recover(); r != nil {
+				_ = c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"error": "internal server error",
+				})
+			}
+		}()
+		return c.Next()
+	})
 	app.Post("/public/agents/register", handler.Register)
 
 	body := `{"name":"test","displayName":"Test Agent","description":"A test agent","agentType":"claude"}`
 	req := httptest.NewRequest("POST", "/public/agents/register", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	// No X-AIM-API-Key header
+	// No X-AIM-API-Key header -- endpoint is public, should NOT return 401
 
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	// Without a real agentService wired up, we expect 500 (nil pointer on service call),
+	// but critically NOT 401 -- the endpoint no longer requires authentication
+	assert.NotEqual(t, fiber.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestPublicAgentHandler_Register_MissingAgentType(t *testing.T) {
+	handler := &PublicAgentHandler{}
+	app := fiber.New()
+	app.Post("/public/agents/register", handler.Register)
+
+	// Has name, displayName, description but missing agentType
+	body := `{"name":"test","displayName":"Test Agent","description":"A test agent"}`
+	req := httptest.NewRequest("POST", "/public/agents/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
 // ===========================


### PR DESCRIPTION
## Summary
- Removes `X-AIM-API-Key` header requirement from `POST /api/v1/public/agents/register`
- Endpoint is now truly public — matches README's "one-line agent registration" promise
- Uses authenticated user/org IDs when available (via OptionalAuthMiddleware), falls back to zero UUIDs for unauthenticated registration
- Adds `StrictRateLimitMiddleware` to the entire `/public` route group (was unprotected)
- Fixes validation error to include `agentType` in required fields list

## Test plan
- [ ] `curl -X POST localhost:8080/api/v1/public/agents/register -H 'Content-Type: application/json' -d '{"name":"test","displayName":"Test","description":"test","agentType":"claude"}'` returns 201 with agent details
- [ ] Same request WITHOUT any auth headers succeeds
- [ ] Missing `agentType` returns clear error: "name, displayName, description, and agentType are required"
- [ ] Rate limiting kicks in after 10 requests/minute in production mode
- [ ] Existing tests pass: `go test ./apps/backend/internal/interfaces/http/handlers/... -run PublicAgent -v`