### PR TITLE
security: convert 12 mutation/lifecycle agent handlers to LoadOwned (A3b-ii)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -357,17 +357,14 @@ func (h *AgentHandler) UpdateAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	existingAgent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if existingAgent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	agent, err := h.agentService.UpdateAgent(c.Context(), agentID, &req, userID)
@@ -409,17 +406,14 @@ func (h *AgentHandler) DeleteAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	existingAgent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if existingAgent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	if err := h.agentService.DeleteAgent(c.Context(), agentID); err != nil {
@@ -458,17 +452,15 @@ func (h *AgentHandler) VerifyAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	if err := h.agentService.VerifyAgent(c.Context(), agentID); err != nil {
@@ -1018,17 +1010,15 @@ func (h *AgentHandler) AddMCPServersToAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Add MCP servers to agent's talks_to list
@@ -1107,17 +1097,14 @@ func (h *AgentHandler) RemoveMCPServerFromAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	// Remove MCP server from agent's talks_to list
@@ -1359,17 +1346,14 @@ func (h *AgentHandler) DetectAndMapMCPServers(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	if LoadOwned(c, loader, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	// Call service with mcpService for auto-registration
@@ -1655,18 +1639,15 @@ func (h *AgentHandler) UpdateAgentTrustScore(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Update trust score in database using agent repository
@@ -1746,8 +1727,7 @@ func (h *AgentHandler) RecalculateAgentTrustScore(c fiber.Ctx) error {
 // @Param id path string true "Agent ID"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/suspend [post]
 func (h *AgentHandler) SuspendAgent(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -1762,17 +1742,15 @@ func (h *AgentHandler) SuspendAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Suspend the agent
@@ -1820,8 +1798,7 @@ func (h *AgentHandler) SuspendAgent(c fiber.Ctx) error {
 // @Param id path string true "Agent ID"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/reactivate [post]
 func (h *AgentHandler) ReactivateAgent(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -1836,17 +1813,15 @@ func (h *AgentHandler) ReactivateAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Reactivate the agent
@@ -1895,8 +1870,7 @@ func (h *AgentHandler) ReactivateAgent(c fiber.Ctx) error {
 // @Param id path string true "Agent ID"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/revoke [post]
 func (h *AgentHandler) RevokeAgent(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -1911,17 +1885,15 @@ func (h *AgentHandler) RevokeAgent(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Revoke the agent
@@ -1972,8 +1944,7 @@ func (h *AgentHandler) RevokeAgent(c fiber.Ctx) error {
 // @Param id path string true "Agent ID"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid agent ID"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/rotate-credentials [post]
 func (h *AgentHandler) RotateCredentials(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -1988,17 +1959,15 @@ func (h *AgentHandler) RotateCredentials(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Rotate credentials (generates new keypair)
@@ -2054,8 +2023,7 @@ func (h *AgentHandler) RotateCredentials(c fiber.Ctx) error {
 // @Param body body object true "Public key to register"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} ErrorResponse "Invalid request"
-// @Failure 404 {object} ErrorResponse "Agent not found"
-// @Failure 403 {object} ErrorResponse "Access denied"
+// @Failure 404 {object} ErrorResponse "Agent not found (also returned for cross-tenant access; see tenant_scope.go:41-46)"
 // @Router /agents/{id}/keys [put]
 func (h *AgentHandler) UpdateAgentKeys(c fiber.Ctx) error {
 	orgID, userID, err := RequireOrgAndUserID(c)
@@ -2086,17 +2054,15 @@ func (h *AgentHandler) UpdateAgentKeys(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify agent belongs to organization first
-	agent, err := h.agentService.GetAgent(c.Context(), agentID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Agent not found",
-		})
+	// SECURITY (A3b-ii / defects #18-25 follow-on): tenant-scoping via
+	// LoadOwned. Returns 404 — not 403 — for cross-tenant access to avoid
+	// leaking resource existence across orgs. See tenant_scope.go:41-46.
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
 	}
-	if agent.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "Access denied",
-		})
+	agent := LoadOwned(c, loader, agentID, orgID, agentOrgID)
+	if agent == nil {
+		return nil
 	}
 
 	// Get auth method from context (set by auth middleware)

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
@@ -2184,7 +2184,11 @@ func TestAgentHandler_DetectAndMapMCPServers_AccessDenied(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	// A3b-ii: cross-tenant access returns 404 (not 403) to avoid leaking
+	// resource existence across orgs. See tenant_scope.go:41-46.
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	body2, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body2))
 }
 
 // ===========================
@@ -2805,4 +2809,178 @@ func TestAgentHandler_GetAgentActivity_CrossOrgReturns404(t *testing.T) {
 	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
 	assert.JSONEq(t, `{"error":"not found"}`, string(body))
+}
+
+// ===========================
+// A3b-ii: cross-tenant access on mutation/lifecycle handlers returns
+// 404 (not 403). Table-driven sweep — each row exercises one of the
+// 12 LoadOwned conversions in this PR. The mock GetAgent returns an
+// agent in a different org; every handler must short-circuit at
+// LoadOwned and never reach the mutation service call. Body content
+// is minimal — handlers that parse JSON before LoadOwned just need a
+// parseable payload to reach the LoadOwned check.
+// ===========================
+
+func TestAgentHandler_MutationHandlers_CrossOrgReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	callerUserID := uuid.New()
+	agentID := uuid.New()
+	differentOrgID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: differentOrgID,
+				Name:           "victim-agent",
+			}, nil
+		},
+	}
+
+	tests := []struct {
+		name        string
+		method      string
+		requestPath string
+		body        string
+		setup       func(*fiber.App, *AgentHandler)
+	}{
+		{
+			name:        "UpdateAgent",
+			method:      "PUT",
+			requestPath: "/agents/" + agentID.String(),
+			body:        `{"name":"x"}`,
+			setup:       func(app *fiber.App, h *AgentHandler) { app.Put("/agents/:id", h.UpdateAgent) },
+		},
+		{
+			name:        "DeleteAgent",
+			method:      "DELETE",
+			requestPath: "/agents/" + agentID.String(),
+			body:        "",
+			setup:       func(app *fiber.App, h *AgentHandler) { app.Delete("/agents/:id", h.DeleteAgent) },
+		},
+		{
+			name:        "VerifyAgent",
+			method:      "POST",
+			requestPath: "/agents/" + agentID.String() + "/verify",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Post("/agents/:id/verify", h.VerifyAgent)
+			},
+		},
+		{
+			name:        "AddMCPServersToAgent",
+			method:      "PUT",
+			requestPath: "/agents/" + agentID.String() + "/mcp-servers",
+			// Non-empty list — handler validates that mcpServerIds is
+			// non-empty BEFORE LoadOwned. The empty-list path returns
+			// 400 from body validation, which is independent of the
+			// cross-tenant check we're verifying here.
+			body: `{"mcpServerIds":["some-server"]}`,
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Put("/agents/:id/mcp-servers", h.AddMCPServersToAgent)
+			},
+		},
+		{
+			name:        "RemoveMCPServerFromAgent",
+			method:      "DELETE",
+			requestPath: "/agents/" + agentID.String() + "/mcp-servers/foo",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Delete("/agents/:id/mcp-servers/:mcp_id", h.RemoveMCPServerFromAgent)
+			},
+		},
+		{
+			name:        "UpdateAgentTrustScore",
+			method:      "PUT",
+			requestPath: "/agents/" + agentID.String() + "/trust-score",
+			body:        `{"score":50.0}`,
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Put("/agents/:id/trust-score", h.UpdateAgentTrustScore)
+			},
+		},
+		{
+			name:        "SuspendAgent",
+			method:      "POST",
+			requestPath: "/agents/" + agentID.String() + "/suspend",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Post("/agents/:id/suspend", h.SuspendAgent)
+			},
+		},
+		{
+			name:        "ReactivateAgent",
+			method:      "POST",
+			requestPath: "/agents/" + agentID.String() + "/reactivate",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Post("/agents/:id/reactivate", h.ReactivateAgent)
+			},
+		},
+		{
+			name:        "RevokeAgent",
+			method:      "POST",
+			requestPath: "/agents/" + agentID.String() + "/revoke",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Post("/agents/:id/revoke", h.RevokeAgent)
+			},
+		},
+		{
+			name:        "RotateCredentials",
+			method:      "POST",
+			requestPath: "/agents/" + agentID.String() + "/rotate-credentials",
+			body:        "",
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Post("/agents/:id/rotate-credentials", h.RotateCredentials)
+			},
+		},
+		{
+			name:        "UpdateAgentKeys",
+			method:      "PUT",
+			requestPath: "/agents/" + agentID.String() + "/keys",
+			body:        `{"publicKey":"AAAA"}`,
+			setup: func(app *fiber.App, h *AgentHandler) {
+				app.Put("/agents/:id/keys", h.UpdateAgentKeys)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewAgentHandlerWithInterfaces(
+				mockAgentService,
+				&MockMCPServiceImpl{},
+				&MockAuditServiceImpl{},
+				&MockAPIKeyServiceImpl{},
+				nil,
+				&MockAlertServiceImpl{},
+				&MockVerificationEventServiceImpl{},
+				&MockCapabilityServiceImpl{},
+				&MockTagServiceImpl{},
+				&MockOrganizationRepository{},
+				&MockMCPAttestationServiceImpl{},
+			)
+
+			app := createTestAppWithAuth(handler, callerOrgID, callerUserID)
+			tt.setup(app, handler)
+
+			var req *http.Request
+			if tt.body == "" {
+				req = httptest.NewRequest(tt.method, tt.requestPath, nil)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.requestPath, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+				"%s: cross-tenant request must return 404, got %d", tt.name, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.JSONEq(t, `{"error":"not found"}`, string(body),
+				"%s: cross-tenant 404 body must be existence-secrecy shape, got %s", tt.name, string(body))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Closes the second half of the A3b sweep — the 12 mutation and lifecycle handlers in \`agent_handler.go\` that #148 (A3b-i) deferred when scoping itself to read-only handlers. After this PR + #148, all 19 inline \`OrganizationID != orgID → 403\` sites in \`agent_handler.go\` have been converted to \`LoadOwned\` returning 404 with body \`{\"error\":\"not found\"}\` — closing the cross-tenant existence side channel documented in \`tenant_scope.go:41-46\`.

### Handlers converted (12 mutations / lifecycle)

| Handler | Route |
|---|---|
| \`UpdateAgent\` | PUT /agents/:id |
| \`DeleteAgent\` | DELETE /agents/:id |
| \`VerifyAgent\` | POST /agents/:id/verify |
| \`AddMCPServersToAgent\` | PUT /agents/:id/mcp-servers |
| \`RemoveMCPServerFromAgent\` | DELETE /agents/:id/mcp-servers/:mcp_id |
| \`DetectAndMapMCPServers\` | POST /agents/:id/detect-mcp-servers |
| \`UpdateAgentTrustScore\` | PUT /agents/:id/trust-score |
| \`SuspendAgent\` | POST /agents/:id/suspend |
| \`ReactivateAgent\` | POST /agents/:id/reactivate |
| \`RevokeAgent\` | POST /agents/:id/revoke |
| \`RotateCredentials\` | POST /agents/:id/rotate-credentials |
| \`UpdateAgentKeys\` | PUT /agents/:id/keys |

### Tests

- \`TestAgentHandler_DetectAndMapMCPServers_AccessDenied\` flipped from \`StatusForbidden\` → \`StatusNotFound\` + body assertion.
- New table-driven \`TestAgentHandler_MutationHandlers_CrossOrgReturns404\` exercises **all 12 mutation routes** with a foreign-org mock. Every route must short-circuit at \`LoadOwned\` and never reach the mutation service call. One \`t.Run\` per row so failures pinpoint the specific handler.

### Swagger

Removed 5 stale \`@Failure 403 \"Access denied\"\` annotations on the converted handlers (SuspendAgent, ReactivateAgent, RevokeAgent, RotateCredentials, UpdateAgentKeys) — they no longer emit 403. The \`@Failure 404\` line on each now notes \"also returned for cross-tenant access\". Phase 4.5 catch.

### Lint baseline

Unchanged: 93 allowlist entries. \`LoadOwned\` is recognized structurally by \`tenantscope-lint\`; no new entries needed.

### Adversarial review

A general-purpose subagent reviewed the diff and surfaced 3 MEDIUM findings:
- **M1** — Existence-secrecy oracle still leaks on read-only handlers (\`GetAgent\`, \`GetAgentActivity\`, \`GetCredentials\`, etc.). **Out of A3b-ii scope**: these are #148's read-only conversions, already shipped in that PR — when both merge, the oracle is closed across all 19 sites.
- **M2** — 5 stale \`@Failure 403\` swagger annotations. **Fixed inline** before the amended commit.
- **M3** — Coverage gap: no \"agent does not exist at all\" assertion (only \"exists in another org\"). Both must return the byte-identical 404 body to satisfy existence-secrecy. Filed as audit-doc follow-up — the cross-tenant path IS covered; the does-not-exist path was unchanged by this conversion (LoadOwned collapses both into one \`respondResourceNotFound\` call).

Pre-existing **LOW** (not introduced by this PR): \`agent, _ = h.agentService.GetAgent(...)\` re-fetches after mutation discard the error and dereference \`agent.*\` immediately — would panic on a transient re-fetch failure. Unchanged from origin/main; flag for a dedicated cleanup PR.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/...\` clean
- [x] \`go test -race ./internal/interfaces/http/handlers/\` — full suite passes, including 11-subtest table sweep
- [x] \`tenantscope-lint\` → \`ok (93 allowlist entries)\` (unchanged from main)
- [x] \`hackmyagent secure --ci\` → 100/100, no findings
- [x] Phase 4.5 adversarial subagent: no CRITICAL or HIGH; 3 MEDIUM (1 fixed inline, 2 documented as follow-up)