### PR TITLE
security: tenant-scoping helper + AST lint + 5 confidently-closed defects (P0 foundation for #18-25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,24 @@ permissions:
   contents: read
 
 jobs:
+  # AST lint that catches HTTP handlers reading c.Params("id"|"agent_id")
+  # without invoking the tenant-scoping helper (LoadOwned or
+  # LoadOwnedViaAgent). The structural guarantee for the defect #18-25
+  # cluster — a future handler that forgets tenant scoping fails CI before
+  # merge. Pre-existing handlers without the helper are allowlisted (see
+  # cmd/tenantscope-lint/main.go) and tracked for systematic follow-up.
+  tenant-scoping-lint:
+    name: Tenant-scoping lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/backend/go.sum
+      - name: No handler reads :id without LoadOwned
+        run: ./scripts/lint-tenant-scoping.sh
+
   # Detect which parts of the monorepo changed
   changes:
     name: Detect Changes

--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1087,6 +1087,7 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 		MCPAttestation: handlers.NewMCPAttestationHandler(
 			services.MCPAttestation,
 			services.Audit,
+			repos.Agent,
 		),
 		Security: handlers.NewSecurityHandler(
 			services.Security,

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -1,0 +1,412 @@
+// tenantscope-lint walks the HTTP handler package and reports any handler
+// that reads c.Params("id") or c.Params("agent_id") without invoking one of
+// the registered tenant-scoping helpers (LoadOwned, LoadOwnedViaAgent).
+//
+// The lint is the structural guarantee for the defect #18-25 cluster: it
+// catches future handlers that forget to enforce tenant scoping AT LINT TIME,
+// so a regression cannot ship.
+//
+// Allowlist: handlers genuinely operate cross-tenant (system health checks,
+// public agent discovery, etc.) and must be added by name to the allowlist
+// below with a one-line justification.
+//
+// Run:
+//
+//	go run ./cmd/tenantscope-lint ./internal/interfaces/http/handlers
+//	go run ./cmd/tenantscope-lint  # defaults to the handlers package
+//
+// Exit code: 0 on pass, 1 on any violation.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// allowlist names handler functions that legitimately operate across
+// organizations and therefore do not need to invoke LoadOwned. Each entry
+// must include a one-line justification.
+var allowlist = map[string]string{
+	// Public agent discovery — intentionally cross-org for the public registry.
+	// Returns only redacted fields; full resource never crosses the boundary.
+	"PublicAgentHandler.GetPublicAgent":       "public registry endpoint; returns only redacted fields",
+	"PublicAgentHandler.ListPublicAgents":     "public registry endpoint; returns only redacted fields",
+	"PublicMCPHandler.GetPublicMCPServer":     "public MCP registry endpoint; returns only redacted fields",
+	"PublicMCPHandler.ListPublicMCPServers":   "public MCP registry endpoint; returns only redacted fields",
+	"PublicRegistrationHandler.GetRegistrationByID": "public registration status check before login",
+
+	// Lifecycle endpoints that operate on the calling agent's own ID by
+	// design — the SDK auth middleware has already verified the caller IS
+	// this agent, so additional org check would be redundant.
+	"LifecycleHandler.GetRevocationList": "system endpoint; iterates all agents for revocation list",
+
+	// Authentication endpoints — operate on credentials, not org-scoped resources.
+	"AuthRefreshHandler.Refresh":             "token refresh; not a resource read",
+	"AuthHandler.Login":                      "login flow; org assignment is the OUTPUT, not the gate",
+	"SDKTokenRecoveryHandler.RecoverToken":   "token recovery; not a resource read",
+	"OAuthTokenHandler.Token":                "OAuth token issuance; not a resource read",
+	"DeviceAuthHandler.RequestDevice":        "device auth flow; not a resource read",
+	"DeviceAuthHandler.PollDevice":           "device auth flow; not a resource read",
+
+	// Detection / community intelligence — read-only system endpoints that
+	// aggregate cross-org telemetry (no per-org resource being returned).
+	"DetectionHandler.GetThreatLevel":        "aggregated threat telemetry; no per-org resource",
+	"CommunityIntelligenceHandler.GetIntel":  "aggregated community intel; no per-org resource",
+
+	// Registry bridge — federation endpoint that operates on bridge identity.
+	"RegistryBridgeHandler.Verify":           "registry federation; bridge identity is the resource",
+
+	// ---------------------------------------------------------------
+	// AUDIT-BASELINE: 71 pre-existing handlers that read c.Params("id"|
+	// "agent_id") without any visible OrganizationID reference. These
+	// PREDATE the LoadOwned helper introduced in this PR. They are not
+	// known-safe — they require manual review. The lint allowlists them
+	// here so this PR can ship the structural fix for the 8 cited defects
+	// (#18-25) without blocking on a 71-handler manual audit. Each entry
+	// must be removed from this section as it is reviewed; the reviewer
+	// either confirms the handler is intentionally cross-tenant and moves
+	// it to the section above with a per-entry justification, or wires
+	// LoadOwned into the handler.
+	//
+	// Tracking: ~/workspace/opena2a-org/todo/2026-05-18-aim-defect-audit-
+	// from-lf-demo-prep.md (defect #18-25 follow-up section to be added).
+	// ---------------------------------------------------------------
+	"A2AHandler.DeleteSkill":                                 "audit-baseline: needs review",
+	"A2AHandler.GetA2ATrustScore":                            "audit-baseline: needs review",
+	"A2AHandler.GetAgentAttestations":                        "audit-baseline: needs review",
+	"A2AHandler.GetAgentCard":                                "audit-baseline: needs review",
+	"A2AHandler.GetAgentSkills":                              "audit-baseline: needs review",
+	"A2AHandler.GetConsensusStatus":                          "audit-baseline: needs review",
+	"A2AHandler.GetPeerTrustScore":                           "audit-baseline: needs review",
+	"A2AHandler.GetTrustScoreAlt":                            "audit-baseline: needs review",
+	"A2AHandler.RecordInteraction":                           "audit-baseline: needs review",
+	"A2AHandler.RevokeConsent":                               "audit-baseline: needs review",
+	"A2AHandler.SignRequest":                                 "audit-baseline: needs review",
+	"A2AHandler.UpdateAgentCard":                             "audit-baseline: needs review",
+	"A2AHandler.UpdateTaskState":                             "audit-baseline: needs review",
+	"A2AHandler.UpdateTrustScore":                            "audit-baseline: needs review",
+	"AdminHandler.AcknowledgeAlert":                          "audit-baseline: needs review",
+	"AdminHandler.ApproveRegistrationRequest":                "audit-baseline: needs review",
+	"AdminHandler.ApproveUser":                               "audit-baseline: needs review",
+	"AdminHandler.DeactivateUser":                            "audit-baseline: needs review",
+	"AdminHandler.RejectRegistrationRequest":                 "audit-baseline: needs review",
+	"AdminHandler.RejectUser":                                "audit-baseline: needs review",
+	"AdminHandler.ResolveAlert":                              "audit-baseline: needs review",
+	"AdminHandler.UpdateUserRole":                            "audit-baseline: needs review",
+	"AgentHandler.LogCapabilityResult":                       "audit-baseline: needs review",
+	"APIKeyHandler.DeleteAPIKey":                             "audit-baseline: needs review",
+	"APIKeyHandler.DisableAPIKey":                            "audit-baseline: needs review",
+	"AuthorizeHandler.Authorize":                             "audit-baseline: needs review",
+	"CapabilityHandler.GetAgentCapabilities":                 "audit-baseline: needs review",
+	"CapabilityHandler.GetViolationsByAgent":                 "audit-baseline: needs review",
+	"CapabilityRequestHandlers.CreateCapabilityRequest":      "audit-baseline: needs review",
+	"CapabilityRequestHandlers.ListAgentCapabilityRequests":  "audit-baseline: needs review",
+	"CapabilityRequestHandlers.RejectCapabilityRequest":      "audit-baseline: needs review",
+	"DetectionHandler.GetDetectionStatus":                    "audit-baseline: needs review",
+	"DetectionHandler.GetLatestCapabilityReport":             "audit-baseline: needs review",
+	"DetectionHandler.ReportCapabilities":                    "audit-baseline: needs review",
+	"DetectionHandler.ReportDetection":                       "audit-baseline: needs review",
+	"MCPAttestationHandler.AttestMCP":                        "audit-baseline: needs review",
+	"MCPAttestationHandler.GetAgentMCPServers":               "audit-baseline: needs review",
+	"MCPAttestationHandler.GetAttestationChallenge":          "audit-baseline: needs review",
+	"MCPAttestationHandler.GetConnectedAgents":               "audit-baseline: needs review",
+	"MCPAttestationHandler.GetConsensusStatus":               "audit-baseline: needs review",
+	"MCPAttestationHandler.GetMCPAttestations":               "audit-baseline: needs review",
+	"MCPAttestationHandler.ManualAttestMCP":                  "audit-baseline: needs review",
+	"MCPAttestationHandler.RevokeAllAttestationsByAgent":     "audit-baseline: needs review",
+	"MCPGraphHandler.GetMCPServerConnections":                "audit-baseline: needs review",
+	"MCPHandler.GetConnectedAgents":                          "audit-baseline: needs review",
+	"MCPHandler.VerifyMCPCapability":                         "audit-baseline: needs review",
+	"PublicMCPHandler.VerifyMCPAction":                       "audit-baseline: needs review",
+	"SDKTokenHandler.RevokeToken":                            "audit-baseline: needs review",
+	"SecretsHandler.DeleteNamespace":                         "audit-baseline: needs review",
+	"SecretsHandler.GetNamespace":                            "audit-baseline: needs review",
+	"SecretsHandler.RotateCredential":                        "audit-baseline: needs review",
+	"SecretsHandler.StoreCredential":                         "audit-baseline: needs review",
+	"SecurityPolicyHandler.DeletePolicy":                     "audit-baseline: needs review",
+	"SecurityPolicyHandler.GetPolicy":                        "audit-baseline: needs review",
+	"SecurityPolicyHandler.TogglePolicy":                     "audit-baseline: needs review",
+	"SecurityPolicyHandler.UpdatePolicy":                     "audit-baseline: needs review",
+	"TagHandler.AddTagsToAgent":                              "audit-baseline: needs review",
+	"TagHandler.AddTagsToMCPServer":                          "audit-baseline: needs review",
+	"TagHandler.GetAgentTags":                                "audit-baseline: needs review",
+	"TagHandler.GetMCPServerTags":                            "audit-baseline: needs review",
+	"TagHandler.RemoveTagFromAgent":                          "audit-baseline: needs review",
+	"TagHandler.RemoveTagFromMCPServer":                      "audit-baseline: needs review",
+	"TagHandler.SuggestTagsForAgent":                         "audit-baseline: needs review",
+	"TagHandler.SuggestTagsForMCPServer":                     "audit-baseline: needs review",
+	"TagHandler.UpdateTag":                                   "audit-baseline: needs review",
+	"VerificationEventHandler.DeleteVerificationEvent":       "audit-baseline: needs review",
+	"VerificationEventHandler.GetAgentVerificationEvents":    "audit-baseline: needs review",
+	"VerificationEventHandler.GetMCPVerificationEvents":      "audit-baseline: needs review",
+	"VerificationEventHandler.GetVerificationEvent":          "audit-baseline: needs review",
+	"VerificationHandler.GetVerification":                    "DEFECT #23 deferred: handler mounted on both public /api/v1/verifications/:id (no auth) and SDK-token /api/v1/sdk-api/verifications/:id (audit-cited); needs route split before tenant-scoping can apply.",
+	"VerificationHandler.SubmitVerificationResult":           "audit-baseline: needs review",
+	"VerificationHandler.UpdateExecutionStatus":              "audit-baseline: needs review",
+}
+
+// recognizedHelpers names the helper functions that satisfy the lint.
+// Any handler invoking one of these on a path that derives from
+// c.Params("id"|"agent_id"|"agent-id") is considered properly tenant-scoped.
+var recognizedHelpers = map[string]bool{
+	"LoadOwned":         true,
+	"LoadOwnedViaAgent": true,
+}
+
+// paramKeys names the URL-param keys whose reads we want to gate. Reading
+// any of these and not subsequently calling a recognized helper is a
+// violation unless the function is on the allowlist.
+var paramKeys = map[string]bool{
+	"id":       true,
+	"agent_id": true,
+	"agent-id": true,
+}
+
+type violation struct {
+	File    string
+	Line    int
+	Handler string
+}
+
+func main() {
+	dir := "./internal/interfaces/http/handlers"
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	}
+	dir = filepath.Clean(dir)
+
+	violations, err := scanDirectory(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tenantscope-lint: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(violations) == 0 {
+		fmt.Printf("tenantscope-lint: ok (%d allowlist entries; scanned %s)\n", len(allowlist), dir)
+		os.Exit(0)
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		return violations[i].Line < violations[j].Line
+	})
+
+	fmt.Fprintf(os.Stderr, "tenantscope-lint: %d handler(s) read c.Params(\"id\"|\"agent_id\") without invoking LoadOwned/LoadOwnedViaAgent:\n\n", len(violations))
+	for _, v := range violations {
+		fmt.Fprintf(os.Stderr, "  %s:%d  %s\n", v.File, v.Line, v.Handler)
+	}
+	fmt.Fprintln(os.Stderr, `
+To fix each violation:
+  1. Add RequireOrganizationID(c) at the top of the handler.
+  2. Wrap the resource load in LoadOwned or LoadOwnedViaAgent before
+     returning the resource or using it for any state mutation.
+  3. If the handler genuinely operates cross-tenant, add its qualified
+     name (HandlerStructName.MethodName) to the allowlist in
+     cmd/tenantscope-lint/main.go with a one-line justification.
+
+See apps/backend/internal/interfaces/http/handlers/tenant_scope.go for the
+helper documentation and the SECURITY rationale for 404-not-403.`)
+	os.Exit(1)
+}
+
+func scanDirectory(dir string) ([]violation, error) {
+	var violations []violation
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Test files run their own suites; production handlers are the
+		// target. The lint also intentionally skips its own implementation
+		// files (none live in this directory).
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		violations = append(violations, scanFile(fset, file, path)...)
+	}
+	return violations, nil
+}
+
+func scanFile(fset *token.FileSet, file *ast.File, path string) []violation {
+	var out []violation
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || fn.Recv == nil {
+			continue
+		}
+		handlerName := receiverTypeName(fn) + "." + fn.Name.Name
+		if _, allowed := allowlist[handlerName]; allowed {
+			continue
+		}
+
+		readsParam, paramLine := bodyReadsTenantParam(fset, fn.Body)
+		if !readsParam {
+			continue
+		}
+		if bodyInvokesHelper(fn.Body) {
+			continue
+		}
+		// Many existing handlers tenant-scope inline rather than through the
+		// helper (e.g. `if agent.OrganizationID != orgID { 403 }`). Those
+		// pre-date the helper and are not the lint's target — the lint
+		// catches handlers that have forgotten tenant scoping entirely. A
+		// handler that mentions `OrganizationID` anywhere in its body is
+		// treated as "thought about it." This is intentionally permissive;
+		// pair the lint with a code review for new handlers to push them
+		// toward the helper for consistency.
+		if bodyMentionsOrganizationID(fn.Body) {
+			continue
+		}
+		out = append(out, violation{
+			File:    path,
+			Line:    paramLine,
+			Handler: handlerName,
+		})
+	}
+	return out
+}
+
+// bodyMentionsOrganizationID returns true if the function body contains any
+// identifier or selector with the name "OrganizationID". This is the cheap
+// "did the handler consider organization scoping at all" check. False
+// positives are acceptable here — the goal is to catch handlers that have
+// completely forgotten, not to enforce the helper as the only valid pattern.
+func bodyMentionsOrganizationID(body *ast.BlockStmt) bool {
+	var found bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch x := n.(type) {
+		case *ast.Ident:
+			if x.Name == "OrganizationID" {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if x.Sel != nil && x.Sel.Name == "OrganizationID" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// receiverTypeName returns the concrete receiver type name for a method
+// declaration. Pointer receivers and value receivers both unwrap to the
+// underlying type identifier.
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	expr := fn.Recv.List[0].Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// bodyReadsTenantParam returns true and the line number of the first match
+// if the function body invokes c.Params(...) with a tenant-relevant key
+// (id, agent_id, agent-id).
+func bodyReadsTenantParam(fset *token.FileSet, body *ast.BlockStmt) (bool, int) {
+	var (
+		found bool
+		line  int
+	)
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "Params" {
+			return true
+		}
+		if len(call.Args) == 0 {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		// lit.Value is the quoted string including the surrounding quotes.
+		key := strings.Trim(lit.Value, `"`)
+		if _, want := paramKeys[key]; want {
+			found = true
+			line = fset.Position(call.Pos()).Line
+			return false
+		}
+		return true
+	})
+	return found, line
+}
+
+// bodyInvokesHelper returns true if any call inside the function body has
+// the selector or identifier equal to a recognized helper name. This
+// matches both `LoadOwned(...)` direct invocations and
+// `handlers.LoadOwned(...)` qualified ones (same package, but defensive).
+func bodyInvokesHelper(body *ast.BlockStmt) bool {
+	var found bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.Ident:
+			if recognizedHelpers[f.Name] {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if f.Sel != nil && recognizedHelpers[f.Sel.Name] {
+				found = true
+				return false
+			}
+		case *ast.IndexExpr:
+			// Generic call site like LoadOwned[T](...). Fun resolves to an
+			// IndexExpr; the function identifier lives in X.
+			if id, ok := f.X.(*ast.Ident); ok && recognizedHelpers[id.Name] {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/apps/backend/internal/application/tag_service.go
+++ b/apps/backend/internal/application/tag_service.go
@@ -75,6 +75,17 @@ func (s *TagService) CreateTag(ctx context.Context, input CreateTagInput) (*doma
 	return tag, nil
 }
 
+// GetTagByID retrieves a single tag by ID. The HTTP layer uses this to
+// verify tenant ownership (via LoadOwned) before invoking DeleteTag, which
+// itself has no orgID parameter.
+func (s *TagService) GetTagByID(ctx context.Context, tagID uuid.UUID) (*domain.Tag, error) {
+	tag, err := s.tagRepo.GetByID(ctx, tagID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tag: %w", err)
+	}
+	return tag, nil
+}
+
 // GetTagsByOrganization retrieves all tags for an organization
 func (s *TagService) GetTagsByOrganization(ctx context.Context, orgID uuid.UUID, category *domain.TagCategory) ([]*domain.Tag, error) {
 	tags, err := s.tagRepo.List(ctx, orgID, category)

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler.go
@@ -705,18 +705,22 @@ func (h *AdminHandler) GetAuditLogByID(c fiber.Ctx) error {
 		})
 	}
 
-	// Get audit log from service
-	auditLog, err := h.getAuditService().GetByID(c.Context(), auditLogID)
+	orgID, err := RequireOrganizationID(c)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to fetch audit log",
-		})
+		return err
 	}
 
+	// SECURITY (defect #21): tenant-scoping. An admin in org A used to be
+	// able to read any audit log by guessing its UUID. LoadOwned wraps the
+	// service GetByID, verifies auditLog.OrganizationID == orgID, and
+	// returns the same 404 for both "not found" and "exists in another
+	// org" to prevent a cross-tenant existence side channel.
+	loader := func(id uuid.UUID) (*domain.AuditLog, error) {
+		return h.getAuditService().GetByID(c.Context(), id)
+	}
+	auditLog := LoadOwned(c, loader, auditLogID, orgID, auditLogOrgID)
 	if auditLog == nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Audit log not found",
-		})
+		return nil
 	}
 
 	return c.JSON(auditLog)

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler_integration_test.go
@@ -1310,7 +1310,13 @@ func TestAdminHandler_GetAuditLogByID_ServiceError(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	// Behavior change (PR for defect #21): loader errors now collapse into
+	// 404 instead of 500 so the response shape cannot be used to
+	// distinguish "row exists in another org" from "DB error" — both look
+	// like "not found" to the caller. See handlers.LoadOwned for the
+	// SECURITY rationale. A future PR may introduce domain.ErrNotFound to
+	// re-establish the 404-vs-500 distinction for genuine DB failures.
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
 func TestAdminHandler_ExportAuditLogs_Success(t *testing.T) {

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -12,11 +12,20 @@ import (
 )
 
 // CapabilityHandler handles capability-related HTTP requests
+// agentByIDLookup is the single-method subset of any agent repository this
+// handler needs. Both domain.AgentRepository (the production type) and the
+// test-side MockAgentRepositoryerImpl satisfy it via Go structural typing,
+// which lets the handler accept either without having to define a shared
+// interface upstream that both sides agree on.
+type agentByIDLookup interface {
+	GetByID(id uuid.UUID) (*domain.Agent, error)
+}
+
 type CapabilityHandler struct {
 	// Concrete service pointers (used by existing code)
 	capabilityService        *application.CapabilityService
 	capabilityRequestService *application.CapabilityRequestService
-	agentRepo                domain.AgentRepository
+	agentRepo                agentByIDLookup
 	orgRepo                  domain.OrganizationRepository
 
 	// Interface fields for testability (used when set)
@@ -38,7 +47,11 @@ func NewCapabilityHandler(
 	}
 }
 
-// NewCapabilityHandlerWithInterfaces creates a CapabilityHandler using interfaces for testability
+// NewCapabilityHandlerWithInterfaces creates a CapabilityHandler using
+// interfaces for testability. Tests that exercise paths past the
+// tenant-scoping check (defect #25 fix) must overwrite handler.agentRepo
+// with a scenario-specific mock that returns an agent whose
+// OrganizationID matches the caller's org in the test's c.Locals.
 func NewCapabilityHandlerWithInterfaces(
 	capabilityService CapabilityServicer,
 ) *CapabilityHandler {
@@ -105,6 +118,13 @@ func (h *CapabilityHandler) GrantCapability(c fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Error: "Invalid organization ID type in context",
 		})
+	}
+
+	// SECURITY (defect #25): verify the agent referenced by URL parameter
+	// belongs to the caller's organization. Without this check, a valid SDK
+	// token for org A could grant capabilities to agent B in org C.
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	capSvc := h.getCapabilityService()

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
@@ -476,7 +476,15 @@ func TestCapabilityHandler_GrantCapability_Success(t *testing.T) {
 		},
 	}
 
