### PR TITLE
security: close AttestMCP body-AgentID cross-tenant IDOR (P0)

### DIFF
--- a/apps/backend/internal/application/mcp_attestation_service.go
+++ b/apps/backend/internal/application/mcp_attestation_service.go
@@ -23,6 +23,27 @@ import (
 // tenant boundaries; see tenant_scope.go:41-46 in handlers.
 var ErrAttestationNotFound = errors.New("attestation not found")
 
+// ErrAttestationFailed is returned by VerifyAndRecordAttestation when
+// the attestation cannot proceed because of an existence-or-ownership
+// problem: the MCP server does not exist, the agent does not exist, the
+// agent belongs to a different organization than the MCP server, the
+// agent is unverified, or its trust score is too low. The cases are
+// deliberately collapsed to a single sentinel so the HTTP layer cannot
+// echo distinguishable error strings back to the caller — that would
+// leak victim-org state (agent status enum, trust score, agent existence)
+// to a same-token-different-body attacker.
+var ErrAttestationFailed = errors.New("attestation failed")
+
+// ErrAttestationInvalid is returned by VerifyAndRecordAttestation when
+// the attestation payload itself is malformed or fails cryptographic
+// validation: malformed agent_id, missing public key, signature
+// verification failure, challenge replay, expired timestamp. Separate
+// from ErrAttestationFailed because the HTTP layer maps both to a
+// single 403 response — keeping them as distinct sentinels lets server
+// logs differentiate the two without exposing the difference to the
+// client.
+var ErrAttestationInvalid = errors.New("attestation invalid")
+
 // Multi-Agent Consensus Configuration
 // These thresholds determine when an MCP server is considered "verified" by the community
 const (
@@ -221,7 +242,27 @@ func (s *MCPAttestationService) GenerateChallenge(
 	}, nil
 }
 
-// VerifyAndRecordAttestation verifies and records an agent's attestation of an MCP server
+// VerifyAndRecordAttestation verifies and records an agent's attestation of an MCP server.
+//
+// Gate ordering is security-critical (see todo
+// 2026-05-21-attestmcp-body-agentid-class2-idor.md). The body-supplied
+// AgentID lets a holder of org-A's Ed25519 token target a victim agent
+// in org B. Every existence- and ownership-related check MUST happen
+// BEFORE any status / trust / signature path that would leak victim
+// state or write into the victim's alert table:
+//
+//	1. Parse agent_id from the body payload.
+//	2. Load the path-MCP. Not-found → ErrAttestationFailed.
+//	3. Load the body-Agent.  Not-found → ErrAttestationFailed.
+//	4. ORG ISOLATION: mcpServer.OrganizationID == agent.OrganizationID.
+//	   Mismatch → ErrAttestationFailed.
+//	5. Only NOW: status, trust score, alert writes, signature, challenge,
+//	   timestamp, persistence.
+//
+// All early-gate failures collapse to a single sentinel
+// (ErrAttestationFailed) so the HTTP layer cannot leak which check
+// fired. Post-gate signature/payload errors collapse to
+// ErrAttestationInvalid.
 func (s *MCPAttestationService) VerifyAndRecordAttestation(
 	ctx context.Context,
 	mcpServerID uuid.UUID,
@@ -230,25 +271,64 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 	// 1. Parse agent ID from attestation
 	agentID, err := uuid.Parse(req.Attestation.AgentID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid agent_id in attestation: %w", err)
+		return nil, fmt.Errorf("%w: invalid agent_id in attestation: %v", ErrAttestationInvalid, err)
 	}
 
-	// 2. Fetch agent (MUST be Ed25519 verified)
+	// 2. Verify MCP server exists FIRST (before any agent lookup or alert
+	// write). Collapsing not-found to ErrAttestationFailed prevents a
+	// cross-tenant MCP-ID probe from differentiating "MCP exists in
+	// another org" from "MCP does not exist."
+	mcpServer, err := s.mcpRepo.GetByID(mcpServerID)
+	if err != nil || mcpServer == nil {
+		fmt.Printf("🔒 AttestMCP: mcp server lookup failed for %s: %v\n", mcpServerID, err)
+		return nil, ErrAttestationFailed
+	}
+
+	// 3. Load agent. Same sentinel for not-found.
 	agent, err := s.agentRepo.GetByID(agentID)
-	if err != nil {
-		return nil, fmt.Errorf("agent not found: %w", err)
+	if err != nil || agent == nil {
+		fmt.Printf("🔒 AttestMCP: agent lookup failed for %s: %v\n", agentID, err)
+		return nil, ErrAttestationFailed
+	}
+
+	// 4. ORGANIZATION ISOLATION: agent and MCP server must share an
+	// organization. This check MUST precede every status / trust /
+	// alert / signature path — otherwise a holder of org-A's Ed25519
+	// token can use a body-supplied victim AgentID in org B to probe
+	// victim agent status, leak the victim's trust score, and plant
+	// attacker-controlled Alert rows in the victim org. The check is
+	// the single trust boundary for body-supplied AgentIDs and replaces
+	// what would otherwise be a handler-layer LoadOwned (which the
+	// handler comment correctly rejects because Ed25519 signature is
+	// the canonical caller-identity proof).
+	//
+	// Defense-in-depth: explicitly reject uuid.Nil on either side. The
+	// DB enforces NOT NULL on agents.organization_id and
+	// mcp_servers.organization_id, so production rows never have
+	// uuid.Nil here — but a future repo bug that returns a zero-valued
+	// struct on miss would otherwise satisfy the equality check
+	// (uuid.Nil == uuid.Nil). Failing fast on uuid.Nil collapses both
+	// "row not found" and "row has zero org" into ErrAttestationFailed
+	// without touching the cross-org disclosure surface.
+	if agent.OrganizationID == uuid.Nil || mcpServer.OrganizationID == uuid.Nil ||
+		mcpServer.OrganizationID != agent.OrganizationID {
+		fmt.Printf("🔒 AttestMCP organization isolation: agent %s (org: %s) targeted MCP %s (org: %s)\n",
+			agentID, agent.OrganizationID, mcpServerID, mcpServer.OrganizationID)
+		return nil, ErrAttestationFailed
 	}
 
 	fmt.Printf("🔍 Agent fetched from DB: ID=%s, Status=%s, VerifiedAt=%v\n", agent.ID, agent.Status, agent.VerifiedAt)
 
 	if agent.Status != domain.AgentStatusVerified {
 		fmt.Printf("❌ Agent status check failed: expected %s, got %s\n", domain.AgentStatusVerified, agent.Status)
-		return nil, fmt.Errorf("only verified agents can attest MCPs (agent status: %s)", agent.Status)
+		return nil, fmt.Errorf("%w: agent status %s", ErrAttestationFailed, agent.Status)
 	}
 
 	fmt.Printf("✅ Agent status check passed: %s\n", agent.Status)
 
-	// 2b. Check agent trust score - block if too low, warn if borderline
+	// 5. Check agent trust score - block if too low, warn if borderline.
+	// SAFE: any alert.Create below runs with agent.OrganizationID, which
+	// EQUALS mcpServer.OrganizationID by the gate at step 4.
 	minTrust := getMinAgentTrustForAttestation()
 	warnThreshold := getWarnAgentTrustThreshold()
 
@@ -262,19 +342,13 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 
 		// Create security alert for blocked attestation
 		if s.alertRepo != nil {
-			mcpServer, _ := s.mcpRepo.GetByID(mcpServerID)
-			mcpName := mcpServerID.String()
-			if mcpServer != nil {
-				mcpName = mcpServer.Name
-			}
-
 			alert := &domain.Alert{
 				ID:             uuid.New(),
 				OrganizationID: agent.OrganizationID,
 				AlertType:      domain.AlertLowTrustAttestationBlock,
 				Severity:       domain.AlertSeverityHigh,
 				Title:          fmt.Sprintf("Low-trust agent blocked from attesting MCP server"),
-				Description:    fmt.Sprintf("Agent '%s' (trust score: %.1f%%) attempted to attest MCP server '%s' but was blocked due to trust score below threshold (%.0f%%).", agent.DisplayName, agent.TrustScore*100, mcpName, minTrust*100),
+				Description:    fmt.Sprintf("Agent '%s' (trust score: %.1f%%) attempted to attest MCP server '%s' but was blocked due to trust score below threshold (%.0f%%).", agent.DisplayName, agent.TrustScore*100, mcpServer.Name, minTrust*100),
 				ResourceType:   "agent",
 				ResourceID:     agent.ID,
 				AgentName:      agent.DisplayName,
@@ -282,7 +356,7 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 					"agentTrustScore": agent.TrustScore * 100,
 					"minThreshold":    minTrust * 100,
 					"mcpServerId":     mcpServerID.String(),
-					"mcpServerName":   mcpName,
+					"mcpServerName":   mcpServer.Name,
 					"action":          "blocked",
 				},
 				CreatedAt: time.Now().UTC(),
@@ -294,7 +368,7 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 			}
 		}
 
-		return nil, fmt.Errorf("agent trust score (%.1f%%) is below minimum threshold (%.0f%%) required for attestation", agent.TrustScore*100, minTrust*100)
+		return nil, fmt.Errorf("%w: trust score %.1f%% below minimum %.0f%%", ErrAttestationFailed, agent.TrustScore*100, minTrust*100)
 	}
 
 	// Check for borderline trust score - allow but create warning alert
@@ -302,19 +376,13 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 		fmt.Printf("⚠️ Agent trust score %.2f%% is below warning threshold %.0f%% - creating alert\n",
 			agent.TrustScore*100, warnThreshold*100)
 
-		mcpServer, _ := s.mcpRepo.GetByID(mcpServerID)
-		mcpName := mcpServerID.String()
-		if mcpServer != nil {
-			mcpName = mcpServer.Name
-		}
-
 		alert := &domain.Alert{
 			ID:             uuid.New(),
 			OrganizationID: agent.OrganizationID,
 			AlertType:      domain.AlertLowTrustAttestation,
 			Severity:       domain.AlertSeverityWarning,
 			Title:          fmt.Sprintf("Low-trust agent attesting MCP server"),
-			Description:    fmt.Sprintf("Agent '%s' (trust score: %.1f%%) is attesting MCP server '%s'. This attestation will have reduced weight in confidence calculations.", agent.DisplayName, agent.TrustScore*100, mcpName),
+			Description:    fmt.Sprintf("Agent '%s' (trust score: %.1f%%) is attesting MCP server '%s'. This attestation will have reduced weight in confidence calculations.", agent.DisplayName, agent.TrustScore*100, mcpServer.Name),
 			ResourceType:   "agent",
 			ResourceID:     agent.ID,
 			AgentName:      agent.DisplayName,
@@ -322,7 +390,7 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 				"agentTrustScore": agent.TrustScore * 100,
 				"warnThreshold":   warnThreshold * 100,
 				"mcpServerId":     mcpServerID.String(),
-				"mcpServerName":   mcpName,
+				"mcpServerName":   mcpServer.Name,
 				"action":          "allowed_with_warning",
 			},
 			CreatedAt: time.Now().UTC(),
@@ -335,13 +403,13 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 	}
 
 	if agent.PublicKey == nil || *agent.PublicKey == "" {
-		return nil, fmt.Errorf("agent has no public key registered")
+		return nil, fmt.Errorf("%w: agent has no public key registered", ErrAttestationInvalid)
 	}
 
