### PR TITLE
security: close audit-doc #49 + #51 — capability handler cross-tenant reads

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -105,8 +105,6 @@ var allowlist = map[string]string{
 	"APIKeyHandler.DeleteAPIKey":                            "audit-baseline: needs review",
 	"APIKeyHandler.DisableAPIKey":                           "audit-baseline: needs review",
 	"AuthorizeHandler.Authorize":                            "audit-baseline: needs review",
-	"CapabilityHandler.GetAgentCapabilities":                "audit-baseline: needs review",
-	"CapabilityHandler.GetViolationsByAgent":                "audit-baseline: needs review",
 	"CapabilityRequestHandlers.CreateCapabilityRequest":     "audit-baseline: needs review",
 	"CapabilityRequestHandlers.ListAgentCapabilityRequests": "audit-baseline: needs review",
 	"CapabilityRequestHandlers.RejectCapabilityRequest":     "audit-baseline: needs review",

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -353,9 +353,15 @@ func (h *CapabilityHandler) RegisterCapability(c fiber.Ctx) error {
 // @Success 200 {array} domain.AgentCapability
 // @Failure 400 {object} ErrorResponse
 // @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Failure 500 {object} ErrorResponse
 // @Router /agents/{id}/capabilities [get]
 func (h *CapabilityHandler) GetAgentCapabilities(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
 	agentID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
@@ -363,11 +369,20 @@ func (h *CapabilityHandler) GetAgentCapabilities(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (audit doc #51): tenant-scope by verifying the path
+	// agentID belongs to the caller's org BEFORE reading capabilities.
+	// Same IDOR shape as #49 (GetViolationsByAgent); the lint's
+	// audit-baseline grandfathered both since PR #136. Returns 404 on
+	// cross-tenant access for existence-secrecy.
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
+	}
+
 	activeOnly := c.Query("activeOnly", "true") == "true"
 
 	capSvc := h.getCapabilityService()
 	capabilities, err := capSvc.GetAgentCapabilities(
-		context.Background(),
+		c.Context(),
 		agentID,
 		activeOnly,
 	)
@@ -499,14 +514,28 @@ func (h *CapabilityHandler) VerifyAction(c fiber.Ctx) error {
 // @Success 200 {object} ViolationsResponse
 // @Failure 400 {object} ErrorResponse
 // @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Failure 500 {object} ErrorResponse
 // @Router /agents/{id}/violations [get]
 func (h *CapabilityHandler) GetViolationsByAgent(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
 	agentID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 			Error: "Invalid agent ID",
 		})
+	}
+
+	// SECURITY (audit doc #49): tenant-scope by verifying the path
+	// agentID belongs to the caller's org BEFORE reading violations.
+	// Returns 404 — not 403 — on cross-tenant access to preserve
+	// existence-secrecy. See tenant_scope.go:41-46.
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	limit := 20
@@ -525,7 +554,7 @@ func (h *CapabilityHandler) GetViolationsByAgent(c fiber.Ctx) error {
 
 	capSvc := h.getCapabilityService()
 	violations, total, err := capSvc.GetViolationsByAgent(
-		context.Background(),
+		c.Context(),
 		agentID,
 		limit,
 		offset,

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler_integration_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -26,6 +27,7 @@ import (
 
 func TestCapabilityHandler_GetAgentCapabilities_Success(t *testing.T) {
 	agentID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
 		GetAgentCapabilitiesFunc: func(ctx context.Context, aID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {
@@ -37,9 +39,17 @@ func TestCapabilityHandler_GetAgentCapabilities_Success(t *testing.T) {
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
-	app.Get("/agents/:id/capabilities", handler.GetAgentCapabilities)
+	app.Get("/agents/:id/capabilities", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetAgentCapabilities(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/capabilities", nil)
 	resp, err := app.Test(req)
@@ -55,10 +65,14 @@ func TestCapabilityHandler_GetAgentCapabilities_Success(t *testing.T) {
 }
 
 func TestCapabilityHandler_GetAgentCapabilities_InvalidID(t *testing.T) {
+	orgID := uuid.New()
 	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
 
 	app := fiber.New()
-	app.Get("/agents/:id/capabilities", handler.GetAgentCapabilities)
+	app.Get("/agents/:id/capabilities", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetAgentCapabilities(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/invalid-uuid/capabilities", nil)
 	resp, err := app.Test(req)
@@ -70,6 +84,7 @@ func TestCapabilityHandler_GetAgentCapabilities_InvalidID(t *testing.T) {
 
 func TestCapabilityHandler_GetAgentCapabilities_ServiceError(t *testing.T) {
 	agentID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
 		GetAgentCapabilitiesFunc: func(ctx context.Context, aID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {
@@ -78,9 +93,17 @@ func TestCapabilityHandler_GetAgentCapabilities_ServiceError(t *testing.T) {
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
-	app.Get("/agents/:id/capabilities", handler.GetAgentCapabilities)
+	app.Get("/agents/:id/capabilities", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetAgentCapabilities(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/capabilities", nil)
 	resp, err := app.Test(req)
@@ -187,6 +210,7 @@ func TestCapabilityHandler_RevokeCapability_ServiceError(t *testing.T) {
 
 func TestCapabilityHandler_GetViolationsByAgent_Success(t *testing.T) {
 	agentID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
 		GetViolationsByAgentFunc: func(ctx context.Context, aID uuid.UUID, limit, offset int) ([]*domain.CapabilityViolation, int, error) {
@@ -197,9 +221,17 @@ func TestCapabilityHandler_GetViolationsByAgent_Success(t *testing.T) {
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
-	app.Get("/agents/:id/violations", handler.GetViolationsByAgent)
+	app.Get("/agents/:id/violations", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetViolationsByAgent(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/violations", nil)
 	resp, err := app.Test(req)
@@ -216,10 +248,14 @@ func TestCapabilityHandler_GetViolationsByAgent_Success(t *testing.T) {
 }
 
 func TestCapabilityHandler_GetViolationsByAgent_InvalidID(t *testing.T) {
+	orgID := uuid.New()
 	handler := NewCapabilityHandlerWithInterfaces(&MockCapabilityServiceImpl{})
 
 	app := fiber.New()
-	app.Get("/agents/:id/violations", handler.GetViolationsByAgent)
+	app.Get("/agents/:id/violations", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetViolationsByAgent(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/invalid-uuid/violations", nil)
 	resp, err := app.Test(req)
@@ -231,6 +267,7 @@ func TestCapabilityHandler_GetViolationsByAgent_InvalidID(t *testing.T) {
 
 func TestCapabilityHandler_GetViolationsByAgent_ServiceError(t *testing.T) {
 	agentID := uuid.New()
+	orgID := uuid.New()
 
 	mockCapabilityService := &MockCapabilityServiceImpl{
 		GetViolationsByAgentFunc: func(ctx context.Context, aID uuid.UUID, limit, offset int) ([]*domain.CapabilityViolation, int, error) {
@@ -239,9 +276,17 @@ func TestCapabilityHandler_GetViolationsByAgent_ServiceError(t *testing.T) {
 	}
 
 	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID}, nil
+		},
+	}
 
 	app := fiber.New()
-	app.Get("/agents/:id/violations", handler.GetViolationsByAgent)
+	app.Get("/agents/:id/violations", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.GetViolationsByAgent(c)
+	})
 
 	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/violations", nil)
 	resp, err := app.Test(req)
@@ -249,6 +294,90 @@ func TestCapabilityHandler_GetViolationsByAgent_ServiceError(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+// Audit-doc #49: cross-tenant violation read must return 404 with
+// existence-secrecy body, never disclose that the agent exists in
+// another org. Uses a captured-flag pattern (NOT t.Fatalf) because
+// fiber's app.Test runs the handler on a separate goroutine; t.Fatalf
+// from a non-test-goroutine calls runtime.Goexit on that goroutine
+// only and would NOT fail this test. Mirrors the panic-proof pattern
+// from PR #146.
+func TestCapabilityHandler_GetViolationsByAgent_CrossOrgReturns404(t *testing.T) {
+	agentID := uuid.New()
+	callerOrgID := uuid.New()
+	differentOrgID := uuid.New()
+
+	serviceCalled := false
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetViolationsByAgentFunc: func(ctx context.Context, aID uuid.UUID, limit, offset int) ([]*domain.CapabilityViolation, int, error) {
+			serviceCalled = true
+			return nil, 0, nil
+		},
+	}
+
+	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: differentOrgID}, nil
+		},
+	}
+
+	app := fiber.New()
+	app.Get("/agents/:id/violations", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.GetViolationsByAgent(c)
+	})
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/violations", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+	assert.False(t, serviceCalled, "service must NOT be called for a cross-tenant request — security regression")
+}
+
+// Audit-doc #51: GetAgentCapabilities cross-tenant must return 404,
+// not 200 with the foreign agent's capability list. Same panic-proof
+// pattern as the #49 test.
+func TestCapabilityHandler_GetAgentCapabilities_CrossOrgReturns404(t *testing.T) {
+	agentID := uuid.New()
+	callerOrgID := uuid.New()
+	differentOrgID := uuid.New()
+
+	serviceCalled := false
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetAgentCapabilitiesFunc: func(ctx context.Context, aID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {
+			serviceCalled = true
+			return nil, nil
+		},
+	}
+
+	handler := NewCapabilityHandlerWithInterfaces(mockCapabilityService)
+	handler.agentRepo = &MockAgentRepositoryerImpl{
+		GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: differentOrgID}, nil
+		},
+	}
+
+	app := fiber.New()
+	app.Get("/agents/:id/capabilities", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.GetAgentCapabilities(c)
+	})
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/capabilities", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+	assert.False(t, serviceCalled, "service must NOT be called for a cross-tenant request — security regression")
 }
 
 // ===========================


### PR DESCRIPTION
## Summary

Closes two sibling read-side IDORs in `capability_handler.go` that were both lint-allowlisted as `audit-baseline: needs review` since #136 and never re-evaluated.

- **#49** `GET /agents/:id/violations` (`GetViolationsByAgent`) — surfaced by adversarial review during #149.
- **#51** `GET /agents/:id/capabilities` (`GetAgentCapabilities`) — surfaced by adversarial review on the FIRST commit of this PR (the one that only fixed #49). Same handler file, same threat shape; rolling in avoids the "fix one sibling, leave the next" pattern.

### Fix (both handlers)

\`\`\`go
orgID, err := RequireOrganizationID(c)
if err != nil { return err }
agentID, _ := uuid.Parse(c.Params("id"))
if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
    return nil
}
\`\`\`

Also switched `context.Background()` → `c.Context()` in both handlers.

### Tests

- Updated 6 existing tests (\`_Success\`, \`_InvalidID\`, \`_ServiceError\` for both handlers) to supply \`organization_id\` and a mock \`agentRepo\` returning a matching agent.
- Added 2 new \`_CrossOrgReturns404\` tests using a **captured-flag panic-proof pattern** (NOT \`t.Fatalf\` — fiber \`app.Test\` runs the handler on a separate goroutine, and \`t.Fatalf\` on a non-test goroutine calls \`runtime.Goexit\` on THAT goroutine only). Matches PR #146.

### Swagger doc

Added \`@Failure 404 \"Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)\"\` to both godoc blocks.

### Lint allowlist deltas

Removed both \`audit-baseline: needs review\` entries:
- \`CapabilityHandler.GetViolationsByAgent\`
- \`CapabilityHandler.GetAgentCapabilities\`

Both handlers now satisfy the lint structurally via \`LoadOwned\` recognition. Net: 93 → 91 entries on this branch.

### Adversarial-review history

This PR went through two rounds of Phase 4.5 review:

1. First-commit review (only #49 fix) — surfaced **CRITICAL** sibling IDOR in \`GetAgentCapabilities\`, **HIGH** \`t.Fatalf\`-goroutine-race in the cross-org test, **MEDIUM** swagger drift. All three rolled into the amended commit.
2. The amended commit closes both #49 and #51 in one coherent slice and matches the panic-proof test pattern.

### Audit doc

- \`#49\` flipped to ✓ FIXED with the actual mechanism cited.
- \`#51\` filed retroactively as a new entry in the audit doc and flipped to ✓ FIXED in the same commit.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/...\` clean
- [x] \`go test -race ./internal/interfaces/http/handlers/\` clean (5 tests for the affected handlers all pass)
- [x] \`tenantscope-lint\` → \`ok (91 allowlist entries)\`
- [x] \`hackmyagent secure --ci\` → 100/100, no findings
- [x] adversarial subagent review surfaced 1 CRITICAL + 1 HIGH + 1 MEDIUM, all addressed inline