### PR TITLE
fix(fga): bound async intent-check pool + replace pq_from_strings with pq.Array

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -379,6 +379,17 @@ func main() {
 		log.Fatal("Server forced to shutdown:", err)
 	}
 
+	// Drain the FGA async intent-check worker pool. Bound the wait at 10s
+	// so we don't deadlock shutdown on a hung NanoMind daemon — the
+	// per-call HTTP timeout (800ms) caps individual workers regardless.
+	if services.FGA != nil {
+		fgaShutdownCtx, fgaShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := services.FGA.Shutdown(fgaShutdownCtx); err != nil {
+			log.Printf("⚠️  FGA engine shutdown timed out: %v", err)
+		}
+		fgaShutdownCancel()
+	}
+
 	log.Println("Server exited")
 }
 

--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -32,9 +32,12 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
 )
 
@@ -110,8 +113,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -8,15 +8,45 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// Async intent-check worker pool defaults. The pool bounds the number of
+// in-flight NanoMind daemon calls per process; the queue gives a small
+// burst buffer before backpressure forces drops. Both are package-level
+// constants for now (no config knob until backpressure telemetry tells
+// us they need tuning).
+//
+// Shutdown budget invariant:
+//
+//	fgaAsyncQueueSize × checkIntentSyncTimeout(800ms) / fgaAsyncWorkers
+//	  ≤ services.FGA.Shutdown ctx in cmd/server/main.go (currently 10s)
+//
+// Today: 64 × 800ms / 8 = 6.4s — fits in the 10s shutdown budget. Bump
+// fgaAsyncQueueSize past 100 (or extend the per-call HTTP timeout) and
+// the budget in main.go must move with it, or workers can be SIGKILL'd
+// mid-flight under k8s/systemd grace windows.
+const (
+	fgaAsyncWorkers   = 8
+	fgaAsyncQueueSize = 64
+)
+
+// asyncIntentJob is one queued MEDIUM-risk intent check. ctx carries the
+// fga.authorize parent span, detached from the request lifetime so the
+// worker isn't cancelled when the caller returns.
+type asyncIntentJob struct {
+	ctx context.Context
+	req *FGARequest
+}
 
 // FGAEngine implements the 5-step Fine-Grained Authorization flow.
 // Steps 1-4 must complete in < 10ms P99 (no external calls).
@@ -34,6 +64,19 @@ type FGAEngine struct {
 	tracer       trace.Tracer
 	decisions    metric.Int64Counter
 	latency      metric.Int64Histogram
+	asyncDropped metric.Int64Counter
+
+	// Async intent-check worker pool. Owned by the engine, drained by
+	// Shutdown. asyncDone is closed exactly once by Shutdown to signal
+	// "stop accepting new dispatches"; asyncQueue is NEVER closed (closing
+	// it would race with dispatch — `select { case ch <- v; default: }`
+	// still picks the closed-channel send case and panics, defeating the
+	// non-blocking dispatch contract). Workers exit when asyncDone is
+	// closed and the queue is drained.
+	asyncQueue chan asyncIntentJob
+	asyncDone  chan struct{}
+	asyncWg    sync.WaitGroup
+	asyncOnce  sync.Once // makes Shutdown idempotent
 }
 
 // FGARequest represents an authorization request to the FGA engine.
@@ -113,8 +156,15 @@ func NewFGAEngine(db *sql.DB, agentSvc *AgentService, logger *slog.Logger) *FGAE
 	if err != nil {
 		logger.Warn("fga latency histogram init failed", "error", err)
 	}
+	asyncDropped, err := meter.Int64Counter(
+		"fga.async_intent_dropped",
+		metric.WithDescription("Async intent checks dropped because the worker queue was full"),
+	)
+	if err != nil {
+		logger.Warn("fga async_intent_dropped counter init failed", "error", err)
+	}
 