-	// 3. Verify signature using agent's public key
+	// 6. Verify signature using agent's public key
 	attestationJSON, err := req.Attestation.ToCanonicalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize attestation: %w", err)
+		return nil, fmt.Errorf("%w: failed to serialize attestation: %v", ErrAttestationInvalid, err)
 	}
 
 	// Debug: Print what we're verifying
@@ -353,17 +421,17 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 	valid, err := s.cryptoService.Verify(*agent.PublicKey, attestationJSON, req.Signature)
 	if err != nil {
 		fmt.Printf("❌ Crypto verification error: %v\n", err)
-		return nil, fmt.Errorf("signature verification failed: %w", err)
+		return nil, fmt.Errorf("%w: signature verification error: %v", ErrAttestationInvalid, err)
 	}
 
 	if !valid {
 		fmt.Printf("❌ Signature verification returned FALSE\n")
-		return nil, fmt.Errorf("invalid attestation signature")
+		return nil, ErrAttestationInvalid
 	}
 
 	fmt.Printf("✅ Attestation signature verification PASSED\n")
 
-	// 4. PROOF OF KEY POSSESSION: Validate server-generated challenge (prevents replay attacks)
+	// 7. PROOF OF KEY POSSESSION: Validate server-generated challenge (prevents replay attacks)
 	// If a challenge is provided, validate it. For backward compatibility, challenge is optional
 	// but required for new attestations (when challenge is present in payload)
 	var challengeRecord *domain.AttestationChallenge
