### PR TITLE
security: close defects #18/#19/#19b — body-supplied UUID tenant scoping

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1094,6 +1094,7 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 			services.MCPAttestation,
 			services.Audit,
 			repos.Agent,
+			repos.MCPServer,
 		),
 		Security: handlers.NewSecurityHandler(
 			services.Security,

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -203,6 +203,13 @@ type AgentRepositoryer interface {
 	GetByMCPServerName(mcpServerName string, orgID uuid.UUID) ([]*domain.Agent, error)
 }
 
+// MCPServerRepositoryer defines the methods from MCPServerRepository that
+// handlers use. Narrow on purpose: handlers only need to load by ID for
+// tenant-scope LoadOwned checks (defects #19/#19b).
+type MCPServerRepositoryer interface {
+	GetByID(id uuid.UUID) (*domain.MCPServer, error)
+}
+
 // VerificationEventRepositoryer defines the methods from VerificationEventRepository that handlers use
 type VerificationEventRepositoryer interface {
 	GetByMCPServer(mcpServerID uuid.UUID, limit, offset int) ([]*domain.VerificationEvent, int, error)

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -12,18 +12,21 @@ import (
 type MCPAttestationHandler struct {
 	attestationService *application.MCPAttestationService
 	auditService       *application.AuditService
-	agentRepo          domain.AgentRepository
+	agentRepo          AgentRepositoryer
+	mcpServerRepo      MCPServerRepositoryer
 }
 
 func NewMCPAttestationHandler(
 	attestationService *application.MCPAttestationService,
 	auditService *application.AuditService,
-	agentRepo domain.AgentRepository,
+	agentRepo AgentRepositoryer,
+	mcpServerRepo MCPServerRepositoryer,
 ) *MCPAttestationHandler {
 	return &MCPAttestationHandler{
 		attestationService: attestationService,
 		auditService:       auditService,
 		agentRepo:          agentRepo,
+		mcpServerRepo:      mcpServerRepo,
 	}
 }
 
@@ -690,6 +693,15 @@ func (h *MCPAttestationHandler) RecordMCPConnection(c fiber.Ctx) error {
 		return nil
 	}
 
+	// SECURITY (defect #19 follow-up): the body-supplied mcpServerID is
+	// also attacker-controlled. A legitimate own-org agent could otherwise
+	// record fake connections referencing any MCP server UUID in any org.
+	// LoadOwned returns 404 (indistinguishable from nonexistent) on cross-
+	// org or unknown UUIDs, preserving existence secrecy.
+	if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
+		return nil
+	}
+
 	// Record the connection
 	connection, err := h.attestationService.RecordAgentMCPConnection(
 		c.Context(),
@@ -799,7 +811,39 @@ func (h *MCPAttestationHandler) RecordMCPUsageReport(c fiber.Ctx) error {
 		})
 	}
 
-	// Calculate totals for response
+	// SECURITY (defect #19b): pre-validate every body-supplied mcpServerID
+	// against the caller's organization BEFORE any writes. Without this,
+	// an SDK token for a legitimate own-org agent can record fake usage
+	// reports referencing any mcpServerID in any org (the audit's "single
+	// SDK token can create fake usage reports for any agent/MCP across
+	// the entire system"). LoadOwned returns 404 on cross-org or unknown
+	// UUIDs, identical to nonexistent — no existence side channel.
+	//
+	// Malformed UUIDs preserve the existing silent-skip behavior at the
+	// :827 path. Closing the malformed-vs-cross-org reporting oracle is
+	// audit-baseline work tracked separately in A3d; this PR closes the
+	// write-side hole only.
+	//
+	// Pre-pass instead of in-loop check so a cross-org probe in the
+	// middle of an otherwise legitimate batch does NOT cause partial
+	// writes — the entire request aborts before any service call.
+	validatedServerIDs := make(map[string]uuid.UUID, len(req.MCPServers))
+	for serverIDStr := range req.MCPServers {
+		mcpServerID, parseErr := uuid.Parse(serverIDStr)
+		if parseErr != nil {
+			continue
+		}
+		if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
+			return nil
+		}
+		validatedServerIDs[serverIDStr] = mcpServerID
+	}
+
+	// Calculate totals for response. Counts come from the input map and are
+	// not affected by which entries actually wrote — preserves the existing
+	// response shape so a client probing usage-report behavior cannot tell
+	// from serversReported/totalInvocations whether a particular UUID was
+	// honored. Malformed UUIDs raise the same response shape.
 	serversReported := len(req.MCPServers)
 	totalInvocations := 0
 
