### PR TITLE
fix: frontend Docker healthcheck always failing

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -98,7 +98,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://0.0.0.0:3000"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,7 +249,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://0.0.0.0:3000"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infrastructure/docker/Dockerfile.frontend
+++ b/infrastructure/docker/Dockerfile.frontend
@@ -29,6 +29,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
 
 # Copy standalone build
 COPY --from=builder /app/.next/standalone ./


### PR DESCRIPTION
## Summary
- Frontend container healthcheck had FailingStreak of 45,797 — `wget http://localhost:3000` failed because Next.js binds to the container hostname, not localhost
- Adds `ENV HOSTNAME="0.0.0.0"` to Dockerfile.frontend so Next.js binds to all interfaces
- Updates healthcheck URLs in both `docker-compose.yml` and `docker-compose.quickstart.yml` to use `http://0.0.0.0:3000`

## Test plan
- [ ] `docker compose build frontend` succeeds
- [ ] `docker compose up frontend` — container reports healthy within 30 seconds
- [ ] `docker inspect aim-frontend --format '{{.State.Health.Status}}'` returns "healthy"
- [ ] Dashboard accessible at `http://localhost:3000`