### PR TITLE
fix(security): platform admin allowlist replaces per-domain auto-approval (PR-A)

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -256,7 +256,7 @@ func main() {
 				"email":    emailStatus,
 			},
 			"features": fiber.Map{
-				"oauth":              false, // OAuth disabled
+				"oauth":              os.Getenv("GOOGLE_CLIENT_ID") != "",
 				"email_registration": true,
 				"mcp_auto_detection": true,
 				"trust_scoring":      true,

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -84,9 +84,13 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 		return nil, fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	// Check if this is the first user from this email domain (auto-approve if yes)
+	// SECURITY: Auto-approve ONLY for platform admins listed in AIM_PLATFORM_ADMINS env var.
+	// Per-domain auto-approval was removed in PR-A (2026-04-14) because it allowed
+	// domain squatting — anyone could claim "first registrant" of a victim's domain
+	// and become admin of that org. Domain claims now require explicit DNS verification
+	// (see PR-B) and team creation is an explicit user action (see PR-C).
 	emailDomain := extractEmailDomain(email)
-	shouldAutoApprove := s.shouldAutoApproveFirstUser(ctx, emailDomain)
+	shouldAutoApprove := isPlatformAdmin(email)
 
 	// Create new manual registration request
 	req := domain.NewUserRegistrationRequestManual(
@@ -96,13 +100,12 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 		hashedPassword,
 	)
 
-	// Auto-approve if first user from this domain
 	if shouldAutoApprove {
 		req.Status = domain.RegistrationStatusApproved
 		now := time.Now()
 		req.ReviewedAt = &now
-		req.ReviewedBy = nil // System auto-approval (no reviewer)
-		fmt.Printf("✅ Auto-approving first user from domain: %s\n", emailDomain)
+		req.ReviewedBy = nil // System auto-approval (platform admin allowlist)
+		fmt.Printf("✅ Auto-approving platform admin: %s\n", email)
 	}
 
 	// Save registration request
@@ -643,25 +646,25 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 	return newOrg.ID, nil
 }
 