+	// Tenant-scoping (defect #25 fix) requires the agent referenced by URL
+	// to belong to the caller's org. Mock returns an agent owned by orgID
+	// so LoadOwned succeeds and execution proceeds to the capability grant.
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: id, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
 	app.Post("/agents/:id/capabilities", func(c fiber.Ctx) error {
@@ -584,6 +592,12 @@ func TestCapabilityHandler_GrantCapability_ValidationError(t *testing.T) {
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	// Tenant-scoping (defect #25 fix) precondition.
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: id, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
 	app.Post("/agents/:id/capabilities", func(c fiber.Ctx) error {

--- a/apps/backend/internal/interfaces/http/handlers/capability_request_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_request_handler.go
@@ -205,16 +205,23 @@ func (h *CapabilityRequestHandlers) GetCapabilityRequest(c fiber.Ctx) error {
 		})
 	}
 
-	request, err := h.service.GetRequest(c.Context(), id)
+	orgID, err := RequireOrganizationID(c)
 	if err != nil {
-		if err.Error() == "capability request not found" {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-				"error": "capability request not found",
-			})
-		}
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "failed to get capability request",
-		})
+		return err
+	}
+
+	// SECURITY (defect #22): CapabilityRequest has no OrganizationID field;
+	// ownership is determined by the request's AgentID -> Agent.OrganizationID.
+	// Without this check, an admin in org A could read pending capability
+	// requests for agents in org B by guessing request UUIDs.
+	loader := func(reqID uuid.UUID) (*domain.CapabilityRequestWithDetails, error) {
+		return h.service.GetRequest(c.Context(), reqID)
+	}
+	request := LoadOwnedViaAgent(c, loader, id, orgID,
+		func(r *domain.CapabilityRequestWithDetails) uuid.UUID { return r.AgentID },
+		h.agentRepo)
+	if request == nil {
+		return nil
 	}
 
 	return c.Status(fiber.StatusOK).JSON(request)
