### PR TITLE
docs(observability): clarify scan_verdict provenance (producer-emitted, HMA integration on roadmap)

### DIFF
--- a/apps/backend/docs/OBSERVABILITY.md
+++ b/apps/backend/docs/OBSERVABILITY.md
@@ -70,7 +70,7 @@ These names match Slide 14 of the May 22 Observability Summit talk and the AIM S
 | `agent.capability` | string | span attribute, log attribute | The capability being authorized (e.g. `read:bookings`) |
 | `agent.trust_score` | double | resource attribute | 9-factor weighted trust score |
 | `agent.drift_score` | double | metric, resource attribute | 0-1 saturated drift signal |
-| `agent.scan_verdict` | string | resource attribute | `clean`, `warn`, `dirty` |
+| `agent.scan_verdict` | string | resource attribute | Producer-emitted security scan verdict. Read from `agent_security_contexts.scan_verdict`. Producer is expected to write this from a real scanner; the HackMyAgent integration that performs that write is on the roadmap. Enum values: `clean`, `warnings`, `findings`, `critical`, `unknown`. |
 | `fga.step` | string | span attribute on child spans | One of: `capability_check`, `attribute_check`, `context_check`, `chain_check`, `intent_check_sync`, `intent_check_async` |
 | `fga.outcome` | string | span attribute, log attribute, metric label | `ALLOW`, `DENY`, `DENY_INTENT`, `DENY_CONTEXT`, `DENY_CHAIN`, `DENY_ATTRIBUTE`, `ERROR` (transient infra failures: `loadPolicy` / `HasCapability` returned an error) |
 | `fga.denied_by` | string | span attribute, log attribute, metric label | Step that denied (set when `fga.outcome != ALLOW`) |


### PR DESCRIPTION
## Summary

Single-row clarification of the `agent.scan_verdict` documentation in `apps/backend/docs/OBSERVABILITY.md`. Replaces a 3-value enum stub (`clean`, `warn`, `dirty`) that did not match either the proposal YAML or the Go enforcement at `fga_engine.go:701`. New row carries:

- The 5-value YAML-consistent enum (`clean`, `warnings`, `findings`, `critical`, `unknown`).
- A provenance note: the value is read from `agent_security_contexts.scan_verdict`, the producer is expected to write that from a real scanner, the HackMyAgent integration that performs the write is on the roadmap.

This matches the producer-emitted framing already documented in the sibling proposal repo at https://github.com/opena2a-org/otel-semconv-agent-identity (commit `75b2e1a`). The two files are mirrors of each other; landing this PR keeps them in sync.

Why this matters before Friday: the Observability Summit talk references `scan_verdict` as a producer-emitted decision input. The previous wording's bare enum left readers free to infer a normative-computed semantics. Audit at `~/audit-scan-verdict-2026-05-20.md` documents the gap; this PR is the docs-side closure.

## Test plan

- [x] `grep -P '[—–]' apps/backend/docs/OBSERVABILITY.md` returns no matches (em-dash discipline preserved from PR #140).
- [x] `go build ./...` and `go vet ./...` clean against `apps/backend/`.
- [x] Single-row diff: no other content touched.
- [x] New wording matches the verbatim mirror at `docs/REFERENCE-IMPLEMENTATION.md` in the proposal repo.
- [x] `/pre-push-review` ran (Phases 1, 2, 3, 7; 4 / 4.5 / 5 / 6 skipped per docs-only skip conditions).