-	return &FGAEngine{
+	e := &FGAEngine{
 		db:             db,
 		agentSvc:       agentSvc,
 		daemonURL:      "http://127.0.0.1:47200",
@@ -123,7 +173,112 @@ func NewFGAEngine(db *sql.DB, agentSvc *AgentService, logger *slog.Logger) *FGAE
 		tracer:         tracer,
 		decisions:      decisions,
 		latency:        latency,
+		asyncDropped:   asyncDropped,
+		asyncQueue:     make(chan asyncIntentJob, fgaAsyncQueueSize),
+		asyncDone:      make(chan struct{}),
 	}
+	e.startAsyncWorkers(fgaAsyncWorkers)
+	return e
+}
+
+// startAsyncWorkers boots N goroutines that drain the async intent queue.
+// Each worker creates a child span (`fga.intent_check_async.worker`) that
+// chains into the parent fga.authorize span captured at dispatch. Workers
+// exit when asyncDone is closed and the queue has been drained.
+func (e *FGAEngine) startAsyncWorkers(n int) {
+	for i := 0; i < n; i++ {
+		e.asyncWg.Add(1)
+		go func() {
+			defer e.asyncWg.Done()
+			for {
+				select {
+				case <-e.asyncDone:
+					// Shutdown signalled. Drain whatever is queued at this
+					// moment, then exit. Use a non-blocking inner select so
+					// we don't wedge if every queued job has already been
+					// claimed by a sibling worker.
+					for {
+						select {
+						case job := <-e.asyncQueue:
+							e.runAsyncWorker(job)
+						default:
+							return
+						}
+					}
+				case job := <-e.asyncQueue:
+					e.runAsyncWorker(job)
+				}
+			}
+		}()
+	}
+}
+
+// recordAsyncDrop accounts for one dropped async intent-check dispatch.
+// reason is one of: "shutdown" (engine.Shutdown signalled), "queue_full"
+// (worker pool saturated). Touches the dispatch span, the dropped
+// counter, and a WARN log so operators see backpressure in three
+// signals at once.
+func (e *FGAEngine) recordAsyncDrop(ctx context.Context, span trace.Span, req *FGARequest, reason string) {
+	span.SetAttributes(
+		attribute.Bool("fga.dispatched", false),
+		attribute.Bool("fga.async_dropped", true),
+		attribute.String("fga.async_drop_reason", reason),
+	)
+	if e.asyncDropped != nil {
+		e.asyncDropped.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("fga.async_drop_reason", reason),
+		))
+	}
+	e.logger.WarnContext(ctx, fmt.Sprintf("fga.async_intent dropped (%s)", reason),
+		slog.String("agent.id", req.AgentID.String()),
+		slog.String("agent.capability", req.Capability),
+		slog.String("fga.async_drop_reason", reason),
+	)
+}
+
+// runAsyncWorker executes a single async intent-check job under a worker
+// span. Extracted so the steady-state and shutdown-drain paths share one
+// span/log shape.
+func (e *FGAEngine) runAsyncWorker(job asyncIntentJob) {
+	workerCtx, workerSpan := e.tracer.Start(job.ctx, "fga.intent_check_async.worker",
+		trace.WithAttributes(
+			attribute.String("fga.step", "intent_check_async"),
+		),
+	)
+	e.checkIntentAsync(workerCtx, job.req)
+	workerSpan.End()
+}
+
+// Shutdown stops the async intent-check worker pool. It signals workers
+// to stop accepting new jobs (close asyncDone), drain whatever is already
+// in flight or queued, and exit. The passed context's deadline is the
+// upper bound; if it expires before the pool drains, Shutdown returns
+// ctx.Err(). Per-worker NanoMind HTTP calls keep their own 800ms timeout
+// regardless, so workers can't block the shutdown indefinitely.
+//
+// asyncQueue is intentionally NOT closed: dispatches that race with
+// Shutdown read asyncDone instead and drop cleanly via the shutdown
+// branch in their select, with no risk of "send on closed channel"
+// panic.
+//
+// Safe to call multiple times; subsequent calls are no-ops.
+func (e *FGAEngine) Shutdown(ctx context.Context) error {
+	var shutdownErr error
+	e.asyncOnce.Do(func() {
+		close(e.asyncDone)
+		done := make(chan struct{})
+		go func() {
+			e.asyncWg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+			shutdownErr = nil
+		case <-ctx.Done():
+			shutdownErr = ctx.Err()
+		}
+	})
+	return shutdownErr
 }
 
 // SetDaemonURL configures the NanoMind daemon endpoint.
@@ -345,11 +500,38 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 		_, asyncSpan := e.tracer.Start(ctx, "fga.intent_check_async",
 			trace.WithAttributes(
 				attribute.String("fga.step", "intent_check_async"),
-				attribute.Bool("fga.dispatched", true),
 			),
 		)
+
+		// Build a context that carries the fga.authorize parent span but
+		// is detached from the request lifetime — the caller returning
+		// (and cancelling its ctx) must not kill the async check.
+		// trace.ContextWithSpan is belt-and-suspenders: WithoutCancel
+		// preserves all values including the otel context, but pinning
+		// the parent span explicitly is robust to propagator changes.
+		parentSpan := trace.SpanFromContext(ctx)
+		detached := trace.ContextWithSpan(context.WithoutCancel(ctx), parentSpan)
+
+		// Priority-select: the outer non-blocking receive on asyncDone
+		// gives strict priority to "shutdown in progress" over an enqueue
+		// attempt. Go's select picks uniformly among ready cases, so a
+		// flat three-way select would race during shutdown — items could
+		// land in the queue with no consumer left to drain them. Nesting
+		// makes the rule explicit: if asyncDone is closed, never send.
+		// asyncQueue is never closed (see FGAEngine.asyncQueue doc), so
+		// the inner send case can't panic.
+		select {
+		case <-e.asyncDone:
+			e.recordAsyncDrop(ctx, asyncSpan, req, "shutdown")
+		default:
+			select {
+			case e.asyncQueue <- asyncIntentJob{ctx: detached, req: req}:
+				asyncSpan.SetAttributes(attribute.Bool("fga.dispatched", true))
+			default:
+				e.recordAsyncDrop(ctx, asyncSpan, req, "queue_full")
+			}
+		}
 		asyncSpan.End()
-		go e.checkIntentAsync(context.Background(), req) // detached context for fire-and-forget
 	}
 	// LOW: skip intent check entirely
 
