### PR TITLE
fix: Azure Cloud wiring — Redis TLS, middleware proxy, DB migration

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"log"
@@ -107,6 +108,7 @@ func main() {
 			Port:     cfg.Redis.Port,
 			Password: cfg.Redis.Password,
 			DB:       cfg.Redis.DB,
+			UseTLS:   cfg.Redis.UseTLS,
 		})
 		if err != nil {
 			log.Printf("⚠️  Cache initialization failed: %v", err)
@@ -391,11 +393,19 @@ func initDatabase(cfg *config.Config) (*sql.DB, error) {
 }
 
 func initRedis(cfg *config.Config) (*redis.Client, error) {
-	client := redis.NewClient(&redis.Options{
+	opts := &redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port),
 		Password: cfg.Redis.Password,
 		DB:       cfg.Redis.DB,
-	})
+	}
+
+	if cfg.Redis.UseTLS {
+		opts.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	client := redis.NewClient(opts)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/apps/backend/internal/config/config.go
+++ b/apps/backend/internal/config/config.go
@@ -54,6 +54,7 @@ type RedisConfig struct {
 	Port     int
 	Password string
 	DB       int
+	UseTLS   bool
 }
 
 // JWTConfig holds JWT configuration
@@ -109,6 +110,7 @@ func Load() (*Config, error) {
 			Port:     getEnvAsInt("REDIS_PORT", 6379),
 			Password: getEnv("REDIS_PASSWORD", ""),
 			DB:       getEnvAsInt("REDIS_DB", 0),
+			UseTLS:   getEnv("REDIS_USE_TLS", "false") == "true",
 		},
 	JWT: JWTConfig{
 		Secret:          getEnvRequired("JWT_SECRET"),

--- a/apps/backend/internal/infrastructure/cache/redis.go
+++ b/apps/backend/internal/infrastructure/cache/redis.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -20,15 +21,24 @@ type CacheConfig struct {
 	Port     int
 	Password string
 	DB       int
+	UseTLS   bool
 }
 
 // NewRedisCache creates a new Redis cache client
 func NewRedisCache(config *CacheConfig) (*RedisCache, error) {
-	client := redis.NewClient(&redis.Options{
+	opts := &redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", config.Host, config.Port),
 		Password: config.Password,
 		DB:       config.DB,
-	})
+	}
+
+	if config.UseTLS {
+		opts.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	client := redis.NewClient(opts)
 
 	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/apps/backend/migrations/088_add_verification_events_reason_updated_at.sql
+++ b/apps/backend/migrations/088_add_verification_events_reason_updated_at.sql
@@ -1,0 +1,9 @@
+-- Migration: Add missing reason and updated_at columns to verification_events
+-- The expiration cleanup job references these columns but they were never added
+-- to the original schema (005_create_verification_events_table.sql)
+
+ALTER TABLE verification_events ADD COLUMN IF NOT EXISTS reason TEXT;
+ALTER TABLE verification_events ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+COMMENT ON COLUMN verification_events.reason IS 'Reason for the verification result (e.g., expiration reason)';
+COMMENT ON COLUMN verification_events.updated_at IS 'Timestamp of the last update to this verification event';

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -15,8 +15,14 @@ const ROUTE_PERMISSIONS: Record<string, string[]> = {
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
+  // API and backend-proxied routes — let rewrites handle them
+  const backendRoutes = ['/api/', '/health', '/.well-known/', '/metrics']
+  if (backendRoutes.some(route => pathname.startsWith(route))) {
+    return NextResponse.next()
+  }
+
   // Public routes that don't require authentication
-  const publicRoutes = ['/login', '/auth/callback', '/auth/login', '/auth/register', '/auth/registration-pending', '/auth/forgot-password', '/auth/change-password', '/auth/reset-password']
+  const publicRoutes = ['/login', '/auth/callback', '/auth/login', '/auth/register', '/auth/registration-pending', '/auth/forgot-password', '/auth/change-password', '/auth/reset-password', '/get-started']
   const isPublicRoute = publicRoutes.some(route => pathname.startsWith(route))
 
   // If accessing a public route, allow it

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["AIM_BACKEND_URL", "NEXT_PUBLIC_API_URL"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- Add Redis TLS support (required by Azure Redis on port 6380) via `REDIS_USE_TLS` env var
- Add missing `reason` and `updated_at` columns to `verification_events` table (fixes expiration cleanup job error every 5 min)
- Exclude `/api/`, `/health`, `/.well-known/`, `/metrics` from Next.js auth middleware so Vercel rewrites can proxy them to Azure backend
- Add `AIM_BACKEND_URL` to turbo.json env passthrough (prevents infinite loop in Vercel production)

## Infrastructure changes (already applied)
- Vercel: `AIM_BACKEND_URL` env var set, root directory updated to `apps/web`
- Azure: Redis password secret configured on `aim-prod-backend` container
- Azure: Service principal `aim-github-cd` created, `AZURE_CREDENTIALS` GitHub secret set

## Test plan
- [x] `curl https://aim.opena2a.org/health` returns healthy JSON
- [x] `curl https://aim.opena2a.org/.well-known/aip` returns AIP discovery
- [x] `curl https://aim.opena2a.org/api/v1/status` returns operational status
- [x] Go backend builds clean
- [x] Pre-push checks pass (build + tests + lint)
- [ ] After merge + redeploy: verify Redis shows "connected" in status
- [ ] After merge + redeploy: verify no more expiration cleanup errors in logs