### PR TITLE
security: tenant-scope 11 A2AHandler agent-scoped routes (A3d-vii.a)

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -79,20 +79,9 @@ var allowlist = map[string]string{
 	// Tracking: ~/workspace/opena2a-org/todo/2026-05-18-aim-defect-audit-
 	// from-lf-demo-prep.md (defect #18-25 follow-up section to be added).
 	// ---------------------------------------------------------------
-	"A2AHandler.DeleteSkill":                                "audit-baseline: needs review",
-	"A2AHandler.GetA2ATrustScore":                           "audit-baseline: needs review",
-	"A2AHandler.GetAgentAttestations":                       "audit-baseline: needs review",
-	"A2AHandler.GetAgentCard":                               "audit-baseline: needs review",
-	"A2AHandler.GetAgentSkills":                             "audit-baseline: needs review",
-	"A2AHandler.GetConsensusStatus":                         "audit-baseline: needs review",
-	"A2AHandler.GetPeerTrustScore":                          "audit-baseline: needs review",
-	"A2AHandler.GetTrustScoreAlt":                           "audit-baseline: needs review",
-	"A2AHandler.RecordInteraction":                          "audit-baseline: needs review",
-	"A2AHandler.RevokeConsent":                              "audit-baseline: needs review",
-	"A2AHandler.SignRequest":                                "audit-baseline: needs review",
-	"A2AHandler.UpdateAgentCard":                            "audit-baseline: needs review",
-	"A2AHandler.UpdateTaskState":                            "audit-baseline: needs review",
-	"A2AHandler.UpdateTrustScore":                           "audit-baseline: needs review",
+	"A2AHandler.DeleteSkill":                                "stub-handler: returns 204 No Content with no service dispatch. Path :id is a skill UUID; once a DeleteSkill service method exists, scope at handler layer (A3d-vii.c follow-up). Not exploitable today.",
+	"A2AHandler.RevokeConsent":                              "P1 IDOR deferred (A3d-vii.b): path :id is a consent UUID and the service calls a2aRepo.Revoke with no ownership check. domain.A2AConsentRecord.OrganizationID *uuid.UUID is nullable but direct; fix is plain LoadOwned with a nullable-aware accessor (A2APolicy-style, mirroring A3d-v RegistrationRequest pattern). Live IDOR — any authenticated A2A caller can revoke any tenant's consent by guessing UUIDs.",
+	"A2AHandler.UpdateTaskState":                            "P1 IDOR deferred (A3d-vii.b): path :id is an A2ATask UUID; the task has ClientAgentID + RemoteAgentID but NO direct OrganizationID. Fix is LoadOwnedViaAgent on ClientAgentID (caller-side participant; RemoteAgentID may be cross-org per A2A protocol). Live IDOR — any authenticated A2A caller can mutate any tenant's task state by guessing UUIDs.",
 	"AdminHandler.AcknowledgeAlert":                         "audit-baseline: needs review",
 	"AdminHandler.ApproveRegistrationRequest":               "audit-baseline: needs review",
 	"AdminHandler.ApproveUser":                              "audit-baseline: needs review",
@@ -174,9 +163,16 @@ var allowlist = map[string]string{
 // recognizedHelpers names the helper functions that satisfy the lint.
 // Any handler invoking one of these on a path that derives from
 // c.Params("id"|"agent_id"|"agent-id") is considered properly tenant-scoped.
+//
+// `loadOwnedAgent` is the A2A-specific wrapper (a2a_handler.go) that
+// hides the agentService.GetAgent->LoadOwned closure boilerplate. The
+// lint recognizes it the same as LoadOwned because the unwrapping is
+// a one-line forwarder; treating it as a recognized helper avoids
+// every A2A handler having to repeat the closure inline.
 var recognizedHelpers = map[string]bool{
 	"LoadOwned":         true,
 	"LoadOwnedViaAgent": true,
+	"loadOwnedAgent":    true,
 }
 
 // paramKeys names the URL-param keys whose reads we want to gate. Reading

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -15,7 +15,15 @@ import (
 // A2AHandler handles A2A (Agent-to-Agent) protocol endpoints
 type A2AHandler struct {
 	a2aService   *application.A2AService
-	agentService *application.AgentService
+	// agentService is typed as the interface (AgentServicer) rather than the
+	// concrete *application.AgentService so tests can swap a mock. The
+	// constructor still accepts the concrete service — Go satisfies the
+	// interface implicitly at assignment. Only GetAgent is called from this
+	// handler today (used by loadOwnedAgent for tenant scoping); the field
+	// could be narrowed further to a 1-method interface, but reusing the
+	// established AgentServicer interface matches the pattern in the rest of
+	// the handlers package.
+	agentService AgentServicer
 	auditService *application.AuditService
 }
 
@@ -30,6 +38,23 @@ func NewA2AHandler(
 		agentService: agentService,
 		auditService: auditService,
 	}
+}
+
+// loadOwnedAgent is the A2A-specific wrapper around LoadOwned. It adapts
+// agentService.GetAgent (the only agent loader A2AHandler has access to)
+// to the LoadOwned loader signature. On any failure path (loader error,
+// cross-tenant mismatch, nil resource) it writes a 404 + {"error":"not
+// found"} body to the response and returns nil. Callers MUST `return
+// nil` to let fiber finalize the response.
+//
+// Mirrors the inline closure first used at GetSkillAttestations (A3c #43)
+// and consolidates the pattern for the A3d-vii.a sweep — wraps 11
+// agent-scoped handlers with a single line each.
+func (h *A2AHandler) loadOwnedAgent(c fiber.Ctx, agentID, orgID uuid.UUID) *domain.Agent {
+	loader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
+	}
+	return LoadOwned(c, loader, agentID, orgID, agentOrgID)
 }
 
 // ============================================================================
@@ -117,6 +142,17 @@ func (h *A2AHandler) GetAgentCard(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid agent ID",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. Bound on both
+	// `/agents/:id/card` and `/cards/:id` (SDK alt); :id is the agent
+	// UUID in both. Cross-tenant access → 404 not found.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
 	}
 
 	// Get enhanced card with AIM extensions
@@ -212,6 +248,19 @@ func (h *A2AHandler) SignRequest(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-vii.a): tenant-scope the path agent AFTER body
+	// validation (matches RecordMCPConnection precedent — preserves
+	// existing 400-shape contracts). Signing for a cross-tenant agent
+	// would expose key material via the signing service; LoadOwned
+	// short-circuits to 404.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
+	}
+
 	signature, err := h.a2aService.SignA2ARequest(
 		c.Context(),
 		agentID,
@@ -280,6 +329,17 @@ func (h *A2AHandler) GetA2ATrustScore(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid agent ID",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. Trust scores
+	// disclose competitive/operational information; cross-tenant reads
+	// are an existence + value leak. LoadOwned → 404 on mismatch.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
 	}
 
 	// First try to get existing trust score
@@ -371,10 +431,31 @@ func (h *A2AHandler) GetPeerTrustScore(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-vii.a): tenant-scope the PATH agent only. A2A peer
+	// trust is fundamentally cross-org by protocol design — agents in
+	// different orgs build trust relationships through interactions, so
+	// the peer agent MUST NOT be scoped. The path agent however is the
+	// subject of the trust query and must belong to the caller's org;
+	// otherwise this endpoint becomes an enumeration oracle for which
+	// org-B agents trust which org-C peers.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
+	}
+
 	trust, err := h.a2aService.GetPeerTrustScore(c.Context(), agentID, peerID)
 	if err != nil {
+		// SECURITY (A3d-vii.a Phase 4.5): normalize the post-LoadOwned
+		// "not found" body to match `tenant_scope.go:respondResourceNotFound`.
+		// Pre-fix the body text differed between cross-tenant access ({"error":"not found"})
+		// and "peer relation missing for a same-org agent"
+		// ({"error":"Peer trust relationship not found"}), giving a same-org
+		// caller a side channel to distinguish the two states.
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Peer trust relationship not found",
+			"error": "not found",
 		})
 	}
 
