### PR TITLE
Promote nonNilStrings to sqlarray util + wire ctx into FGA checkIntentSync

### DIFF
--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -736,7 +738,6 @@ func (e *FGAEngine) checkChain(ctx context.Context, req *FGARequest, policy *FGA
 func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *IntentCheckResult {
 	start := time.Now()
 
-	client := &http.Client{Timeout: 800 * time.Millisecond}
 	inferBody := map[string]interface{}{
 		"intent": "INTENT_CHECK",
 		"input":  req.Capability + " on " + req.Resource,
@@ -746,13 +747,30 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 	}
 	bodyBytes, _ := json.Marshal(inferBody)
 
-	resp, err := client.Post(e.daemonURL+"/v1/infer", "application/json", strings.NewReader(string(bodyBytes)))
+	// Use NewRequestWithContext so caller cancellation aborts the
+	// in-flight HTTP call. The 800ms client timeout remains as a
+	// hard upper bound; ctx cancel typically fires first when the
+	// caller is shutting down or has its own deadline.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.daemonURL+"/v1/infer", bytes.NewReader(bodyBytes))
+	if err != nil {
+		e.logger.Debug("intent check request build failed", "error", err)
+		return &IntentCheckResult{
+			IntentClass: "unknown",
+			Confidence:  0,
+			Blocked:     false,
+			LatencyMs:   time.Since(start).Milliseconds(),
+		}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 800 * time.Millisecond}
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		e.logger.Debug("NanoMind daemon unavailable for intent check", "error", err)
 		return &IntentCheckResult{
 			IntentClass: "unknown",
 			Confidence:  0,
-			Blocked:     false, // fail open if daemon unavailable
+			Blocked:     false, // fail open if daemon unavailable or ctx cancelled
 			LatencyMs:   time.Since(start).Milliseconds(),
 		}
 	}
@@ -851,8 +869,8 @@ func (e *FGAEngine) recordToolCall(ctx context.Context, req *FGARequest, result 
 		`INSERT INTO tool_call_history (agent_id, capability, object_path, attributes_accessed, data_class, authorized, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq.Array(nonNilStrings(req.Attributes)), req.DataClass,
-		result.Allowed, pq.Array(nonNilStrings(result.StepsTriggered)),
+		pq.Array(sqlarray.NonNilStrings(req.Attributes)), req.DataClass,
+		result.Allowed, pq.Array(sqlarray.NonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record tool call", "agentId", req.AgentID, "error", err)
@@ -867,8 +885,8 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 		`INSERT INTO access_attestations (agent_id, capability, resource_path, attributes_accessed, fga_outcome, fga_steps_triggered)
 		 VALUES ($1, $2, $3, $4, $5, $6)`,
 		req.AgentID, req.Capability, req.Resource,
-		pq.Array(nonNilStrings(req.Attributes)), result.Outcome,
-		pq.Array(nonNilStrings(result.StepsTriggered)),
+		pq.Array(sqlarray.NonNilStrings(req.Attributes)), result.Outcome,
+		pq.Array(sqlarray.NonNilStrings(result.StepsTriggered)),
 	)
 	if err != nil {
 		e.logger.Error("failed to record access attestation", "agentId", req.AgentID, "error", err)
@@ -878,19 +896,6 @@ func (e *FGAEngine) recordAttestation(ctx context.Context, req *FGARequest, resu
 // ============================================================================
 // Helpers
 // ============================================================================
-
-// nonNilStrings returns s if non-nil, else an empty []string. Used to
-// preserve the previous pq_from_strings emission shape: pq.Array(nil)
-// renders as SQL NULL, but the legacy helper rendered as `{}`. Storing
-// NULL where the schema (or downstream audit queries) expected an empty
-// array would change behavior — and would crash on NOT NULL columns
-// (e.g. emergency_declarations.granted_caps).
-func nonNilStrings(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
-}
 
 // matchPattern matches a simple wildcard pattern (supports trailing *)
 func matchPattern(value, pattern string) bool {

--- a/apps/backend/internal/application/fga_engine_intent_ctx_test.go
+++ b/apps/backend/internal/application/fga_engine_intent_ctx_test.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -23,12 +22,9 @@ func TestCheckIntentSync_RespectsCtxCancel(t *testing.T) {
 	// Daemon hangs until either the client cancels (we want this) or
 	// the test finishes (release channel as a safety net).
 	release := make(chan struct{})
-	var handlerCancelled sync.WaitGroup
-	handlerCancelled.Add(1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
-			handlerCancelled.Done()
 		case <-release:
 		}
 	}))

--- a/apps/backend/internal/application/fga_engine_intent_ctx_test.go
+++ b/apps/backend/internal/application/fga_engine_intent_ctx_test.go
@@ -1,0 +1,120 @@
+package application
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestCheckIntentSync_RespectsCtxCancel asserts that ctx cancellation
+// aborts the in-flight HTTP call to the NanoMind daemon, returning well
+// before the 800ms client timeout would fire.
+//
+// Without ctx wiring, this test would block until the client.Timeout
+// expires (≈ 800ms). With ctx wiring, client.Do returns immediately on
+// cancel and checkIntentSync returns a fail-open IntentCheckResult.
+func TestCheckIntentSync_RespectsCtxCancel(t *testing.T) {
+	// Daemon hangs until either the client cancels (we want this) or
+	// the test finishes (release channel as a safety net).
+	release := make(chan struct{})
+	var handlerCancelled sync.WaitGroup
+	handlerCancelled.Add(1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			handlerCancelled.Done()
+		case <-release:
+		}
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+		closeIdleHTTPConnections()
+	}()
+
+	logs := &captureHandler{}
+	engine := &FGAEngine{
+		daemonURL: srv.URL,
+		logger:    slog.New(logs),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel before the 800ms client timeout would fire. If ctx isn't
+	// honored, checkIntentSync blocks for the full 800ms and this test
+	// fails the deadline assertion below.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result := engine.checkIntentSync(ctx, &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "test:capability",
+		Resource:   "test/resource",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("checkIntentSync took %s; expected < 500ms (ctx cancel ignored, hit 800ms client timeout?)", elapsed)
+	}
+	if result == nil {
+		t.Fatal("checkIntentSync returned nil result on ctx cancel; expected fail-open IntentCheckResult")
+	}
+	if result.Blocked {
+		t.Fatal("checkIntentSync blocked on ctx cancel; expected fail-open (Blocked=false)")
+	}
+}
+
+// TestCheckIntentSync_RespectsCtxDeadline asserts that a context with a
+// short deadline aborts the call, again well before the 800ms client
+// timeout. Same shape as the cancel test, but exercises the deadline
+// branch since http transports treat them slightly differently.
+func TestCheckIntentSync_RespectsCtxDeadline(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+		closeIdleHTTPConnections()
+	}()
+
+	logs := &captureHandler{}
+	engine := &FGAEngine{
+		daemonURL: srv.URL,
+		logger:    slog.New(logs),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result := engine.checkIntentSync(ctx, &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "test:capability",
+		Resource:   "test/resource",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("checkIntentSync took %s; expected < 500ms (ctx deadline ignored, hit 800ms client timeout?)", elapsed)
+	}
+	if result == nil {
+		t.Fatal("checkIntentSync returned nil result on ctx deadline; expected fail-open IntentCheckResult")
+	}
+	if result.Blocked {
+		t.Fatal("checkIntentSync blocked on ctx deadline; expected fail-open (Blocked=false)")
+	}
+}

--- a/apps/backend/internal/application/pam_service.go
+++ b/apps/backend/internal/application/pam_service.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 )
 
 // PAMService implements Privileged Access Management for AI agent fleets.
@@ -230,7 +232,7 @@ func (s *PAMService) DeclareEmergency(ctx context.Context, decl *EmergencyDeclar
 				affected_agents, granted_caps, justification, status)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 			decl.ID, decl.IncidentID, decl.DeclaredBy, decl.DeclaredAt, decl.ExpiresAt,
-			pq_from_uuids(decl.AffectedAgents), pq.Array(nonNilStrings(decl.GrantedCaps)),
+			pq_from_uuids(decl.AffectedAgents), pq.Array(sqlarray.NonNilStrings(decl.GrantedCaps)),
 			decl.Justification, decl.Status,
 		)
 		if err != nil {

--- a/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
+++ b/apps/backend/internal/infrastructure/repository/secret_namespace_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain/secrets"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 )
 
 type SecretNamespaceRepository struct {
@@ -33,7 +34,7 @@ func (r *SecretNamespaceRepository) Create(ns *secrets.SecretNamespace) error {
 	`
 	_, err := r.db.Exec(query,
 		ns.ID, ns.AgentID, ns.Namespace, string(ns.BackendType),
-		pq.Array(ns.Operations), pq.Array(ns.URLPatterns),
+		pq.Array(sqlarray.NonNilStrings(ns.Operations)), pq.Array(sqlarray.NonNilStrings(ns.URLPatterns)),
 		string(ns.Status), ns.CreatedAt, ns.UpdatedAt, ns.CreatedBy,
 	)
 	if err != nil {

--- a/apps/backend/internal/util/sqlarray/sqlarray.go
+++ b/apps/backend/internal/util/sqlarray/sqlarray.go
@@ -1,0 +1,20 @@
+// Package sqlarray contains small helpers for safely passing []string
+// values to lib/pq's pq.Array on INSERT/UPDATE.
+package sqlarray
+
+// NonNilStrings returns s if non-nil, else an empty []string.
+//
+// pq.Array(nil) renders as SQL NULL, which (a) violates NOT NULL TEXT[]
+// constraints (e.g. emergency_declarations.granted_caps,
+// secret_namespaces.operations) and (b) silently changes audit semantics
+// on nullable columns vs. the previous helper that emitted '{}'.
+//
+// Callers wrapping write-side pq.Array should pass through this helper:
+//
+//	pq.Array(sqlarray.NonNilStrings(req.Attributes))
+func NonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/apps/backend/internal/util/sqlarray/sqlarray_test.go
+++ b/apps/backend/internal/util/sqlarray/sqlarray_test.go
@@ -1,0 +1,49 @@
+package sqlarray
+
+import "testing"
+
+func TestNonNilStrings_NilBecomesEmpty(t *testing.T) {
+	got := NonNilStrings(nil)
+	if got == nil {
+		t.Fatal("NonNilStrings(nil) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("NonNilStrings(nil) returned len=%d; want 0", len(got))
+	}
+}
+
+func TestNonNilStrings_EmptyPassesThrough(t *testing.T) {
+	in := []string{}
+	got := NonNilStrings(in)
+	if got == nil {
+		t.Fatal("NonNilStrings([]string{}) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("got len=%d; want 0", len(got))
+	}
+}
+
+func TestNonNilStrings_PopulatedPreserved(t *testing.T) {
+	in := []string{"read", "write", "delete"}
+	got := NonNilStrings(in)
+	if len(got) != len(in) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("element %d: got %q want %q", i, got[i], in[i])
+		}
+	}
+}
+
+// TestNonNilStrings_AliasesInput documents that NonNilStrings does NOT
+// copy the slice — it returns the input directly when non-nil. Callers
+// relying on this invariant (e.g. avoiding an extra allocation in hot
+// paths) should not be broken by future "defensive copy" refactors.
+func TestNonNilStrings_AliasesInput(t *testing.T) {
+	in := []string{"a", "b"}
+	got := NonNilStrings(in)
+	if &in[0] != &got[0] {
+		t.Fatal("NonNilStrings copied the slice; expected aliasing of input")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #115 (`fix/fga-engine-async-and-pq-array`). **Depends on #115 merging first** — once #115 lands, retarget this PR to `main`.

Two follow-ups from the adversarial review of #115:

1. **Promote `nonNilStrings` to `internal/util/sqlarray.NonNilStrings`** — the `pq.Array(nil) → SQL NULL` defense was a private helper inside `application/fga_engine.go`. It's now needed in `application/pam_service.go` and `infrastructure/repository/secret_namespace_repository.go` (the `secret_namespaces.operations` / `secret_namespaces.url_patterns` columns are `TEXT[] NOT NULL` per migration 087, and the previous `pq.Array(ns.Operations)` write site crashed on a SecretNamespace posted without those fields). New shared package with a unit test that covers nil → `[]string{}` round-trip.

2. **Wire caller `ctx` into `checkIntentSync`** — the FGA daemon HTTP call previously used `client.Post(...)`, which ignores the caller's context. Switched to `http.NewRequestWithContext(ctx, …)` so cancellation aborts the call within the 800ms client timeout instead of stranding the goroutine. Benefits both the HIGH-risk sync path (caller's ctx) and the MEDIUM-risk async worker path (the detached-but-shutdown-aware ctx from #115). Added `TestCheckIntentSync_RespectsCtxCancel` (hanging `httptest.Server` + `context.WithCancel`) and `TestCheckIntentSync_RespectsCtxDeadline` to lock the behavior in.

### Commits
- `f9d4acd` — Promote nonNilStrings to internal/util/sqlarray and wire ctx into checkIntentSync
- `edfa33d` — Drop unused sync.WaitGroup in TestCheckIntentSync_RespectsCtxCancel

### Deferred follow-ups (tracked, not blocking this PR)

These were surfaced during the session-99 audit but are out of scope here. See `.claude-sessions/session-99-secretless-pq-array-and-intent-ctx.md` "Follow-ups" section for full detail.

1. `security_repository.go:278` — `incident.AffectedResources` `pq.Array` write site. The `security_incidents` table has no migration in `apps/backend/migrations/`. Locate the schema (in-code DDL? dead code?) before deciding whether to wrap with `sqlarray.NonNilStrings` or delete the dead repo methods.
2. `pq_from_uuids` audit (`pam_service.go:347`) — promote sibling helper to `sqlarray.NonNilUUIDs` and migrate `pam_service.go:235`.
3. `pq_array` scanner (`fga_engine.go:917`) — read-side helper. Move to `internal/util/sqlarray/` so all DB-array helpers sit together. No functional change.
4. Defense-in-depth: domain constructors (`secrets.SecretNamespace`, `domain.SecurityIncident`, `domain.EmergencyDeclaration`) initialize `[]string` fields to `[]string{}` rather than nil. Reduces "I forgot the helper" regression surface.
5. CI lint rule that flags `pq.Array(<bare-slice>)` write sites not wrapped by a known-safe helper. Catches regressions automatically.
6. Webhook events: `webhooks_events_not_empty CHECK (array_length(events, 1) > 0)` constraint — verify the HTTP handler / service rejects empty `events` before it reaches the repo. Helper alone won't save us from the CHECK violation.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/util/sqlarray/...` passes (round-trip + nil/empty)
- [x] `go test ./internal/application/ -run TestCheckIntentSync` passes (cancel + deadline)
- [x] `internal/application -race` (97s) — clean
- [x] Smoke harness end-to-end: backend boots on 18080, `/authorize` produces a `fga.authorize` parent span + 1 child in Tempo
- [x] Pre-push gate Phases 1–8 pass
- [x] HMA scan: 95/100, only pre-existing `.gitleaks.toml` MEDIUM (unchanged from main)