@@ -371,33 +439,33 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 		challengeRecord, err = s.attestationRepo.GetChallengeByValue(req.Attestation.Challenge)
 		if err != nil {
 			fmt.Printf("❌ Challenge not found: %s\n", req.Attestation.Challenge)
-			return nil, fmt.Errorf("invalid or unknown challenge - please request a new challenge")
+			return nil, fmt.Errorf("%w: invalid or unknown challenge", ErrAttestationInvalid)
 		}
 
 		// Validate challenge hasn't expired
 		if time.Now().UTC().After(challengeRecord.ExpiresAt) {
 			fmt.Printf("❌ Challenge expired at %s\n", challengeRecord.ExpiresAt)
-			return nil, fmt.Errorf("challenge expired - please request a new challenge")
+			return nil, fmt.Errorf("%w: challenge expired", ErrAttestationInvalid)
 		}
 
 		// Validate challenge hasn't been used (replay attack prevention)
 		if challengeRecord.UsedAt != nil {
 			fmt.Printf("❌ Challenge already used at %s (replay attack detected)\n", challengeRecord.UsedAt)
-			return nil, fmt.Errorf("challenge already used (possible replay attack)")
+			return nil, fmt.Errorf("%w: challenge already used", ErrAttestationInvalid)
 		}
 
 		// Validate challenge was issued for this agent
 		if challengeRecord.AgentID != agentID {
 			fmt.Printf("❌ Challenge was issued for different agent: %s (expected %s)\n",
 				challengeRecord.AgentID, agentID)
-			return nil, fmt.Errorf("challenge was issued for a different agent")
+			return nil, fmt.Errorf("%w: challenge agent mismatch", ErrAttestationInvalid)
 		}
 
 		// Validate challenge was issued for this MCP server
 		if challengeRecord.MCPServerID != mcpServerID {
 			fmt.Printf("❌ Challenge was issued for different MCP: %s (expected %s)\n",
 				challengeRecord.MCPServerID, mcpServerID)
-			return nil, fmt.Errorf("challenge was issued for a different MCP server")
+			return nil, fmt.Errorf("%w: challenge mcp mismatch", ErrAttestationInvalid)
 		}
 
 		fmt.Printf("✅ Challenge validated: proof of private key possession confirmed\n")