@@ -669,8 +851,8 @@ func (e *FGAEngine) recordToolCall(ctx context.Context, req *FGARequest, result 
 		`INSERT INTO tool_call_history (agent_id, capability, object_path, attributes_accessed, data_class, authorized, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq_from_strings(req.Attributes), req.DataClass,
-		result.Allowed, pq_from_strings(result.StepsTriggered),
+		pq.Array(nonNilStrings(req.Attributes)), req.DataClass,
+		result.Allowed, pq.Array(nonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record tool call", "agentId", req.AgentID, "error", err)
@@ -685,8 +867,8 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 		`INSERT INTO access_attestations (agent_id, capability, resource_path, attributes_accessed, fga_outcome, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq_from_strings(req.Attributes), result.Outcome,
-		pq_from_strings(result.StepsTriggered),
+		pq.Array(nonNilStrings(req.Attributes)), result.Outcome,
+		pq.Array(nonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record access attestation", "agentId", req.AgentID, "error", err)
@@ -696,6 +878,19 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 // ============================================================================
 // Helpers
 // ============================================================================
+
+// nonNilStrings returns s if non-nil, else an empty []string. Used to
+// preserve the previous pq_from_strings emission shape: pq.Array(nil)
+// renders as SQL NULL, but the legacy helper rendered as `{}`. Storing
+// NULL where the schema (or downstream audit queries) expected an empty
+// array would change behavior — and would crash on NOT NULL columns
+// (e.g. emergency_declarations.granted_caps).
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
 
 // matchPattern matches a simple wildcard pattern (supports trailing *)
 func matchPattern(value, pattern string) bool {
@@ -750,14 +945,3 @@ func (s *pqStringArray) parse(str string) error {
 	return nil
 }
 
-// pq_from_strings converts a string slice to a PostgreSQL array literal.
-func pq_from_strings(arr []string) string {
-	if len(arr) == 0 {
-		return "{}"
-	}
-	parts := make([]string, len(arr))
-	for i, s := range arr {
-		parts[i] = "\"" + strings.ReplaceAll(s, "\"", "\\\"") + "\""
-	}
-	return "{" + strings.Join(parts, ",") + "}"
-}

--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -736,7 +738,6 @@ func (e *FGAEngine) checkChain(ctx context.Context, req *FGARequest, policy *FGA
 func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *IntentCheckResult {
 	start := time.Now()
 
-	client := &http.Client{Timeout: 800 * time.Millisecond}
 	inferBody := map[string]interface{}{
 		"intent": "INTENT_CHECK",
 		"input":  req.Capability + " on " + req.Resource,
@@ -746,13 +747,30 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 	}
 	bodyBytes, _ := json.Marshal(inferBody)
 
-	resp, err := client.Post(e.daemonURL+"/v1/infer", "application/json", strings.NewReader(string(bodyBytes)))
+	// Use NewRequestWithContext so caller cancellation aborts the
+	// in-flight HTTP call. The 800ms client timeout remains as a
+	// hard upper bound; ctx cancel typically fires first when the
+	// caller is shutting down or has its own deadline.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.daemonURL+"/v1/infer", bytes.NewReader(bodyBytes))
+	if err != nil {
+		e.logger.Debug("intent check request build failed", "error", err)
+		return &IntentCheckResult{
+			IntentClass: "unknown",
+			Confidence:  0,
+			Blocked:     false,
+			LatencyMs:   time.Since(start).Milliseconds(),
+		}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 800 * time.Millisecond}
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		e.logger.Debug("NanoMind daemon unavailable for intent check", "error", err)
 		return &IntentCheckResult{
 			IntentClass: "unknown",
 			Confidence:  0,
-			Blocked:     false, // fail open if daemon unavailable
+			Blocked:     false, // fail open if daemon unavailable or ctx cancelled
 			LatencyMs:   time.Since(start).Milliseconds(),
 		}
 	}
@@ -851,8 +869,8 @@ func (e *FGAEngine) recordToolCall(ctx context.Context, req *FGARequest, result 
 		`INSERT INTO tool_call_history (agent_id, capability, object_path, attributes_accessed, data_class, authorized, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq.Array(nonNilStrings(req.Attributes)), req.DataClass,
-		result.Allowed, pq.Array(nonNilStrings(result.StepsTriggered)),
+		pq.Array(sqlarray.NonNilStrings(req.Attributes)), req.DataClass,
+		result.Allowed, pq.Array(sqlarray.NonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record tool call", "agentId", req.AgentID, "error", err)
@@ -867,8 +885,8 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 		`INSERT INTO access_attestations (agent_id, capability, resource_path, attributes_accessed, fga_outcome, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq.Array(nonNilStrings(req.Attributes)), result.Outcome,
-		pq.Array(nonNilStrings(result.StepsTriggered)),
+		pq.Array(sqlarray.NonNilStrings(req.Attributes)), result.Outcome,
+		pq.Array(sqlarray.NonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record access attestation", "agentId", req.AgentID, "error", err)
@@ -878,19 +896,6 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 // ============================================================================
 // Helpers
 // ============================================================================
-
-// nonNilStrings returns s if non-nil, else an empty []string. Used to
-// preserve the previous pq_from_strings emission shape: pq.Array(nil)
-// renders as SQL NULL, but the legacy helper rendered as `{}`. Storing
-// NULL where the schema (or downstream audit queries) expected an empty
-// array would change behavior — and would crash on NOT NULL columns
-// (e.g. emergency_declarations.granted_caps).
-func nonNilStrings(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
-}
 
 // matchPattern matches a simple wildcard pattern (supports trailing *)
 func matchPattern(value, pattern string) bool {

--- a/apps/backend/internal/application/fga_engine_async_test.go
+++ b/apps/backend/internal/application/fga_engine_async_test.go
@@ -1,0 +1,330 @@
+package application
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/goleak"
+)
+
+// captureHandler is a slog.Handler that records every record's message so
+// tests can assert on what was logged.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Message)
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+func (h *captureHandler) count(prefix string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, m := range h.records {
+		if strings.HasPrefix(m, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// newTestEngineForAsync builds an FGAEngine wired only with what the async
+// dispatch + worker path needs: a logger, a tracer, and a sized worker
+// pool. asyncDropped is left nil — the dispatch path nil-checks it. The
+// returned engine has no DB and no agentSvc; tests must not exercise the
+// full Authorize() flow.
+func newTestEngineForAsync(t *testing.T, daemonURL string, tracer trace.Tracer, workers, queueSize int) (*FGAEngine, *captureHandler) {
+	t.Helper()
+	logs := &captureHandler{}
+	e := &FGAEngine{
+		daemonURL:  daemonURL,
+		logger:     slog.New(logs),
+		tracer:     tracer,
+		asyncQueue: make(chan asyncIntentJob, queueSize),
+		asyncDone:  make(chan struct{}),
+	}
+	e.startAsyncWorkers(workers)
+	return e, logs
+}
+
+// dispatchAsync mirrors the MEDIUM-risk dispatch shape from Authorize so
+// tests can drive the queue without standing up a Postgres + agent
+// service. The priority-select shape is load-bearing for shutdown
+// safety, so the test harness must mirror it exactly. Keep in sync with
+// the real branch in Authorize().
+func (e *FGAEngine) dispatchAsync(ctx context.Context, req *FGARequest) {
+	parentSpan := trace.SpanFromContext(ctx)
+	detached := trace.ContextWithSpan(context.WithoutCancel(ctx), parentSpan)
+	select {
+	case <-e.asyncDone:
+		e.logger.WarnContext(ctx, "fga.async_intent dropped (shutdown)",
+			slog.String("agent.id", req.AgentID.String()),
+			slog.String("agent.capability", req.Capability),
+			slog.String("fga.async_drop_reason", "shutdown"),
+		)
+	default:
+		select {
+		case e.asyncQueue <- asyncIntentJob{ctx: detached, req: req}:
+		default:
+			e.logger.WarnContext(ctx, "fga.async_intent dropped (queue full)",
+				slog.String("agent.id", req.AgentID.String()),
+				slog.String("agent.capability", req.Capability),
+				slog.String("fga.async_drop_reason", "queue_full"),
+			)
+		}
+	}
+}
+
+// TestAsyncIntent_BackpressureDrops fires more requests than the queue +
+// worker pool can hold while the daemon hangs, and asserts that the
+// excess dispatches log a backpressure WARN.
+func TestAsyncIntent_BackpressureDrops(t *testing.T) {
+	// Snapshot baseline goroutines BEFORE we touch httptest, http.Client
+	// transports, or the worker pool — so the post-test goleak only flags
+	// goroutines this test created.
+	leakOpt := goleak.IgnoreCurrent()
+
+	// Daemon that blocks until the test releases it. While blocked, all
+	// pool workers are stuck on the HTTP call, so further sends fill the
+	// queue and then hit the default branch (drop).
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		_, _ = io.WriteString(w, `{"result":"ok","confidence":0,"attackClass":""}`)
+	}))
+	defer func() {
+		closeIdleHTTPConnections()
+		goleak.VerifyNone(t, leakOpt)
+	}()
+	defer srv.Close()
+
+	const (
+		workers   = 2
+		queueSize = 4
+		extra     = 10 // beyond pool + queue capacity
+	)
+
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	engine, logs := newTestEngineForAsync(t, srv.URL, tp.Tracer("test"), workers, queueSize)
+
+	totalSent := workers + queueSize + extra
+	for i := 0; i < totalSent; i++ {
+		engine.dispatchAsync(context.Background(), &FGARequest{
+			AgentID:    uuid.New(),
+			Capability: "test:capability",
+		})
+	}
+
+	// Give the dispatch loop a moment to fill workers + queue + drop the
+	// rest. Drops are observed synchronously on dispatch (it's a select
+	// default), so this is a conservative wait, not a poll.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if logs.count("fga.async_intent dropped") >= extra {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dropped := logs.count("fga.async_intent dropped")
+	assert.GreaterOrEqualf(t, dropped, extra,
+		"expected >= %d dropped dispatches, got %d (workers=%d queue=%d sent=%d)",
+		extra, dropped, workers, queueSize, totalSent)
+
+	// Release blocked daemon handlers so workers can drain on Shutdown.
+	close(release)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, engine.Shutdown(shutdownCtx))
+}
+
+// TestAsyncIntent_NoGoroutineLeak asserts that after Shutdown returns
+// cleanly, the engine has not left any worker goroutines running. Uses
+// goleak.IgnoreCurrent() to ignore goroutines that existed before the
+// engine was constructed (e.g. test runtime, default HTTP transport).
+func TestAsyncIntent_NoGoroutineLeak(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"result":"ok","confidence":0,"attackClass":""}`)
+	}))
+	defer srv.Close()
+
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	// Snapshot baseline goroutines BEFORE engine init so goleak only
+	// flags engine-owned goroutines that didn't shut down.
+	leakOpt := goleak.IgnoreCurrent()
+
+	const workers = 4
+	engine, _ := newTestEngineForAsync(t, srv.URL, tp.Tracer("test"), workers, 8)
+
+	// At least the worker pool should be live now.
+	require.GreaterOrEqual(t, runtime.NumGoroutine(), workers,
+		"expected at least %d goroutines (the worker pool) after engine init",
+		workers)
+
+	// Push a few jobs and let them complete.
+	for i := 0; i < 3; i++ {
+		engine.dispatchAsync(context.Background(), &FGARequest{
+			AgentID:    uuid.New(),
+			Capability: "test:capability",
+		})
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, engine.Shutdown(shutdownCtx))
+
+	// HTTP keep-alive goroutines linger by design; close them so the
+	// leak check only reflects engine-owned goroutines.
+	closeIdleHTTPConnections()
+
+	goleak.VerifyNone(t, leakOpt)
+}
+
+// closeIdleHTTPConnections forces the default HTTP transport to release
+// keep-alive workers. Without this, goleak observes idle conn pool
+// goroutines created by the test's httptest.Server interactions and
+// flags them as leaks.
+func closeIdleHTTPConnections() {
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		t.CloseIdleConnections()
+	}
+}
+
+// TestAsyncIntent_DispatchAfterShutdown_NoPanic is the regression test
+// for the adversarial review's HIGH finding: a `select { case ch <- v;
+// default }` on a CLOSED channel still picks the send case and panics,
+// because closed-channel sends are "ready" for select. The fix is the
+// three-way select with a separate asyncDone signal — asyncQueue is
+// never closed, so the send case can't panic. This test fires
+// dispatches AFTER Shutdown to prove the path is safe.
+func TestAsyncIntent_DispatchAfterShutdown_NoPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"result":"ok","confidence":0,"attackClass":""}`)
+	}))
+	defer srv.Close()
+
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	engine, logs := newTestEngineForAsync(t, srv.URL, tp.Tracer("test"), 2, 4)
+
+	// Shut the engine down first — workers exit, asyncDone closed.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, engine.Shutdown(shutdownCtx))
+
+	// Now fire dispatches. With the old single-case select, this would
+	// panic with "send on closed channel". With the new three-way
+	// select, asyncDone is closed so each dispatch picks the shutdown
+	// branch and drops cleanly.
+	require.NotPanics(t, func() {
+		for i := 0; i < 20; i++ {
+			engine.dispatchAsync(context.Background(), &FGARequest{
+				AgentID:    uuid.New(),
+				Capability: "test:capability",
+			})
+		}
+	}, "dispatch after Shutdown must not panic")
+
+	// Every dispatch should have dropped under the shutdown reason.
+	require.GreaterOrEqualf(t, logs.count("fga.async_intent dropped (shutdown)"), 20,
+		"expected 20 shutdown-reason drops, got %d", logs.count("fga.async_intent dropped (shutdown)"))
+
+	// Idempotent Shutdown: second call returns nil and doesn't deadlock.
+	require.NoError(t, engine.Shutdown(shutdownCtx))
+}
+
+// TestAsyncIntent_TraceParentChained asserts that the worker's span
+// (`fga.intent_check_async.worker`) is rooted in the same trace as the
+// caller's `fga.authorize` span. Without this, the async check shows up
+// as a detached trace in Tempo, which was the original H2 finding.
+func TestAsyncIntent_TraceParentChained(t *testing.T) {
+	leakOpt := goleak.IgnoreCurrent()
+	defer func() {
+		closeIdleHTTPConnections()
+		goleak.VerifyNone(t, leakOpt)
+	}()
+
+	// Track whether the daemon was actually hit so we know the worker
+	// ran (and produced its span).
+	var daemonHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&daemonHits, 1)
+		_, _ = io.WriteString(w, `{"result":"ok","confidence":0,"attackClass":""}`)
+	}))
+	defer srv.Close()
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+	engine, _ := newTestEngineForAsync(t, srv.URL, tracer, 2, 4)
+
+	// Simulate the fga.authorize parent.
+	parentCtx, parentSpan := tracer.Start(context.Background(), "fga.authorize")
+	expectedTraceID := parentSpan.SpanContext().TraceID()
+
+	engine.dispatchAsync(parentCtx, &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "test:capability",
+	})
+	parentSpan.End()
+
+	// Wait for the worker to process the job.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&daemonHits) >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.EqualValues(t, 1, atomic.LoadInt32(&daemonHits),
+		"daemon should have been hit exactly once (worker ran)")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, engine.Shutdown(shutdownCtx))
+
+	// Find the worker span in the recorder and assert its trace ID.
+	ended := rec.Ended()
+	var workerSpan sdktrace.ReadOnlySpan
+	for _, s := range ended {
+		if s.Name() == "fga.intent_check_async.worker" {
+			workerSpan = s
+			break
+		}
+	}
+	require.NotNil(t, workerSpan, "expected an fga.intent_check_async.worker span")
+	assert.Equal(t, expectedTraceID, workerSpan.SpanContext().TraceID(),
+		"worker span must chain into the fga.authorize trace, not start a detached one")
+	assert.Equal(t, parentSpan.SpanContext().SpanID(), workerSpan.Parent().SpanID(),
+		"worker span's parent should be the fga.authorize span")
+}

--- a/apps/backend/internal/application/fga_engine_intent_ctx_test.go
+++ b/apps/backend/internal/application/fga_engine_intent_ctx_test.go
@@ -1,0 +1,116 @@
+package application
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestCheckIntentSync_RespectsCtxCancel asserts that ctx cancellation
+// aborts the in-flight HTTP call to the NanoMind daemon, returning well
+// before the 800ms client timeout would fire.
+//
+// Without ctx wiring, this test would block until the client.Timeout
+// expires (≈ 800ms). With ctx wiring, client.Do returns immediately on
+// cancel and checkIntentSync returns a fail-open IntentCheckResult.
+func TestCheckIntentSync_RespectsCtxCancel(t *testing.T) {
+	// Daemon hangs until either the client cancels (we want this) or
+	// the test finishes (release channel as a safety net).
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+		closeIdleHTTPConnections()
+	}()
+
+	logs := &captureHandler{}
+	engine := &FGAEngine{
+		daemonURL: srv.URL,
+		logger:    slog.New(logs),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel before the 800ms client timeout would fire. If ctx isn't
+	// honored, checkIntentSync blocks for the full 800ms and this test
+	// fails the deadline assertion below.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result := engine.checkIntentSync(ctx, &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "test:capability",
+		Resource:   "test/resource",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("checkIntentSync took %s; expected < 500ms (ctx cancel ignored, hit 800ms client timeout?)", elapsed)
+	}
+	if result == nil {
+		t.Fatal("checkIntentSync returned nil result on ctx cancel; expected fail-open IntentCheckResult")
+	}
+	if result.Blocked {
+		t.Fatal("checkIntentSync blocked on ctx cancel; expected fail-open (Blocked=false)")
+	}
+}
+
+// TestCheckIntentSync_RespectsCtxDeadline asserts that a context with a
+// short deadline aborts the call, again well before the 800ms client
+// timeout. Same shape as the cancel test, but exercises the deadline
+// branch since http transports treat them slightly differently.
+func TestCheckIntentSync_RespectsCtxDeadline(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+		closeIdleHTTPConnections()
+	}()
+
+	logs := &captureHandler{}
+	engine := &FGAEngine{
+		daemonURL: srv.URL,
+		logger:    slog.New(logs),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result := engine.checkIntentSync(ctx, &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "test:capability",
+		Resource:   "test/resource",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("checkIntentSync took %s; expected < 500ms (ctx deadline ignored, hit 800ms client timeout?)", elapsed)
+	}
+	if result == nil {
+		t.Fatal("checkIntentSync returned nil result on ctx deadline; expected fail-open IntentCheckResult")
+	}
+	if result.Blocked {
+		t.Fatal("checkIntentSync blocked on ctx deadline; expected fail-open (Blocked=false)")
+	}
+}

--- a/apps/backend/internal/application/fga_engine_pq_integration_test.go
+++ b/apps/backend/internal/application/fga_engine_pq_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFGA_PqArray_RoundTripSpecialChars is the regression test for H4. The
+// previous hand-rolled `pq_from_strings` only escaped `"`, so any
+// attribute element containing `\`, `{`, `}`, or `,` would corrupt the
+// audit-attestation table on insert. With pq.Array, those characters
+// must round-trip cleanly.
+//
+// Build-tag gated: requires a Postgres reachable via TEST_DATABASE_URL.
+// Skip if absent so the unit-test pipeline stays self-contained. Run via
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestFGA_PqArray_RoundTripSpecialChars \
+//	  ./internal/application/...
+func TestFGA_PqArray_RoundTripSpecialChars(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration round-trip test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	// Pin a single connection so CREATE TEMP TABLE / INSERT / SELECT all
+	// share the same session; otherwise the pool can route the SELECT to
+	// a connection that never saw the temp table.
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Use a throwaway temp table so we don't depend on (or pollute) any
+	// production schema. text[] mirrors attributes_accessed +
+	// fga_steps_triggered in tool_call_history / access_attestations.
+	_, err = conn.ExecContext(ctx, `CREATE TEMP TABLE pq_roundtrip (id SERIAL PRIMARY KEY, attrs TEXT[])`)
+	require.NoError(t, err)
+
+	// Each of these would have been mangled by pq_from_strings:
+	//   `,`  was element-separator, would split the value mid-element
+	//   `{` / `}`  bracket-confused the parser
+	//   `\`  was un-escaped, broke the next quoted character
+	// The standalone `"` case (the one pq_from_strings did handle) is
+	// included to confirm we didn't regress that.
+	want := []string{
+		`comma,inside`,
+		`brace{open`,
+		`brace}close`,
+		`back\slash`,
+		`quote"inside`,
+		`combined ,{}\"`,
+		`empty-next-is-ok`,
+		``,
+	}
+
+	_, err = conn.ExecContext(ctx, `INSERT INTO pq_roundtrip (attrs) VALUES ($1)`, pq.Array(want))
+	require.NoError(t, err, "pq.Array insert must accept arbitrary string values")
+
+	var got []string
+	err = conn.QueryRowContext(ctx, `SELECT attrs FROM pq_roundtrip ORDER BY id DESC LIMIT 1`).Scan(pq.Array(&got))
+	require.NoError(t, err)
+	require.Equal(t, want, got,
+		"pq.Array must round-trip every special-char value byte-for-byte; pq_from_strings did not")
+}

--- a/apps/backend/internal/application/fga_engine_test.go
+++ b/apps/backend/internal/application/fga_engine_test.go
@@ -146,8 +146,3 @@ func TestPqArray_Parse(t *testing.T) {
 	assert.Len(t, arr, 0)
 }
 
-func TestPqFromStrings(t *testing.T) {
-	assert.Equal(t, "{}", pq_from_strings(nil))
-	assert.Equal(t, "{}", pq_from_strings([]string{}))
-	assert.Equal(t, `{"a","b"}`, pq_from_strings([]string{"a", "b"}))
-}

--- a/apps/backend/internal/application/pam_service.go
+++ b/apps/backend/internal/application/pam_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
 
 // PAMService implements Privileged Access Management for AI agent fleets.
@@ -229,7 +230,7 @@ func (s *PAMService) DeclareEmergency(ctx context.Context, decl *EmergencyDeclar
 				affected_agents, granted_caps, justification, status)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 			decl.ID, decl.IncidentID, decl.DeclaredBy, decl.DeclaredAt, decl.ExpiresAt,
-			pq_from_uuids(decl.AffectedAgents), pq_from_strings(decl.GrantedCaps),
+			pq_from_uuids(decl.AffectedAgents), pq.Array(nonNilStrings(decl.GrantedCaps)),
 			decl.Justification, decl.Status,
 		)
 		if err != nil {

--- a/apps/backend/internal/application/pam_service.go
+++ b/apps/backend/internal/application/pam_service.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 )
 
 // PAMService implements Privileged Access Management for AI agent fleets.
@@ -230,7 +232,7 @@ func (s *PAMService) DeclareEmergency(ctx context.Context, decl *EmergencyDeclar
 				affected_agents, granted_caps, justification, status)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 			decl.ID, decl.IncidentID, decl.DeclaredBy, decl.DeclaredAt, decl.ExpiresAt,
-			pq_from_uuids(decl.AffectedAgents), pq.Array(nonNilStrings(decl.GrantedCaps)),
+			pq_from_uuids(decl.AffectedAgents), pq.Array(sqlarray.NonNilStrings(decl.GrantedCaps)),
 			decl.Justification, decl.Status,
 		)
 		if err != nil {

--- a/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 )
 
 type SecretNamespaceRepository struct {
@@ -33,7 +34,7 @@ func (r *SecretNamespaceRepository) Create(ns *secrets.SecretNamespace) error {
 	`
 	_, err := r.db.Exec(query,
 		ns.ID, ns.AgentID, ns.Namespace, string(ns.BackendType),
-		pq.Array(ns.Operations), pq.Array(ns.URLPatterns),
+		pq.Array(sqlarray.NonNilStrings(ns.Operations)), pq.Array(sqlarray.NonNilStrings(ns.URLPatterns)),
 		string(ns.Status), ns.CreatedAt, ns.UpdatedAt, ns.CreatedBy,
 	)
 	if err != nil {

--- a/apps/backend/internal/util/sqlarray/sqlarray.go
+++ b/apps/backend/internal/util/sqlarray/sqlarray.go
@@ -1,0 +1,20 @@
+// Package sqlarray contains small helpers for safely passing []string
+// values to lib/pq's pq.Array on INSERT/UPDATE.
+package sqlarray
+
+// NonNilStrings returns s if non-nil, else an empty []string.
+//
+// pq.Array(nil) renders as SQL NULL, which (a) violates NOT NULL TEXT[]
+// constraints (e.g. emergency_declarations.granted_caps,
+// secret_namespaces.operations) and (b) silently changes audit semantics
+// on nullable columns vs. the previous helper that emitted '{}'.
+//
+// Callers wrapping write-side pq.Array should pass through this helper:
+//
+//	pq.Array(sqlarray.NonNilStrings(req.Attributes))
+func NonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/apps/backend/internal/util/sqlarray/sqlarray_test.go
+++ b/apps/backend/internal/util/sqlarray/sqlarray_test.go
@@ -1,0 +1,49 @@
+package sqlarray
+
+import "testing"
+
+func TestNonNilStrings_NilBecomesEmpty(t *testing.T) {
+	got := NonNilStrings(nil)
+	if got == nil {
+		t.Fatal("NonNilStrings(nil) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("NonNilStrings(nil) returned len=%d; want 0", len(got))
+	}
+}
+
+func TestNonNilStrings_EmptyPassesThrough(t *testing.T) {
+	in := []string{}
+	got := NonNilStrings(in)
+	if got == nil {
+		t.Fatal("NonNilStrings([]string{}) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("got len=%d; want 0", len(got))
+	}
+}
+
+func TestNonNilStrings_PopulatedPreserved(t *testing.T) {
+	in := []string{"read", "write", "delete"}
+	got := NonNilStrings(in)
+	if len(got) != len(in) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("element %d: got %q want %q", i, got[i], in[i])
+		}
+	}
+}
+
+// TestNonNilStrings_AliasesInput documents that NonNilStrings does NOT
+// copy the slice — it returns the input directly when non-nil. Callers
+// relying on this invariant (e.g. avoiding an extra allocation in hot
+// paths) should not be broken by future "defensive copy" refactors.
+func TestNonNilStrings_AliasesInput(t *testing.T) {
+	in := []string{"a", "b"}
+	got := NonNilStrings(in)
+	if &in[0] != &got[0] {
+		t.Fatal("NonNilStrings copied the slice; expected aliasing of input")
+	}
+}


### PR DESCRIPTION
## Summary

Land **P1 #3 (H2)** and **P1 #4 (H4)** from the OTel exporters follow-up list spawned out of #114. Single PR, scoped to `apps/backend/internal/application/fga_engine.go` plus one collateral migration in `pam_service.go` and the graceful-shutdown wiring in `cmd/server/main.go`.

Source plan: `todo/2026-04-28-fga-engine-p1-handoff.md`.

### H2 — bound the async intent-check goroutine

Today (pre-PR), MEDIUM-risk policies dispatched intent checks via:

```go
go e.checkIntentAsync(context.Background(), req)
```

Three bugs:

1. **Detached trace.** `context.Background()` drops the parent's trace context — the async check shows up as an orphaned trace in Tempo, not as a child of `fga.authorize`.
2. **Unbounded concurrency.** A burst of MEDIUM-risk authorizations spawns one goroutine per request, each holding an 800ms-timeout HTTP call to the NanoMind daemon.
3. **No shutdown signal.** Goroutines outlive `app.Shutdown()` — under SIGTERM the process can be killed mid-NanoMind-call.

The replacement is an engine-scoped worker pool:

- 8 worker goroutines drain a 64-deep buffered channel.
- Dispatch uses a **priority-select** (nested) — `<-asyncDone` beats the queue send when both are ready, so shutdown-in-progress always drops cleanly instead of leaking items into an empty pool.
- The dispatch captures the parent `fga.authorize` span and propagates it via `trace.ContextWithSpan(context.WithoutCancel(ctx), parentSpan)`. Workers create an `fga.intent_check_async.worker` child span that chains into the same trace tree.
- Drops (queue full **or** shutdown) increment `fga.async_intent_dropped` (labelled by reason), emit a WARN log, and tag the dispatch span.
- New `FGAEngine.Shutdown(ctx context.Context) error` closes `asyncDone`, waits on a `sync.WaitGroup` with the passed ctx as the deadline. Wired into `cmd/server/main.go` with a 10s budget.
- `asyncQueue` is **never** closed — `select { case ch <- v; default }` on a closed channel still picks the send case and panics, defeating the non-blocking dispatch contract. The `asyncDone` signal is the safe alternative.

A const-relationship comment in `fga_engine.go` documents the budget invariant: `fgaAsyncQueueSize × 800ms / fgaAsyncWorkers ≤ services.FGA.Shutdown ctx`.

### H4 — replace `pq_from_strings` with `pq.Array`

The hand-rolled `pq_from_strings` only escaped `"`, so element values containing `\`, `{`, `}`, or `,` would corrupt the audit-attestation table on insert.

- Replaced at all five call sites: `recordToolCall` (×2), `recordAttestation` (×2), `pam_service.DeclareEmergency` (×1).
- Deleted `pq_from_strings` and its unit test.
- `pq.Array(nil)` emits SQL NULL whereas the legacy helper emitted `'{}'`. A small `nonNilStrings()` helper preserves the previous empty-array semantics — necessary because `emergency_declarations.granted_caps` is `TEXT[] NOT NULL DEFAULT '{}'`, so a nil slice would be a constraint violation.

### Pre-existing concerns flagged (out of scope, separate PRs)

Adversarial review surfaced two pre-existing issues that this PR does **not** fix:

1. `apps/backend/internal/infrastructure/repository/secret_namespace_repository.go:36` calls `pq.Array(ns.Operations)` / `pq.Array(ns.URLPatterns)` against `TEXT[] NOT NULL DEFAULT '{}'` columns. Same nil → NULL crash mode this PR's `nonNilStrings` helper was built for, but in a different domain.
2. `checkIntentSync` uses `client.Post`, not `http.NewRequestWithContext`. The 800ms `client.Timeout` is the only ceiling, so worker shutdown ctx cancellation isn't honored mid-flight. Tight against the 10s shutdown budget; load-bearing under k8s/systemd grace windows.

Both are tracked in `todo/2026-04-28-fga-engine-p1-handoff.md` follow-ups.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/application/...` — full package, 100s, all green
- [x] `go test -race ./internal/interfaces/http/handlers/...` — green
- [x] Four new async tests under `-race`:
  - `TestAsyncIntent_BackpressureDrops` — N > pool+queue with hanging daemon, ≥extra drops logged
  - `TestAsyncIntent_NoGoroutineLeak` — `goleak.IgnoreCurrent` baseline + `VerifyNone` after Shutdown
  - `TestAsyncIntent_DispatchAfterShutdown_NoPanic` — 20 dispatches post-Shutdown, all drop via "shutdown" reason, no panic, idempotent Shutdown
  - `TestAsyncIntent_TraceParentChained` — `tracetest.SpanRecorder` confirms worker span has parent trace ID and parent span ID matching `fga.authorize`
- [x] Integration test (build tag `integration`, skip-if-no-`TEST_DATABASE_URL`): round-trips an attribute string containing each of `"`, `\`, `{`, `}`, `,` and a combined `,{}\"`. Verified locally against `postgres:16-alpine` — passes.
- [x] `apps/backend/deployments/otel-demo/smoke-backend.sh` — full hermetic real-backend smoke (port-overridden via `LOKI_PORT=33100 TEMPO_HTTP_PORT=33200 GRAFANA_PORT=33001` because another local stack owned the defaults). Outcome: `outcome=DENY`, trace landed in Tempo with 1 fga.* child (`capability_check`) — exactly the no-policy demo path; the async branch is not exercised by the smoke as expected.
- [x] `npx hackmyagent secure --ci` — 95/100, 1 MEDIUM (pre-existing `.gitleaks.toml` regex-pattern false positive).
- [x] Two adversarial code reviews (general-purpose subagent, blind to my reasoning) — first surfaced the closed-channel panic + the NOT NULL crash mode (both fixed inline), second confirmed no new issues introduced by the fixes.
- [x] `/pre-push-review` end-to-end — PASS.