### PR TITLE
ci(deploy): pin Azure Container Apps to digest + unique revision suffix

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
     inputs:
       backend_image:
-        description: "Backend image tag (default: latest)"
+        description: "Backend image tag to resolve (default: latest)"
         default: "latest"
       frontend_image:
-        description: "Frontend image tag (default: latest)"
+        description: "Frontend image tag to resolve (default: latest)"
         default: "latest"
 
 permissions:
@@ -41,7 +41,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Determine image tags
+      - name: Log in to GHCR (for imagetools digest lookup)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine input image tags
         id: tags
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -52,25 +59,49 @@ jobs:
             echo "frontend_tag=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Deploy backend
-        uses: azure/container-apps-deploy-action@v2
-        with:
-          resourceGroup: ${{ env.RESOURCE_GROUP }}
-          containerAppName: ${{ env.BACKEND_APP }}
-          imageToDeploy: ${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.backend_tag }}
-          registryUrl: ghcr.io
-          registryUsername: ${{ github.actor }}
-          registryPassword: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve image digests
+        id: digests
+        run: |
+          set -euo pipefail
 
-      - name: Deploy frontend
-        uses: azure/container-apps-deploy-action@v2
-        with:
-          resourceGroup: ${{ env.RESOURCE_GROUP }}
-          containerAppName: ${{ env.FRONTEND_APP }}
-          imageToDeploy: ${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.frontend_tag }}
-          registryUrl: ghcr.io
-          registryUsername: ${{ github.actor }}
-          registryPassword: ${{ secrets.GITHUB_TOKEN }}
+          BACKEND_REF="${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.backend_tag }}"
+          FRONTEND_REF="${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.frontend_tag }}"
+
+          echo "Resolving backend digest for $BACKEND_REF"
+          BACKEND_DIGEST=$(docker buildx imagetools inspect "$BACKEND_REF" --format '{{.Manifest.Digest}}')
+          echo "backend_digest=$BACKEND_DIGEST"
+          echo "backend_digest=$BACKEND_DIGEST" >> $GITHUB_OUTPUT
+
+          echo "Resolving frontend digest for $FRONTEND_REF"
+          FRONTEND_DIGEST=$(docker buildx imagetools inspect "$FRONTEND_REF" --format '{{.Manifest.Digest}}')
+          echo "frontend_digest=$FRONTEND_DIGEST"
+          echo "frontend_digest=$FRONTEND_DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Compute revision suffix
+        id: suffix
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          SUFFIX="sha-${SHORT_SHA}-${GITHUB_RUN_NUMBER}"
+          echo "suffix=$SUFFIX"
+          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+
+      - name: Deploy backend (digest-pinned, unique revision)
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --name "${{ env.BACKEND_APP }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --image "${{ env.BACKEND_IMAGE }}@${{ steps.digests.outputs.backend_digest }}" \
+            --revision-suffix "${{ steps.suffix.outputs.suffix }}"
+
+      - name: Deploy frontend (digest-pinned, unique revision)
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --name "${{ env.FRONTEND_APP }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --image "${{ env.FRONTEND_IMAGE }}@${{ steps.digests.outputs.frontend_digest }}" \
+            --revision-suffix "${{ steps.suffix.outputs.suffix }}"
 
       - name: Wait for backend health
         run: |
@@ -123,9 +154,10 @@ jobs:
             --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null || echo "unknown")
 
           echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "| Service | URL |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|-----|" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend | https://${BACKEND_URL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend | https://${FRONTEND_URL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend Image | ${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.backend_tag }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend Image | ${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.frontend_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend URL | https://${BACKEND_URL} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend URL | https://${FRONTEND_URL} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend image | ${{ env.BACKEND_IMAGE }}@${{ steps.digests.outputs.backend_digest }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend image | ${{ env.FRONTEND_IMAGE }}@${{ steps.digests.outputs.frontend_digest }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Revision suffix | ${{ steps.suffix.outputs.suffix }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -50,64 +50,113 @@ jobs:
 
       - name: Determine input image tags
         id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BACKEND_INPUT: ${{ github.event.inputs.backend_image }}