@@ -405,27 +473,14 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 		fmt.Printf("⚠️  No challenge provided (legacy attestation mode - consider upgrading SDK)\n")
 	}
 
-	// 5. Check attestation is recent (< 5 minutes old)
+	// 8. Check attestation is recent (< 5 minutes old)
 	attestationTime, err := time.Parse(time.RFC3339, req.Attestation.Timestamp)
 	if err != nil {
-		return nil, fmt.Errorf("invalid timestamp format: %w", err)
+		return nil, fmt.Errorf("%w: invalid timestamp format: %v", ErrAttestationInvalid, err)
 	}
 
 	if time.Since(attestationTime) > 5*time.Minute {
-		return nil, fmt.Errorf("attestation expired (older than 5 minutes)")
-	}
-
-	// 6. Verify MCP server exists and organization isolation
-	mcpServer, err := s.mcpRepo.GetByID(mcpServerID)
-	if err != nil {
-		return nil, fmt.Errorf("mcp server not found: %w", err)
-	}
-
-	// ORGANIZATION ISOLATION: Agent can only attest MCP servers in the same organization
-	if mcpServer.OrganizationID != agent.OrganizationID {
-		fmt.Printf("🔒 Organization isolation violation: agent %s (org: %s) attempted to attest MCP %s (org: %s)\n",
-			agentID, agent.OrganizationID, mcpServerID, mcpServer.OrganizationID)
-		return nil, fmt.Errorf("cannot attest MCP servers from other organizations")
+		return nil, fmt.Errorf("%w: attestation expired (older than 5 minutes)", ErrAttestationInvalid)
 	}
 
 	// 7. Mark challenge as used (MUST happen before storing attestation to prevent race conditions)

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -114,6 +114,15 @@ type MCPAttestationServicer interface {
 	GetMCPServersForAgent(ctx context.Context, agentID uuid.UUID) ([]*domain.MCPServer, error)
 }
 
