### PR TITLE
fix: eliminate duplicate Prometheus metric registration

### DIFF
--- a/apps/backend/internal/infrastructure/metrics/prometheus.go
+++ b/apps/backend/internal/infrastructure/metrics/prometheus.go
@@ -8,40 +8,24 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/expfmt"
 )
 
-// Custom registry to avoid conflicts with default registry
+// Custom registry to avoid conflicts with default registry.
+// All metrics use factory to atomically create and register,
+// preventing duplicate registration errors on Gather().
 var registry = prometheus.NewRegistry()
 
-func init() {
-	// Register all metrics with custom registry
-	registry.MustRegister(
-		httpRequestsTotal,
-		httpRequestDuration,
-		securityAlertsTotal,
-		securityThreatsTotal,
-		trustScoreGauge,
-		trustScoreHistogram,
-		agentOperationsTotal,
-		activeAgentsGauge,
-		mcpServersTotal,
-		mcpAttestationsTotal,
-		verificationEventsTotal,
-		verificationDuration,
-		complianceChecksTotal,
-		complianceViolationsTotal,
-		databaseConnectionsActive,
-		databaseQueryDuration,
-		apiKeyOperationsTotal,
-		activeAPIKeysGauge,
-		auditLogsTotal,
-	)
-}
+// factory creates and registers metrics with the custom registry in a single
+// step, eliminating the race between prometheus.New* and registry.MustRegister
+// that caused "collected metric was collected before with the same name and
+// label values" errors during Gather().
+var factory = promauto.With(registry)
 
 var (
 	// HTTP metrics
-	httpRequestsTotal = prometheus.NewCounterVec(
+	httpRequestsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_http_requests_total",
 			Help: "Total number of HTTP requests",
@@ -49,7 +33,7 @@ var (
 		[]string{"method", "path", "status"},
 	)
 
-	httpRequestDuration = prometheus.NewHistogramVec(
+	httpRequestDuration = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "aim_http_request_duration_seconds",
 			Help:    "HTTP request duration in seconds",
@@ -59,7 +43,7 @@ var (
 	)
 
 	// Security metrics
-	securityAlertsTotal = prometheus.NewCounterVec(
+	securityAlertsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_security_alerts_total",
 			Help: "Total number of security alerts",
@@ -67,7 +51,7 @@ var (
 		[]string{"severity", "type"},
 	)
 
-	securityThreatsTotal = prometheus.NewCounterVec(
+	securityThreatsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_security_threats_total",
 			Help: "Total number of detected security threats",
@@ -76,7 +60,7 @@ var (
 	)
 
 	// Trust score metrics
-	trustScoreGauge = prometheus.NewGaugeVec(
+	trustScoreGauge = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "aim_trust_score",
 			Help: "Current trust score of agents",
@@ -84,7 +68,7 @@ var (
 		[]string{"agent_id", "agent_name"},
 	)
 
-	trustScoreHistogram = prometheus.NewHistogram(
+	trustScoreHistogram = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "aim_trust_score_distribution",
 			Help:    "Distribution of trust scores across all agents",
@@ -93,7 +77,7 @@ var (
 	)
 
 	// Agent metrics
-	agentOperationsTotal = prometheus.NewCounterVec(
+	agentOperationsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_agent_operations_total",
 			Help: "Total number of agent operations",
@@ -101,7 +85,7 @@ var (
 		[]string{"operation", "status"},
 	)
 
-	activeAgentsGauge = prometheus.NewGauge(
+	activeAgentsGauge = factory.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "aim_active_agents",
 			Help: "Number of currently active agents",
@@ -109,14 +93,14 @@ var (
 	)
 
 	// MCP Server metrics
-	mcpServersTotal = prometheus.NewGauge(
+	mcpServersTotal = factory.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "aim_mcp_servers_total",
 			Help: "Total number of registered MCP servers",
 		},
 	)
 
-	mcpAttestationsTotal = prometheus.NewCounterVec(
+	mcpAttestationsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_mcp_attestations_total",
 			Help: "Total number of MCP attestations",
@@ -125,7 +109,7 @@ var (
 	)
 
 	// Verification metrics
-	verificationEventsTotal = prometheus.NewCounterVec(
+	verificationEventsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_verification_events_total",
 			Help: "Total number of verification events",
@@ -133,7 +117,7 @@ var (
 		[]string{"event_type", "status"},
 	)
 
-	verificationDuration = prometheus.NewHistogramVec(
+	verificationDuration = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "aim_verification_duration_seconds",
 			Help:    "Duration of verification events in seconds",
@@ -143,7 +127,7 @@ var (
 	)
 
 	// Compliance metrics
-	complianceChecksTotal = prometheus.NewCounterVec(
+	complianceChecksTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_compliance_checks_total",
 			Help: "Total number of compliance checks",
@@ -151,7 +135,7 @@ var (
 		[]string{"check_type", "status"},
 	)
 
-	complianceViolationsTotal = prometheus.NewCounter(
+	complianceViolationsTotal = factory.NewCounter(
 		prometheus.CounterOpts{
 			Name: "aim_compliance_violations_total",
 			Help: "Total number of compliance violations detected",
@@ -159,14 +143,14 @@ var (
 	)
 
 	// Database metrics
-	databaseConnectionsActive = prometheus.NewGauge(
+	databaseConnectionsActive = factory.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "aim_database_connections_active",
 			Help: "Number of active database connections",
 		},
 	)
 
-	databaseQueryDuration = prometheus.NewHistogramVec(
+	databaseQueryDuration = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "aim_database_query_duration_seconds",
 			Help:    "Database query duration in seconds",
@@ -176,7 +160,7 @@ var (
 	)
 
 	// API Key metrics
-	apiKeyOperationsTotal = prometheus.NewCounterVec(
+	apiKeyOperationsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_api_key_operations_total",
 			Help: "Total number of API key operations",
@@ -184,7 +168,7 @@ var (
 		[]string{"operation", "status"},
 	)
 
-	activeAPIKeysGauge = prometheus.NewGauge(
+	activeAPIKeysGauge = factory.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "aim_active_api_keys",
 			Help: "Number of currently active API keys",
@@ -192,7 +176,7 @@ var (
 	)
 
 	// Audit log metrics
-	auditLogsTotal = prometheus.NewCounterVec(
+	auditLogsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aim_audit_logs_total",
 			Help: "Total number of audit log entries",

--- a/apps/backend/internal/infrastructure/metrics/prometheus_test.go
+++ b/apps/backend/internal/infrastructure/metrics/prometheus_test.go
@@ -61,6 +61,36 @@ func TestNormalizePath(t *testing.T) {
 	}
 }
 
+func TestRegistryGatherNoDuplicates(t *testing.T) {
+	// Record some metrics to exercise collectors with realistic label combinations
+	httpRequestsTotal.WithLabelValues("GET", "/api/v1/agents", "200").Inc()
+	httpRequestsTotal.WithLabelValues("POST", "/api/v1/agents", "201").Inc()
+	httpRequestDuration.WithLabelValues("GET", "/api/v1/agents", "200").Observe(0.05)
+	RecordSecurityAlert("high", "brute_force")
+	RecordAgentOperation("create", "success")
+	RecordComplianceCheck("policy", "pass")
+	RecordAuditLog("create", "agent")
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("registry.Gather() returned error (duplicate registration?): %v", err)
+	}
+
+	if len(families) == 0 {
+		t.Fatal("registry.Gather() returned zero metric families")
+	}
+
+	// Verify no duplicate metric family names
+	seen := make(map[string]bool)
+	for _, f := range families {
+		name := f.GetName()
+		if seen[name] {
+			t.Errorf("duplicate metric family: %s", name)
+		}
+		seen[name] = true
+	}
+}
+
 func TestIsNumeric(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- `/metrics` endpoint returned 100+ errors: "collected metric was collected before with the same name and label values"
- Root cause: metrics were created with `prometheus.NewCounterVec()` as package-level vars, then registered separately in `init()` via `registry.MustRegister()` — this two-step pattern caused duplicate registration
- Fix: replaced with `promauto.With(registry)` factory which atomically creates AND registers each metric in one step, eliminating the race
- The `GETT` method label was already handled by existing `normalizeMethod()` which maps garbled methods to "UNKNOWN"
- Added test for duplicate Gather() calls to prevent regression

## Test plan
- [ ] `go test ./apps/backend/internal/infrastructure/metrics/... -v` passes
- [ ] Start backend, `curl localhost:8080/metrics` returns clean Prometheus output (no errors)
- [ ] Verify `aim_http_requests_total` metric has correct method labels (GET, POST, etc., not GETT)