### PR TITLE
security: close defect #40 — MCPServerRepository.GetByURL cross-tenant leak

### DIFF
--- a/apps/backend/internal/application/agent_service_test.go
+++ b/apps/backend/internal/application/agent_service_test.go
@@ -1906,8 +1906,8 @@ func (m *AgentServiceMockMCPServerRepository) GetByOrganization(orgID uuid.UUID)
 	return args.Get(0).([]*domain.MCPServer), args.Error(1)
 }
 
-func (m *AgentServiceMockMCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
-	args := m.Called(url)
+func (m *AgentServiceMockMCPServerRepository) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
+	args := m.Called(url, orgID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/apps/backend/internal/application/mcp_service.go
+++ b/apps/backend/internal/application/mcp_service.go
@@ -96,8 +96,18 @@ type AddPublicKeyRequest struct {
 // sdkTokenID is optional - tracks which SDK token was used to create this server
 // apiKeyID is optional - tracks which API key was used to create this server
 func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRequest, orgID, userID uuid.UUID, agentID *uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID) (*domain.MCPServer, error) {
-	// Check if MCP server with this URL already exists
-	existing, _ := s.mcpRepo.GetByURL(req.URL)
+	// Check if THIS organization already has an MCP server at this URL.
+	// SECURITY (defect #40): The lookup is org-scoped at the repository
+	// layer. The mcp_servers table has UNIQUE(organization_id, url), so
+	// the same URL can legally coexist across organizations; a global
+	// lookup would leak cross-tenant existence via the 409 response
+	// (returning the victim's UUID + name), allow attackers to create
+	// agent-MCP connections to cross-org MCP servers, and let them
+	// mutate the victim's capabilities/version in the update branch
+	// below. With the org filter, cross-org collisions return nil here
+	// and execution proceeds to create a same-URL MCP server in the
+	// caller's org — which the DB constraint permits.
+	existing, _ := s.mcpRepo.GetByURL(req.URL, orgID)
 	if existing != nil {
 		// ✅ Even if MCP server exists, create agent-MCP connection for THIS agent
 		// This allows multiple agents to register connections to the same MCP server

--- a/apps/backend/internal/application/mcp_service_test.go
+++ b/apps/backend/internal/application/mcp_service_test.go
@@ -1,11 +1,16 @@
 package application
 
 import (
+	"database/sql"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ========================================
@@ -454,4 +459,79 @@ func TestMCPService_DefaultVerificationURLPath(t *testing.T) {
 
 	expectedURL := baseURL + defaultPath
 	assert.Equal(t, "https://mcp.example.com/.well-known/mcp/verify", expectedURL)
+}
+
+// ========================================
+// MCPServerRepository.GetByURL — defect #40 cross-org scoping
+// ========================================
+//
+// SECURITY context: defect #40 was a cross-tenant existence leak via
+// MCPService.CreateMCPServer's URL-collision check. The repository's
+// GetByURL was unscoped and returned any org's matching row, which
+// then leaked the victim's UUID + name in the handler's 409 response
+// AND allowed the service's existing-found branch to create a
+// cross-org agent-MCP connection AND mutate the victim's
+// capabilities/version. The fix adds an organization_id filter at
+// the SQL layer; these tests pin that filter so a future edit that
+// drops it (or transposes args) is caught at unit-test time.
+//
+// The mcp_servers table has UNIQUE(organization_id, url), so the
+// same URL can legally exist in multiple organizations — the lookup
+// MUST be org-scoped or the schema and the application contradict.
+
+func TestMCPServerRepository_GetByURL_FiltersByOrganization(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := repository.NewMCPServerRepository(db)
+	url := "https://mcp.example.com"
+	callerOrgID := uuid.New()
+
+	// The query MUST contain the organization_id filter clause and MUST
+	// be invoked with both (url, orgID) args, in that order, matching
+	// the placeholders $1 and $2.
+	mock.ExpectQuery(regexp.QuoteMeta("WHERE url = $1 AND organization_id = $2")).
+		WithArgs(url, callerOrgID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "organization_id", "name", "description", "url", "version",
+			"public_key", "status", "is_verified", "last_verified_at",
+			"verification_url", "capabilities", "trust_score",
+			"registered_by_agent", "created_by", "created_at", "updated_at",
+			"verification_method", "attestation_count", "confidence_score",
+			"last_attested_at",
+		}))
+
+	_, _ = repo.GetByURL(url, callerOrgID)
+
+	require.NoError(t, mock.ExpectationsWereMet(),
+		"GetByURL must issue SQL filtered by organization_id; a mismatch here means the security filter has regressed")
+}
+
+func TestMCPServerRepository_GetByURL_CrossOrgReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := repository.NewMCPServerRepository(db)
+	url := "https://victim.example.com"
+	callerOrgID := uuid.New()
+
+	// Simulate the cross-org case: the victim's row exists in the DB
+	// but the WHERE-clause filter on organization_id eliminates it,
+	// so the query returns no rows.
+	mock.ExpectQuery(regexp.QuoteMeta("WHERE url = $1 AND organization_id = $2")).
+		WithArgs(url, callerOrgID).
+		WillReturnError(sql.ErrNoRows)
+
+	server, err := repo.GetByURL(url, callerOrgID)
+
+	// Pre-fix behaviour: server would be a populated *MCPServer from
+	// the victim's org. Post-fix: nil. The caller (MCPService.CreateMCPServer)
+	// treats nil-existing as "no collision" and proceeds to create —
+	// which the DB's UNIQUE(organization_id, url) constraint permits.
+	assert.Nil(t, server,
+		"GetByURL must return nil on cross-org URL collision; returning a populated server would leak cross-tenant existence")
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -196,8 +196,8 @@ func (m *SharedMockMCPServerRepository) GetByOrganization(orgID uuid.UUID) ([]*d
 	return args.Get(0).([]*domain.MCPServer), args.Error(1)
 }
 
-func (m *SharedMockMCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
-	args := m.Called(url)
+func (m *SharedMockMCPServerRepository) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
+	args := m.Called(url, orgID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/apps/backend/internal/application/registry_bridge_service_test.go
+++ b/apps/backend/internal/application/registry_bridge_service_test.go
@@ -154,7 +154,7 @@ func (m *mockMCPServerRepoForBridge) GetByID(id uuid.UUID) (*domain.MCPServer, e
 func (m *mockMCPServerRepoForBridge) GetByOrganization(orgID uuid.UUID) ([]*domain.MCPServer, error) {
 	return nil, nil
 }
-func (m *mockMCPServerRepoForBridge) GetByURL(url string) (*domain.MCPServer, error) {
+func (m *mockMCPServerRepoForBridge) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
 	return nil, nil
 }
 func (m *mockMCPServerRepoForBridge) Update(s *domain.MCPServer) error  { return nil }

--- a/apps/backend/internal/application/tag_service_test.go
+++ b/apps/backend/internal/application/tag_service_test.go
@@ -290,8 +290,8 @@ func (m *MockMCPServerRepoForTags) GetByName(orgID uuid.UUID, name string) (*dom
 	return args.Get(0).(*domain.MCPServer), args.Error(1)
 }
 
-func (m *MockMCPServerRepoForTags) GetByURL(url string) (*domain.MCPServer, error) {
-	args := m.Called(url)
+func (m *MockMCPServerRepoForTags) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
+	args := m.Called(url, orgID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/apps/backend/internal/domain/mcp_server.go
+++ b/apps/backend/internal/domain/mcp_server.go
@@ -61,7 +61,12 @@ type MCPServerRepository interface {
 	Create(server *MCPServer) error
 	GetByID(id uuid.UUID) (*MCPServer, error)
 	GetByOrganization(orgID uuid.UUID) ([]*MCPServer, error)
-	GetByURL(url string) (*MCPServer, error)
+	// GetByURL returns the MCP server with the given URL within the
+	// caller's organization, or nil if none exists. The orgID filter is
+	// load-bearing: the mcp_servers table has UNIQUE(organization_id,
+	// url), so the same URL can legally exist in multiple organizations.
+	// A nil-org lookup would leak cross-tenant existence (defect #40).
+	GetByURL(url string, orgID uuid.UUID) (*MCPServer, error)
 	Update(server *MCPServer) error
 	Delete(id uuid.UUID) error
 	List(limit, offset int) ([]*MCPServer, error)

--- a/apps/backend/internal/infrastructure/repository/mcp_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_repository.go
@@ -253,7 +253,12 @@ func (r *MCPServerRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.MCPS
 	return servers, nil
 }
 
-func (r *MCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
+// GetByURL returns the MCP server matching the URL within the given
+// organization. The org filter is the security guarantee — the
+// mcp_servers table has UNIQUE(organization_id, url), so the same URL
+// can legally exist in multiple organizations; a nil-org lookup would
+// leak cross-tenant existence (defect #40).
+func (r *MCPServerRepository) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
 	query := `
 		SELECT
 			id, organization_id, name, description, url, version,
@@ -261,7 +266,7 @@ func (r *MCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
 			capabilities, trust_score, registered_by_agent, created_by, created_at, updated_at,
 			verification_method, attestation_count, confidence_score, last_attested_at
 		FROM mcp_servers
-		WHERE url = $1
+		WHERE url = $1 AND organization_id = $2
 	`
 
 	server := &domain.MCPServer{}
@@ -271,7 +276,7 @@ func (r *MCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
 	var publicKey sql.NullString
 	var verificationURL sql.NullString
 
-	err := r.db.QueryRow(query, url).Scan(
+	err := r.db.QueryRow(query, url, orgID).Scan(
 		&server.ID,
 		&server.OrganizationID,
 		&server.Name,

--- a/apps/backend/internal/testutil/mocks/repositories.go
+++ b/apps/backend/internal/testutil/mocks/repositories.go
@@ -554,8 +554,8 @@ func (m *MockMCPServerRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.
 	return args.Get(0).([]*domain.MCPServer), args.Error(1)
 }
 
-func (m *MockMCPServerRepository) GetByURL(url string) (*domain.MCPServer, error) {
-	args := m.Called(url)
+func (m *MockMCPServerRepository) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
+	args := m.Called(url, orgID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}


### PR DESCRIPTION
## Summary

Closes audit-doc defect **#40** (filed during A3a adversarial review). Pre-fix, `POST /api/v1/mcp-servers` with a URL colliding against a victim org's existing MCP server was a three-way cross-tenant leak:

| Class | Surface | File |
|---|---|---|
| (a) Read-side oracle | 409 response body echoes victim's `existingId` + `name` | `mcp_handler.go:278-281` |
| (b) Write-side cross-org connection | `agent_mcp_connections` row links caller's agent → victim's MCP server | `mcp_service.go:104-128` (pre-fix) |
| (c) Write-side cross-org mutation | Caller's request rewrites victim's capabilities + version | `mcp_service.go:137-157` (pre-fix) |

The audit doc filed (a) as the headline; (b) and (c) were noticed during this PR's investigation. All three collapse to "branch unreachable" with the same one-line repository-layer scoping fix.

## Fix

Scope `MCPServerRepository.GetByURL` to the caller's organization at the SQL layer. The mcp_servers table has `UNIQUE(organization_id, url)` (migration 004), so the same URL legally coexists across organizations — the global lookup contradicted the schema's intent.

```sql
-- Pre-fix
WHERE url = $1

-- Post-fix
WHERE url = $1 AND organization_id = $2
```

Cross-org collisions now return nil → the existing-found branch in `MCPService.CreateMCPServer` is skipped → execution proceeds to insert a new same-URL MCP server in the caller's org (which the DB constraint permits).

## Why repository-layer scoping, not service-layer post-check

The audit-doc preferred a service-layer post-check that returns a uniform 409 with no identifiers. I deviated to the repository-layer filter:

- The audit-doc preference predates noticing the write-side bugs (b) and (c). Service-layer guards would need three touch points (response, connection-create, mutation).
- The service-layer "uniform 409" still leaks "URL is taken somewhere" via the 409 itself.
- The DB schema **expects** per-org scoping. Repository-layer alignment removes the footgun for any future caller of `GetByURL`.

## Diff scope

| File | Δ | Purpose |
|---|---|---|
| `internal/domain/mcp_server.go` | +6/-1 | Interface signature + security docstring |
| `internal/infrastructure/repository/mcp_repository.go` | +8/-3 | Impl signature + SQL clause + security docstring |
| `internal/application/mcp_service.go` | +13/-2 | Caller passes orgID + SECURITY comment block |
| `internal/application/mcp_service_test.go` | +80/0 | Two new sqlmock-based regression tests |
| `internal/application/{agent,tag,registry_bridge}_service_test.go` | +2/-2 each | Mock signature updates |
| `internal/application/mocks_test.go` | +2/-2 | Shared mock signature |
| `internal/testutil/mocks/repositories.go` | +2/-2 | Testutil mock signature |

**115/15 lines across 9 files.** No incidental drift; reverted an over-eager `gofmt -w` that picked up pre-existing column drift in unrelated structs.

## Tests

- **`TestMCPServerRepository_GetByURL_FiltersByOrganization`** — asserts the SQL contains `WHERE url = $1 AND organization_id = $2` and is invoked with both args in correct order. Direct regression guard: a future edit that drops the clause OR transposes args fails at unit-test time.
- **`TestMCPServerRepository_GetByURL_CrossOrgReturnsNotFound`** — asserts that when the SQL filter eliminates the row (the cross-org case), the repository returns nil server. The caller in `MCPService.CreateMCPServer` relies on this nil to skip the leaky branch.

## Verification

- `go build ./...` → clean.
- `go vet ./...` → clean.
- `go test -race -count=1 ./internal/application/... ./internal/interfaces/http/handlers/...` → ok (87s + 1.6s respectively, full suites).
- `go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers` → ok (93 allowlist entries).
- HMA `secure --ci` on `internal/application/` → 98/100 (1 LOW pre-existing for missing `.gitignore` in subdir).
- Phase 4.5 adversarial review: PASS. Verified caller `orgID` provenance (server-trusted middleware sources only), confirmed single production caller, verified same-org wire-format preservation, confirmed bugs (b) and (c) collapse to unreachable code in the cross-tenant case, verified sqlmock tests pin clause + arg order.

`tests/integration/pqc_e2e_test.go` continues to fail with admin-login 401 (pre-existing — admin password rotated locally; identical failure on origin/main).

## Test plan

- [ ] CI: confirm tenantscope-lint job still green (93 entries) and new sqlmock tests pass.
- [ ] Code review: confirm the `WHERE url = $1 AND organization_id = $2` clause + `QueryRow(query, url, orgID)` arg order match.
- [ ] Manual integration: register an MCP server at `https://shared.example.com` in org A as user A. Then, authenticated as user B in org B, attempt to register the same URL → expect 201 (a new MCP server in org B with that URL), NOT 409 with org A's identifiers.
- [ ] Manual same-org: register `https://my-mcp.example.com` twice as same user → expect first 201, second 409 with `existingId` + `name` (legitimate SDK retry semantics preserved).
- [ ] Manual cross-org mutation check: attacker submits the same URL with `capabilities: ["read", "write", "exfiltrate"]`. Verify the victim's MCP server in another org is NOT mutated — query the victim's row before and after.

## Follow-ups (not in this PR)

- **Service-level integration test (MEDIUM, from Phase 4.5):** add `TestMCPService_CreateMCPServer_CrossOrgURLCollisionProceedsToInsert` exercising the full chain with mock repo. Requires refactoring `MCPService.mcpRepo` from concrete `*repository.MCPServerRepository` to the domain interface for mockability — same scope-creep tradeoff as the deferred STRICT-mode test on PR #145. Recommend filing as a small mockability refactor PR.
- **Discarded error at call site (LOW, pre-existing):** `existing, _ := s.mcpRepo.GetByURL(req.URL, orgID)` swallows all error classes; on transient DB failure the service silently proceeds to Create and surfaces 500. Worth tightening to distinguish "not found" from "DB failure" in a follow-up.
- **Audit `MCPService.UpdateMCPServer` and `DeleteMCPServer` for similar gaps** at the service layer (handler-level orgID checks exist for Update; should audit Delete).

## Related work

- Defect #18 (closed in PR #143 / A3a) — body-supplied UUID oracle in CreateMCPServer. #40 is the URL-supplied path of the same threat class.
- PR #144 / A3c (tenantscope-lint broadening) — surfaced 6 sibling defects (#42-47).
- PR #145 (defect #48 / RegisterCapability LoadOwned) — closed a related cross-tenant write-side IDOR via the same pattern.