+          FRONTEND_INPUT: ${{ github.event.inputs.frontend_image }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "backend_tag=${{ github.event.inputs.backend_image || 'latest' }}" >> $GITHUB_OUTPUT
-            echo "frontend_tag=${{ github.event.inputs.frontend_image || 'latest' }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BACKEND_TAG="${BACKEND_INPUT:-latest}"
+            FRONTEND_TAG="${FRONTEND_INPUT:-latest}"
           else
-            echo "backend_tag=latest" >> $GITHUB_OUTPUT
-            echo "frontend_tag=latest" >> $GITHUB_OUTPUT
+            BACKEND_TAG="latest"
+            FRONTEND_TAG="latest"
           fi
+          # Defend against injection: restrict tag charset
+          if ! [[ "$BACKEND_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid backend tag: $BACKEND_TAG" >&2
+            exit 1
+          fi
+          if ! [[ "$FRONTEND_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Invalid frontend tag: $FRONTEND_TAG" >&2
+            exit 1
+          fi
+          echo "backend_tag=$BACKEND_TAG" >> "$GITHUB_OUTPUT"
+          echo "frontend_tag=$FRONTEND_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Resolve image digests
         id: digests
+        env:
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          BACKEND_TAG: ${{ steps.tags.outputs.backend_tag }}
+          FRONTEND_TAG: ${{ steps.tags.outputs.frontend_tag }}
         run: |
           set -euo pipefail
 
-          BACKEND_REF="${{ env.BACKEND_IMAGE }}:${{ steps.tags.outputs.backend_tag }}"
-          FRONTEND_REF="${{ env.FRONTEND_IMAGE }}:${{ steps.tags.outputs.frontend_tag }}"
+          BACKEND_REF="${BACKEND_IMAGE}:${BACKEND_TAG}"
+          FRONTEND_REF="${FRONTEND_IMAGE}:${FRONTEND_TAG}"
 
           echo "Resolving backend digest for $BACKEND_REF"
           BACKEND_DIGEST=$(docker buildx imagetools inspect "$BACKEND_REF" --format '{{.Manifest.Digest}}')
           echo "backend_digest=$BACKEND_DIGEST"
-          echo "backend_digest=$BACKEND_DIGEST" >> $GITHUB_OUTPUT
 
           echo "Resolving frontend digest for $FRONTEND_REF"
           FRONTEND_DIGEST=$(docker buildx imagetools inspect "$FRONTEND_REF" --format '{{.Manifest.Digest}}')
           echo "frontend_digest=$FRONTEND_DIGEST"
-          echo "frontend_digest=$FRONTEND_DIGEST" >> $GITHUB_OUTPUT
+
+          # Sanity-check digest format: sha256:<64 hex>
+          if ! [[ "$BACKEND_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Invalid backend digest: $BACKEND_DIGEST" >&2
+            exit 1
+          fi
+          if ! [[ "$FRONTEND_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Invalid frontend digest: $FRONTEND_DIGEST" >&2
+            exit 1
+          fi
+
+          echo "backend_digest=$BACKEND_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=$FRONTEND_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Compute revision suffix
         id: suffix
         run: |
+          set -euo pipefail
           SHORT_SHA="${GITHUB_SHA::7}"
           SUFFIX="sha-${SHORT_SHA}-${GITHUB_RUN_NUMBER}"
           echo "suffix=$SUFFIX"
-          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
 
       - name: Deploy backend (digest-pinned, unique revision)
+        env:
+          APP: ${{ env.BACKEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
+          IMAGE: ${{ env.BACKEND_IMAGE }}
+          DIGEST: ${{ steps.digests.outputs.backend_digest }}
+          SUFFIX: ${{ steps.suffix.outputs.suffix }}
         run: |
           set -euo pipefail
           az containerapp update \
-            --name "${{ env.BACKEND_APP }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --image "${{ env.BACKEND_IMAGE }}@${{ steps.digests.outputs.backend_digest }}" \
-            --revision-suffix "${{ steps.suffix.outputs.suffix }}"
+            --name "$APP" \
+            --resource-group "$RG" \
+            --image "${IMAGE}@${DIGEST}" \
+            --revision-suffix "$SUFFIX"
 
       - name: Deploy frontend (digest-pinned, unique revision)
+        env:
+          APP: ${{ env.FRONTEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
+          IMAGE: ${{ env.FRONTEND_IMAGE }}
+          DIGEST: ${{ steps.digests.outputs.frontend_digest }}
+          SUFFIX: ${{ steps.suffix.outputs.suffix }}
         run: |
           set -euo pipefail
           az containerapp update \
-            --name "${{ env.FRONTEND_APP }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --image "${{ env.FRONTEND_IMAGE }}@${{ steps.digests.outputs.frontend_digest }}" \
-            --revision-suffix "${{ steps.suffix.outputs.suffix }}"
+            --name "$APP" \
+            --resource-group "$RG" \
+            --image "${IMAGE}@${DIGEST}" \
+            --revision-suffix "$SUFFIX"
 
       - name: Wait for backend health
+        env:
+          APP: ${{ env.BACKEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
         run: |
+          set -euo pipefail
           BACKEND_URL=$(az containerapp show \
-            --name ${{ env.BACKEND_APP }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --name "$APP" \
+            --resource-group "$RG" \
             --query "properties.configuration.ingress.fqdn" -o tsv)
 
           echo "Backend URL: https://${BACKEND_URL}"
@@ -121,14 +170,17 @@ jobs:
             sleep 10
           done
 
-          # Final check
           curl -sf "https://${BACKEND_URL}/health" || (echo "Backend health check failed" && exit 1)
 
       - name: Verify deployment
+        env:
+          APP: ${{ env.BACKEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
         run: |
+          set -euo pipefail
           BACKEND_URL=$(az containerapp show \
-            --name ${{ env.BACKEND_APP }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --name "$APP" \
+            --resource-group "$RG" \
             --query "properties.configuration.ingress.fqdn" -o tsv)
 
           echo "=== Health ==="
@@ -142,22 +194,33 @@ jobs:
 
       - name: Post deployment summary
         if: always()
+        env:
+          BACKEND_APP: ${{ env.BACKEND_APP }}
+          FRONTEND_APP: ${{ env.FRONTEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          BACKEND_DIGEST: ${{ steps.digests.outputs.backend_digest }}
+          FRONTEND_DIGEST: ${{ steps.digests.outputs.frontend_digest }}
+          SUFFIX: ${{ steps.suffix.outputs.suffix }}
         run: |
           BACKEND_URL=$(az containerapp show \
-            --name ${{ env.BACKEND_APP }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --name "$BACKEND_APP" \
+            --resource-group "$RG" \
             --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null || echo "unknown")
 
           FRONTEND_URL=$(az containerapp show \
-            --name ${{ env.FRONTEND_APP }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --name "$FRONTEND_APP" \
+            --resource-group "$RG" \
             --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null || echo "unknown")
 
-          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend URL | https://${BACKEND_URL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend URL | https://${FRONTEND_URL} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend image | ${{ env.BACKEND_IMAGE }}@${{ steps.digests.outputs.backend_digest }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend image | ${{ env.FRONTEND_IMAGE }}@${{ steps.digests.outputs.frontend_digest }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Revision suffix | ${{ steps.suffix.outputs.suffix }} |" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Deployment Summary"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Backend URL | https://${BACKEND_URL} |"
+            echo "| Frontend URL | https://${FRONTEND_URL} |"
+            echo "| Backend image | ${BACKEND_IMAGE}@${BACKEND_DIGEST} |"
+            echo "| Frontend image | ${FRONTEND_IMAGE}@${FRONTEND_DIGEST} |"
+            echo "| Revision suffix | ${SUFFIX} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -118,6 +118,22 @@ jobs:
           echo "suffix=$SUFFIX"
           echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
 
+      - name: Refresh GHCR pull credential on backend app
+        env:
+          APP: ${{ env.BACKEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
+          REG_USER: ${{ github.actor }}
+          REG_PASS: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          az containerapp registry set \
+            --name "$APP" \
+            --resource-group "$RG" \
+            --server ghcr.io \
+            --username "$REG_USER" \
+            --password "$REG_PASS" \
+            --output none
+
       - name: Deploy backend (digest-pinned, unique revision)
         env:
           APP: ${{ env.BACKEND_APP }}
@@ -132,6 +148,22 @@ jobs:
             --resource-group "$RG" \
             --image "${IMAGE}@${DIGEST}" \
             --revision-suffix "$SUFFIX"
+
+      - name: Refresh GHCR pull credential on frontend app
+        env:
+          APP: ${{ env.FRONTEND_APP }}
+          RG: ${{ env.RESOURCE_GROUP }}
+          REG_USER: ${{ github.actor }}
+          REG_PASS: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          az containerapp registry set \
+            --name "$APP" \
+            --resource-group "$RG" \
+            --server ghcr.io \
+            --username "$REG_USER" \
+            --password "$REG_PASS" \
+            --output none
 
       - name: Deploy frontend (digest-pinned, unique revision)
         env:

--- a/docs/specs/deploy-azure-digest-pinning.md
+++ b/docs/specs/deploy-azure-digest-pinning.md
@@ -1,0 +1,79 @@
+# Brief: Pin Azure Container Apps deploys to digest + unique revision suffix
+
+## Problem
+
+`deploy-azure.yml` uses `azure/container-apps-deploy-action@v2` with
+`imageToDeploy: ghcr.io/opena2a-org/aim-server:latest`. Azure Container Apps
+treats the image reference as equal across deploys when the tag string is the
+same — so pushing a new `:latest` does not guarantee the container app pulls
+the new digest. The ARM revision is created, but it can re-use the cached
+manifest.
+
+**Incident:** 2026-04-14, 15 minutes lost on a PR-A deploy that the workflow
+reported as "success" while the container kept running the previous revision.
+Discovered only by inspecting `revisions[].createdTime` vs workflow run time.
+See memory `feedback_azure_image_tag_deploy_silent_noop.md`.
+
+## Decision
+
+**[CHIEF-CA] DECISION:** Pin every deploy to a sha256 digest resolved at
+deploy time, and assign each revision a unique suffix derived from
+`github.sha` + `github.run_number`.
+
+**RATIONALE:** Digest references are content-addressed — Azure cannot cache
+a stale image when the target digest changes. A unique revision suffix makes
+every deploy observable (`az containerapp revision list` shows a new row)
+and rollback-able.
+
+**ALTERNATIVES REJECTED:**
+- Keep the deploy-action, add a follow-up `az containerapp revision restart`
+  — treats the symptom, not the cause; still cache-prone on the first update.
+- Emit the digest as an artifact from `docker-publish.yml` and consume it
+  — works but couples two workflows via artifact plumbing. Resolving the
+  digest at deploy time from the tag is simpler and self-contained.
+- Deploy by SHA tag (`:<long-sha>`) via `docker/metadata-action type=sha` —
+  tag-addressed, not content-addressed. Tag still mutable in principle; and
+  the deploy workflow would need the source SHA from the completed
+  Docker Publish run, which is not trivial across workflow_run triggers.
+
+**ESCALATION:** none. This follows the documented CSR threat guidance and
+does not change the deploy surface, credentials, or trust model.
+
+## Design
+
+Replace the two `azure/container-apps-deploy-action@v2` steps with raw
+`az containerapp update` calls, preceded by a digest-resolution step:
+
+1. **GHCR login** — `docker/login-action@v3` with `${{ github.token }}` so
+   `docker buildx imagetools inspect` can read the `:latest` manifest.
+2. **Resolve digests** — for each of `aim-server` and `aim-dashboard`,
+   `docker buildx imagetools inspect <image>:<tag> --format '{{.Manifest.Digest}}'`
+   and write the result to `$GITHUB_OUTPUT`.
+3. **Deploy backend** — `az containerapp update --image <image>@<digest>
+   --revision-suffix sha-<7-char-sha>-<run-number>`.
+4. **Deploy frontend** — same.
+
+Suffix format: `sha-${SHORT_SHA}-${GITHUB_RUN_NUMBER}`. Lowercase hex +
+numeric; satisfies the revision-suffix charset (`[a-z0-9]([-a-z0-9]*[a-z0-9])?`).
+The run number makes manual redeploys of the same SHA unique.
+
+## What stays the same
+
+- Trigger: `workflow_run` on successful Docker Publish.
+- Azure Login step, Wait-for-health, Verify deployment, Summary — unchanged.
+- `workflow_dispatch` inputs still accept `latest` or a specific tag; the
+  resolve step handles either.
+
+## Test plan
+
+- Dry-run: push to a throwaway branch with a trivial backend change, verify
+  workflow passes and backend revision has the new suffix + new digest.
+- Confirm `az containerapp revision list -n aim-prod-backend -g aim-production-rg`
+  shows the new revision as Active within ~60s of workflow completion.
+- Confirm `curl https://aim.oa2a.org/health` still returns 200.
+
+## Out of scope
+
+- Digest verification via cosign (separate hardening, tracked as follow-up).
+- Extending the pattern to `ca-aim-backend-prod` (different product, different
+  session owns that repo).


### PR DESCRIPTION
## Summary
- Replaces `azure/container-apps-deploy-action@v2` with raw `az containerapp update` calls.
- Resolves image digest at deploy time via `docker buildx imagetools inspect`; deploys `<image>@sha256:<digest>` instead of `<image>:latest`.
- Assigns each revision a unique suffix: `sha-<7-char-sha>-<run-number>`.
- Hardens shell steps: user inputs routed through `env:` (not direct `${{ }}` interpolation), tag charset allow-listed, digest format verified.

## Why
See `docs/specs/deploy-azure-digest-pinning.md`. Fixes the silent-noop deploy bug (incident 2026-04-14, 15 min). `:latest` deploys can leave the container running the prior digest; the workflow reports success anyway.

**[CHIEF-CA] DECISION** captured in brief. No credential, trust model, or deploy-surface change.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] After merge: trigger via `workflow_dispatch` with `latest` tags to confirm:
  - [ ] digest resolution step runs and prints `sha256:...`
  - [ ] `az containerapp revision list -n aim-prod-backend -g aim-production-rg` shows a new active revision with suffix `sha-<sha>-<run>`
  - [ ] `curl https://aim.oa2a.org/health` returns 200
- [ ] Leave a note to verify the next workflow_run-triggered deploy also succeeds end-to-end before relying on it for Phase 7 cutover.

## Out of scope
- cosign digest signature verification during deploy (tracked separately)
- Applying the same pattern to `ca-aim-backend-prod` (different product, different session owns that repo)