### PR TITLE
fga: emit fga.authorize span on the SDK /verifications route

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1126,6 +1126,7 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 			services.Trust,
 			services.VerificationEvent,
 			repos.Organization,
+			services.FGA,
 		),
 		VerificationEvent: handlers.NewVerificationEventHandler(
 			services.VerificationEvent,

--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -587,6 +587,95 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 }
 
 // emitDecisionTelemetry emits the per-decision metric + structured log line.
+// EmitSDKVerificationSpan emits an fga.authorize parent span (plus an
+// fga.capability_check child) that mirrors the shape produced by the
+// /api/v1/agents/{id}/authorize path, but from the SDK route at
+// /api/v1/sdk-api/verifications. The SDK route's enforcement still flows
+// through AgentService.VerifyCapability; this method exists only so the
+// observability surface is consistent across both routes, matching the
+// nine SemConv attributes locked in the OBSERVABILITY.md proposal.
+//
+// No DB writes, no engine state changes, no NanoMind dispatch. Span
+// emission only. Safe to call from any handler that has already made the
+// authorization decision and just needs the trace to show up in Tempo.
+func (e *FGAEngine) EmitSDKVerificationSpan(
+	ctx context.Context,
+	agentID uuid.UUID,
+	keyAlgorithm string,
+	trustScore float64,
+	capability string,
+	allowed bool,
+	denialReason string,
+) {
+	if e == nil || e.tracer == nil {
+		return
+	}
+	ctx, parent := e.tracer.Start(ctx, "fga.authorize",
+		trace.WithAttributes(
+			attribute.String("agent.id", agentID.String()),
+			attribute.String("agent.capability", capability),
+		),
+	)
+	defer parent.End()
+
+	if keyAlgorithm != "" {
+		parent.SetAttributes(attribute.String("agent.public_key.algorithm", keyAlgorithm))
+	}
+	parent.SetAttributes(attribute.Float64("agent.trust_score", trustScore))
+
+	// agent.scan_verdict + agent.drift_score + agent.active_alerts come from
+	// the local ASC summary (fail-open: if not present, those three attrs
+	// simply do not land on the span, matching the /authorize path's behavior).
+	if summary := e.fetchASCRiskSummary(ctx, agentID); summary != nil {
+		if summary.ScanVerdict != "" {
+			parent.SetAttributes(attribute.String("agent.scan_verdict", summary.ScanVerdict))
+		}
+		parent.SetAttributes(attribute.Float64("agent.drift_score", summary.DriftScore))
+		parent.SetAttributes(attribute.Int("agent.active_alerts", summary.ActiveAlerts))
+	}
+
+	// The trace reflects the policy decision, not the SDK response.
+	// VerifyCapability returns a non-empty denialReason on both ALLOW and DENY
+	// paths (the clean-allow path emits "Action matches registered capabilities
+	// and passes all security policies"). The discriminator is the word
+	// "violation": the monitoring-mode-observed-but-not-blocked path emits
+	// "capability violation logged". Anything containing "violation" is a real
+	// policy violation that observability tools should see as DENY.
+	//
+	// This is the "truth diverges from UX" observability story: SDK callers in
+	// monitoring mode receive allowed=true; the trace records DENY anyway.
+	violated := !allowed || strings.Contains(strings.ToLower(denialReason), "violation")
+	outcome := "ALLOW"
+	deniedBy := ""
+	if violated {
+		outcome = "DENY"
+		// SDK route only runs the capability check today, so denials all map
+		// to capability_check. If/when other checks land on this route, this
+		// mapping should grow to reflect them.
+		deniedBy = "capability_check"
+	}
+	parent.SetAttributes(attribute.String("fga.outcome", outcome))
+	if deniedBy != "" {
+		parent.SetAttributes(attribute.String("fga.denied_by", deniedBy))
+	}
+
+	// Emit the fga.capability_check child span so fga.step lands on the
+	// trace where the proposal expects it (per-step child, not parent).
+	// fga.allowed mirrors the policy decision, not the SDK response.
+	_, child := e.tracer.Start(ctx, "fga.capability_check",
+		trace.WithAttributes(
+			attribute.String("fga.step", "capability_check"),
+			attribute.String("agent.id", agentID.String()),
+			attribute.String("agent.capability", capability),
+			attribute.Bool("fga.allowed", !violated),
+		),
+	)
+	if violated {
+		child.SetAttributes(attribute.String("fga.denied_reason", denialReason))
+	}
+	child.End()
+}
+
 // Called from the deferred span finalizer in Authorize so it runs on every
 // return path (allow, deny, error). The slog logger is bridged through
 // telemetry, so trace.id and span.id auto-attach.

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler.go
@@ -28,6 +28,11 @@ type VerificationHandler struct {
 	verificationEventService *application.VerificationEventService
 	orgRepo                  domain.OrganizationRepository
 
+	// Observability shim: emits an fga.authorize span shape mirroring the
+	// /api/v1/agents/{id}/authorize path. SDK route's actual enforcement
+	// still flows through AgentService.VerifyCapability. Optional; nil-safe.
+	fgaEngine *application.FGAEngine
+
 	// Interface fields for testability (used when set)
 	agentServicer             AgentServicerForVerification
 	auditServicer             AuditServicerForVerification
@@ -44,6 +49,7 @@ func NewVerificationHandler(
 	trustService *application.TrustCalculator,
 	verificationEventService *application.VerificationEventService,
 	orgRepo domain.OrganizationRepository,
+	fgaEngine *application.FGAEngine,
 ) *VerificationHandler {
 	return &VerificationHandler{
 		agentService:             agentService,
@@ -52,6 +58,7 @@ func NewVerificationHandler(
 		trustService:             trustService,
 		verificationEventService: verificationEventService,
 		orgRepo:                  orgRepo,
+		fgaEngine:                fgaEngine,
 	}
 }
 
@@ -223,6 +230,22 @@ func (h *VerificationHandler) CreateVerification(c fiber.Ctx) error {
 		req.Context,
 		c.IP(), // Capture source IP for security tracking
 	)
+
+	// Emit the fga.authorize observability surface so SDK-route verifications
+	// show up in Tempo with the same nine SemConv attributes as the
+	// /api/v1/agents/{id}/authorize path. Decision is already made above; this
+	// is span emission only, no side effects.
+	if h.fgaEngine != nil {
+		h.fgaEngine.EmitSDKVerificationSpan(
+			c.Context(),
+			agentID,
+			agent.KeyAlgorithm,
+			trustScore,
+			req.Capability,
+			allowed,
+			denialReason,
+		)
+	}
 
 	// Check if this is a JIT (Just-In-Time) access request that needs admin approval
 	isJITRequest := false

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler_test.go
@@ -17,7 +17,7 @@ import (
 // ===========================
 
 func TestNewVerificationHandler_NilDeps(t *testing.T) {
-	handler := NewVerificationHandler(nil, nil, nil, nil, nil, nil)
+	handler := NewVerificationHandler(nil, nil, nil, nil, nil, nil, nil)
 	assert.NotNil(t, handler)
 }
 


### PR DESCRIPTION
## Summary

The `/api/v1/agents/{id}/authorize` handler emits a `fga.authorize` parent span plus per-step child spans with the 9 locked SemConv attributes from `OBSERVABILITY.md`. The SDK route at `/api/v1/sdk-api/verifications` goes through `AgentService.VerifyCapability` and emitted **no spans** — SDK-driven verifications were invisible to Tempo / Honeycomb / Datadog even though the same authorization decision was being made.

This was flagged in the 2026-05-20 audit (`~/audit-otel-semconv-2026-05-20.md` § 9: *"migrate SDK from /verifications to /authorize OR add FGAEngine.Authorize call inside VerificationHandler.CreateVerification"*). The Observability Summit talk on 2026-05-22 needs SDK-driven calls to land in Tempo, so this is the smaller of the two options: keep the existing decision flow, add a span-emission shim.

## What changed

- `application/fga_engine.go`: new exported `FGAEngine.EmitSDKVerificationSpan` method. Mirrors the parent + capability_check child span shape produced by `Authorize`. Derives attributes from inputs the SDK handler already has (agent identity, capability, allowed, denialReason). No DB writes, no engine state changes, no NanoMind dispatch — span emission only.
- `interfaces/http/handlers/verification_handler.go`: `VerificationHandler` gains an optional `*FGAEngine` field and calls `EmitSDKVerificationSpan` after `VerifyCapability` returns.
- `cmd/server/main.go`: wires `services.FGA` through `NewVerificationHandler`.
- `handlers/verification_handler_test.go`: nil-deps constructor test updated for the new parameter (still passes nil).

## Truth-vs-UX divergence is preserved

In monitoring mode, `VerifyCapability` returns `(allowed=true, denialReason="... violation logged")` for policy violations — the SDK caller sees `approved`, but the trace records `fga.outcome=DENY` with `denied_by=capability_check`. The discriminator is the word `violation` in `denialReason`, matching the two return paths in `AgentService.VerifyCapability` (`agent_service.go:1232` violation path vs `:1372` clean-allow path).

This is the observability story for the talk: the trace records the policy decision; the SDK response can diverge from it; observability tools see the truth.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./internal/interfaces/http/handlers/ ./internal/application/` all pass (~90s)
- [x] Verified end-to-end: ran `python flight_agent.py` interactively, both `search NYC` (capability declared) and `inject data-exfil` (capability not declared) produced `fga.authorize` traces in Tempo
- [x] DENY trace has all 9 locked SemConv attrs (8 on parent + `fga.step` on child)
- [x] ALLOW trace has 8 of 9 (`fga.denied_by` correctly absent on allows)
- [x] `agent.scan_verdict` + `agent.drift_score` come from `agent_security_contexts` (existing behavior on the `/authorize` path)

## Out of scope

This shim closes the SDK-route observability gap; it does NOT migrate the SDK to call `/authorize` directly. The proper long-term migration is still tracked under the audit's section 9.