-// shouldAutoApproveFirstUser checks if this is the first user from a domain
-// Returns true if:
-// 1. No organization exists for this domain, OR
-// 2. Organization exists but has zero users
-func (s *RegistrationService) shouldAutoApproveFirstUser(ctx context.Context, emailDomain string) bool {
-	// Check if organization exists
-	org, err := s.orgRepo.GetByDomain(emailDomain)
-	if err != nil || org == nil {
-		// Organization doesn't exist - this is the first user from this domain
-		return true
-	}
-
-	// Organization exists - check if it has any users
-	existingUsers, err := s.userRepo.GetByOrganization(org.ID)
-	if err != nil {
-		// Can't determine, be conservative and require approval
+// isPlatformAdmin returns true if the email is in the AIM_PLATFORM_ADMINS allowlist.
+// Platform admins are AIM Cloud operators (e.g., the OpenA2A team), distinct from
+// customer org admins. The allowlist is a comma-separated env var, e.g.:
+//
+//	AIM_PLATFORM_ADMINS=info@opena2a.org,ops@opena2a.org
+//
+// Email comparison is case-insensitive and trims whitespace. Empty env var means
+// no platform admins exist (safe default — only approved-by-existing-admin users
+// can register).
+func isPlatformAdmin(email string) bool {
+	allowlist := os.Getenv("AIM_PLATFORM_ADMINS")
+	if allowlist == "" {
 		return false
 	}
-
-	// Auto-approve if no existing users in the organization
-	return len(existingUsers) == 0
+	target := strings.ToLower(strings.TrimSpace(email))
+	for _, entry := range strings.Split(allowlist, ",") {
+		if strings.ToLower(strings.TrimSpace(entry)) == target {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -430,55 +430,30 @@ func TestRegistrationService_DefaultOrganizationValues(t *testing.T) {
 }
 
 // ========================================
-// Auto-Approval Logic Tests
+// Platform Admin Allowlist Tests
 // ========================================
 
-func TestRegistrationService_AutoApprovalConditions(t *testing.T) {
-	// Document and test the auto-approval logic
-	// shouldAutoApproveFirstUser returns true when:
-	// 1. No organization exists for this domain, OR
-	// 2. Organization exists but has zero users
-
+func TestIsPlatformAdmin(t *testing.T) {
 	tests := []struct {
-		name          string
-		orgExists     bool
-		userCount     int
-		shouldApprove bool
+		name      string
+		allowlist string
+		email     string
+		want      bool
 	}{
-		{
-			name:          "no org exists - should auto-approve",
-			orgExists:     false,
-			userCount:     0,
-			shouldApprove: true,
-		},
-		{
-			name:          "org exists with no users - should auto-approve",
-			orgExists:     true,
-			userCount:     0,
-			shouldApprove: true,
-		},
-		{
-			name:          "org exists with users - should not auto-approve",
-			orgExists:     true,
-			userCount:     1,
-			shouldApprove: false,
-		},
-		{
-			name:          "org exists with many users - should not auto-approve",
-			orgExists:     true,
-			userCount:     10,
-			shouldApprove: false,
-		},
+		{name: "empty allowlist denies all", allowlist: "", email: "info@opena2a.org", want: false},
+		{name: "single match", allowlist: "info@opena2a.org", email: "info@opena2a.org", want: true},
+		{name: "single non-match", allowlist: "info@opena2a.org", email: "other@opena2a.org", want: false},
+		{name: "case insensitive email", allowlist: "info@opena2a.org", email: "Info@OpenA2A.Org", want: true},
+		{name: "case insensitive allowlist", allowlist: "Info@OpenA2A.Org", email: "info@opena2a.org", want: true},
+		{name: "multi-entry allowlist", allowlist: "alice@x.com,info@opena2a.org,bob@y.com", email: "info@opena2a.org", want: true},
+		{name: "multi-entry no match", allowlist: "alice@x.com,bob@y.com", email: "info@opena2a.org", want: false},
+		{name: "whitespace tolerant", allowlist: " info@opena2a.org , alice@x.com ", email: "info@opena2a.org", want: true},
+		{name: "no domain squat: same-domain non-listed denied", allowlist: "info@opena2a.org", email: "attacker@opena2a.org", want: false},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Document the expected behavior
-			if !tt.orgExists || tt.userCount == 0 {
-				assert.True(t, tt.shouldApprove)
-			} else {
-				assert.False(t, tt.shouldApprove)
-			}
+			t.Setenv("AIM_PLATFORM_ADMINS", tt.allowlist)
+			assert.Equal(t, tt.want, isPlatformAdmin(tt.email))
 		})
 	}
 }

--- a/apps/backend/migrations/089_cleanup_test_users_pre_platform_admin.sql
+++ b/apps/backend/migrations/089_cleanup_test_users_pre_platform_admin.sql
@@ -1,0 +1,27 @@
+-- Migration: Remove test users created during AIM Cloud bring-up before
+-- platform-admin allowlist was enforced (PR-A).
+--
+-- Context: Prior to this PR, the registration service auto-approved the first
+-- user from any new email domain as admin of an auto-created org. During cloud
+-- bring-up testing on 2026-04-13/14, two test users were created via this path:
+--   - deploy-test@opena2a.org (admin of auto-created opena2a.org org)
+--   - sec-audit-2026-04-13@opena2a.org (pending registration request)
+--
+-- Both are test data with no real value. Removing them so the post-PR-A state
+-- starts clean: no users exist until info@opena2a.org registers as platform
+-- admin via the new AIM_PLATFORM_ADMINS allowlist.
+--
+-- Cascading deletes via FK constraints will clean up: agents, api_keys,
+-- audit logs scoped to those users/orgs.
+
+DELETE FROM user_registration_requests
+ WHERE email IN ('deploy-test@opena2a.org', 'sec-audit-2026-04-13@opena2a.org');
+
+DELETE FROM users
+ WHERE email IN ('deploy-test@opena2a.org', 'sec-audit-2026-04-13@opena2a.org');
+
+-- Remove the auto-created opena2a.org organization if it has no remaining users.
+-- Safe-by-construction: this only matches if the test-user delete above emptied it.
+DELETE FROM organizations
+ WHERE domain = 'opena2a.org'
+   AND NOT EXISTS (SELECT 1 FROM users WHERE organization_id = organizations.id);


### PR DESCRIPTION
## Summary
- Replaces per-domain auto-approval (anyone could squat any domain by registering first) with `AIM_PLATFORM_ADMINS` env-var allowlist
- Fixes hardcoded `oauth: false` in `/api/v1/status` to reflect actual config
- Migration 089 cleans up 2 test users created during cloud bring-up

## Threat addressed
**Domain squatting (CSR threat #1):** Before this PR, registering `attacker@bigbank.com` would auto-create a `bigbank.com` org with the attacker as admin. Real Big Bank employees signing up later would be locked into pending status under attacker control. This PR removes that path entirely.

## What this is NOT
- Not a complete auth redesign — that requires PR-B (DNS TXT domain verification) and PR-C (personal accounts vs teams + invitations). See chief decisions in 2026-04-14 session.
- Not a personal-email denylist — deferred to PR-C where the team-creation flow exists to gate.

## Test plan
- [x] Unit tests pass (`TestIsPlatformAdmin` — 9 cases including case-insensitivity, whitespace, multi-entry, same-domain non-listed denied)
- [x] Full registration test suite passes
- [x] Backend builds clean
- [x] Pre-push gate passed (build + tests + lint)
- [ ] After merge + deploy: `info@opena2a.org` env var set on Azure (✓ already set)
- [ ] After merge + deploy: register `info@opena2a.org` → returns `status: approved` (platform admin)
- [ ] After merge + deploy: register any other email → returns `status: pending` (no auto-claim)

## Follow-ups (not in this PR)
- PR-B: DNS TXT domain verification (this week)
- PR-C: Personal accounts vs teams + invitations + personal-email denylist (next week)
- Wire Google OAuth to the new platform-admin model (after PR-C)