### PR TITLE
security: convert inline 403-on-cross-org checks to LoadOwned (A3b-i, 7 read-only handlers)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -321,18 +321,15 @@ func (h *AgentHandler) GetAgent(c fiber.Ctx) error {
 		})
 	}
 
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-
-	// Verify agent belongs to organization
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	return c.JSON(h.enrichAgentResponse(c, agent))
@@ -812,17 +809,15 @@ func (h *AgentHandler) DownloadSDK(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Get agent credentials (decrypts private key)
@@ -921,17 +916,15 @@ func (h *AgentHandler) GetCredentials(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Get agent credentials (decrypts private key)
@@ -1197,17 +1190,15 @@ func (h *AgentHandler) GetAgentMCPServers(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Return MCP server details with connection metadata
@@ -1462,19 +1453,19 @@ func (h *AgentHandler) GetAgentByIdentifier(c fiber.Ctx) error {
 	var agent *domain.Agent
 
 	if err == nil {
-		// It's a UUID, get by ID
-		agent, err = h.agentService.GetAgent(c.Context(), agentID)
-		if err != nil {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-				"error": "Agent not found",
-			})
+		// It's a UUID, get by ID.
+		// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via
+		// LoadOwned. Returns 404 — not 403 — for cross-tenant access to
+		// avoid leaking resource existence across orgs. The name branch
+		// below uses GetAgentByName which already filters by orgID, so a
+		// cross-org name lookup naturally returns "not found" with no
+		// existence side channel either way.
+		loader := func(id uuid.UUID) (*domain.Agent, error) {
+			return h.agentService.GetAgent(c.Context(), id)
 		}
-
-		// Verify agent belongs to the organization
-		if agent.OrganizationID != orgID {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-				"error": "Agent does not belong to your organization",
-			})
+		agent = LoadOwned(c, loader, agentID, orgID, agentOrgID)
+		if agent == nil {
+			return nil
 		}
 	} else {
 		// It's a name, get by name
@@ -1581,18 +1572,14 @@ func (h *AgentHandler) GetAgentAlerts(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	// Parse pagination params
@@ -2189,17 +2176,14 @@ func (h *AgentHandler) GetAgentActivity(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b / defects #18-25 follow-on): tenant-scoping via LoadOwned.
+	// Returns 404 — not 403 — for cross-tenant access to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	// SECURITY: Validate pagination to prevent DoS

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -900,8 +900,7 @@ func (h *AgentHandler) DownloadSDK(c fiber.Ctx) error {
 // @Param id path string true "Agent ID"
 // @Success 200 {object} CredentialsResponse
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/credentials [get]
 func (h *AgentHandler) GetCredentials(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -2160,8 +2159,7 @@ func (h *AgentHandler) UpdateAgentKeys(c fiber.Ctx) error {
 // @Param offset query int false "Pagination offset (default 0)"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/activity [get]
 func (h *AgentHandler) GetAgentActivity(c fiber.Ctx) error {
 	orgID, err := RequireOrganizationID(c)

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
@@ -282,7 +282,11 @@ func TestAgentHandler_GetAgent_WrongOrganization(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	// A3b: cross-tenant access returns 404 (not 403) to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
 }
 
 // ===========================
@@ -1920,7 +1924,11 @@ func TestAgentHandler_GetAgentAlerts_AccessDenied(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	// A3b: cross-tenant access returns 404 (not 403) to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
 }
 
 func TestAgentHandler_GetAgentAlerts_SuccessWithPagination(t *testing.T) {
@@ -2376,7 +2384,11 @@ func TestAgentHandler_DownloadSDK_WrongOrganization(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	// A3b: cross-tenant access returns 404 (not 403) to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
 }
 
 func TestAgentHandler_DownloadSDK_CredentialsError(t *testing.T) {
@@ -2614,4 +2626,183 @@ func TestAgentHandler_GetAgentTrustScoreHistory_InvalidAgentID(t *testing.T) {
 
 	// The handler delegates to trustScoreHandler which is nil, so expect 500
 	assert.True(t, resp.StatusCode >= 400, "Expected error status")
+}
+
+// ===========================
+// A3b: cross-tenant access on read-only handlers returns 404 (not 403).
+// New tests for handlers previously without cross-org coverage. Pairs with
+// the flips of *_WrongOrganization / *_AccessDenied tests above for the
+// same handler family.
+// ===========================
+
+func TestAgentHandler_GetCredentials_CrossOrgReturns404(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+	differentOrgID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: differentOrgID,
+				Name:           "test-agent",
+			}, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents/:id/credentials", handler.GetCredentials)
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/credentials", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+}
+
+func TestAgentHandler_GetAgentMCPServers_CrossOrgReturns404(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+	differentOrgID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: differentOrgID,
+				Name:           "test-agent",
+			}, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents/:id/mcp-servers", handler.GetAgentMCPServers)
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/mcp-servers", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+}
+
+func TestAgentHandler_GetAgentByIdentifier_UUID_CrossOrgReturns404(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+	differentOrgID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: differentOrgID,
+				Name:           "test-agent",
+			}, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents/by-identifier/:identifier", handler.GetAgentByIdentifier)
+
+	req := httptest.NewRequest("GET", "/agents/by-identifier/"+agentID.String(), nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+}
+
+func TestAgentHandler_GetAgentActivity_CrossOrgReturns404(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+	differentOrgID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: differentOrgID,
+				Name:           "test-agent",
+			}, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents/:id/activity", handler.GetAgentActivity)
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/activity", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
 }


### PR DESCRIPTION
## Summary

Continues the A3 tenant-scoping pass after #136 / #143 / #144 / #145 / #146 / #147. Converts the **read-only single-agent handlers** in \`apps/backend/internal/interfaces/http/handlers/agent_handler.go\` from the inline pattern

\`\`\`go
agent, err := h.agentService.GetAgent(ctx, agentID)
if err != nil { return 404 }
if agent.OrganizationID != orgID { return 403 }
\`\`\`

to \`LoadOwned(c, loader, agentID, orgID, agentOrgID)\`, which returns **404 for both \"row missing\" and \"row exists in another org\"** — closing the cross-tenant existence side channel documented in [\`tenant_scope.go:41-46\`](apps/backend/internal/interfaces/http/handlers/tenant_scope.go#L41-L46).

### Handlers converted (7, all idempotent reads)

| Handler | Route | Conversion |
|---|---|---|
| \`GetAgent\` | \`GET /agents/:id\` | LoadOwned (keep return) |
| \`DownloadSDK\` | \`GET /agents/:id/sdk\` | LoadOwned (keep return — \`agent.Name\` used for audit + SDK gen) |
| \`GetCredentials\` | \`GET /agents/:id/credentials\` | LoadOwned (keep return — \`agent.Name\` used for audit) |
| \`GetAgentMCPServers\` | \`GET /agents/:id/mcp-servers\` | LoadOwned (keep return — \`agent.TalksTo\` used) |
| \`GetAgentByIdentifier\` (UUID branch) | \`GET /agents/by-identifier/:identifier\` | LoadOwned in UUID branch; name branch unchanged (\`GetAgentByName\` already filters by orgID at SQL level) |
| \`GetAgentAlerts\` | \`GET /agents/:id/alerts\` | LoadOwned (discard return — \`agentID\` used downstream) |
| \`GetAgentActivity\` | \`GET /agents/:id/activity\` | LoadOwned (discard return — \`agentID\` used downstream) |

### Tests

- Flip \`TestAgentHandler_GetAgent_WrongOrganization\`, \`TestAgentHandler_GetAgentAlerts_AccessDenied\`, \`TestAgentHandler_DownloadSDK_WrongOrganization\` from \`StatusForbidden\` → \`StatusNotFound\` + body shape \`{\"error\":\"not found\"}\`.
- Add cross-org coverage for the four previously-untested handlers: \`GetCredentials\`, \`GetAgentMCPServers\`, \`GetAgentByIdentifier\` (UUID), \`GetAgentActivity\`.

### Swagger doc

- Strike stale \`@Failure 403 \"Access denied\"\` from \`GetCredentials\` and \`GetAgentActivity\` (the only two of the seven that had a 403 swagger line). Phase 4.5 catch.

### Tenantscope-lint baseline

Unchanged: 93 entries, 0 violations. The \`LoadOwned\` helper is recognized via the existing AST rule, no allowlist additions needed.

## Deferred to A3b-ii+

12 inline-403 sites remain in \`agent_handler.go\` mutation/lifecycle handlers (\`UpdateAgent\`, \`DeleteAgent\`, \`VerifyAgent\`, \`AddMCPServersToAgent\`, \`RemoveMCPServerFromAgent\`, \`DetectAndMapMCPServers\`, \`UpdateAgentTrustScore\`, \`SuspendAgent\`, \`ReactivateAgent\`, \`RevokeAgent\`, \`RotateCredentials\`, \`UpdateAgentKeys\`), plus 30 sites across \`mcp_handler.go\` (12), \`a2a_handler.go\` (3), \`trust_score_handler.go\` (4), \`webhook_handler.go\` (4), \`admin_handler.go\` (3), \`agent_security_endpoints.go\` (2), \`pqc_endpoints.go\` (4). Each will be its own A3b-N tranche, scoped at <10 handlers per PR.

A separate LOW Phase 4.5 finding: the \`GetAgentByIdentifier\` UUID and name branches now both return 404 for cross-org but with different body shapes. The cross-tenant existence channel IS closed (the name branch's \`GetByName\` filters by orgID at the SQL layer), so the residual asymmetry only discloses \"input was UUID vs name\" — not cross-org. Will be normalized in a follow-up.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/...\` clean
- [x] \`go test -race ./internal/interfaces/http/handlers/\` clean
- [x] \`tenantscope-lint\` baseline unchanged (93/0)
- [x] HMA scan (\`hackmyagent secure --ci\`) → 100/100, no findings
- [x] 7 cross-org tests pass (3 flipped + 4 new)
- [x] Phase 4.5 adversarial subagent reviewed; MEDIUM addressed inline, LOW noted for follow-up