### PR TITLE
docs: adopt standardized README (Desktop draft + 3 fact-check corrections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
-Cryptographic identity, capability authorization, and audit trails for AI agents. Open source, Apache 2.0.
+Cryptographic identity, capability authorization, and audit trails for AI agents. Apache 2.0.
 
 [![CI](https://github.com/opena2a-org/agent-identity-management/actions/workflows/ci.yml/badge.svg)](https://github.com/opena2a-org/agent-identity-management/actions/workflows/ci.yml)
 [![Security](https://github.com/opena2a-org/agent-identity-management/actions/workflows/security.yml/badge.svg)](https://github.com/opena2a-org/agent-identity-management/actions/workflows/security.yml)
@@ -25,7 +25,7 @@ Identity created
   Stored in:   ~/.opena2a/aim-core/
 ```
 
-The agent now has an Ed25519 keypair, a local audit log at `~/.opena2a/aim-core/audit.jsonl`, and a trust score. No server required.
+The agent has an Ed25519 keypair, a local audit log at `~/.opena2a/aim-core/audit.jsonl`, and a trust score. No server required.
 
 After an incident:
 
@@ -37,13 +37,29 @@ Reads back credential injections, file accesses, config changes, and capability 
 
 ## Three deployment modes
 
-| Mode | When | What you get |
+| Mode | When | Includes |
 |---|---|---|
 | **Local-only** | Solo developer, single machine | Ed25519 keypair, `audit.jsonl`, YAML capability policies, 8-factor trust score, cross-tool event bridges |
 | **Self-hosted** | Team or fleet | Above plus PostgreSQL audit, REST API, dashboard, OAuth, 5-step FGA, 9-factor real-time trust, MCP attestation, PAM, SIEM adapters |
-| **AIM Cloud** | Same as self-hosted, no infrastructure to run | Managed at [aim.opena2a.org](https://aim.opena2a.org) |
+| **AIM Cloud** | Same as self-hosted with no infrastructure to operate | Managed at [aim.opena2a.org](https://aim.opena2a.org) |
 
 All three share the same audit-event schema. Local agents can push history to a server via `AIMCore.enableReporting()`.
+
+## Dashboard
+
+Available in Self-hosted and AIM Cloud modes.
+
+![Fleet overview](docs/images/dashboard-security.png)
+*Fleet overview: agents monitored, actions blocked, and risk by category.*
+
+![Agent registry](docs/images/agents.png)
+*Agent registry with trust scores and verification status per agent.*
+
+![Per-agent trust score breakdown](docs/images/agent-trust-score.png)
+*Per-agent 8-factor trust score breakdown with weighted signal contributions.*
+
+![MCP supply chain](docs/images/supply-chain.png)
+*MCP server dependencies with multi-agent attestation status.*
 
 ## Install
 
@@ -54,6 +70,12 @@ npm install -g opena2a-cli      # CLI
 npm install @opena2a/aim-core   # TypeScript library
 ```
 
+### Homebrew
+
+```bash
+brew install opena2a-org/tap/opena2a
+```
+
 ### Docker
 
 ```bash
@@ -62,7 +84,7 @@ shasum -a 256 quickstart.sh     # verify against the SHA in the latest release n
 bash quickstart.sh
 ```
 
-Brings up `aim-server` + `aim-dashboard` + PostgreSQL + Redis. Dashboard at `localhost:3000`, API at `localhost:8080`. Login credentials printed at the end of the run.
+Brings up `aim-server`, `aim-dashboard`, PostgreSQL, and Redis. Dashboard at `localhost:3000`, API at `localhost:8080`. Login credentials print at the end of the run.
 
 Production deployment (Azure, GCP, AWS): [infrastructure/DEPLOYMENT.md](infrastructure/DEPLOYMENT.md).
 
@@ -87,9 +109,9 @@ pip install -e sdk/python
 cd examples/flight-search-agent && python3 flight_agent.py
 ```
 
-The `docker-compose.yml` also brings up Elasticsearch, MinIO, NATS, Prometheus, Grafana, and Loki. Skip those services with the minimal command above.
+The full `docker-compose.yml` also brings up Elasticsearch, MinIO, NATS, Prometheus, Grafana, and Loki. Skip those services with the minimal command above.
 
-### Verifying what you installed
+### Verifying what was installed
 
 Every release publishes via npm Trusted Publishing with SLSA v1 provenance. No long-lived `NPM_TOKEN`. GitHub Actions exchanges its OIDC token with npm at publish time.
 
@@ -98,7 +120,7 @@ npm view @opena2a/aim-core dist.attestations --json
 # Expects non-empty result with predicateType "https://slsa.dev/provenance/v1"
 ```
 
-Identity files (`~/.opena2a/aim-core/identity.json`) are written `mode 0600`. OAuth tokens live in the OS keychain by default; `~/.opena2a/auth.json` stores metadata only.
+Identity files (`~/.opena2a/aim-core/identity.json`) are written `mode 0600`. OAuth tokens live in the OS keychain by default. `~/.opena2a/auth.json` stores metadata only.
 
 ## How the local audit log fills up
 
@@ -107,12 +129,12 @@ Identity files (`~/.opena2a/aim-core/identity.json`) are written `mode 0600`. OA
 ```text
 Secretless events    ──┐
 HMA scan findings    ──┤
-HMA ARP runtime      ──┤
-ConfigGuard events   ──┼─→ ~/.opena2a/aim-core/audit.jsonl
+HMA ARP runtime      ──┼─→ ~/.opena2a/aim-core/audit.jsonl
+ConfigGuard events   ──┤
 Shield events        ──┘
 ```
 
-No decorator, no library import in agent code. Run `attach --all` once, work normally, and after an incident the audit log holds a deduplicated, timestamp-ordered trail of credential injections, file accesses, network calls, config tampering, and scan findings.
+No decorator. No library import in agent code. Run `attach --all` once, work normally, and after an incident the audit log holds a deduplicated, timestamp-ordered trail of credential injections, file accesses, network calls, config tampering, and scan findings.
 
 Capability authorization (deny-before-execute, FGA, intent classification) requires the server. See [Server features](#server-features).
 
@@ -124,23 +146,72 @@ Capability authorization (deny-before-execute, FGA, intent classification) requi
 | Python | `pip install -e sdk/python`, or download from [dashboard](https://aim.opena2a.org) Settings → SDK Downloads | Server |
 | Java | `org.opena2a:aim-sdk:1.0.0`, or `cd sdk/java && mvn package` | Server |
 
-The TypeScript SDK is the only one that runs without a server (it backs local mode). Python and Java SDKs talk to the AIM backend over HTTP. Working examples for all three live in [`examples/`](examples/).
+TypeScript is the only SDK that runs without a server. It backs local mode. Python and Java SDKs talk to the AIM backend over HTTP. Working examples for all three live in [`examples/`](examples/).
+
+### Python
+
+Register an agent in one line. Add `@agent.perform_action` to each function that performs a capability.
+
+```python
+from aim_sdk import secure
+
+agent = secure("my-first-agent")
+
+@agent.perform_action(capability="weather:fetch")
+def fetch_weather(city):
+    return f"Weather in {city}: Sunny"
+```
+
+`secure()` generates an Ed25519 keypair, registers the agent with the AIM backend, stores credentials, and auto-detects the framework from imports (`langchain`, `crewai`, `llama_index`, `anthropic`, `openai`). When both a framework and an LLM provider are present, the framework wins.
+
+`@agent.perform_action` signs each invocation, runs it through 5-step FGA on the server, and records the outcome in the audit log. Risk level auto-detects from the capability string using two lookup tables in [`sdk/python/aim_sdk/risk_detector.py`](sdk/python/aim_sdk/risk_detector.py):
+
+- **Namespace prefix.** `payment:`, `admin:`, `system:`, `billing:`, `finance:` map to critical. `email:`, `notification:`, `sms:`, `user:`, `auth:`, `secret:`, `credential:` map to high. `db:`, `database:`, `file:`, `storage:`, `cache:` map to medium. `api:`, `weather:`, `search:`, `geocode:`, `translate:`, `time:`, `math:`, `util:` map to low.
+- **Action suffix.** `:read`, `:fetch`, `:get`, `:list`, `:query`, `:view`, `:check`, `:validate` map to low. `:write`, `:update`, `:create`, `:modify`, `:save`, `:upload` map to medium. `:delete`, `:send`, `:execute`, `:run`, `:invoke`, `:export`, `:transfer` map to high. `:process`, `:refund`, `:charge`, `:approve`, `:drop`, `:truncate`, `:wipe`, `:terminate` map to critical.
+
+When namespace and action disagree the higher risk wins. A `SPECIFIC_CAPABILITY_MAP` in the same file overrides both for known patterns (for example `user:delete` escalates to critical). Pass `risk_level="critical"` to override, and `jit_access=True` to pause execution until a human approves in the dashboard.
+
+Full example: [`examples/flight-search-agent/flight_agent.py`](examples/flight-search-agent/flight_agent.py).
 
 ## Server features
 
-5-step Fine-Grained Authorization (FGA) on every privileged action: capability check, attribute check, context check, chain check, intent check. The intent check uses [NanoMind](https://huggingface.co/opena2a/nanomind-security-analyst), a 3M-parameter local model. Sub-10ms for steps 1-4, up to 800ms for the intent check on HIGH-risk operations.
+### 5-step Fine-Grained Authorization
 
-9-factor real-time trust scoring on every action. Trust gates capability access via per-capability thresholds.
+Every privileged action runs through five checks before execution.
 
-MCP server attestation via multi-agent consensus. 3+ attesters across 2+ owners equals verified.
+| Step | Check | Latency budget |
+|---|---|---|
+| 1 | Capability | <10ms |
+| 2 | Attribute | <10ms |
+| 3 | Context | <10ms |
+| 4 | Chain | <10ms |
+| 5 | Intent (NanoMind) | up to 800ms on HIGH-risk operations |
 
-Privileged Access Management with three tiers (STANDARD, PRIVILEGED, SUPER_PRIVILEGED), human approval gates, break-glass override, certification campaigns.
+Step 5 uses the [NanoMind security classifier](https://huggingface.co/opena2a/nanomind-security-classifier), a 3M-parameter local Mamba model. No external calls.
 
-CyberArk integration: CCP for vaulted credential retrieval, PSM for privileged session recording.
+### Trust-gated capabilities
 
-SIEM adapters for Splunk HEC and Microsoft Sentinel Data Collector. Buffered batch delivery, retry, severity filtering.
+9-factor real-time trust scoring runs on every action. Per-capability thresholds gate access.
 
-Web dashboard: agent registry, trust score breakdowns, MCP network graph, audit timeline, capability requests, policy editor.
+### MCP attestation
+
+Multi-agent consensus. 3+ attesters across 2+ owners equals verified.
+
+### Privileged Access Management
+
+Three tiers: STANDARD, PRIVILEGED, SUPER_PRIVILEGED. Human approval gates, break-glass override, and certification campaigns.
+
+### CyberArk integration
+
+CCP for vaulted credential retrieval. PSM for privileged session recording.
+
+### SIEM adapters
+
+Splunk HEC and Microsoft Sentinel Data Collector. Buffered batch delivery, retry, severity filtering.
+
+### Web dashboard
+
+Agent registry, trust score breakdowns, MCP network graph, audit timeline, capability requests, policy editor.
 
 ## Trust scoring
 
@@ -159,7 +230,7 @@ The local and server trust scores measure different things.
 | Network controlled | 10% | Egress policy detected |
 | Heartbeat monitored | 10% | ARP runtime heartbeat present |
 
-**Server (9 factors)** answers "is the agent behaving in a way I should still trust right now?" Updates on every action. Source: [`apps/backend/internal/domain/trust_score.go`](apps/backend/internal/domain/trust_score.go).
+**Server (9 factors)** answers "is the agent behaving in a way that should still be trusted right now?" Updates on every action. Source: [`apps/backend/internal/domain/trust_score.go`](apps/backend/internal/domain/trust_score.go).
 
 | Factor | Weight | Source |
 |---|---|---|
@@ -185,7 +256,7 @@ docker compose up -d
 ./smoke-backend.sh
 ```
 
-Every `fga.authorize` decision lands as a parent span with 5 child spans (one per FGA step). 9 SemConv attributes ride the parent: `agent.id`, `agent.public_key.algorithm`, `agent.trust_score`, `agent.drift_score`, `agent.scan_verdict`, `agent.capability`, `fga.step`, `fga.outcome`, `fga.denied_by`. The attribute set is proposed to the OpenTelemetry Semantic Conventions WG. Proposal: `briefs/otel-exporters-aim-backend.md`.
+Every `fga.authorize` decision lands as a parent span with 5 child spans (one per FGA step). 9 SemConv attributes ride the parent: `agent.id`, `agent.public_key.algorithm`, `agent.trust_score`, `agent.drift_score`, `agent.scan_verdict`, `agent.capability`, `fga.step`, `fga.outcome`, `fga.denied_by`. The attribute set is proposed to the OpenTelemetry Semantic Conventions WG. Full design notes: [`apps/backend/docs/OBSERVABILITY.md`](apps/backend/docs/OBSERVABILITY.md).
 
 ## Demos
 
@@ -202,10 +273,10 @@ Four runnable demos in [`examples/`](examples/):
 
 | Guide | Time |
 |---|---|
-| [Register my agent](docs/use-cases/register-my-agent.md) | 2 min |
+| [Register an agent](docs/use-cases/register-my-agent.md) | 2 min |
 | [Audit agent actions](docs/use-cases/audit-agent-actions.md) | 5 min |
 | [Enforce capabilities](docs/use-cases/enforce-capabilities.md) | 5 min |
-| [Embed in my app](docs/use-cases/embed-in-my-app.md) | 10 min |
+| [Embed in an app](docs/use-cases/embed-in-my-app.md) | 10 min |
 | [Fleet governance](docs/use-cases/fleet-governance.md) | 30 min |
 | [SIEM forwarding](docs/use-cases/siem-forwarding.md) | 15 min |
 | [CyberArk vault integration](docs/use-cases/cyberark-integration.md) | 20 min |


### PR DESCRIPTION
Adopt the README structure Claude Desktop drafted in Deliverable 1 of the OpenA2A README Standardization Brief. This becomes the reference; the same structure applies to the other four OpenA2A repo READMEs in follow-up PRs.

## What's restored vs my over-tightened version (PR #123)

1. Dashboard screenshot block, inline (not buried under `<details>`). Files already exist at `docs/images/{dashboard-security,agents,agent-trust-score,supply-chain}.png`.
2. Python SDK section with `secure()`, `@perform_action`, risk-level auto-detection, and `jit_access` documented.
3. NanoMind classifier link corrected: now points at the 3M-parameter `nanomind-security-classifier` (the model FGA Step 5 actually invokes), not the ~1B-parameter `nanomind-security-analyst`.

## Three fact-checked corrections to Desktop's draft

I verified every technical claim against the codebase before merging. Three of Desktop's specifics were fabrications:

| # | Desktop wrote | Reality | Fix in this PR |
|---|---|---|---|
| 1 | Risk-level table as a single suffix-pattern grid (`*:read → low`, `payment:* → critical`) | Two lookup tables in `sdk/python/aim_sdk/risk_detector.py`: `NAMESPACE_RISK_MAP` (prefix) + `ACTION_RISK_MAP` (suffix), with `SPECIFIC_CAPABILITY_MAP` override | Rewrote the section to describe both tables honestly with representative entries, links to source as ground truth |
| 2 | OTel brief at `briefs/otel-exporters-aim-backend.md` | File does not exist | Replaced with `apps/backend/docs/OBSERVABILITY.md` (actual design notes) |
| 3 | `brew install opena2a/tap/opena2a-cli` | Tap is `opena2a-org/homebrew-tap`, formula file is `opena2a.rb` | Corrected to `brew install opena2a-org/tap/opena2a` |

## Sequencing note: VHS demo GIF deferred

Desktop's Deliverable 3 (the VHS `.tape` script for an AIM CLI demo GIF) hasn't arrived yet. This README does NOT reference `docs/images/aim-cli-demo.gif` in this commit. When the tape script lands, a follow-up PR will:

1. Commit `docs/images/aim-cli-demo.tape` (the VHS source script).
2. Render the GIF locally with `vhs docs/images/aim-cli-demo.tape`.
3. Commit `docs/images/aim-cli-demo.gif` (the binary).
4. Add the image reference back between the Quick start block and the Three deployment modes section.

## Style spec status

Desktop's Deliverable 2 (README Style Spec) is being treated as the de-facto spec embodied in this README. Desktop's separate Website Style Spec was filed at `~/workspace/opena2a-org/todo/2026-05-11-opena2a-website-style-spec.md` as out-of-scope for the current sprint.

## Constraints honored

- No em dashes (verified by grep). Per the 2026-05-11 user instruction.
- No marketing slogans. The three specific phrases the user called out (`Same wire format, your call`, `That's the local-first promise`, the `--with-aim flag bundles` sentence) are gone.
- No emojis.
- Stats match canonical numbers: 209 + 29 + 164 HMA breakdown, 8-factor local + 9-factor server trust scores separately tabulated.
- NanoMind models distinguished by purpose (classifier vs analyst).

## Test plan

- [x] Phase 1 sensitive files: PASS (docs-only diff)
- [x] Phase 2 syntax: N/A (Markdown)
- [x] Phase 3 AI review: every command, file path, SDK reference verified against the codebase. Risk-level table and OTel brief path corrected during this review.
- [x] Phase 7 docs accuracy: no stale references, all three flagged phrases gone, no em dashes, all 4 dashboard image files exist.

Length: 304 lines (393 → 233 → 304). The Python SDK section, restored dashboard screenshots, and the risk-detector explanation account for most of the growth back from 233.