@@ -248,6 +255,25 @@ func (h *CapabilityRequestHandlers) ApproveCapabilityRequest(c fiber.Ctx) error 
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "invalid capability request ID",
 		})
+	}
+
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
+	// SECURITY (defect #22, the worst finding in the audit): cross-tenant
+	// privilege escalation. Before this check, an admin in org A could
+	// approve a pending capability request for an agent in org B and thereby
+	// grant arbitrary capabilities to a stranger's agent. Verify ownership
+	// BEFORE invoking ApproveRequest so the grant cannot happen.
+	loader := func(reqID uuid.UUID) (*domain.CapabilityRequestWithDetails, error) {
+		return h.service.GetRequest(c.Context(), reqID)
+	}
+	if LoadOwnedViaAgent(c, loader, id, orgID,
+		func(r *domain.CapabilityRequestWithDetails) uuid.UUID { return r.AgentID },
+		h.agentRepo) == nil {
+		return nil
 	}
 
 	if err := h.service.ApproveRequest(c.Context(), id, userID); err != nil {

--- a/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
@@ -37,6 +37,19 @@ func (h *LifecycleHandler) Heartbeat(c fiber.Ctx) error {
 		})
 	}
 
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
+	// SECURITY (defect #20): verify the agent belongs to the caller's
+	// organization before mutating its heartbeat or trust score. Without this
+	// check, any SDK token holder can spoof liveness signals for agents in
+	// other organizations.
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
+	}
+
 	agent, err := h.agentService.RecordHeartbeat(c.Context(), agentID)
 	if err != nil {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -12,15 +12,18 @@ import (
 type MCPAttestationHandler struct {
 	attestationService *application.MCPAttestationService
 	auditService       *application.AuditService
+	agentRepo          domain.AgentRepository
 }
 
 func NewMCPAttestationHandler(
 	attestationService *application.MCPAttestationService,
 	auditService *application.AuditService,
+	agentRepo domain.AgentRepository,
 ) *MCPAttestationHandler {
 	return &MCPAttestationHandler{
 		attestationService: attestationService,
 		auditService:       auditService,
+		agentRepo:          agentRepo,
 	}
 }
 
@@ -672,6 +675,21 @@ func (h *MCPAttestationHandler) RecordMCPConnection(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (defect #19): verify the agent in the URL belongs to the
+	// caller's organization before recording the MCP connection. Without
+	// this check, an SDK token for org A can record fake MCP connections
+	// for any agent in any org by guessing UUIDs. Placed AFTER the body
+	// validation so that malformed-input tests retain their 400-shape
+	// contract; the security boundary is the service call below, not the
+	// JSON parse.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
+	}
+
 	// Record the connection
 	connection, err := h.attestationService.RecordAgentMCPConnection(
 		c.Context(),
@@ -738,6 +756,18 @@ func (h *MCPAttestationHandler) RecordMCPUsageReport(c fiber.Ctx) error {
 			"error":   "Invalid agent ID",
 			"message": err.Error(),
 		})
+	}
+
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
+	// SECURITY (defect #19b): same tenant-scoping pattern as
+	// RecordMCPConnection. Verify the URL agent belongs to caller's org
+	// before processing the usage report body.
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	// Parse request body

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
@@ -25,7 +25,7 @@ func withMCPAttestationContext(handler func(c fiber.Ctx) error) fiber.Handler {
 // ===========================
 
 func TestNewMCPAttestationHandler_NilDeps(t *testing.T) {
-	handler := NewMCPAttestationHandler(nil, nil)
+	handler := NewMCPAttestationHandler(nil, nil, nil)
 	assert.NotNil(t, handler)
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
@@ -231,10 +231,20 @@ func (h *MCPHandler) CreateMCPServer(c fiber.Ctx) error {
 	}
 
 	// ✅ If SDK passes RegisteredByAgent in request body, use it for connection tracking
-	// This allows OAuth-authenticated requests to still create agent-MCP connections
+	// This allows OAuth-authenticated requests to still create agent-MCP connections.
+	//
+	// SECURITY (defect #18): the body-supplied agent ID is attacker-controlled.
+	// Before this check, an SDK token for org A could register an MCP linked to
+	// an agent in org B by passing B's agent UUID in RegisteredByAgent. Verify
+	// the referenced agent belongs to the caller's org; if not (or the agent
+	// does not exist), silently drop the link (treat it as if the field was
+	// not supplied) rather than 404 the whole request — the MCP registration
+	// itself is otherwise valid.
 	if req.RegisteredByAgent != "" && agentID == nil {
 		if parsedAgentID, err := uuid.Parse(req.RegisteredByAgent); err == nil {
-			agentID = &parsedAgentID
+			if agent, err := h.agentRepository.GetByID(parsedAgentID); err == nil && agent != nil && agent.OrganizationID == orgID {
+				agentID = &parsedAgentID
+			}
 		}
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/tag_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/tag_handler.go
@@ -226,6 +226,22 @@ func (h *TagHandler) DeleteTag(c fiber.Ctx) error {
 		})
 	}
 
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
+	// SECURITY (defect #24): tenant-scoping. TagService.DeleteTag(ctx, tagID)
+	// has no orgID parameter, so prior code allowed any authenticated caller
+	// to delete tags owned by any organization. Load the tag first and
+	// verify ownership before invoking the unscoped delete.
+	loader := func(id uuid.UUID) (*domain.Tag, error) {
+		return h.tagService.GetTagByID(c.Context(), id)
+	}
+	if LoadOwned(c, loader, tagID, orgID, tagOrgID) == nil {
+		return nil
+	}
+
 	// Delete tag
 	if err := h.tagService.DeleteTag(c.Context(), tagID); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{

--- a/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
+++ b/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// agentOrgID extracts OrganizationID from a *domain.Agent for use with
+// LoadOwned. Defined once at package scope to keep handler call sites concise
+// and to give the AST lint a stable symbol name to recognize.
+func agentOrgID(a *domain.Agent) uuid.UUID { return a.OrganizationID }
+
+// tagOrgID extracts OrganizationID from a *domain.Tag.
+func tagOrgID(t *domain.Tag) uuid.UUID { return t.OrganizationID }
+
+// auditLogOrgID extracts OrganizationID from a *domain.AuditLog.
+func auditLogOrgID(a *domain.AuditLog) uuid.UUID { return a.OrganizationID }
+
+// verificationEventOrgID extracts OrganizationID from a
+// *domain.VerificationEvent.
+func verificationEventOrgID(v *domain.VerificationEvent) uuid.UUID { return v.OrganizationID }
+
+// mcpServerOrgID extracts OrganizationID from a *domain.MCPServer.
+func mcpServerOrgID(m *domain.MCPServer) uuid.UUID { return m.OrganizationID }
+
+// LoadOwned loads a resource by ID via the provided loader and verifies the
+// caller's organization owns it. On any failure path (loader error,
+// cross-tenant mismatch, nil resource) the helper writes HTTP 404 to the
+// response and returns nil; on success it returns the resource.
+//
+// Calling pattern:
+//
+//	resource := LoadOwned(c, loader, resourceID, callerOrgID, orgIDOf)
+//	if resource == nil {
+//	    return nil // helper already wrote the 404 response
+//	}
+//	// use resource
+//
+// SECURITY: 404 — not 403 — is intentional for cross-tenant access. Returning
+// 403 would leak the existence of the resource in another organization, a
+// cross-tenant side channel that lets an attacker enumerate valid resource
+// IDs across the system. By returning 404 for both "row does not exist" and
+// "row exists in another org" the response is indistinguishable from the
+// caller's perspective.
+//
+// The helper returns nil rather than an error sentinel because Fiber's
+// default error handler overrides response status when a handler returns a
+// non-nil error. Writing 404 and then returning a sentinel would let Fiber
+// rewrite the response to 500, defeating the security guarantee. The caller
+// must `return nil` after seeing a nil resource so Fiber considers the
+// response complete.
+//
+// The orgIDOf accessor is provided by the caller because Go generics cannot
+// reach into struct fields by name. Every AIM domain type that participates
+// in tenant scoping has an OrganizationID uuid.UUID field; the accessor is
+// usually a one-line lambda like `func(a *domain.Agent) uuid.UUID { return a.OrganizationID }`.
+//
+// Loader-error distinction (not-found vs database failure) is intentionally
+// collapsed here. The repository layer in this codebase returns a plain
+// error("...not found") string for missing rows rather than a sentinel, so a
+// type-based check would be fragile. A future PR can introduce
+// domain.ErrNotFound and distinguish 404 from 500 here.
+func LoadOwned[T any](
+	c fiber.Ctx,
+	loader func(uuid.UUID) (*T, error),
+	resourceID uuid.UUID,
+	callerOrgID uuid.UUID,
+	orgIDOf func(*T) uuid.UUID,
+) *T {
+	resource, err := loader(resourceID)
+	if err != nil || resource == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	if orgIDOf(resource) != callerOrgID {
+		respondResourceNotFound(c)
+		return nil
+	}
+	return resource
+}
+
+// LoadOwnedViaAgent is the FK-lookup variant of LoadOwned for resources whose
+// tenant ownership is determined by their associated agent rather than their
+// own OrganizationID field. Used for capability requests, verification
+// events that reference an agent, and other agent-scoped child resources.
+//
+// The flow: load the resource → load the referenced agent via agentRepo →
+// verify agent.OrganizationID == callerOrgID. Any failure along the way
+// produces the same 404 as LoadOwned, preserving the no-side-channel
+// guarantee.
+func LoadOwnedViaAgent[T any](
+	c fiber.Ctx,
+	loader func(uuid.UUID) (*T, error),
+	resourceID uuid.UUID,
+	callerOrgID uuid.UUID,
+	agentIDOf func(*T) uuid.UUID,
+	agentRepo domain.AgentRepository,
+) *T {
+	resource, err := loader(resourceID)
+	if err != nil || resource == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	agentID := agentIDOf(resource)
+	if agentID == uuid.Nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	agent, err := agentRepo.GetByID(agentID)
+	if err != nil || agent == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	if agent.OrganizationID != callerOrgID {
+		respondResourceNotFound(c)
+		return nil
+	}
+	return resource
+}
+
+func respondResourceNotFound(c fiber.Ctx) {
+	_ = c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+		"error": "not found",
+	})
+}

--- a/apps/backend/internal/interfaces/http/handlers/tenant_scope_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/tenant_scope_test.go
@@ -1,0 +1,232 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+type fakeResource struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+}
+
+func resourceOrgID(r *fakeResource) uuid.UUID { return r.OrganizationID }
+
+// TestLoadOwned_HappyPath: resource exists and is owned by the caller's org →
+// helper returns the resource, no HTTP response written, no error.
+func TestLoadOwned_HappyPath(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	resourceID := uuid.New()
+	resource := &fakeResource{ID: resourceID, OrganizationID: callerOrg}
+
+	loader := func(id uuid.UUID) (*fakeResource, error) {
+		if id != resourceID {
+			t.Fatalf("loader called with unexpected id %s", id)
+		}
+		return resource, nil
+	}
+
+	var got *fakeResource
+	app.Get("/x", func(c fiber.Ctx) error {
+		got = LoadOwned(c, loader, resourceID, callerOrg, resourceOrgID)
+		if got != nil {
+			return c.Status(fiber.StatusOK).JSON(fiber.Map{"ok": true})
+		}
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/x", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if got != resource {
+		t.Fatalf("LoadOwned returned %v, want %v", got, resource)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("happy path got status %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestLoadOwned_CrossTenantReturns404: resource exists but belongs to a
+// different org → helper writes 404 and returns nil. This is the structural
+// fix for defects #18-25.
+func TestLoadOwned_CrossTenantReturns404(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	otherOrg := uuid.New()
+	resourceID := uuid.New()
+	resource := &fakeResource{ID: resourceID, OrganizationID: otherOrg}
+
+	loader := func(id uuid.UUID) (*fakeResource, error) {
+		return resource, nil
+	}
+
+	var got *fakeResource
+	app.Get("/x", func(c fiber.Ctx) error {
+		got = LoadOwned(c, loader, resourceID, callerOrg, resourceOrgID)
+		if got == nil {
+			return nil
+		}
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"ok": true})
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/x", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("cross-tenant returned non-nil resource %v; want nil to prevent caller from using it", got)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("cross-tenant got status %d, want 404 (NOT 403 — see SECURITY note in LoadOwned)", resp.StatusCode)
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var parsed map[string]any
+	_ = json.Unmarshal(bodyBytes, &parsed)
+	if parsed["error"] != "not found" {
+		t.Fatalf("cross-tenant body = %v, want {error: not found} (no leak of org/resource shape)", parsed)
+	}
+}
+
+// TestLoadOwned_NotFoundReturns404: loader returns (nil, ErrXxx) → 404.
+// Same external observation as cross-tenant — no side channel.
+func TestLoadOwned_NotFoundReturns404(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	resourceID := uuid.New()
+
+	loader := func(id uuid.UUID) (*fakeResource, error) {
+		return nil, errors.New("agent not found")
+	}
+
+	var got *fakeResource
+	app.Get("/x", func(c fiber.Ctx) error {
+		got = LoadOwned(c, loader, resourceID, callerOrg, resourceOrgID)
+		if got == nil {
+			return nil
+		}
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"ok": true})
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/x", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loader error returned non-nil resource; want nil")
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("loader error got status %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestLoadOwned_NilResourceReturns404: loader returns (nil, nil) — buggy
+// loader, but the helper must not panic and must not let the caller
+// dereference a nil pointer.
+func TestLoadOwned_NilResourceReturns404(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	resourceID := uuid.New()
+
+	loader := func(id uuid.UUID) (*fakeResource, error) {
+		return nil, nil
+	}
+
+	var got *fakeResource
+	app.Get("/x", func(c fiber.Ctx) error {
+		got = LoadOwned(c, loader, resourceID, callerOrg, resourceOrgID)
+		if got == nil {
+			return nil
+		}
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"ok": true})
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/x", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("nil resource path returned non-nil; want nil")
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("nil resource got status %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestLoadOwned_DoesNotLeakOrgIDOnCrossTenant: response body must be
+// indistinguishable between not-found and cross-tenant. Defensive check that
+// extends TestLoadOwned_CrossTenantReturns404.
+func TestLoadOwned_DoesNotLeakOrgIDOnCrossTenant(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	otherOrg := uuid.New()
+	resourceID := uuid.New()
+	resource := &fakeResource{ID: resourceID, OrganizationID: otherOrg}
+
+	loader := func(id uuid.UUID) (*fakeResource, error) {
+		return resource, nil
+	}
+
+	app.Get("/cross", func(c fiber.Ctx) error {
+		_ = LoadOwned(c, loader, resourceID, callerOrg, resourceOrgID)
+		return nil
+	})
+	app.Get("/missing", func(c fiber.Ctx) error {
+		_ = LoadOwned(c, func(uuid.UUID) (*fakeResource, error) { return nil, errors.New("nope") }, resourceID, callerOrg, resourceOrgID)
+		return nil
+	})
+
+	cross, _ := app.Test(httptest.NewRequest("GET", "/cross", nil))
+	missing, _ := app.Test(httptest.NewRequest("GET", "/missing", nil))
+
+	if cross.StatusCode != missing.StatusCode {
+		t.Fatalf("status code leaks cross-tenant signal: cross=%d, missing=%d", cross.StatusCode, missing.StatusCode)
+	}
+	crossBody, _ := io.ReadAll(cross.Body)
+	missingBody, _ := io.ReadAll(missing.Body)
+	if string(crossBody) != string(missingBody) {
+		t.Fatalf("response body leaks cross-tenant signal:\n  cross=%q\n  missing=%q", crossBody, missingBody)
+	}
+}
+
+// TestLoadOwned_HandlerReturningNilPreserves404: this is the regression test
+// for the bug I caught during pre-push gate — when the handler returns the
+// helper's err sentinel (the OLD contract), Fiber's default error handler
+// overwrites the 404 with 500. The new contract (helper returns *T only;
+// caller returns nil after seeing nil resource) is verified here end-to-end.
+func TestLoadOwned_HandlerReturningNilPreserves404(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	callerOrg := uuid.New()
+	otherOrg := uuid.New()
+	resourceID := uuid.New()
+	resource := &fakeResource{ID: resourceID, OrganizationID: otherOrg}
+
+	app.Get("/probe", func(c fiber.Ctx) error {
+		got := LoadOwned(c,
+			func(uuid.UUID) (*fakeResource, error) { return resource, nil },
+			resourceID, callerOrg, resourceOrgID,
+		)
+		if got == nil {
+			return nil // <-- the contract; do NOT return an error
+		}
+		return c.JSON(got)
+	})
+
+	resp, _ := app.Test(httptest.NewRequest("GET", "/probe", nil))
+	if resp.StatusCode != 404 {
+		t.Fatalf("regression: got %d, want 404. Fiber's default error handler may be overwriting the helper's 404", resp.StatusCode)
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler.go
@@ -899,6 +899,14 @@ func (h *VerificationHandler) GetVerification(c fiber.Ctx) error {
 		})
 	}
 
+	// NOTE (defect #23, deferred from this PR): tenant-scoping not applied
+	// here because GetVerification is mounted on BOTH a public route
+	// (/api/v1/verifications/:id, no auth middleware) and an SDK-token route
+	// (/api/v1/sdk-api/verifications/:id, audit-cited). Closing the SDK-route
+	// surface needs a route split (separate handler method) so the public
+	// route is not broken. Tracked as follow-up; for now this handler
+	// remains on the audit-baseline allowlist in cmd/tenantscope-lint.
+
 	// Query verification event from database
 	event, err := h.getVerificationEventService().GetVerificationEvent(c.Context(), vid)
 	if err != nil {

--- a/scripts/lint-tenant-scoping.sh
+++ b/scripts/lint-tenant-scoping.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# lint-tenant-scoping.sh — invokes the tenantscope-lint Go binary against the
+# HTTP handlers package. Wraps the binary so the CI workflow has a stable
+# entry point and so developers can run it locally without remembering the
+# `go run` path.
+#
+# Usage:
+#   ./scripts/lint-tenant-scoping.sh
+#
+# Exit code: 0 on pass, 1 on any new violation, 2 on tool error.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root/apps/backend"
+
+go run ./cmd/tenantscope-lint ./internal/interfaces/http/handlers


### PR DESCRIPTION
## Summary

**Foundation PR** for the audit's defect #18-25 tenant-scoping cluster. Ships the architectural fix (helper + AST lint) and confidently closes **5 of 8** cited defects. Three are partially closed or deferred with explicit rationale below — the adversarial pre-push review flagged residual surfaces that warrant their own focused follow-up PRs.

Audit reference: `~/workspace/opena2a-org/todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md`.

## What's in this PR

### Architecture

| Piece | File | Purpose |
|---|---|---|
| `LoadOwned[T]` generic helper | `handlers/tenant_scope.go` | Loads resource → verifies `OrganizationID == callerOrgID` → 404 on any failure path. Returns `*T` or nil. |
| `LoadOwnedViaAgent[T]` variant | `handlers/tenant_scope.go` | FK-lookup variant for resources whose ownership is via Agent (CapabilityRequest has no OrganizationID; uses AgentID -> Agent.OrganizationID). |
| `tenantscope-lint` AST binary | `cmd/tenantscope-lint/main.go` | CI lint: rejects handlers reading `c.Params("id"\|"agent_id"\|"agent-id")` without `LoadOwned` or any `OrganizationID` reference. Allowlist for pre-existing handlers (15 known-cross-tenant + 71 audit-baseline + 1 explicit-deferral for #23). |
| CI job | `.github/workflows/ci.yml` | `tenant-scoping-lint` runs unconditionally on every PR. |

### [CHIEF-CA] decision

**404 (not 403) on cross-tenant mismatch.** 403 leaks resource existence in another org; 404 is indistinguishable from "doesn't exist." The 404 contract is documented in `handlers/tenant_scope.go` with the security rationale.

**Helper returns `*T` only (not error).** Initial sentinel-error contract caused Fiber's default error handler to overwrite the helper's 404 with 500 — caught mid-implementation, refactored, regression-tested.

## Defect coverage

### Confidently closed (5)

- **#20** `lifecycle_handler.Heartbeat` — LoadOwned(agent) before any state mutation
- **#21** `admin_handler.GetAuditLogByID` — LoadOwned(auditLog)
- **#22** `capability_request_handler.GetCapabilityRequest` + `ApproveCapabilityRequest` — LoadOwnedViaAgent. This was *"the worst finding in the audit"*: cross-tenant privilege escalation through what was supposed to be the security gate in strict mode.
- **#24** `tag_handler.DeleteTag` — LoadOwned(tag); `TagService.GetTagByID` added because `DeleteTag(ctx, tagID)` had no orgID parameter.
- **#25** `capability_handler.GrantCapability` — LoadOwned(agent). Sibling `RegisterCapability` already did this check; the bug was that `GrantCapability` didn't.

### Partially closed (3) — residual oracles/gaps from adversarial review

- **#18** `mcp_handler.CreateMCPServer` — Body-supplied `RegisteredByAgent` is now org-checked, so the **write** path is closed (cross-org link no longer created). The **read** signal remains: the response body still echoes the field, leaking a UUID-by-UUID oracle for in-org vs cross-org agents. **Follow-up:** redact agentID from response when linkage was dropped.
- **#19** `mcp_attestation_handler.RecordMCPConnection` — URL `agent_id` is tenant-scoped via LoadOwned. Body-supplied `mcpServerID` is **NOT** verified. An attacker with a legitimate agent in their own org can still record attestations referencing any MCP server UUID in any org. **Follow-up:** extend the check to load + verify the body-supplied MCP server.
- **#19b** `mcp_attestation_handler.RecordMCPUsageReport` — Same shape as #19.

### Deferred (1)

- **#23** `verification_handler.GetVerification` — Same handler method is mounted on both `/api/v1/verifications/:id` (public, no auth middleware) and `/api/v1/sdk-api/verifications/:id` (SDK-token route the audit cites). Tenant-scoping the shared method breaks the public route. **Follow-up:** route split into two handler methods (one public-redacted, one SDK-scoped). Tracked in the lint allowlist with per-entry rationale.

## Adversarial pre-push review caveats

The 8-phase pre-push gate ran. Adversarial self-review surfaced findings that are **intentionally not addressed in this PR** but documented honestly so the next sprint can pick them up with the lint already in place catching new regressions:

- **403/404 hybrid:** 10+ sibling handlers in `agent_handler.go` / `mcp_handler.go` still return 403, undermining this PR's 404 enumeration-prevention guarantee. Closing requires patching those handlers in a follow-up PR.
- **Lint param-key blind spots:** Lint only watches `id` / `agent_id` / `agent-id`. ~10 other live keys (`orgId`, `agentId`, `tagId`, `mcp_id`, `audit_id`, `attestation_id`, etc.) are not watched. Quick follow-up to broaden the regex.
- **Lint `bodyMentionsOrganizationID` heuristic:** A handler that logs `agent.OrganizationID` without comparing it passes the lint. Mitigation requires data-flow analysis; this PR accepts the vibe-check as defense-in-depth and pairs it with code review for new handlers.
- **Audit-baseline allowlist contains 71 entries**, several of which are mutating cross-tenant surfaces that should arguably have been fixed inline rather than allowlisted: `RejectCapabilityRequest` (symmetric to Approve, same priv-esc class), `SecretsHandler.{StoreCredential,RotateCredential,DeleteNamespace,GetNamespace}`, `SecurityPolicyHandler.{Delete,Update,Toggle}Policy`, `APIKeyHandler.{Delete,Disable}APIKey`, `AdminHandler.{Approve,Reject,Deactivate}User`, `MCPAttestationHandler.RevokeAllAttestationsByAgent`, `VerificationEventHandler.DeleteVerificationEvent`. These need their own sprint.
- **CRITICAL caught and reverted:** an unrelated alert-suppression hunk in `verification_handler.go:322` (not authored by this PR but present in the working tree when the file was staged) was reverted in the amended commit. Final diff for `verification_handler.go` shows only the #23 deferral comment.

## Test plan

- [x] `go build ./...` — green
- [x] `go vet ./internal/interfaces/http/handlers/... ./cmd/...` — green
- [x] `go test -race ./internal/interfaces/http/handlers/...` — green (full handlers suite + 6 LoadOwned unit tests including the Fiber-overwrite regression)
- [x] `./scripts/lint-tenant-scoping.sh` — green; sanity-tested by reverting one fix and confirming the lint catches the regression
- [x] HackMyAgent `secure --ci` on PR surface — 100/100 HARDENED, 0 findings
- [x] Adversarial self-review by independent subagent — CRITICAL surfaced and reverted; HIGH findings documented above
- [x] Pre-push 8-phase quality gate run, results in `.pre-push-review-passed`

## Known limitations honest summary

This PR is the **foundation**, not the whole fix. It ships:
- One architectural helper with a documented contract and regression-tested calling convention
- A CI lint that catches future regressions for `c.Params("id"|"agent_id"|"agent-id")` shapes
- 5 confident defect closures
- 3 partial closures with named residuals and follow-up directions
- 1 explicit deferral with named blocker
- 71 audit-baseline allowlist entries that map a much larger latent surface than the 8-defect cluster — direct evidence that the audit's hypothesis ("many handlers forgot") is confirmed at scale

The next PR's job is the 403/404 hybrid + the partial-closure follow-ups + at least the mutating audit-baseline entries.

## References

- Audit doc: `~/workspace/opena2a-org/todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md` (#20/#21/#22/#24/#25 marked ✓ FIXED; #18/#19/#19b marked ⚠ PARTIAL; #23 marked ⚠ DEFERRED)
- Sprint prompt: `~/workspace/opena2a-org/todo/2026-05-18-aim-hardening-sprint-fresh-session-prompt.md`
- Session file: `~/workspace/opena2a-org/.claude-sessions/session-aim-hardening-p0-tenant-scoping.md`
- Sibling PR in flight: #127 (hardening/p0-bootstrap-secrets, defects #16/#17/#33/#34/#35/#36)