@@ -525,6 +606,12 @@ func (h *A2AHandler) LogTask(c fiber.Ctx) error {
 
 // UpdateTaskState updates the state of an A2A task
 // PUT /api/v1/a2a/tasks/:id/state
+// NOTE (A3d-vii): UpdateTaskState is intentionally NOT closed in
+// A3d-vii.a. The path :id is a TASK UUID, not an agent UUID — the
+// service does not take orgID and there is no current FK-via-agent
+// resolution helper. Tracked in the audit doc as A3d-vii.c follow-up
+// (LoadOwnedViaAgent on tasks once domain.A2ATask gets an AgentID
+// accessor exposed at the handler layer).
 func (h *A2AHandler) UpdateTaskState(c fiber.Ctx) error {
 	taskID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
@@ -576,6 +663,15 @@ func (h *A2AHandler) GetAgentSkills(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid agent ID",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the path agent.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
 	}
 
 	skills, err := h.a2aService.GetAgentSkills(c.Context(), agentID)
@@ -1192,6 +1288,21 @@ func (h *A2AHandler) GetConsensusStatus(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. Bound on both
+	// `/consensus/:agentId/:skillId` and `/agents/:id/skills/:skillId/consensus`
+	// — both route forms identify the SAME agent UUID via the fallback
+	// parameter lookup above. SkillID is a non-UUID identifier and is
+	// not scoped here; cross-tenant skill enumeration via a same-org
+	// agent is bounded by what skills that agent has, which is already
+	// authorized.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
+	}
+
 	result, err := h.a2aService.GetConsensusStatus(c.Context(), agentID, skillID)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -1248,6 +1359,17 @@ func (h *A2AHandler) GetAgentAttestations(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid agent ID",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. Sibling of
+	// GetSkillAttestations (A3c #43, already merged) on the SDK route
+	// `/a2a/agents/:id/attestations`.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
 	}
 
 	skillID := c.Query("skillId")
@@ -1417,6 +1539,16 @@ func (h *A2AHandler) GetTrustScoreAlt(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. SDK alt route
+	// `/a2a/trust/:id` — same semantics as GetA2ATrustScore above.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
+	}
+
 	// First try to get existing trust score
 	score, err := h.a2aService.GetA2ATrustScore(c.Context(), agentID)
 	if err != nil || score == nil || score.A2ATrustScore == nil || *score.A2ATrustScore == 0 {
@@ -1542,6 +1674,18 @@ func (h *A2AHandler) UpdateTrustScore(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-vii.a): tenant-scope the path agent AFTER body
+	// validation (preserves 400-shape contract for _InvalidJSON tests).
+	// Trust-score writes have integrity impact across the trust graph;
+	// LoadOwned confines the write to agents in caller's org.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, targetAgentID, orgID) == nil {
+		return nil
+	}
+
 	// Compute and return the updated trust score
 	score, err := h.a2aService.ComputeA2ATrustScore(c.Context(), targetAgentID)
 	if err != nil {
@@ -1580,6 +1724,25 @@ func (h *A2AHandler) RecordInteraction(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the PATH target agent.
+	// Placed AFTER body validation per the RecordMCPConnection
+	// precedent so existing `_InvalidJSON` tests retain their
+	// 400-shape contract. Note this is the opposite role from
+	// GetPeerTrustScore (where path :id is the caller-side agent and
+	// peer_id is the cross-org peer): here path :id IS the target
+	// peer, so scoping it confines the recompute side effect
+	// (`ComputeA2ATrustScore(targetAgentID)` at line ~1635) to agents
+	// in caller's own org. Without this gate, any authenticated A2A
+	// caller could trigger trust-score recomputation across any org
+	// by submitting fake interactions against a guessed target UUID.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, targetAgentID, orgID) == nil {
+		return nil
 	}
 
 	// Update peer trust based on interaction
@@ -1745,6 +1908,16 @@ func (h *A2AHandler) UpdateAgentCard(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
 		})
+	}
+
+	// SECURITY (A3d-vii.a): tenant-scope the path agent. SDK alt
+	// route `PUT /a2a/cards/:id`. Placed AFTER body validation.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if h.loadOwnedAgent(c, agentID, orgID) == nil {
+		return nil
 	}
 
 	// Get existing card

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler_cross_tenant_test.go
@@ -1,0 +1,231 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// ===========================
+// A3d-vii.a: cross-tenant access on the 11 agent-scoped A2AHandler
+// routes must return 404 with existence-secrecy body. The LoadOwned
+// guard (via loadOwnedAgent helper) short-circuits BEFORE any
+// a2aService dispatch; a2aService and auditService are nil here, so
+// any bypass that reached them would panic and surface as a 500 —
+// observably distinct from the 404 the tests assert. Same pattern as
+// PR #185 (A3d-vi MCPAttestationHandler) and PR #150's panic-proof
+// cross-org test on GetViolationsByAgent.
+//
+// Never use t.Fatalf inside a fiber app.Test mock goroutine — fiber
+// v3 runs handlers on a separate goroutine and runtime.Goexit from a
+// non-test goroutine does not fail the test (memory:
+// feedback_fiber_app_test_goroutine_t_fatalf_race).
+// ===========================
+
+func TestA2AHandler_AgentScoped_CrossOrgReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	callerUserID := uuid.New()
+	callerAgentID := uuid.New()
+	differentOrgID := uuid.New()
+	pathID := uuid.New()
+
+	agentSvc := &MockAgentServiceImpl{
+		GetAgentFunc: func(_ context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             id,
+				OrganizationID: differentOrgID,
+				Name:           "victim-agent",
+			}, nil
+		},
+	}
+
+	// a2aService and auditService are nil — any handler path that
+	// reaches them after LoadOwned would panic and surface as a 500.
+	handler := &A2AHandler{
+		a2aService:   nil,
+		agentService: agentSvc,
+		auditService: nil,
+	}
+
+	setLocals := func(c fiber.Ctx) {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("user_id", callerUserID)
+		c.Locals("agent_id", callerAgentID)
+	}
+
+	cases := []struct {
+		name        string
+		method      string
+		mount       func(app *fiber.App)
+		requestPath string
+		body        string
+	}{
+		{
+			name:   "GetAgentCard_CrossOrg",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/card", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetAgentCard(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/card",
+		},
+		{
+			name:   "SignRequest_CrossOrg",
+			method: "POST",
+			mount: func(app *fiber.App) {
+				app.Post("/a2a/agents/:id/sign", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.SignRequest(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/sign",
+			body:        `{"method":"GET","path":"/x","body":""}`,
+		},
+		{
+			name:   "GetA2ATrustScore_CrossOrg",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/trust-score", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetA2ATrustScore(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/trust-score",
+		},
+		{
+			name:   "GetPeerTrustScore_CrossOrgPathAgent",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/peers/:peer_id/trust", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetPeerTrustScore(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/peers/" + uuid.New().String() + "/trust",
+		},
+		{
+			name:   "GetAgentSkills_CrossOrg",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/skills", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetAgentSkills(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/skills",
+		},
+		{
+			name:   "GetConsensusStatus_CrossOrgAgent_AltPath",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/skills/:skillId/consensus", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetConsensusStatus(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/skills/test-skill/consensus",
+		},
+		{
+			name:   "GetConsensusStatus_CrossOrgAgent_AgentIdParam",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/consensus/:agentId/:skillId", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetConsensusStatus(c)
+				})
+			},
+			requestPath: "/a2a/consensus/" + pathID.String() + "/test-skill",
+		},
+		{
+			name:   "GetAgentAttestations_CrossOrg",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/agents/:id/attestations", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetAgentAttestations(c)
+				})
+			},
+			requestPath: "/a2a/agents/" + pathID.String() + "/attestations",
+		},
+		{
+			name:   "GetTrustScoreAlt_CrossOrg",
+			method: "GET",
+			mount: func(app *fiber.App) {
+				app.Get("/a2a/trust/:id", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.GetTrustScoreAlt(c)
+				})
+			},
+			requestPath: "/a2a/trust/" + pathID.String(),
+		},
+		{
+			name:   "UpdateTrustScore_CrossOrgTarget",
+			method: "PUT",
+			mount: func(app *fiber.App) {
+				app.Put("/a2a/trust/:id", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.UpdateTrustScore(c)
+				})
+			},
+			requestPath: "/a2a/trust/" + pathID.String(),
+			body:        `{"score":0.5,"confidence":0.5,"reason":"x"}`,
+		},
+		{
+			name:   "RecordInteraction_CrossOrgTarget",
+			method: "POST",
+			mount: func(app *fiber.App) {
+				app.Post("/a2a/trust/:id/interaction", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.RecordInteraction(c)
+				})
+			},
+			requestPath: "/a2a/trust/" + pathID.String() + "/interaction",
+			body:        `{"taskType":"x","success":true,"durationMs":1}`,
+		},
+		{
+			name:   "UpdateAgentCard_CrossOrg",
+			method: "PUT",
+			mount: func(app *fiber.App) {
+				app.Put("/a2a/cards/:id", func(c fiber.Ctx) error {
+					setLocals(c)
+					return handler.UpdateAgentCard(c)
+				})
+			},
+			requestPath: "/a2a/cards/" + pathID.String(),
+			body:        `{"name":"x","description":"y","version":"z","endpoint":"e","skills":[]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			tc.mount(app)
+
+			r := httptest.NewRequest(tc.method, tc.requestPath, strings.NewReader(tc.body))
+			if tc.body != "" {
+				r.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := app.Test(r)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+				"cross-org request must return 404 (existence-secrecy); 500 would mean loadOwnedAgent was bypassed and the nil a2aService was reached")
+			body, _ := io.ReadAll(resp.Body)
+			assert.JSONEq(t, `{"error":"not found"}`, string(body),
+				"cross-org body must be the standard not-found shape")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Close 11 of 14 audit-baseline \`A2AHandler.*\` entries on the tenantscope-lint allowlist via handler-layer \`LoadOwned\`. Lint allowlist: **83 → 72**. Remaining 3 entries (DeleteSkill, RevokeConsent, UpdateTaskState) stay on the allowlist with new rationale and are filed as A3d-vii.b/c follow-ups.

## Routes closed

| Handler | Routes | Notes |
|---|---|---|
| \`GetAgentCard\` | \`/a2a/agents/:id/card\` + \`/a2a/cards/:id\` | both forms = agent UUID |
| \`SignRequest\` | \`POST /a2a/agents/:id/sign\` | LoadOwned after body validation |
| \`GetA2ATrustScore\` | \`/a2a/agents/:id/trust-score\` | |
| \`GetAgentSkills\` | \`/a2a/agents/:id/skills\` | |
| \`GetAgentAttestations\` | \`/a2a/agents/:id/attestations\` | SDK route |
| \`GetPeerTrustScore\` | \`/a2a/agents/:id/peers/:peer_id/trust\` | path agent scoped; peer NOT scoped (A2A peer trust is cross-org by design) |
| \`GetConsensusStatus\` | \`/a2a/consensus/:agentId/:skillId\` + \`/a2a/agents/:id/skills/:skillId/consensus\` | fallback param lookup; both forms = agent UUID |
| \`GetTrustScoreAlt\` | \`/a2a/trust/:id\` (SDK) | |
| \`UpdateTrustScore\` | \`PUT /a2a/trust/:id\` (SDK) | LoadOwned after body validation |
| \`RecordInteraction\` | \`POST /a2a/trust/:id/interaction\` (SDK) | target IS scoped (recompute side effect would otherwise move cross-org trust graph) |
| \`UpdateAgentCard\` | \`PUT /a2a/cards/:id\` (SDK) | LoadOwned after body validation |

## Implementation notes

- New private helper \`(h *A2AHandler).loadOwnedAgent(c, agentID, orgID) *domain.Agent\` wraps \`LoadOwned\` with the \`agentService.GetAgent\` closure so each handler edit is a single line. Added to \`tenantscope-lint::recognizedHelpers\` so the lint accepts it as equivalent to a direct \`LoadOwned\` call.
- \`A2AHandler.agentService\` field type widened from \`*application.AgentService\` (concrete) to \`AgentServicer\` (interface) to enable test mocking via the existing \`MockAgentServiceImpl\`. Constructor signature unchanged.
- For handlers with bodies (SignRequest, UpdateTrustScore, RecordInteraction, UpdateAgentCard) the LoadOwned guard is placed AFTER body validation — matches \`RecordMCPConnection\` precedent so existing 400-shape tests retain contract.
- Cross-tenant tests use nil-deref-as-proof pattern: \`a2aService\` and \`auditService\` are nil — any bypass surfaces as 500, observably distinct from the asserted 404.
- **Phase 4.5 finding addressed inline:** \`GetPeerTrustScore\` post-load 404 body normalized from \`\"Peer trust relationship not found\"\` to \`\"not found\"\` — closes a same-org existence side channel where the body text could distinguish \"path agent in another org\" from \"path agent is mine but peer-relation missing\".

## Out of scope (filed as follow-ups; lint allowlist updated with corrected rationale)

- **P1:** \`todo/2026-05-21-a3d-vii-b-a2a-deferred-idors.md\` — \`RevokeConsent\` and \`UpdateTaskState\` are LIVE cross-tenant IDORs today. RevokeConsent fix: plain \`LoadOwned\` with a nullable-aware accessor on \`A2AConsentRecord.OrganizationID *uuid.UUID\`. UpdateTaskState fix: \`LoadOwnedViaAgent\` on \`A2ATask.ClientAgentID\` (RemoteAgentID is cross-org by A2A design).
- **No action today:** \`DeleteSkill\` is a stub (returns 204 with no service dispatch). Allowlist rationale updated; close once a real service method exists.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/interfaces/http/handlers/...\` — full handlers package green (12 sub-tests in the new \`TestA2AHandler_AgentScoped_CrossOrgReturns404\` + the previously-existing tests)
- [x] \`go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers\` — \`ok (72 allowlist entries)\`
- [x] Phase 4.5 adversarial review — PASS for the 11-handler scope; one tiny body-text fix applied in this PR; 2 P1 siblings filed as follow-up