### PR TITLE
fix(sync): reconcile aim-cloud go.mod via go mod tidy after sync

### DIFF
--- a/scripts/sync-to-cloud.sh
+++ b/scripts/sync-to-cloud.sh
@@ -396,6 +396,44 @@ sync_sdk() {
   fi
 }
 
+# -- Dependency reconciliation -------------------------------------------------
+# Public repo and aim-cloud keep independent go.mod files (`.sync-protect`-ed):
+# public has AIM Secrets backends (cloud.google.com/secretmanager, Azure
+# keyvault, HashiCorp vault, etc.); aim-cloud has Stripe. When the sync copies
+# Go source that imports a dep public has added, aim-cloud's go.mod is missing
+# it and `go build` reports `updates to go.mod needed`. Running `go mod tidy`
+# in aim-cloud's tree pulls in the new transitive deps while keeping Stripe
+# (because protected main.go + internal/infrastructure/stripe/ still reference
+# it). Without this, every public dependency bump breaks the sync pipeline.
+
+reconcile_go_deps() {
+  if $DRY_RUN; then
+    log_info "--- Dry run: skipping go mod tidy ---"
+    return
+  fi
+
+  log_info "--- Reconciling aim-cloud go.mod with synced code ---"
+
+  local dst_backend="$TARGET/apps/backend"
+
+  if [[ ! -f "$dst_backend/go.mod" ]]; then
+    log_info "No go.mod in target backend, skipping tidy"
+    return
+  fi
+
+  if (cd "$dst_backend" && go mod tidy 2>&1); then
+    log_info "go mod tidy: DONE"
+  else
+    echo ""
+    echo "========================================="
+    echo "go mod tidy FAILED -- aim-cloud cannot reconcile deps."
+    echo "Likely cause: synced code imports a package public added but"
+    echo "the module proxy cannot resolve from aim-cloud's module path."
+    echo "========================================="
+    exit 1
+  fi
+}
+
 # -- Build verification --------------------------------------------------------
 
 verify_build() {
@@ -446,6 +484,7 @@ rewrite_imports
 sync_frontend
 sync_migrations
 sync_sdk
+reconcile_go_deps
 verify_build
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes the first-order cause of 11+ consecutive `sync-to-cloud.yml` failures by running `go mod tidy` in aim-cloud's backend tree between the file sync and `verify_build`.

## Root cause (misdiagnosed in `aim-cloud/docs/specs/deploy-consolidation.md`)

The brief claimed the sync script overwrites aim-cloud's `go.mod` with public's. **It does not** — the script globs `*.go` files only (see `sync_backend`) and explicitly skips `package.json` (see `sync_frontend` line 291 comment). What actually happens:

1. Sync copies Go source files that import packages public has added (AIM Secrets v2 backends — GCP secretmanager, Azure keyvault, AWS secretsmanager, HashiCorp vault, 1Password — landed via PRs #99/#100).
2. aim-cloud's `go.mod` never saw those deps.
3. `verify_build` runs `go build ./...`, which fails: `updates to go.mod needed; to update it: go mod tidy`.

## Fix

New `reconcile_go_deps()` step runs `go mod tidy` in `$TARGET/apps/backend/` before `verify_build`. Tidy pulls the missing transitive deps into aim-cloud's `go.mod` while keeping cloud-only deps (Stripe) because `.sync-protect`-ed `cmd/server/main.go` + `internal/infrastructure/stripe/` still import them.

## Validation (local)

Ran `scripts/sync-to-cloud.sh` against aim-cloud HEAD (`af12bc5`):
- 12 missing packages resolved cleanly in one tidy pass.
- `go.mod` diff: new deps added; Stripe (`github.com/stripe/stripe-go/v76`) retained.
- No changes to versioned deps aim-cloud had pinned differently (fxamacker/cbor v2.9.0, golang.org/x/crypto v0.48.0 — tidy respects existing require blocks).

## Partial fix — follow-up required (CA-012)

Running the sync locally after this fix surfaces a **deeper drift problem**: ~189 shared files between `aim-cloud/apps/backend` and public have diverged (plus 38 cloud-only files aim-cloud has). First failure after tidy: `platform_admin_repository.go:345: user.IsPlatformAdmin undefined` — aim-cloud's `domain/user.go` has cloud-only `IsPlatformAdmin` that public's version lacks; the sync overwrites it, breaking the cloud-only `platform_admin_service.go`.

`.sync-protect` currently covers only `cmd/server/main.go` + `internal/infrastructure/stripe/`. A separate audit is needed to decide, for each of the ~189 drifted shared files, whether it should be `.sync-protect`-ed (cloud-enhanced) or have aim-cloud's version reverted to accept public's (drift-from-public).

**This PR alone will not turn sync-to-cloud.yml green on the next run.** It removes the go-mod class of failures; the shared-file drift class remains. Tracked for follow-up as CA-012.

## Test plan

- [x] Dry-run sync (`--dry-run` still skips tidy, behavior unchanged).
- [x] Wet-run sync against aim-cloud HEAD — tidy succeeds, no Stripe regression.
- [ ] Merge + re-run `sync-to-cloud.yml` — expect it to get past the tidy step and fail at the shared-file drift instead (progress marker).

## Companion PR

`opena2a-org/aim-cloud#11` — appends `go.mod`, `go.sum`, `apps/web/package.json`, `apps/web/package-lock.json` to `.sync-protect` (defensive, documents existing behavior).

## Related

- `aim-cloud/docs/specs/deploy-consolidation.md` — Step 1 of deploy consolidation plan (session 71).
- Brief's root-cause text needs correction after this merges.