### PR TITLE
chore(lint): remove redundant #48 allowlist entry + panic-proof cross-org test

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -153,35 +153,29 @@ var allowlist = map[string]string{
 	"VerificationHandler.UpdateExecutionStatus":             "audit-baseline: needs review",
 
 	// ---------------------------------------------------------------
-	// A3c-FLAGGED: 7 handlers surfaced 2026-05-20. Six were caught
-	// directly by broadening paramKeys to cover the snake_case +
-	// camelCase URL-param spellings for tenant-scoped resources
-	// beyond `id`/`agent_id` (#42-47). The seventh (#48,
-	// CapabilityHandler.RegisterCapability) was NOT caught by the
-	// lint — adversarial review surfaced it as a sibling-of-#25
-	// IDOR (write-side, SDK auth path) that the lenient
-	// `bodyMentionsOrganizationID` heuristic silently exempts
-	// because the handler mentions `agent.OrganizationID` only to
-	// look up the VICTIM resource's org, never to compare against
-	// the caller. It is allowlisted here so that any future
-	// heuristic tightening surfaces an explicit deferred entry
-	// rather than a suddenly-blocking violation, and so reviewers
-	// walking the audit-baseline section find it tracked.
-	//
-	// Each handler in this block reads its resource ID from the
-	// path without invoking LoadOwned (or, for #48, without
-	// comparing the mentioned OrganizationID to the caller).
-	// Service-layer enforcement (if any) needs manual verification
-	// before these can be moved to a per-entry justification or
-	// wired through LoadOwned. Filed as defects #42-48 in
+	// A3c-FLAGGED: 6 handlers surfaced 2026-05-20 by broadening
+	// paramKeys to cover the snake_case + camelCase URL-param
+	// spellings for tenant-scoped resources beyond `id`/`agent_id`.
+	// Each handler reads its resource ID from the path without
+	// invoking LoadOwned and without a visible OrganizationID
+	// identifier check at the handler layer. Service-layer
+	// enforcement (if any) needs manual verification before these
+	// can be moved to a per-entry justification or wired through
+	// LoadOwned. Filed as defects #42-47 in
 	// todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md.
 	// Closing these is A3b/A3d scope.
+	//
+	// Historical note: a seventh defensive entry for
+	// CapabilityHandler.RegisterCapability (#48) lived here from
+	// PR #144 (A3c) until PR #145 wrapped the handler with
+	// LoadOwned. The entry was removed because the handler now
+	// satisfies the lint structurally (LoadOwned recognition path).
+	// The audit doc #48 retains the full historical record.
 	// ---------------------------------------------------------------
 	"A2AHandler.GetSkillAttestations":               "audit-baseline: needs review (A3c-flagged #43)",
 	"A2AHandler.ListUserConsents":                   "audit-baseline: needs review (A3c-flagged #42)",
 	"CapabilityHandler.GetRecentViolations":         "audit-baseline: needs review (A3c-flagged #46)",
 	"CapabilityHandler.GetViolationsByOrganization": "audit-baseline: needs review (A3c-flagged #45)",
-	"CapabilityHandler.RegisterCapability":          "audit-baseline: needs review (A3c-flagged #48; lint-exempt today via bodyMentionsOrganizationID — entry future-proofs heuristic tightening)",
 	"CapabilityHandler.RevokeCapability":            "audit-baseline: needs review (A3c-flagged #44)",
 	"MCPAttestationHandler.RevokeAttestation":       "audit-baseline: needs review (A3c-flagged #47)",
 }

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
@@ -656,6 +656,14 @@ func TestNewCapabilityHandlerWithInterfaces_WithMock(t *testing.T) {
 // before the handler reaches `orgRepo.GetByID(agent.OrganizationID)`.
 // Without this fix the request would, in MONITORING mode, auto-grant the
 // requested capability on agent B.
+//
+// REGRESSION GUARANTEE: The mock `orgRepo` records whether it was
+// invoked. A future change that removes the `LoadOwned` wrap (or
+// otherwise routes cross-org execution past the scoping check) reaches
+// `orgRepo.GetByID(agent.OrganizationID)` at the post-LoadOwned org
+// lookup, sets the flag, and the post-call assertion fails with a clear
+// message. This makes the test a clean structural guard rather than
+// relying on a downstream nil-pointer panic if `orgRepo` were left unset.
 func TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404(t *testing.T) {
 	agentID := uuid.New()
 	callerOrgID := uuid.New()
@@ -666,6 +674,13 @@ func TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404(t *testing.T) 
 	handler.agentRepo = &MockAgentRepositoryerImpl{
 		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
 			return &domain.Agent{ID: id, OrganizationID: otherOrgID}, nil
+		},
+	}
+	orgRepoCalled := false
+	handler.orgRepo = &MockOrganizationRepository{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Organization, error) {
+			orgRepoCalled = true
+			return &domain.Organization{ID: id, EnforcementMode: domain.EnforcementModeMonitoring}, nil
 		},
 	}
 
@@ -692,6 +707,13 @@ func TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404(t *testing.T) 
 	assert.Equal(t, "not found", body404["error"])
 	assert.NotContains(t, body404, "agentId")
 	assert.NotContains(t, body404, "organizationId")
