### PR TITLE
docs: link AIM Cloud /get-started from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Reads back credential injections, file accesses, config changes, and capability 
 |---|---|---|
 | **Local-only** | Solo developer, single machine | Ed25519 keypair, `audit.jsonl`, YAML capability policies, 8-factor trust score, cross-tool event bridges |
 | **Self-hosted** | Team or fleet | Above plus PostgreSQL audit, REST API, dashboard, OAuth, 5-step FGA, 9-factor real-time trust, MCP attestation, PAM, SIEM adapters |
-| **AIM Cloud** | Same as self-hosted with no infrastructure to operate | Managed at [aim.opena2a.org](https://aim.opena2a.org) |
+| **AIM Cloud** | Same as self-hosted with no infrastructure to operate | Managed at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started) |
 
 All three share the same audit-event schema. Local agents can push history to a server via `AIMCore.enableReporting()`.
 

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -2,6 +2,8 @@
 
 Agent Identity Management SDK for Java. Provides cryptographic identity verification, capability-based access control, and security logging for AI agents.
 
+Managed hosting available at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started). Self-host instructions below.
+
 ## Quick Start
 
 ```java

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -4,6 +4,8 @@
 
 Cryptographic verification with zero configuration.
 
+Managed hosting available at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started). Self-host instructions below.
+
 ---
 
 ## See It Work in 60 Seconds!

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -2,6 +2,8 @@
 
 Official TypeScript SDK for Agent Identity Management (AIM) - secure identity verification for AI agents.
 
+Managed hosting available at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started). Self-host instructions below.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

`aim.opena2a.org/get-started` is the only indexable page on the AIM Cloud subdomain (per `apps/web/app/robots.ts`, `Disallow: /` + `Allow: /get-started`). Linking it directly from this repo's READMEs gives Google an inbound reference from an established public repo and gives readers a one-click sign-up path.

Currently the AIM landing page is "Discovered — not indexed" in Google Search Console; established-repo backlinks are the standard signal that bumps a URL from "Discovered" to "Indexed."

## Changes

- `README.md`: "AIM Cloud" deployment-mode row now points to `/get-started` instead of the bare apex
- `sdk/python/README.md`, `sdk/typescript/README.md`, `sdk/java/README.md`: add a single line near the intro:
  > Managed hosting available at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started). Self-host instructions below.

Documentation-only; no code, dependency, or workflow changes.

## Test plan

- [x] Markdown renders correctly (one-line addition, valid link syntax)
- [x] No unrelated edits