### PR TITLE
security: close 6 A3c-flagged cross-tenant IDORs (#42–#47)

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -153,31 +153,28 @@ var allowlist = map[string]string{
 	"VerificationHandler.UpdateExecutionStatus":             "audit-baseline: needs review",
 
 	// ---------------------------------------------------------------
-	// A3c-FLAGGED: 6 handlers surfaced 2026-05-20 by broadening
-	// paramKeys to cover the snake_case + camelCase URL-param
-	// spellings for tenant-scoped resources beyond `id`/`agent_id`.
-	// Each handler reads its resource ID from the path without
-	// invoking LoadOwned and without a visible OrganizationID
-	// identifier check at the handler layer. Service-layer
-	// enforcement (if any) needs manual verification before these
-	// can be moved to a per-entry justification or wired through
-	// LoadOwned. Filed as defects #42-47 in
-	// todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md.
-	// Closing these is A3b/A3d scope.
-	//
-	// Historical note: a seventh defensive entry for
-	// CapabilityHandler.RegisterCapability (#48) lived here from
-	// PR #144 (A3c) until PR #145 wrapped the handler with
-	// LoadOwned. The entry was removed because the handler now
-	// satisfies the lint structurally (LoadOwned recognition path).
-	// The audit doc #48 retains the full historical record.
+	// Service-layer-enforced tenant scoping. The lint's AST scan cannot
+	// see across the handler/service boundary, so handlers that push
+	// the org check into the service (rather than wrapping the path
+	// load in LoadOwned at the handler layer) need an allowlist entry
+	// with the enforcement mechanism cited.
 	// ---------------------------------------------------------------
-	"A2AHandler.GetSkillAttestations":               "audit-baseline: needs review (A3c-flagged #43)",
-	"A2AHandler.ListUserConsents":                   "audit-baseline: needs review (A3c-flagged #42)",
-	"CapabilityHandler.GetRecentViolations":         "audit-baseline: needs review (A3c-flagged #46)",
-	"CapabilityHandler.GetViolationsByOrganization": "audit-baseline: needs review (A3c-flagged #45)",
-	"CapabilityHandler.RevokeCapability":            "audit-baseline: needs review (A3c-flagged #44)",
-	"MCPAttestationHandler.RevokeAttestation":       "audit-baseline: needs review (A3c-flagged #47)",
+	"A2AHandler.ListUserConsents":             "service-layer scoping: A2AService.ListUserConsents requires callerOrgID and the repo query filters by organization_id (A3c #42 closed in PR TBD).",
+	"MCPAttestationHandler.RevokeAttestation": "service-layer scoping: MCPAttestationService.RevokeAttestation requires callerOrgID and returns application.ErrAttestationNotFound for both not-found and cross-tenant (A3c #47 closed in PR TBD).",
+
+	// ---------------------------------------------------------------
+	// Historical notes:
+	// - A3c-FLAGGED defects #42, #43, #44, #45, #46, #47 were
+	//   surfaced 2026-05-20 by broadening paramKeys (PR #144).
+	//   Defects #43, #44 now satisfy the lint structurally via
+	//   LoadOwned/agent.OrganizationID checks at the handler layer.
+	//   Defects #45, #46 were dead-handler removals (handlers were
+	//   never mounted). Defects #42 and #47 require allowlist
+	//   entries above because their fix lives at the service layer.
+	// - Defect #48 (RegisterCapability) lived here from PR #144 until
+	//   PR #145 wrapped the handler with LoadOwned. The audit doc
+	//   #48 retains the full historical record.
+	// ---------------------------------------------------------------
 }
 
 // recognizedHelpers names the helper functions that satisfy the lint.

--- a/apps/backend/internal/application/a2a_service.go
+++ b/apps/backend/internal/application/a2a_service.go
@@ -811,8 +811,12 @@ func (s *A2AService) RevokeConsent(ctx context.Context, consentID uuid.UUID, rea
 }
 
 // ListUserConsents lists all consent records for a user
-func (s *A2AService) ListUserConsents(ctx context.Context, userID string, includeRevoked bool) ([]*domain.A2AConsentRecord, error) {
-	return s.consentRepo.ListByUser(ctx, userID, includeRevoked)
+// ListUserConsents lists consent records for a userID that belong to
+// the caller's organization. SECURITY (A3c #42): orgID is required;
+// without it, any authenticated caller could enumerate consents across
+// tenants by walking userIDs.
+func (s *A2AService) ListUserConsents(ctx context.Context, userID string, orgID uuid.UUID, includeRevoked bool) ([]*domain.A2AConsentRecord, error) {
+	return s.consentRepo.ListByUser(ctx, userID, orgID, includeRevoked)
 }
 
 // ListAllConsents lists all consent records with pagination

--- a/apps/backend/internal/application/capability_service.go
+++ b/apps/backend/internal/application/capability_service.go
@@ -331,6 +331,16 @@ func (s *CapabilityService) GrantCapability(
 	return capability, nil
 }
 
+// GetCapabilityByID returns a single capability by its UUID. Callers
+// must enforce tenant scoping themselves — this method does NOT filter
+// by organization.
+func (s *CapabilityService) GetCapabilityByID(
+	ctx context.Context,
+	capabilityID uuid.UUID,
+) (*domain.AgentCapability, error) {
+	return s.capabilityRepo.GetCapabilityByID(capabilityID)
+}
+
 // RevokeCapability revokes a capability from an agent
 func (s *CapabilityService) RevokeCapability(
 	ctx context.Context,

--- a/apps/backend/internal/application/mcp_attestation_service.go
+++ b/apps/backend/internal/application/mcp_attestation_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -15,6 +16,12 @@ import (
 	infracrypto "github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/crypto"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
 )
+
+// ErrAttestationNotFound is returned by RevokeAttestation when the
+// attestation does not exist OR exists in another organization. The two
+// cases are deliberately collapsed to preserve existence-secrecy across
+// tenant boundaries; see tenant_scope.go:41-46 in handlers.
+var ErrAttestationNotFound = errors.New("attestation not found")
 
 // Multi-Agent Consensus Configuration
 // These thresholds determine when an MCP server is considered "verified" by the community
@@ -1021,13 +1028,37 @@ func (s *MCPAttestationService) InvalidateExpiredAttestations(ctx context.Contex
 func (s *MCPAttestationService) RevokeAttestation(
 	ctx context.Context,
 	attestationID uuid.UUID,
+	callerOrgID uuid.UUID,
 	revokerID uuid.UUID,
 	reason string,
 ) error {
 	// Get the attestation to find the MCP server ID
 	attestation, err := s.attestationRepo.GetAttestationByID(attestationID)
-	if err != nil {
-		return fmt.Errorf("attestation not found: %w", err)
+	if err != nil || attestation == nil {
+		return ErrAttestationNotFound
+	}
+
+	// SECURITY (A3c #47): tenant-scope the revocation. The attestation
+	// belongs to either the attester's org (when AgentID is set) or the
+	// attested MCP server's org (for manual attestations). Verify the
+	// caller's org matches; on mismatch, return ErrAttestationNotFound
+	// (same as "not in DB") to avoid disclosing cross-tenant existence.
+	var attestationOrgID uuid.UUID
+	if attestation.AgentID != nil {
+		agent, err := s.agentRepo.GetByID(*attestation.AgentID)
+		if err != nil || agent == nil {
+			return ErrAttestationNotFound
+		}
+		attestationOrgID = agent.OrganizationID
+	} else {
+		mcpServer, err := s.mcpRepo.GetByID(attestation.MCPServerID)
+		if err != nil || mcpServer == nil {
+			return ErrAttestationNotFound
+		}
+		attestationOrgID = mcpServer.OrganizationID
+	}
+	if attestationOrgID != callerOrgID {
+		return ErrAttestationNotFound
 	}
 
 	// Invalidate the attestation

--- a/apps/backend/internal/infrastructure/repository/a2a_repository.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_repository.go
@@ -1362,7 +1362,12 @@ func (r *A2AConsentRepository) CheckConsent(ctx context.Context, userID string, 
 	return exists, nil
 }
 
-func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, includeRevoked bool) ([]*domain.A2AConsentRecord, error) {
+func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, orgID uuid.UUID, includeRevoked bool) ([]*domain.A2AConsentRecord, error) {
+	// SECURITY (A3c #42): scope by organization_id to prevent cross-tenant
+	// userId enumeration. A caller in org A must not be able to read a
+	// userId's consents from org B. NULL organization_id rows are
+	// deliberately excluded — those are system-wide / pre-migration
+	// records and need a separate admin path. See tenant_scope.go:41-46.
 	var query string
 	if includeRevoked {
 		query = `
@@ -1372,7 +1377,7 @@ func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, in
 				revoked, revoked_at, revoked_reason, consent_method, evidence,
 				ip_address, user_agent, created_at, updated_at
 			FROM a2a_consent_records
-			WHERE user_id = $1
+			WHERE user_id = $1 AND organization_id = $2
 			ORDER BY granted_at DESC
 		`
 	} else {
@@ -1383,11 +1388,11 @@ func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, in
 				revoked, revoked_at, revoked_reason, consent_method, evidence,
 				ip_address, user_agent, created_at, updated_at
 			FROM a2a_consent_records
-			WHERE user_id = $1 AND revoked = FALSE
+			WHERE user_id = $1 AND organization_id = $2 AND revoked = FALSE
 			ORDER BY granted_at DESC
 		`
 	}
-	return r.queryConsents(ctx, query, userID)
+	return r.queryConsents(ctx, query, userID, orgID)
 }
 
 func (r *A2AConsentRepository) ListAll(ctx context.Context, limit, offset int) ([]*domain.A2AConsentRecord, int, error) {

--- a/apps/backend/internal/infrastructure/repository/a2a_repository.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_repository.go
@@ -1366,8 +1366,14 @@ func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, or
 	// SECURITY (A3c #42): scope by organization_id to prevent cross-tenant
 	// userId enumeration. A caller in org A must not be able to read a
 	// userId's consents from org B. NULL organization_id rows are
-	// deliberately excluded — those are system-wide / pre-migration
-	// records and need a separate admin path. See tenant_scope.go:41-46.
+	// deliberately excluded — including them would reintroduce a
+	// cross-tenant leak (a NULL-org row would be visible to every
+	// caller). The companion fix in A2AHandler.RecordConsent now stamps
+	// caller orgID on every new write, so future rows are always
+	// org-scoped. Existing NULL-org rows from the pre-fix write path
+	// remain dark to this query; a backfill migration (infer org from
+	// grantor_agent_id → agents.organization_id) is filed as audit-doc
+	// follow-up. See tenant_scope.go:41-46.
 	var query string
 	if includeRevoked {
 		query = `

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -847,6 +847,11 @@ func (h *A2AHandler) RevokeConsent(c fiber.Ctx) error {
 // ListUserConsents lists all consent records for a user
 // GET /api/v1/a2a/consent/user/:userId
 func (h *A2AHandler) ListUserConsents(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
 	userID := c.Params("userId")
 	if userID == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -856,7 +861,11 @@ func (h *A2AHandler) ListUserConsents(c fiber.Ctx) error {
 
 	includeRevoked := c.Query("includeRevoked") == "true"
 
-	consents, err := h.a2aService.ListUserConsents(c.Context(), userID, includeRevoked)
+	// SECURITY (A3c #42): the service scopes the query by the caller's
+	// orgID. Cross-tenant userId enumeration returns an empty list, which
+	// is indistinguishable from "user has no consents in your org" — no
+	// existence side channel is exposed.
+	consents, err := h.a2aService.ListUserConsents(c.Context(), userID, orgID, includeRevoked)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),
@@ -1188,6 +1197,11 @@ func (h *A2AHandler) GetConsensusStatus(c fiber.Ctx) error {
 // GetSkillAttestations returns all attestations for an agent's skill
 // GET /api/v1/a2a/attestations/:agentId/:skillId
 func (h *A2AHandler) GetSkillAttestations(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
 	agentID, err := uuid.Parse(c.Params("agentId"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -1196,6 +1210,17 @@ func (h *A2AHandler) GetSkillAttestations(c fiber.Ctx) error {
 	}
 
 	skillID := c.Params("skillId")
+
+	// SECURITY (A3c #43): tenant-scope by verifying the agent belongs to
+	// caller's org BEFORE reading attestations. Returns 404 for
+	// cross-tenant access to preserve existence-secrecy (see
+	// tenant_scope.go:41-46).
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
+	}
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
+	}
 
 	attestations, err := h.a2aService.GetAgentAttestations(c.Context(), agentID, skillID)
 	if err != nil {

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -720,6 +720,14 @@ func (h *A2AHandler) RecordConsent(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3c #42 pair): always stamp the caller's orgID onto the
+	// consent record. Without this, the record lands with
+	// organization_id = NULL and becomes invisible to the new
+	// org-scoped ListUserConsents read path. Any body-supplied
+	// organizationId is overridden — caller's authenticated org is the
+	// only source of truth.
+	req.OrganizationID = &orgID
+
 	// Set IP and User-Agent from request
 	req.IPAddress = c.IP()
 	req.UserAgent = c.Get("User-Agent")

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -48,10 +48,12 @@ func NewCapabilityHandler(
 }
 
 // NewCapabilityHandlerWithInterfaces creates a CapabilityHandler using
-// interfaces for testability. Tests that exercise paths past the
-// tenant-scoping check (defect #25 fix) must overwrite handler.agentRepo
-// with a scenario-specific mock that returns an agent whose
-// OrganizationID matches the caller's org in the test's c.Locals.
+// interfaces for testability. Tests that exercise paths past either of
+// the tenant-scoping checks (defect #25 in GrantCapability, defect #44
+// in RevokeCapability) must overwrite handler.agentRepo with a
+// scenario-specific mock that returns an agent whose OrganizationID
+// matches the caller's org in the test's c.Locals. Without that, the
+// nil agentRepo will panic on first GetByID dispatch.
 func NewCapabilityHandlerWithInterfaces(
 	capabilityService CapabilityServicer,
 ) *CapabilityHandler {

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -393,6 +393,11 @@ func (h *CapabilityHandler) GetAgentCapabilities(c fiber.Ctx) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /agents/{agentId}/capabilities/{capabilityId} [delete]
 func (h *CapabilityHandler) RevokeCapability(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
 	capabilityID, err := uuid.Parse(c.Params("capabilityId"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
@@ -408,9 +413,32 @@ func (h *CapabilityHandler) RevokeCapability(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3c #44): tenant-scope the capability before revocation.
+	// CapabilityService.RevokeCapability does NOT enforce org scoping
+	// internally — without this check, a caller in org A could revoke a
+	// capability in org B by passing the foreign capability UUID. Load
+	// the capability, look up its owning agent, verify the agent's org
+	// matches the caller's org. Returns 404 (not 403) for both "not
+	// found" and "exists in another org" to avoid the cross-tenant
+	// existence side channel; see tenant_scope.go:41-46.
 	capSvc := h.getCapabilityService()
+	capability, err := capSvc.GetCapabilityByID(c.Context(), capabilityID)
+	if err != nil || capability == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	agent, err := h.agentRepo.GetByID(capability.AgentID)
+	if err != nil || agent == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	if agent.OrganizationID != orgID {
+		respondResourceNotFound(c)
+		return nil
+	}
+
 	if err := capSvc.RevokeCapability(
-		context.Background(),
+		c.Context(),
 		capabilityID,
 		&userID,
 	); err != nil {
@@ -544,62 +572,6 @@ func (h *CapabilityHandler) GetViolationsByAgent(c fiber.Ctx) error {
 	})
 }
 
-// GetViolationsByOrganization godoc
-// @Summary Get violations for an organization
-// @Description Retrieve all capability violations for an organization
-// @Tags capabilities
-// @Produce json
-// @Param orgId path string true "Organization ID"
-// @Param limit query int false "Limit" default(20)
-// @Param offset query int false "Offset" default(0)
-// @Success 200 {object} ViolationsResponse
-// @Failure 400 {object} ErrorResponse
-// @Failure 401 {object} ErrorResponse
-// @Failure 500 {object} ErrorResponse
-// @Router /organizations/{orgId}/violations [get]
-func (h *CapabilityHandler) GetViolationsByOrganization(c fiber.Ctx) error {
-	orgID, err := uuid.Parse(c.Params("orgId"))
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
-			Error: "Invalid organization ID",
-		})
-	}
-
-	limit := 20
-	if limitStr := c.Query("limit"); limitStr != "" {
-		if parsedLimit, err := strconv.Atoi(limitStr); err == nil {
-			limit = parsedLimit
-		}
-	}
-
-	offset := 0
-	if offsetStr := c.Query("offset"); offsetStr != "" {
-		if parsedOffset, err := strconv.Atoi(offsetStr); err == nil {
-			offset = parsedOffset
-		}
-	}
-
-	capSvc := h.getCapabilityService()
-	violations, total, err := capSvc.GetViolationsByOrganization(
-		context.Background(),
-		orgID,
-		limit,
-		offset,
-	)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-			Error: err.Error(),
-		})
-	}
-
-	return c.JSON(ViolationsResponse{
-		Violations: violations,
-		Total:      total,
-		Limit:      limit,
-		Offset:     offset,
-	})
-}
-
 // ListCapabilities godoc
 // @Summary List all available capabilities
 // @Description Get all capability types available in the system with metadata
@@ -635,48 +607,6 @@ func (h *CapabilityHandler) ListCapabilities(c fiber.Ctx) error {
 	}
 
 	return c.JSON(response)
-}
-
-// GetRecentViolations godoc
-// @Summary Get recent violations
-// @Description Retrieve violations from the last N minutes for an organization
-// @Tags capabilities
-// @Produce json
-// @Param orgId path string true "Organization ID"
-// @Param minutes query int false "Minutes to look back" default(60)
-// @Success 200 {array} domain.CapabilityViolation
-// @Failure 400 {object} ErrorResponse
-// @Failure 401 {object} ErrorResponse
-// @Failure 500 {object} ErrorResponse
-// @Router /organizations/{orgId}/violations/recent [get]
-func (h *CapabilityHandler) GetRecentViolations(c fiber.Ctx) error {
-	orgID, err := uuid.Parse(c.Params("orgId"))
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
-			Error: "Invalid organization ID",
-		})
-	}
-
-	minutes := 60
-	if minutesStr := c.Query("minutes"); minutesStr != "" {
-		if parsedMinutes, err := strconv.Atoi(minutesStr); err == nil {
-			minutes = parsedMinutes
-		}
-	}
-
-	capSvc := h.getCapabilityService()
-	violations, err := capSvc.GetRecentViolations(
-		context.Background(),
-		orgID,
-		minutes,
-	)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-			Error: err.Error(),
-		})
-	}
-
-	return c.JSON(violations)
 }
 
 // Helper function to extract user ID from JWT claims or use system user for API key auth

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -98,17 +99,27 @@ func TestCapabilityHandler_RevokeCapability_Success(t *testing.T) {
 	agentID := uuid.New()
 	capabilityID := uuid.New()
 	userID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetCapabilityByIDFunc: func(ctx context.Context, capID uuid.UUID) (*domain.AgentCapability, error) {
+			return &domain.AgentCapability{ID: capabilityID, AgentID: agentID}, nil
+		},
 		RevokeCapabilityFunc: func(ctx context.Context, capID uuid.UUID, revokedBy *uuid.UUID) error {
 			return nil
 		},
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
 	app.Delete("/agents/:agentId/capabilities/:capabilityId", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
 		c.Locals("user_id", userID)
 		return handler.RevokeCapability(c)
 	})
@@ -123,11 +134,17 @@ func TestCapabilityHandler_RevokeCapability_Success(t *testing.T) {
 
 func TestCapabilityHandler_RevokeCapability_InvalidCapabilityID_Integration(t *testing.T) {
 	agentID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
 
 	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
 
 	app := fiber.New()
-	app.Delete("/agents/:agentId/capabilities/:capabilityId", handler.RevokeCapability)
+	app.Delete("/agents/:agentId/capabilities/:capabilityId", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		c.Locals("user_id", userID)
+		return handler.RevokeCapability(c)
+	})
 
 	req := httptest.NewRequest("DELETE", "/agents/"+agentID.String()+"/capabilities/invalid-uuid", nil)
 	resp, err := app.Test(req)
@@ -140,11 +157,17 @@ func TestCapabilityHandler_RevokeCapability_InvalidCapabilityID_Integration(t *t
 func TestCapabilityHandler_RevokeCapability_Unauthorized(t *testing.T) {
 	agentID := uuid.New()
 	capabilityID := uuid.New()
+	orgID := uuid.New()
 
 	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
 
 	app := fiber.New()
-	app.Delete("/agents/:agentId/capabilities/:capabilityId", handler.RevokeCapability)
+	// Set org_id but NOT user_id — verifies the user-context guard still
+	// returns 401 after the A3c #44 org-scoping check passes.
+	app.Delete("/agents/:agentId/capabilities/:capabilityId", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.RevokeCapability(c)
+	})
 
 	req := httptest.NewRequest("DELETE", "/agents/"+agentID.String()+"/capabilities/"+capabilityID.String(), nil)
 	resp, err := app.Test(req)
@@ -154,21 +177,74 @@ func TestCapabilityHandler_RevokeCapability_Unauthorized(t *testing.T) {
 	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
 }
 
+// A3c #44: cross-tenant capability revocation must return 404.
+func TestCapabilityHandler_RevokeCapability_CrossOrgReturns404(t *testing.T) {
+	agentID := uuid.New()
+	capabilityID := uuid.New()
+	callerOrgID := uuid.New()
+	differentOrgID := uuid.New()
+	userID := uuid.New()
+
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetCapabilityByIDFunc: func(ctx context.Context, capID uuid.UUID) (*domain.AgentCapability, error) {
+			return &domain.AgentCapability{ID: capabilityID, AgentID: agentID}, nil
+		},
+		RevokeCapabilityFunc: func(ctx context.Context, capID uuid.UUID, revokedBy *uuid.UUID) error {
+			// Should NOT be reached.
+			t.Fatalf("RevokeCapability called for cross-tenant request — security regression")
+			return nil
+		},
+	}
+
+	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: differentOrgID}, nil
+		},
+	}
+
+	app := fiber.New()
+	app.Delete("/agents/:agentId/capabilities/:capabilityId", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("user_id", userID)
+		return handler.RevokeCapability(c)
+	})
+
+	req := httptest.NewRequest("DELETE", "/agents/"+agentID.String()+"/capabilities/"+capabilityID.String(), nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+}
+
 func TestCapabilityHandler_RevokeCapability_ServiceError(t *testing.T) {
 	agentID := uuid.New()
 	capabilityID := uuid.New()
 	userID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetCapabilityByIDFunc: func(ctx context.Context, capID uuid.UUID) (*domain.AgentCapability, error) {
+			return &domain.AgentCapability{ID: capabilityID, AgentID: agentID}, nil
+		},
 		RevokeCapabilityFunc: func(ctx context.Context, capID uuid.UUID, revokedBy *uuid.UUID) error {
 			return assert.AnError
 		},
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
 	app.Delete("/agents/:agentId/capabilities/:capabilityId", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
 		c.Locals("user_id", userID)
 		return handler.RevokeCapability(c)
 	})
@@ -249,55 +325,6 @@ func TestCapabilityHandler_GetViolationsByAgent_ServiceError(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
-}
-
-// ===========================
-// GetViolationsByOrganization Tests
-// ===========================
-
-func TestCapabilityHandler_GetViolationsByOrganization_Success(t *testing.T) {
-	orgID := uuid.New()
-
-	mockCapabilityService := &MockCapabilityServiceImpl{
-		GetViolationsByOrganizationFunc: func(ctx context.Context, oID uuid.UUID, limit, offset int) ([]*domain.CapabilityViolation, int, error) {
-			return []*domain.CapabilityViolation{
-				{ID: uuid.New(), AttemptedCapability: "file:write"},
-				{ID: uuid.New(), AttemptedCapability: "network:connect"},
-			}, 10, nil
-		},
-	}
-
-	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
-
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations", handler.GetViolationsByOrganization)
-
-	req := httptest.NewRequest("GET", "/organizations/"+orgID.String()+"/violations", nil)
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
-
-	var result map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	require.NoError(t, err)
-
-	assert.Equal(t, float64(10), result["total"])
-}
-
-func TestCapabilityHandler_GetViolationsByOrganization_InvalidID(t *testing.T) {
-	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
-
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations", handler.GetViolationsByOrganization)
-
-	req := httptest.NewRequest("GET", "/organizations/invalid-uuid/violations", nil)
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
 // ===========================
@@ -383,70 +410,6 @@ func TestCapabilityHandler_ListCapabilities_ServiceError(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/capabilities", nil)
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
-}
-
-// ===========================
-// GetRecentViolations Tests
-// ===========================
-
-func TestCapabilityHandler_GetRecentViolations_Success(t *testing.T) {
-	orgID := uuid.New()
-
-	mockCapabilityService := &MockCapabilityServiceImpl{
-		GetRecentViolationsFunc: func(ctx context.Context, oID uuid.UUID, minutes int) ([]*domain.CapabilityViolation, error) {
-			return []*domain.CapabilityViolation{
-				{ID: uuid.New(), AttemptedCapability: "file:write"},
-			}, nil
-		},
-	}
-
-	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
-
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations/recent", handler.GetRecentViolations)
-
-	req := httptest.NewRequest("GET", "/organizations/"+orgID.String()+"/violations/recent?minutes=30", nil)
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
-}
-
-func TestCapabilityHandler_GetRecentViolations_InvalidOrgID_Integration(t *testing.T) {
-	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
-
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations/recent", handler.GetRecentViolations)
-
-	req := httptest.NewRequest("GET", "/organizations/invalid-uuid/violations/recent", nil)
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
-}
-
-func TestCapabilityHandler_GetRecentViolations_ServiceError(t *testing.T) {
-	orgID := uuid.New()
-
-	mockCapabilityService := &MockCapabilityServiceImpl{
-		GetRecentViolationsFunc: func(ctx context.Context, oID uuid.UUID, minutes int) ([]*domain.CapabilityViolation, error) {
-			return nil, assert.AnError
-		},
-	}
-
-	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
-
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations/recent", handler.GetRecentViolations)
-
-	req := httptest.NewRequest("GET", "/organizations/"+orgID.String()+"/violations/recent", nil)
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_test.go
@@ -239,24 +239,6 @@ func TestCapabilityHandler_GetViolationsByAgent_InvalidAgentID(t *testing.T) {
 }
 
 // ===========================
-// CapabilityHandler.GetViolationsByOrganization Tests
-// ===========================
-
-func TestCapabilityHandler_GetViolationsByOrganization_InvalidOrgID(t *testing.T) {
-	handler := &CapabilityHandler{}
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations", withCapabilityContext(handler.GetViolationsByOrganization))
-
-	req := httptest.NewRequest("GET", "/organizations/not-a-uuid/violations", nil)
-
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
-}
-
-// ===========================
 // CapabilityHandler.ListCapabilities Tests
 // ===========================
 
@@ -273,24 +255,6 @@ func TestCapabilityHandler_ListCapabilities_NoOrgContext(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
-}
-
-// ===========================
-// CapabilityHandler.GetRecentViolations Tests
-// ===========================
-
-func TestCapabilityHandler_GetRecentViolations_InvalidOrgID(t *testing.T) {
-	handler := &CapabilityHandler{}
-	app := fiber.New()
-	app.Get("/organizations/:orgId/violations/recent", withCapabilityContext(handler.GetRecentViolations))
-
-	req := httptest.NewRequest("GET", "/organizations/not-a-uuid/violations/recent", nil)
-
-	resp, err := app.Test(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -74,6 +74,7 @@ type CapabilityServicer interface {
 	VerifyAction(ctx context.Context, agentID uuid.UUID, requestedCapability string, signature []byte, payload []byte, sourceIP *string, metadata map[string]interface{}) (*application.VerificationResult, error)
 	GrantCapability(ctx context.Context, agentID uuid.UUID, capabilityType string, scope map[string]interface{}, grantedBy *uuid.UUID, executionMode string) (*domain.AgentCapability, error)
 	RevokeCapability(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
+	GetCapabilityByID(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilities(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
 	ListCapabilities(ctx context.Context, orgID uuid.UUID) ([]application.CapabilityDefinition, error)
 	ListCapabilitiesWithMetadata(ctx context.Context, orgID uuid.UUID) (*application.ListCapabilitiesResponse, error)

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -491,6 +491,10 @@ func (h *MCPAttestationHandler) RevokeAttestation(c fiber.Ctx) error {
 			respondResourceNotFound(c)
 			return nil
 		}
+		// Server-side log preserves the underlying cause without
+		// leaking it to the client.
+		fmt.Printf("⚠️  RevokeAttestation failed: attestationID=%s callerOrgID=%s err=%v\n",
+			attestationID, orgID, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to revoke attestation",
 		})

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gofiber/fiber/v3"
@@ -480,17 +481,18 @@ func (h *MCPAttestationHandler) RevokeAttestation(c fiber.Ctx) error {
 		})
 	}
 
-	// Revoke the attestation
-	err = h.attestationService.RevokeAttestation(c.Context(), attestationID, userID, req.Reason)
+	// Revoke the attestation. The service enforces tenant-scoping (A3c
+	// #47) by collapsing "not found" and "cross-tenant" into a single
+	// sentinel error; map both to 404 with the standard not-found body
+	// shape to preserve existence-secrecy.
+	err = h.attestationService.RevokeAttestation(c.Context(), attestationID, orgID, userID, req.Reason)
 	if err != nil {
-		statusCode := fiber.StatusInternalServerError
-		if err.Error() == "attestation not found" {
-			statusCode = fiber.StatusNotFound
+		if errors.Is(err, application.ErrAttestationNotFound) {
+			respondResourceNotFound(c)
+			return nil
 		}
-
-		return c.Status(statusCode).JSON(fiber.Map{
-			"error":   "Failed to revoke attestation",
-			"message": err.Error(),
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to revoke attestation",
 		})
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -368,6 +368,7 @@ type MockCapabilityServiceImpl struct {
 	VerifyActionFunc                  func(ctx context.Context, agentID uuid.UUID, requestedCapability string, signature []byte, payload []byte, sourceIP *string, metadata map[string]interface{}) (*application.VerificationResult, error)
 	GrantCapabilityFunc               func(ctx context.Context, agentID uuid.UUID, capabilityType string, scope map[string]interface{}, grantedBy *uuid.UUID, executionMode string) (*domain.AgentCapability, error)
 	RevokeCapabilityFunc              func(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
+	GetCapabilityByIDFunc             func(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilitiesFunc          func(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
 	ListCapabilitiesFunc              func(ctx context.Context, orgID uuid.UUID) ([]application.CapabilityDefinition, error)
 	ListCapabilitiesWithMetadataFunc  func(ctx context.Context, orgID uuid.UUID) (*application.ListCapabilitiesResponse, error)
@@ -396,6 +397,13 @@ func (m *MockCapabilityServiceImpl) RevokeCapability(ctx context.Context, capabi
 		return m.RevokeCapabilityFunc(ctx, capabilityID, revokedBy)
 	}
 	return nil
+}
+
+func (m *MockCapabilityServiceImpl) GetCapabilityByID(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error) {
+	if m.GetCapabilityByIDFunc != nil {
+		return m.GetCapabilityByIDFunc(ctx, capabilityID)
+	}
+	return nil, nil
 }
 
 func (m *MockCapabilityServiceImpl) GetAgentCapabilities(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {


### PR DESCRIPTION
## Summary

Closes the 6 cross-tenant IDORs surfaced 2026-05-20 by PR #144's broadening of tenantscope-lint paramKeys. Pairs with #148 (A3b-i).

| Defect | Fix mechanism | Test coverage |
|---|---|---|
| **#42** A2A `ListUserConsents` | service-layer scoping: `A2AService.ListUserConsents` requires \`callerOrgID\`; repo query filters `WHERE user_id = $1 AND organization_id = $2` | gap (concrete \`*application.A2AService\`; needs A2AServicer interface follow-up) |
| **#43** A2A `GetSkillAttestations` | handler-layer \`LoadOwned\` wraps the path agentID | mechanism covered by A3b-i suite |
| **#44** Capability `RevokeCapability` | handler-layer: new \`CapabilityServicer.GetCapabilityByID\` → \`agentRepo.GetByID(capability.AgentID)\` → \`respondResourceNotFound\` on cross-tenant | **new test**: \`TestCapabilityHandler_RevokeCapability_CrossOrgReturns404\` |
| **#45** Capability `GetViolationsByOrganization` | dead handler removed (never mounted to a route) | n/a |
| **#46** Capability `GetRecentViolations` | dead handler removed (never mounted to a route) | n/a |
| **#47** MCPAttestation `RevokeAttestation` | service-layer scoping: \`callerOrgID\` parameter + new exported \`application.ErrAttestationNotFound\` sentinel for both not-found and cross-tenant; handler maps to \`respondResourceNotFound\` | gap (concrete \`*application.MCPAttestationService\`; needs MCPAttestationServicer interface follow-up) |

### Adversarial review catches

A general-purpose adversarial subagent reviewed `fc400ba` and surfaced:

- **CRITICAL** — \`RecordConsent\` never stamped \`c.Locals(\"organization_id\")\` onto \`RecordConsentRequest\`, so new consent rows landed with \`organization_id = NULL\` and the new \`ListByUser\` query would have silently dropped them. **Fixed in 5710f6d** (the second commit): the handler now overrides \`req.OrganizationID = &orgID\` regardless of body payload.
- **MEDIUM** — \`NewCapabilityHandlerWithInterfaces\` doc only warned about the defect #25 nil-deref hazard; defect #44 introduces a second \`agentRepo\` dispatch site. Doc updated.
- **LOW** — \`RevokeAttestation\` 500 path lost the underlying error visibility. Added a server-side log line.

### Lint allowlist deltas

- Net: 93 → 89 entries.
- −2 dead handlers (#45/#46): \`GetViolationsByOrganization\`, \`GetRecentViolations\`.
- −6 \`A3c-flagged\` entries (one per defect).
- +2 \`service-layer scoping\` entries (#42, #47) with one-line mechanism citations.

### Follow-ups filed in audit doc

- **#49** \`CapabilityHandler.GetViolationsByAgent\` — live sibling, also unscoped. HIGH. A3b-ii/A3d scope.
- **#50** Pre-fix NULL-org A2A consent rows backfill migration. MEDIUM. Dedicated data-cleanup PR.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/...\` clean
- [x] \`go test -race ./internal/interfaces/http/handlers/\` clean
- [x] \`go test ./internal/application/\` clean
- [x] \`tenantscope-lint\` → \`ok (89 allowlist entries)\`
- [x] \`hackmyagent secure --ci\` → 100/100, no findings
- [x] new \`_CrossOrgReturns404\` test for #44 passes
- [x] adversarial subagent review (1 CRITICAL fixed, 1 MEDIUM fixed, 1 LOW fixed, 2 audit-doc entries filed)
- [ ] manual integration verification for #42, #47 (service-layer) — pending A2AServicer / MCPAttestationServicer interface follow-up so the handler-level test scaffolding can reach them