+
+	// Regression assertion: LoadOwned must short-circuit before the
+	// org-settings lookup. If `orgRepoCalled` is true, the handler
+	// reached the post-LoadOwned org lookup on a cross-org request —
+	// the scoping check was bypassed and the IDOR has regressed.
+	assert.False(t, orgRepoCalled,
+		"orgRepo.GetByID was reached on a cross-org request; LoadOwned scoping was bypassed")
 }
 
 // TestCapabilityHandler_RegisterCapability_NoOrgID_Integration mirrors


### PR DESCRIPTION
## Summary

Post-merge sweep after PR #144 (A3c lint broadening) and PR #145 (#48 RegisterCapability LoadOwned wrap). Two commits:

1. **`chore(lint)`** — Removes the now-redundant `CapabilityHandler.RegisterCapability` allowlist row from the A3c-FLAGGED block in `cmd/tenantscope-lint/main.go`. PR #144 added it defensively because the lint's lenient `bodyMentionsOrganizationID` heuristic exempted the handler; PR #145 wrapped the handler with `LoadOwned` so it now satisfies the lint structurally via the `LoadOwned` recognition path. Comment block reduced from "7 handlers (#42-48)" to "6 handlers (#42-47)" with a short historical note pointing to the audit doc as the persistent record.
2. **`test(handlers)`** — Strengthens `TestCapabilityHandler_RegisterCapability_CrossOrg_Returns404` so a hypothetical future revert of PR #145's LoadOwned wrap produces a CLEAN assertion failure instead of relying on a nil-pointer panic. Surfaced by Phase 4.5 adversarial review of the chore commit.

## Why the panic-proofing matters

Adversarial review of the allowlist-removal commit flagged one HIGH concern: with the defensive entry removed, the lint's `bodyMentionsOrganizationID` heuristic silently exempts `RegisterCapability` (the handler references `agent.OrganizationID` for victim-side org lookups, never for caller comparison). This means a hypothetical revert of PR #145's LoadOwned wrap would NOT be caught by `tenantscope-lint`. The cross-org integration test becomes the sole structural guard.

Pre-this-PR failure mode on revert: `h.orgRepo` is unset in the test fixture, the post-LoadOwned handler reaches `h.orgRepo.GetByID(...)`, nil-pointer panic. CI fails, but as a panic — fragile signal that could be misattributed to a flaky test.

Post-this-PR failure mode on revert: `orgRepo` is wired to a mock that flips `orgRepoCalled = true` on call. The cross-org happy path never reaches it (LoadOwned short-circuits). On a revert, the post-call assertion fails with the explicit message `orgRepo.GetByID was reached on a cross-org request; LoadOwned scoping was bypassed`.

## Diff scope

| File | Δ | Purpose |
|---|---|---|
| `cmd/tenantscope-lint/main.go` | +16/-22 | Remove one allowlist row + rework block comment from "7 handlers" → "6 handlers" + historical note. |
| `internal/interfaces/http/handlers/capability_handler_integration_test.go` | +22/0 | Panic-proof regression assertion in the cross-org test. |

## Verification

- `gofmt -l` → clean.
- `go build ./...` → clean.
- `go vet ./cmd/tenantscope-lint/...` → clean.
- `go test -race ./cmd/tenantscope-lint/... ./internal/interfaces/http/handlers/...` → ok (lint cmd 3 tests + all handler tests including the strengthened cross-org guard).
- `go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers` → ok (93 allowlist entries; was 94 pre-sweep).
- HMA `secure --ci` on `cmd/tenantscope-lint/` → 98/100 (1 LOW pre-existing for missing `.gitignore` in subdir).

## Test plan

- [ ] CI: confirm tenantscope-lint job still green (93 entries).
- [ ] CI: confirm the 6 RegisterCapability tests pass (the strengthened cross-org guard + 5 others).
- [ ] Code review: confirm the historical note in the A3c-FLAGGED block is accurate (PR #144 and PR #145 references resolve to the two merged commits).
- [ ] Manual: remove the `LoadOwned` line from `RegisterCapability` and re-run `go test -run TestCapabilityHandler_RegisterCapability_CrossOrg ./internal/interfaces/http/handlers/...` — expect the strengthened assertion to fire with "orgRepo.GetByID was reached on a cross-org request" (do NOT commit the simulated revert).

## Follow-ups noted by adversarial review (not in this PR)

- **`TestA3cFlaggedBlockMembership`** — no structural test asserts allowlist content shape, count, or membership. A future bulk-edit could silently mis-edit other rows. Recommend a follow-up commit that pins the A3c-FLAGGED block to a known six-entry set keyed to the audit-doc defect numbers. Genuine scope-creep for this chore PR; intentionally deferred.
- **Lint heuristic docstring** at `cmd/tenantscope-lint/main.go:356` still names #48 as the false-negative-class example. Pedagogically valid even though the specific case is closed in source — the heuristic blind spot is real and the example still teaches the right lesson. Touch only if the docstring needs refresh for another reason.

## Related work

- PR #144 — A3c lint broadening; added the now-removed allowlist row defensively.
- PR #145 — #48 RegisterCapability LoadOwned wrap; closed the underlying IDOR.
- PR #136 — Defect #25 fix in `GrantCapability` (the pattern PR #145 mirrored).