### PR TITLE
security: close defect #48 — RegisterCapability cross-tenant IDOR

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -214,16 +214,42 @@ func (h *CapabilityHandler) RegisterCapability(c fiber.Ctx) error {
 		})
 	}
 
-	// Get the agent to verify it exists and get org ID
-	agent, err := h.agentRepo.GetByID(agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{
-			Error: "Agent not found",
+	// Get organization ID from context (PQCAgentMiddleware on the
+	// /sdk-api/agents/:id/capabilities/register route sets this from the
+	// caller-authenticated agent's organization; JWT-auth routes set it
+	// from the user claims).
+	orgIDValue := c.Locals("organization_id")
+	if orgIDValue == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Error: "Organization ID not found in context",
+		})
+	}
+	orgID, ok := orgIDValue.(uuid.UUID)
+	if !ok {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Error: "Invalid organization ID type in context",
 		})
 	}
 
+	// SECURITY (defect #48): verify the agent referenced by the URL
+	// parameter belongs to the caller's organization. Without this check,
+	// a valid SDK-authenticated agent in org A could register capabilities
+	// on agent B in org B by substituting agent B's UUID in the path; in
+	// MONITORING enforcement mode that registration auto-grants the
+	// capability. Same threat class as defect #25, fixed for the sibling
+	// GrantCapability handler in PR #136 via the same LoadOwned pattern.
+	agent := LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil // helper already wrote the 404 response
+	}
+
+	// Resolve the capability service via the helper (sibling handlers in
+	// this file use the same pattern; lets tests inject a mock through
+	// NewCapabilityHandlerWithInterfaces).
+	capSvc := h.getCapabilityService()
+
 	// Check if agent already has this capability