@@ -811,10 +855,11 @@ func (h *MCPAttestationHandler) RecordMCPUsageReport(c fiber.Ctx) error {
 			totalInvocations += toolUsage.Count
 		}
 
-		// Try to parse server ID and record the usage data
-		mcpServerID, parseErr := uuid.Parse(serverID)
-		if parseErr != nil {
-			// Log but continue - invalid UUIDs are skipped
+		mcpServerID, ok := validatedServerIDs[serverID]
+		if !ok {
+			// Either malformed (skipped above) or, if pre-validation
+			// found a cross-org UUID, we already returned 404 — this
+			// loop iteration is unreachable in the cross-org case.
 			continue
 		}
 

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
@@ -1,12 +1,15 @@
 package handlers
 
 import (
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/recover"
 	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +28,7 @@ func withMCPAttestationContext(handler func(c fiber.Ctx) error) fiber.Handler {
 // ===========================
 
 func TestNewMCPAttestationHandler_NilDeps(t *testing.T) {
-	handler := NewMCPAttestationHandler(nil, nil, nil)
+	handler := NewMCPAttestationHandler(nil, nil, nil, nil)
 	assert.NotNil(t, handler)
 }
 
@@ -491,6 +494,92 @@ func TestMCPAttestationHandler_RecordMCPConnection_InvalidMCPServerIDFormat(t *t
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
+// SECURITY (defect #19): RecordMCPConnection — body-supplied mcpServerID
+// belonging to a different organization must return 404 (LoadOwned default),
+// and the response body must NOT echo the supplied UUID (no existence side
+// channel via either status code or body content).
+func TestMCPAttestationHandler_RecordMCPConnection_CrossOrgMCPServerID_Returns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	crossOrgID := uuid.New()
+	agentID := uuid.New()
+	mcpServerID := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: mcpServerID, OrganizationID: crossOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/agents/:agent_id/mcp-connections", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPConnection(c)
+	})
+
+	body := `{"mcpServerId":"` + mcpServerID.String() + `","toolName":"x"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-connections", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode, "cross-org mcpServerID must return 404")
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, mcpServerID.String(), "response body must not echo the body-supplied mcpServerID UUID")
+	assert.NotContains(t, bodyStr, crossOrgID.String(), "response body must not echo the cross-org organization UUID")
+}
+
+// SECURITY (defect #19): RecordMCPConnection — same-org mcpServerID must
+// pass the LoadOwned check. Asserts the security gate is NOT a 404; the
+// downstream service call may fail since attestationService is nil in this
+// test, but the LoadOwned boundary is what matters here.
+func TestMCPAttestationHandler_RecordMCPConnection_SameOrgPassesLoadOwned(t *testing.T) {
+	callerOrgID := uuid.New()
+	agentID := uuid.New()
+	mcpServerID := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: mcpServerID, OrganizationID: callerOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Use(recover.New()) // service is nil; recover the downstream panic so we can inspect status
+	app.Post("/agents/:agent_id/mcp-connections", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPConnection(c)
+	})
+
+	body := `{"mcpServerId":"` + mcpServerID.String() + `","toolName":"x"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-connections", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, fiber.StatusNotFound, resp.StatusCode, "same-org mcpServerID must pass LoadOwned (not 404)")
+	assert.NotEqual(t, fiber.StatusBadRequest, resp.StatusCode, "same-org request must pass JSON validation (not 400)")
+}
+
 // ===========================
 // MCPAttestationHandler.RecordMCPUsageReport Tests
 // ===========================
@@ -524,6 +613,90 @@ func TestMCPAttestationHandler_RecordMCPUsageReport_InvalidAgentID(t *testing.T)
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// SECURITY (defect #19b): RecordMCPUsageReport — body-supplied mcpServerID
+// belonging to a different organization must abort the entire request with
+// 404 (LoadOwned default), avoiding partial writes for any preceding
+// own-org entries. The response body must NOT echo the supplied UUID.
+func TestMCPAttestationHandler_RecordMCPUsageReport_CrossOrgMCPServerID_Returns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	crossOrgID := uuid.New()
+	agentID := uuid.New()
+	mcpServerID := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: mcpServerID, OrganizationID: crossOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/agents/:id/mcp-usage-report", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPUsageReport(c)
+	})
+
+	body := `{"agentId":"` + agentID.String() + `","mcpServers":{"` + mcpServerID.String() + `":{"toolUsage":{"t1":{"count":1,"firstUsed":"2024-01-01T00:00:00Z","lastUsed":"2024-01-01T00:00:00Z"}}}},"reportedAt":"2024-01-01T00:00:00Z"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-usage-report", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode, "cross-org mcpServerID in usage report must return 404")
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, mcpServerID.String(), "response body must not echo the body-supplied mcpServerID UUID")
+	assert.NotContains(t, bodyStr, crossOrgID.String(), "response body must not echo the cross-org organization UUID")
+}
+
+// SECURITY (defect #19b): RecordMCPUsageReport — same-org mcpServerID
+// must pass the LoadOwned pre-validation pass. Service is nil; recover
+// catches downstream panic so the LoadOwned boundary remains observable.
+func TestMCPAttestationHandler_RecordMCPUsageReport_SameOrgPassesLoadOwned(t *testing.T) {
+	callerOrgID := uuid.New()
+	agentID := uuid.New()
+	mcpServerID := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: mcpServerID, OrganizationID: callerOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Use(recover.New())
+	app.Post("/agents/:id/mcp-usage-report", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPUsageReport(c)
+	})
+
+	body := `{"agentId":"` + agentID.String() + `","mcpServers":{"` + mcpServerID.String() + `":{"toolUsage":{"t1":{"count":1,"firstUsed":"2024-01-01T00:00:00Z","lastUsed":"2024-01-01T00:00:00Z"}}}},"reportedAt":"2024-01-01T00:00:00Z"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-usage-report", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, fiber.StatusNotFound, resp.StatusCode, "same-org mcpServerID must pass LoadOwned (not 404)")
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
@@ -240,11 +240,22 @@ func (h *MCPHandler) CreateMCPServer(c fiber.Ctx) error {
 	// does not exist), silently drop the link (treat it as if the field was
 	// not supplied) rather than 404 the whole request — the MCP registration
 	// itself is otherwise valid.
+	//
+	// agentLinkDropped tracks the residual read-oracle path closed below: the
+	// body-supplied agentID was non-empty but was not honored (cross-org,
+	// nonexistent, or unparseable). When true the response is scrubbed to
+	// never echo the supplied UUID — see the redaction step before the JSON
+	// write.
+	agentLinkDropped := false
 	if req.RegisteredByAgent != "" && agentID == nil {
 		if parsedAgentID, err := uuid.Parse(req.RegisteredByAgent); err == nil {
-			if agent, err := h.agentRepository.GetByID(parsedAgentID); err == nil && agent != nil && agent.OrganizationID == orgID {
+			if agent, err := h.getAgentRepository().GetByID(parsedAgentID); err == nil && agent != nil && agent.OrganizationID == orgID {
 				agentID = &parsedAgentID
+			} else {
+				agentLinkDropped = true
 			}
+		} else {
+			agentLinkDropped = true
 		}
 	}
 
@@ -267,7 +278,7 @@ func (h *MCPHandler) CreateMCPServer(c fiber.Ctx) error {
 	}
 
 	// SECURITY: No error logging to prevent information leakage
-	server, err := h.mcpService.CreateMCPServer(c.Context(), &req, orgID, userID, agentID, sdkTokenID, apiKeyID)
+	server, err := h.getMCPService().CreateMCPServer(c.Context(), &req, orgID, userID, agentID, sdkTokenID, apiKeyID)
 	if err != nil {
 		// Return 409 Conflict for duplicate URL errors - include existing server ID for SDK
 		if err.Error() == "mcp server with this URL already exists" {
@@ -288,7 +299,7 @@ func (h *MCPHandler) CreateMCPServer(c fiber.Ctx) error {
 	}
 
 	// Log audit
-	h.auditService.LogAction(
+	h.getAuditService().LogAction(
 		c.Context(),
 		orgID,
 		userID,
@@ -303,6 +314,17 @@ func (h *MCPHandler) CreateMCPServer(c fiber.Ctx) error {
 			"authMethod": c.Locals("auth_method"), // Ed25519 or JWT
 		},
 	)
+
+	// SECURITY (defect #18 read-oracle closure): when a body-supplied
+	// RegisteredByAgent was dropped (cross-org, nonexistent, or unparseable)
+	// the response must not echo the attacker-supplied UUID, and must look
+	// the same as a request that supplied no agentID at all. The service
+	// already sets server.RegisteredByAgent = nil when agentID is nil; this
+	// is belt-and-suspenders against future refactors that might propagate
+	// req.RegisteredByAgent into the response by accident.
+	if agentLinkDropped {
+		server.RegisteredByAgent = nil
+	}
 
 	return c.Status(fiber.StatusCreated).JSON(server)
 }

--- a/apps/backend/internal/interfaces/http/handlers/mcp_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_handler_integration_test.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -549,6 +551,147 @@ func TestMCPHandler_GetConnectedAgents_InvalidID_Integration(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// ===========================
+// MCPHandler.CreateMCPServer — defect #18 read-oracle closure
+// ===========================
+
+// SECURITY (defect #18): CreateMCPServer with a body-supplied
+// `registeredByAgent` UUID that belongs to a different organization must
+// drop the linkage AND scrub the response — the body-supplied UUID and the
+// cross-org organization UUID must not appear anywhere in the response.
+// PR #136 closed the write-side; this guards the read oracle.
+func TestMCPHandler_CreateMCPServer_CrossOrgRegisteredByAgent_NoEcho(t *testing.T) {
+	callerOrgID := uuid.New()
+	crossOrgID := uuid.New()
+	userID := uuid.New()
+	crossOrgAgentID := uuid.New()
+
+	mockMCPService := &MockMCPServiceExtendedImpl{
+		CreateMCPServerFunc: func(ctx context.Context, req *application.CreateMCPServerRequest, orgID, uID uuid.UUID, agentID *uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID) (*domain.MCPServer, error) {
+			// Service is called with agentID == nil because the handler's
+			// cross-org check dropped the body-supplied linkage. Echo that
+			// reality in the returned server: RegisteredByAgent must be nil.
+			return &domain.MCPServer{
+				ID:                uuid.New(),
+				OrganizationID:    orgID,
+				Name:              req.Name,
+				URL:               req.URL,
+				Status:            domain.MCPServerStatusPending,
+				IsVerified:        false,
+				TrustScore:        0,
+				RegisteredByAgent: agentID, // nil when linkage dropped — verified below
+			}, nil
+		},
+	}
+
+	mockAgentRepo := &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			// Simulate a real cross-org agent — exists in the DB but in a
+			// different org. The handler must reject the linkage based on
+			// the OrganizationID mismatch.
+			if id == crossOrgAgentID {
+				return &domain.Agent{ID: id, OrganizationID: crossOrgID}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	mockAudit := &MockAuditServiceImpl{}
+
+	handler := NewMCPHandlerWithInterfaces(
+		mockMCPService, nil, mockAudit, mockAgentRepo, nil, nil, nil,
+	)
+
+	app := fiber.New()
+	app.Post("/mcp-servers", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("user_id", userID)
+		return handler.CreateMCPServer(c)
+	})
+
+	body := `{"name":"x","url":"http://x.example.com","registeredByAgent":"` + crossOrgAgentID.String() + `"}`
+	req := httptest.NewRequest("POST", "/mcp-servers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Registration itself is otherwise valid; the cross-org body field is
+	// just silently dropped, so the 201 contract is preserved.
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode, "MCP registration with cross-org body field should still succeed (silent linkage drop)")
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, crossOrgAgentID.String(), "response body must not echo the cross-org agent UUID supplied in the request body")
+	assert.NotContains(t, bodyStr, crossOrgID.String(), "response body must not echo the cross-org organization UUID")
+}
+
+// SECURITY (defect #18): same-org `registeredByAgent` must be HONORED —
+// the linkage flows through and `registeredByAgent` IS present in the
+// response. This is the legitimate SDK use case; the redaction guard
+// must not over-apply.
+func TestMCPHandler_CreateMCPServer_SameOrgRegisteredByAgent_LinkageHonored(t *testing.T) {
+	callerOrgID := uuid.New()
+	userID := uuid.New()
+	sameOrgAgentID := uuid.New()
+	var receivedAgentID *uuid.UUID
+
+	mockMCPService := &MockMCPServiceExtendedImpl{
+		CreateMCPServerFunc: func(ctx context.Context, req *application.CreateMCPServerRequest, orgID, uID uuid.UUID, agentID *uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID) (*domain.MCPServer, error) {
+			receivedAgentID = agentID
+			return &domain.MCPServer{
+				ID:                uuid.New(),
+				OrganizationID:    orgID,
+				Name:              req.Name,
+				URL:               req.URL,
+				Status:            domain.MCPServerStatusVerified,
+				IsVerified:        true,
+				TrustScore:        75,
+				RegisteredByAgent: agentID,
+			}, nil
+		},
+	}
+
+	mockAgentRepo := &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			if id == sameOrgAgentID {
+				return &domain.Agent{ID: id, OrganizationID: callerOrgID}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	mockAudit := &MockAuditServiceImpl{}
+
+	handler := NewMCPHandlerWithInterfaces(
+		mockMCPService, nil, mockAudit, mockAgentRepo, nil, nil, nil,
+	)
+
+	app := fiber.New()
+	app.Post("/mcp-servers", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("user_id", userID)
+		return handler.CreateMCPServer(c)
+	})
+
+	body := `{"name":"x","url":"http://x.example.com","registeredByAgent":"` + sameOrgAgentID.String() + `"}`
+	req := httptest.NewRequest("POST", "/mcp-servers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode)
+	require.NotNil(t, receivedAgentID, "service must be called with the same-org agentID (linkage honored)")
+	assert.Equal(t, sameOrgAgentID, *receivedAgentID, "service must receive the parsed same-org agentID")
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.Contains(t, bodyStr, sameOrgAgentID.String(), "response body must echo the same-org agent UUID when linkage is honored")
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -1065,6 +1065,19 @@ func (m *MockAgentRepositoryerImpl) GetByMCPServerName(mcpServerName string, org
 	return []*domain.Agent{}, nil
 }
 
+// MockMCPServerRepositoryerImpl implements MCPServerRepositoryer interface (the
+// narrow GetByID-only surface used by tenant-scope LoadOwned checks).
+type MockMCPServerRepositoryerImpl struct {
+	GetByIDFunc func(id uuid.UUID) (*domain.MCPServer, error)
+}
+
+func (m *MockMCPServerRepositoryerImpl) GetByID(id uuid.UUID) (*domain.MCPServer, error) {
+	if m.GetByIDFunc != nil {
+		return m.GetByIDFunc(id)
+	}
+	return nil, nil
+}
+
 // MockVerificationEventRepositoryerImpl implements VerificationEventRepositoryer interface
 type MockVerificationEventRepositoryerImpl struct {
 	GetByMCPServerFunc func(mcpServerID uuid.UUID, limit, offset int) ([]*domain.VerificationEvent, int, error)


### PR DESCRIPTION
## Summary

Closes the three explicitly-PARTIAL tenant-scoping residuals from PR #136 by extending the `LoadOwned` pattern to body-supplied UUIDs in the MCP handlers.

- **#18** (`mcp_handler.go` `CreateMCPServer`): residual read oracle — body-supplied `registeredByAgent` was dropped on cross-org mismatch but the response could in principle echo it. Adds `agentLinkDropped` tracking + defensive `server.RegisteredByAgent = nil` scrub before the JSON write. Defense-in-depth against future refactors of `MCPService.CreateMCPServer` that might inadvertently propagate the request field.
- **#19** (`mcp_attestation_handler.go` `RecordMCPConnection`): body-supplied `mcpServerID` now passes `LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID)` after the existing URL-agent check. 404 on cross-org, indistinguishable from nonexistent.
- **#19b** (`RecordMCPUsageReport`): pre-validation pass over `req.MCPServers` — cross-org UUID anywhere in the batch aborts the entire request with 404 before any `RecordMCPUsageReport` call. Malformed UUIDs preserve the existing silent-skip behavior; closing the malformed-vs-cross-org reporting oracle is audit-baseline work tracked separately (see #41).

## Plumbing

- New narrow interface `MCPServerRepositoryer` (`GetByID` only) — handlers don't need the full `domain.MCPServerRepository` surface for tenant-scope checks.
- `MCPAttestationHandler.agentRepo` narrowed from `domain.AgentRepository` to the existing `AgentRepositoryer` (same set of methods called, consistent with peer handlers, makes the test mocks reusable).
- New `mcpServerRepo` field on `MCPAttestationHandler`; `main.go` passes `repos.MCPServer`.
- `MCPHandler.CreateMCPServer` now routes its service / agent-repo / audit calls through the existing `getXxx()` helpers (the dual-constructor pattern already in the file) so the cross-org branch is exercisable end-to-end from the integration tests.

## Tests

5 new tests cover the security boundary:

- `TestMCPHandler_CreateMCPServer_CrossOrgRegisteredByAgent_NoEcho` — cross-org body UUID is silently dropped; response is 201 with no echo of the supplied UUID or the cross-org organization UUID.
- `TestMCPHandler_CreateMCPServer_SameOrgRegisteredByAgent_LinkageHonored` — same-org body UUID flows through the service and appears in the response (legitimate SDK path preserved).
- `TestMCPAttestationHandler_RecordMCPConnection_CrossOrgMCPServerID_Returns404` — cross-org body `mcpServerID` returns 404 with no UUID echo.
- `TestMCPAttestationHandler_RecordMCPConnection_SameOrgPassesLoadOwned` — same-org body `mcpServerID` passes the gate.
- `TestMCPAttestationHandler_RecordMCPUsageReport_CrossOrgMCPServerID_Returns404` — cross-org body `mcpServerID` aborts the whole usage-report request with 404; no UUID echo.
- `TestMCPAttestationHandler_RecordMCPUsageReport_SameOrgPassesLoadOwned` — same-org body `mcpServerID` passes the pre-validation pass.

Pre-existing input-validation tests still green.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./internal/... ./cmd/...` — all green
- `tenantscope-lint ./internal/interfaces/http/handlers` — ok (87 allowlist entries)
- `npx hackmyagent secure --ci` on the worktree — 100/100, zero findings (209 static + 200 semantic NanoMind checks)
- Adversarial code review of commit 876992a against 7 risk categories (bypass / swallowed errors / escape completeness / detection narrowing / test depth / field-vs-value / TOCTOU) — CLEAN on the PR itself.

## Follow-ups

The adversarial review surfaced two PRE-EXISTING tenant-scope leaks in the same handler chain — out of A3a's stated file scope (mcp_handler / mcp_attestation_handler only) but worth queueing for the next hardening pass. Filed in `todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md`:

- **#40** — `MCPService.CreateMCPServer` 409 response leaks cross-org MCP UUID + name via `GetByURL` without org filter (URL-path variant of #18).
- **#41** — `RecordMCPConnection` 400-vs-404 oracle: malformed body `mcpServerID` returns 400 with `err.Error()`; this PR makes the 404 cross-org path observable. Closing requires treating malformed as 404 too.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms the cross-org assertions in the new tests would fail if the new `LoadOwned` calls / scrub step are removed (mutation check)
- [ ] Reviewer confirms #40 / #41 are appropriate follow-up scope (A3b/A3c/A3d) rather than blockers