+// MCPAttestationVerifier is the narrow verification slice of
+// MCPAttestationService that the AttestMCP handler dispatches to. Kept
+// small so tests can inject a fake that returns ErrAttestationFailed /
+// ErrAttestationInvalid without standing up a real attestation service
+// with its concrete repository pointers.
+type MCPAttestationVerifier interface {
+	VerifyAndRecordAttestation(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error)
+}
+
 // AuthServicer defines the methods from AuthService that handlers use
 type AuthServicer interface {
 	GetUsersByOrganization(ctx context.Context, orgID uuid.UUID) ([]*domain.User, error)

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -12,6 +12,7 @@ import (
 
 type MCPAttestationHandler struct {
 	attestationService *application.MCPAttestationService
+	verifier           MCPAttestationVerifier
 	auditService       *application.AuditService
 	agentRepo          domain.AgentRepository
 }
@@ -23,9 +24,19 @@ func NewMCPAttestationHandler(
 ) *MCPAttestationHandler {
 	return &MCPAttestationHandler{
 		attestationService: attestationService,
+		verifier:           attestationService,
 		auditService:       auditService,
 		agentRepo:          agentRepo,
 	}
+}
+
+// getVerifier returns the injected verifier (set by NewMCPAttestationHandler
+// to attestationService, or overwritten in tests).
+func (h *MCPAttestationHandler) getVerifier() MCPAttestationVerifier {
+	if h.verifier != nil {
+		return h.verifier
+	}
+	return h.attestationService
 }
 
 // GetAttestationChallenge generates a server-side challenge for proof of private key possession
@@ -119,21 +130,28 @@ func (h *MCPAttestationHandler) AttestMCP(c fiber.Ctx) error {
 	}
 
 	// Verify and record attestation
-	// SECURITY: No error logging to prevent information leakage
-	response, err := h.attestationService.VerifyAndRecordAttestation(c.Context(), mcpServerID, &req)
+	// SECURITY: error.Error() is NOT echoed back to the client. The
+	// service collapses existence-or-ownership failures to
+	// ErrAttestationFailed and signature/payload failures to
+	// ErrAttestationInvalid; both map to the SAME fixed-body 403 so an
+	// attacker holding a valid Ed25519 token cannot distinguish "I'm
+	// targeting a victim agent in another org" from "my signature is
+	// bad." Other errors (DB failure, etc.) surface as 500 with a fixed
+	// message — never the wrapped error text, which can carry victim
+	// agent status / trust score / UUID.
+	response, err := h.getVerifier().VerifyAndRecordAttestation(c.Context(), mcpServerID, &req)
 	if err != nil {
-
-		// Determine status code based on error
-		statusCode := fiber.StatusInternalServerError
-		if err.Error() == "only verified agents can attest MCPs" ||
-			err.Error() == "invalid attestation signature" ||
-			err.Error() == "attestation expired (older than 5 minutes)" {
-			statusCode = fiber.StatusForbidden
+		if errors.Is(err, application.ErrAttestationFailed) || errors.Is(err, application.ErrAttestationInvalid) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error":   "Attestation failed",
+				"message": "Attestation could not be verified.",
+			})
 		}
-
-		return c.Status(statusCode).JSON(fiber.Map{
+		// Unexpected error path (DB outage, marshaling bug, etc.).
+		// Generic 500 — no error string surfaced to the client.
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error":   "Attestation failed",
-			"message": err.Error(),
+			"message": "Internal error processing attestation.",
 		})
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_response_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_response_test.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockMCPAttestationVerifier is a captured-flag fake of the
+// MCPAttestationVerifier interface used by the AttestMCP handler tests
+// to inject specific sentinel errors and observe the response mapping.
+type mockMCPAttestationVerifier struct {
+	VerifyAndRecordAttestationFunc func(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error)
+	calls                          int
+}
+
+func (m *mockMCPAttestationVerifier) VerifyAndRecordAttestation(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error) {
+	m.calls++
+	if m.VerifyAndRecordAttestationFunc != nil {
+		return m.VerifyAndRecordAttestationFunc(ctx, mcpServerID, req)
+	}
+	return nil, nil
+}
+
+// A3d-vii.b/AttestMCP P0: a service-layer ErrAttestationFailed (the
+// cross-tenant sentinel — also fires for unknown agent, unknown MCP,
+// org-mismatch, unverified-agent, low-trust-block) MUST map to a 403
+// with a fixed-body response and NO err.Error() echo. The exploit this
+// closes (per todo 2026-05-21-attestmcp-body-agentid-class2-idor.md):
+// an attacker with a valid Ed25519 token for org A could probe victim
+// agents in org B by sending a body AgentID and observing distinct
+// error strings (status enum, trust score, agent existence). Both
+// sentinels collapse to the same response.
+func TestMCPAttestationHandler_AttestMCP_FailedSentinelMapsToFixed403(t *testing.T) {
+	mockVerifier := &mockMCPAttestationVerifier{
+		VerifyAndRecordAttestationFunc: func(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error) {
+			return nil, application.ErrAttestationFailed
+		},
+	}
+
+	handler := &MCPAttestationHandler{verifier: mockVerifier}
+
+	app := fiber.New()
+	app.Post("/mcp-servers/:id/attest", handler.AttestMCP)
+
+	body := `{"attestation":{"agentId":"` + uuid.New().String() + `"},"signature":"sig"}`
+	req := httptest.NewRequest("POST", "/mcp-servers/"+uuid.New().String()+"/attest", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var responseBody map[string]string
+	require.NoError(t, json.Unmarshal(bodyBytes, &responseBody))
+	assert.Equal(t, "Attestation failed", responseBody["error"])
+	assert.Equal(t, "Attestation could not be verified.", responseBody["message"])
+
+	// Critical: no part of the wrapped sentinel text leaks. A response
+	// that contained "attestation failed" alone is not enough — the
+	// service may wrap with %w to include victim agent status / trust
+	// score / UUID. The fixed message above is the entire client-facing
+	// payload.
+	assert.NotContains(t, string(bodyBytes), "SUSPENDED")
+	assert.NotContains(t, string(bodyBytes), "trust")
+	assert.NotContains(t, string(bodyBytes), "cannot attest")
+}
+
+// A3d-vii.b/AttestMCP P0: a wrapped ErrAttestationFailed (the production
+// case — service uses `fmt.Errorf("%w: ...", ErrAttestationFailed)` to
+// add server-side log detail) MUST still map to the same fixed 403.
+func TestMCPAttestationHandler_AttestMCP_WrappedFailedSentinelMapsToFixed403(t *testing.T) {
+	mockVerifier := &mockMCPAttestationVerifier{
+		VerifyAndRecordAttestationFunc: func(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error) {
+			return nil, errorWrap(application.ErrAttestationFailed, "agent status SUSPENDED, trust 12.3%")
+		},
+	}
+
+	handler := &MCPAttestationHandler{verifier: mockVerifier}
+
+	app := fiber.New()
+	app.Post("/mcp-servers/:id/attest", handler.AttestMCP)
+
+	body := `{"attestation":{"agentId":"` + uuid.New().String() + `"},"signature":"sig"}`
+	req := httptest.NewRequest("POST", "/mcp-servers/"+uuid.New().String()+"/attest", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	assert.NotContains(t, string(bodyBytes), "SUSPENDED")
+	assert.NotContains(t, string(bodyBytes), "12.3")
+}
+
+// ErrAttestationInvalid (signature/payload validation failures) maps to
+// the same fixed 403 — both sentinels collapse to one response so the
+// client cannot distinguish "I targeted a victim" from "my signature
+// is bad."
+func TestMCPAttestationHandler_AttestMCP_InvalidSentinelMapsToFixed403(t *testing.T) {
+	mockVerifier := &mockMCPAttestationVerifier{
+		VerifyAndRecordAttestationFunc: func(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error) {
+			return nil, errorWrap(application.ErrAttestationInvalid, "signature verification failed")
+		},
+	}
+
+	handler := &MCPAttestationHandler{verifier: mockVerifier}
+
+	app := fiber.New()
+	app.Post("/mcp-servers/:id/attest", handler.AttestMCP)
+
+	body := `{"attestation":{"agentId":"` + uuid.New().String() + `"},"signature":"sig"}`
+	req := httptest.NewRequest("POST", "/mcp-servers/"+uuid.New().String()+"/attest", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	assert.NotContains(t, string(bodyBytes), "signature verification")
+}
+
+// A non-sentinel error (DB outage, marshaling bug) maps to 500 with the
+// same fixed body — never the wrapped error text.
+func TestMCPAttestationHandler_AttestMCP_UnknownErrorMapsToFixed500(t *testing.T) {
+	mockVerifier := &mockMCPAttestationVerifier{
+		VerifyAndRecordAttestationFunc: func(ctx context.Context, mcpServerID uuid.UUID, req *application.AttestMCPRequest) (*application.AttestMCPResponse, error) {
+			return nil, errors.New("database connection lost; org_xyz_secret_table")
+		},
+	}
+
+	handler := &MCPAttestationHandler{verifier: mockVerifier}
+
+	app := fiber.New()
+	app.Post("/mcp-servers/:id/attest", handler.AttestMCP)
+
+	body := `{"attestation":{"agentId":"` + uuid.New().String() + `"},"signature":"sig"}`
+	req := httptest.NewRequest("POST", "/mcp-servers/"+uuid.New().String()+"/attest", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	assert.NotContains(t, string(bodyBytes), "org_xyz_secret_table")
+	assert.NotContains(t, string(bodyBytes), "database connection")
+}
+
+// errorWrap mirrors the fmt.Errorf("%w: %s") pattern the service uses
+// to attach server-side log detail to a sentinel without changing the
+// sentinel identity for errors.Is.
+func errorWrap(sentinel error, detail string) error {
+	return wrappedErr{sentinel: sentinel, detail: detail}
+}
+
+type wrappedErr struct {
+	sentinel error
+	detail   string
+}
+
+func (e wrappedErr) Error() string { return e.sentinel.Error() + ": " + e.detail }
+func (e wrappedErr) Unwrap() error { return e.sentinel }


### PR DESCRIPTION
## Summary

Closes the P0 documented at `todo/2026-05-21-attestmcp-body-agentid-class2-idor.md`.

`MCPAttestationService.VerifyAndRecordAttestation` ran agent status / trust-score / alert-write paths **before** its organization-isolation gate. A holder of org A's Ed25519 SDK token could submit `POST /api/v1/mcp-servers/<org-A-mcp>/attest` with a body-supplied `attestation.agentId` pointing to a victim agent in org B and observe:

1. Victim agent **status enum** (verified / suspended / revoked / etc.)
2. Victim **trust score** exact percentage
3. Cross-tenant **Alert row planted in victim org** with attacker-controlled `Description` and `Metadata`
4. **Existence oracle** for victim-org agent UUIDs

All four leaked through `err.Error()` echoed verbatim in the handler response body.

## Fix

**Service layer** (`mcp_attestation_service.go`):

- Two new sentinel errors: `ErrAttestationFailed` (existence / ownership / status / trust) and `ErrAttestationInvalid` (signature / payload / challenge / timestamp).
- Reordered `VerifyAndRecordAttestation`: parse → load MCP → load Agent → **org-isolation check** → status → trust → alert → signature → challenge → persist. Every leak-prone or alert-writing step now runs strictly **after** the gate.
- All early-gate failures collapse to `ErrAttestationFailed`; all post-gate cryptographic failures collapse to `ErrAttestationInvalid`.

**Handler layer** (`mcp_attestation_handler.go`):

- `errors.Is(err, ErrAttestationFailed)` || `errors.Is(err, ErrAttestationInvalid)` → fixed 403 body `{"error":"Attestation failed","message":"Attestation could not be verified."}`. **No `err.Error()` echo.** Both sentinels collapse to the same response so a holder of a valid Ed25519 token cannot distinguish "I'm targeting a victim agent" from "my signature is bad."
- Non-sentinel errors → generic 500 body. Never the wrapped error text.
- New narrow `MCPAttestationVerifier` interface allows tests to inject sentinel-returning fakes without standing up the concrete service.

## Phase 4.5 finding applied in-PR

**MEDIUM-1 (defense-in-depth):** the gate now also rejects `agent.OrganizationID == uuid.Nil || mcpServer.OrganizationID == uuid.Nil`. DB enforces `NOT NULL` on both columns so production rows never have `uuid.Nil`, but a future repo bug returning a zero-valued struct on miss would otherwise satisfy the equality check (`uuid.Nil == uuid.Nil`).

## Lint allowlist

No `tenantscope-lint` change — `AttestMCP` is a body-AgentID class-#2 IDOR, not a path-id class. The lint cannot detect this class today (it greps `c.Params(...)`). See `feedback_tenantscope_lint_three_blindspot_classes` memory for the class taxonomy; extending the lint to body-supplied UUIDs is filed as Option D in the sweep prompt.

## Test plan

- [x] `go build ./...` (apps/backend) — clean
- [x] `go test ./internal/interfaces/http/handlers/ -count=1` — all green (4 new sentinel-to-response mapping tests in `mcp_attestation_response_test.go`)
- [x] `go test $(go list ./... | grep -v tests/integration) -count=1` — all green
- [x] `go vet ./...` — clean
- [x] `go run ./cmd/tenantscope-lint/...` — passes (count unchanged; this is a body-class fix)
- [x] Phase 4.5 adversarial subagent review — 1 MEDIUM fixed in-PR (uuid.Nil defense), 2 follow-ups filed at `todo/2026-05-21-attestmcp-followups.md` (SOC audit-log on failure + service-layer cross-org integration test, both blocked on broader repository-interface refactor)
- [ ] Reviewer: verify the gate ordering by reading lines 280-310 in `mcp_attestation_service.go` — every `s.alertRepo.Create(...)` and every error containing victim state MUST appear AFTER the org-isolation gate.

## Behavior change worth release-noting

Same-org clients used to receive descriptive error messages (`"agent trust score (12.3%) is below minimum threshold (30%)..."`, `"only verified agents can attest MCPs (agent status: SUSPENDED)"`, etc.). The new fixed response is `"Attestation could not be verified."` — no descriptive detail. **Server-side logs (the `fmt.Printf` calls) preserve the detail for operators**, but the client must consult logs / dashboard rather than the response body.

## References

- Source todo: `todo/2026-05-21-attestmcp-body-agentid-class2-idor.md`
- Follow-up todo: `todo/2026-05-21-attestmcp-followups.md`
- Companion sweep PR shipped earlier today: #187 (A3d-vii.b — A2AHandler RevokeConsent + UpdateTaskState path-id IDORs)