-	existingCaps, err := h.capabilityService.GetAgentCapabilities(context.Background(), agentID, true)
+	existingCaps, err := capSvc.GetAgentCapabilities(context.Background(), agentID, true)
 	if err == nil {
 		for _, cap := range existingCaps {
 			if cap.CapabilityType == req.CapabilityType {
@@ -248,14 +274,14 @@ func (h *CapabilityHandler) RegisterCapability(c fiber.Ctx) error {
 	// MONITORING mode: Auto-grant the capability
 	if org.EnforcementMode == domain.EnforcementModeMonitoring {
 		// Validate and auto-register the capability type if custom
-		if err := h.capabilityService.ValidateAndRegisterCapability(context.Background(), req.CapabilityType, agent.OrganizationID); err != nil {
+		if err := capSvc.ValidateAndRegisterCapability(context.Background(), req.CapabilityType, agent.OrganizationID); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 				Error: err.Error(),
 			})
 		}
 
 		// Auto-grant the capability
-		capability, err := h.capabilityService.GrantCapability(
+		capability, err := capSvc.GrantCapability(
 			context.Background(),
 			agentID,
 			req.CapabilityType,

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -214,10 +214,11 @@ func (h *CapabilityHandler) RegisterCapability(c fiber.Ctx) error {
 		})
 	}
 
-	// Get organization ID from context (PQCAgentMiddleware on the
-	// /sdk-api/agents/:id/capabilities/register route sets this from the
-	// caller-authenticated agent's organization; JWT-auth routes set it
-	// from the user claims).
+	// Get organization ID from context. The route is mounted only on
+	// the sdkAPI group (cmd/server/main.go:322) which sits behind
+	// PQCAgentMiddleware — the middleware sets organization_id from the
+	// signed agent's database record, not from any caller-controllable
+	// input.
 	orgIDValue := c.Locals("organization_id")
 	if orgIDValue == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
@@ -633,3 +633,154 @@ func TestNewCapabilityHandlerWithInterfaces_WithMock(t *testing.T) {
 	assert.NotNil(t, handler)
 	assert.NotNil(t, handler.capabilityServicer)
 }
+
+// ===========================
+// RegisterCapability Tests (defect #48 — cross-tenant scoping)
+// ===========================
+//
+// SECURITY context: PR #136 fixed defect #25 for the sibling
+// GrantCapability handler by wrapping the URL-derived agentID lookup in
+// LoadOwned so a cross-tenant request returns 404. RegisterCapability had
+// the same IDOR shape but was silently lint-exempt via the
+// `bodyMentionsOrganizationID` lenient heuristic (the handler referenced
+// `agent.OrganizationID` only for victim-side lookups, never compared to
+// the caller). These tests assert the LoadOwned wrap closes the gap.
+
+// TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404 asserts
+// that a caller authenticated to org A cannot register capabilities on an
+// agent in org B by substituting the foreign agent's UUID in the URL.
+// LoadOwned returns 404 (not 403) to preserve existence-secrecy across
+// organizations.
+//
+// Enforcement mode is irrelevant for this test: LoadOwned short-circuits
+// before the handler reaches `orgRepo.GetByID(agent.OrganizationID)`.
+// Without this fix the request would, in MONITORING mode, auto-grant the
+// requested capability on agent B.
+func TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404(t *testing.T) {
+	agentID := uuid.New()
+	callerOrgID := uuid.New()
+	otherOrgID := uuid.New()
+	userID := uuid.New()
+
+	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: id, OrganizationID: otherOrgID}, nil
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/sdk-api/agents/:id/capabilities/register", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("user_id", userID)
+		return handler.RegisterCapability(c)
+	})
+
+	body := `{"capabilityType": "file:read"}`
+	req := httptest.NewRequest("POST", "/sdk-api/agents/"+agentID.String()+"/capabilities/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+
+	// Response body must NOT echo the cross-org agent's UUID or any other
+	// existence signal — same response shape as "agent does not exist."
+	var body404 map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body404))
+	assert.Equal(t, "not found", body404["error"])
+	assert.NotContains(t, body404, "agentId")
+	assert.NotContains(t, body404, "organizationId")
+}
+
+// TestCapabilityHandler_RegisterCapability_NoOrgID_Integration mirrors
+// GrantCapability's defensive coverage for the case where the
+// organization_id local is missing entirely — middleware misconfiguration
+// or a stripped JWT. The handler must 401 before any data access.
+func TestCapabilityHandler_RegisterCapability_NoOrgID_Integration(t *testing.T) {
+	agentID := uuid.New()
+	userID := uuid.New()
+
+	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
+
+	app := fiber.New()
+	app.Post("/sdk-api/agents/:id/capabilities/register", func(c fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		// organization_id intentionally absent
+		return handler.RegisterCapability(c)
+	})
+
+	body := `{"capabilityType": "file:read"}`
+	req := httptest.NewRequest("POST", "/sdk-api/agents/"+agentID.String()+"/capabilities/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestCapabilityHandler_RegisterCapability_SameOrg_Monitoring_AutoGrants
+// confirms the LoadOwned wrap does not break the legitimate happy path
+// for a same-org caller registering on their own agent in MONITORING
+// mode. Without this test, a regression that broke MONITORING auto-grant
+// would not surface in CI.
+func TestCapabilityHandler_RegisterCapability_SameOrg_Monitoring_AutoGrants(t *testing.T) {
+	agentID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetAgentCapabilitiesFunc: func(ctx context.Context, aID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {
+			return nil, nil
+		},
+		ValidateAndRegisterCapabilityFunc: func(ctx context.Context, capability string, oID uuid.UUID) error {
+			return nil
+		},
+		GrantCapabilityFunc: func(ctx context.Context, aID uuid.UUID, capType string, scope map[string]interface{}, grantedBy *uuid.UUID, executionMode string) (*domain.AgentCapability, error) {
+			return &domain.AgentCapability{
+				ID:             uuid.New(),
+				AgentID:        aID,
+				CapabilityType: capType,
+			}, nil
+		},
+	}
+
+	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: id, OrganizationID: orgID}, nil
+		},
+	}
+	handler.orgRepo = &MockOrganizationRepository{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Organization, error) {
+			return &domain.Organization{
+				ID:              id,
+				EnforcementMode: domain.EnforcementModeMonitoring,
+			}, nil
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/sdk-api/agents/:id/capabilities/register", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		c.Locals("user_id", userID)
+		return handler.RegisterCapability(c)
+	})
+
+	body := `{"capabilityType": "file:read"}`
+	req := httptest.NewRequest("POST", "/sdk-api/agents/"+agentID.String()+"/capabilities/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode)
+
+	var registered RegisterCapabilityResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&registered))
+	assert.True(t, registered.Success)
+	assert.Equal(t, "granted", registered.Status)
+	assert.Equal(t, "file:read", registered.CapabilityType)
+}


### PR DESCRIPTION
## Summary

Closes defect **#48** (audit doc: `todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md` § 48). `CapabilityHandler.RegisterCapability` (`apps/backend/internal/interfaces/http/handlers/capability_handler.go:194`) handles `POST /api/v1/sdk-api/agents/:id/capabilities/register` under `PQCAgentMiddleware`. Pre-fix, an SDK-authenticated agent in org A could pass agent B's UUID in the URL and (in MONITORING enforcement mode) auto-grant capabilities on agent B in org B — same threat class as defect #25 (closed for the sibling `GrantCapability` in PR #136).

The lint at `cmd/tenantscope-lint/` silently exempts this handler via the lenient `bodyMentionsOrganizationID` heuristic because the two `OrganizationID` references in the pre-fix handler are victim-side lookups, not authorization comparisons. A3c PR #144 surfaced it via Phase 4.5 adversarial review and filed it as #48 with a defensive allowlist entry.

## What this PR does

1. **Adds caller-org extract + LoadOwned wrap to `RegisterCapability`** mirroring `GrantCapability:109-128`:
   - Extracts caller's `organization_id` from `c.Locals` (401 if absent, 500 on type mismatch — same handling as sibling).
   - Wraps `h.agentRepo.GetByID(agentID)` in `LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID)`. Cross-org returns 404, not 403 — existence-secrecy convention from PR #136.
2. **Sibling-consistency cleanup**: switches the three `h.capabilityService.X(...)` call sites in `RegisterCapability` to `capSvc := h.getCapabilityService()`. RegisterCapability was the only handler in `capability_handler.go` not using the helper; the helper is required for `NewCapabilityHandlerWithInterfaces` mock injection. No behavioral change in production code.
3. **Three integration tests** in `capability_handler_integration_test.go`:
   - `TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404` — caller in org A, agent in org B → asserts 404 with body shape matching "agent does not exist" (no UUID echo, no organization ID echo).
   - `TestCapabilityHandler_RegisterCapability_NoOrgID_Integration` — middleware misconfiguration → 401.
   - `TestCapabilityHandler_RegisterCapability_SameOrg_Monitoring_AutoGrants` — same-org happy path → 201 + `Status: "granted"`.

## Wire-format change (deliberate)

Pre-fix, an agent-not-found returned `{"error": "Agent not found"}` (capital A). Post-fix, both cross-org AND nonexistent-agent return `{"error": "not found"}` (lowercase, from `LoadOwned`'s `respondResourceNotFound`). Same JSON key, different message string. Intentional unification — eliminates a potential message-string oracle. No SDK clients in this repo string-match the message; status code is the contract.

## Adversarial review findings (Phase 4.5, addressed)

| Severity | Finding | Status |
|---|---|---|
| MEDIUM | STRICT-mode path (`capability_handler.go:306-342`) not exercised by any new test. The STRICT branch creates a `capabilityRequestService.CreateRequest(...)` and that service is a concrete `*application.CapabilityRequestService` pointer with no interface, so mock injection requires either a real in-memory service or an interface refactor. | Filed as **follow-up**; out of scope for this PR. LoadOwned short-circuits before the mode check, so the cross-org test result is independent of mode. |
| LOW | Documentation: the comment above the org-ID extraction said "JWT-auth routes set it from the user claims" but the handler is only mounted on `sdkAPI`. | **Fixed** in commit 15d7b1a. |
| LOW | Wire-format change (`"Agent not found"` → `"not found"`). | **Intentional** — see "Wire-format change" section above. |
| LOW | Lint heuristic `bodyMentionsOrganizationID` still permits victim-side `agent.OrganizationID` references. This is the gap that allowed #48 to slip in. | Out of scope. Lint hardening is a separate track; A3c PR #144 documents the blind spot in-source. |
| LOW | Test `NotContains` assertions for `agentId` / `organizationId` in the 404 body are tautological for the current error shape (defensive against future regression). | Acceptable defensive coverage. |

## Lint state

`tenantscope-lint` exits 0 on this branch (the handler now invokes `LoadOwned`, which the lint recognizes). This branch is based on `origin/main` `a046619` — NOT on top of A3c PR #144. After both PRs land, the A3c-flagged #48 allowlist entry in `cmd/tenantscope-lint/main.go` becomes redundant; a separate sweep PR can remove it.

## Verification

- `go build ./...` → clean.
- `go vet ./...` → clean.
- `go test -race ./internal/interfaces/http/handlers/...` → ok (1.4s, full suite including 3 new tests).
- `go test -race $(go list ./... | grep -v tests/integration)` → all green. `tests/integration/pqc_e2e_test.go` continues to fail with 401 on admin login (pre-existing — admin password rotated locally; identical failure on `origin/main`).
- `go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers` → ok (87 allowlist entries; this branch is from main, not A3c).
- `gofmt -l` on the two changed files → clean.
- HMA `secure --ci` against the handlers package → 98/100, 1 LOW pre-existing (`.gitignore` in subdir; AIM root has one).
- Adversarial self-review (Phase 4.5) verdict: PASS with 1 MEDIUM follow-up + LOWs documented above.

## Test plan

- [ ] CI: confirm new tests pass.
- [ ] Manual smoke: run a same-org PQC-signed `POST /sdk-api/agents/:id/capabilities/register` against a local AIM stack in MONITORING mode → expect 201 + `granted`.
- [ ] Manual cross-org check: run the same with a foreign agent's UUID in the path (caller authenticated as own-org agent) → expect 404 with `{"error": "not found"}`.
- [ ] Code review: confirm the LoadOwned wrap mirrors the `GrantCapability:126` pattern verbatim and that the helper migration touches only RegisterCapability (the other 7 capability-handler callers already use the helper).

## Follow-ups (not in this PR)

- STRICT-mode regression test for `RegisterCapability` — requires either an interface on `capabilityRequestService` or a real-in-memory `*application.CapabilityRequestService` in tests. Recommend filing as a separate small refactor PR alongside any future capability_handler edits.
- After A3c PR #144 merges: remove the redundant `CapabilityHandler.RegisterCapability` allowlist entry from `cmd/tenantscope-lint/main.go` in a follow-up sweep PR.
- Lint heuristic tightening: detect mentioned-but-not-compared `OrganizationID` to catch the broader class of false-negatives. Out of scope for both this PR and A3c.

## Related work

- A3c PR #144 — broadened tenantscope-lint paramKeys + filed #48 in audit doc + defensive allowlist entry.
- PR #136 — closed defect #25 in `GrantCapability` via the LoadOwned pattern this PR mirrors.