### PR TITLE
security(lint): add class-#3 service-param scan to tenantscope-lint

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -226,36 +226,95 @@ type violation struct {
 	Handler string
 }
 
+// serviceParamAllowlist names application/service methods that legitimately
+// accept an `orgID` / `organizationID` parameter but do not reference it in
+// their body. The lint catches the "service param accepted-but-unused"
+// class-#3 IDOR (see feedback_tenantscope_lint_three_blindspot_classes in
+// the memory): a service whose signature looks tenant-aware but whose
+// repository call runs `WHERE id = $1` system-wide.
+//
+// Each entry must include a one-line justification. The allowlist must
+// stay small; the goal is to refactor or remove the unused parameter
+// rather than to add entries.
+var serviceParamAllowlist = map[string]string{
+	// AUDIT-BASELINE: pre-existing methods discovered when the
+	// class-#3 scan first landed. Each entry MUST cite the rationale
+	// or the tracking todo. Reviewers fixing the underlying defect
+	// should remove the entry; the allowlist must NOT grow over time.
+
+	// Stub: documented no-op kept for future expansion. orgID is the
+	// future-API surface; no current callsite. (alert_service.go:108-117)
+	"AlertService.CheckAPIKeyExpiry": "stub no-op; orgID reserved for future API key expiry implementation",
+
+	// HIGH IDOR — already tracked. AlertService.AcknowledgeAlert and
+	// ResolveAlert both accept orgID but call alertRepo.Acknowledge
+	// without the tenant filter, so any caller can acknowledge/resolve
+	// any tenant's alert by guessing the UUID. Fix is filed at
+	// todo/2026-05-21-a3d-v-followup-alert-handler-idors.md
+	// (handler-layer LoadOwned via alertRepo.GetByID is the preferred
+	// shape). Remove these entries once the follow-up PR lands.
+	"AlertService.AcknowledgeAlert": "audit-baseline IDOR: see todo/2026-05-21-a3d-v-followup-alert-handler-idors.md",
+	"AlertService.ResolveAlert":     "audit-baseline IDOR: see todo/2026-05-21-a3d-v-followup-alert-handler-idors.md",
+
+	// Pure function on the passed-in baseline argument; no DB call.
+	// orgID is vestigial — kept because callers still pass it but the
+	// method's logic uses only `baseline.CapabilityUsage`. Not an IDOR
+	// risk. Refactor candidate: remove the parameter and update the
+	// (private) callsite in behavior_analysis_service.go.
+	"BehaviorAnalysisService.detectCapabilityDrift": "pure baseline analysis; orgID vestigial; refactor candidate",
+}
+
+// classifyServiceDir treats a directory as the service scan target if
+// its trailing component is "application". Heuristic, but works for
+// every layout this lint targets.
+func classifyServiceDir(dir string) bool {
+	return strings.HasSuffix(filepath.Clean(dir), "/application") ||
+		strings.HasSuffix(filepath.Clean(dir), string(filepath.Separator)+"application")
+}
+
 func main() {
-	dir := "./internal/interfaces/http/handlers"
+	// Default behavior: scan BOTH the handlers directory (handler
+	// param-id-without-LoadOwned class) AND the application services
+	// directory (orgID-param-accepted-but-unused class). Either scan
+	// failing makes the whole invocation fail; allowlists are
+	// independent.
+	handlersDir := "./internal/interfaces/http/handlers"
+	servicesDir := "./internal/application"
 	if len(os.Args) > 1 {
-		dir = os.Args[1]
-	}
-	dir = filepath.Clean(dir)
-
-	violations, err := scanDirectory(dir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tenantscope-lint: %v\n", err)
-		os.Exit(2)
-	}
-
-	if len(violations) == 0 {
-		fmt.Printf("tenantscope-lint: ok (%d allowlist entries; scanned %s)\n", len(allowlist), dir)
-		os.Exit(0)
-	}
-
-	sort.Slice(violations, func(i, j int) bool {
-		if violations[i].File != violations[j].File {
-			return violations[i].File < violations[j].File
+		// Single-directory mode: route based on path. Preserves the
+		// legacy invocation `go run ./cmd/tenantscope-lint
+		// ./internal/interfaces/http/handlers`.
+		dir := filepath.Clean(os.Args[1])
+		if classifyServiceDir(dir) {
+			handlersDir = ""
+			servicesDir = dir
+		} else {
+			handlersDir = dir
+			servicesDir = ""
 		}
-		return violations[i].Line < violations[j].Line
-	})
-
-	fmt.Fprintf(os.Stderr, "tenantscope-lint: %d handler(s) read a tenant-scoped c.Params(...) key without invoking LoadOwned/LoadOwnedViaAgent:\n\n", len(violations))
-	for _, v := range violations {
-		fmt.Fprintf(os.Stderr, "  %s:%d  %s\n", v.File, v.Line, v.Handler)
 	}
-	fmt.Fprintln(os.Stderr, `
+
+	failed := false
+
+	if handlersDir != "" {
+		violations, err := scanDirectory(handlersDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tenantscope-lint: %v\n", err)
+			os.Exit(2)
+		}
+		if len(violations) > 0 {
+			failed = true
+			sort.Slice(violations, func(i, j int) bool {
+				if violations[i].File != violations[j].File {
+					return violations[i].File < violations[j].File
+				}
+				return violations[i].Line < violations[j].Line
+			})
+			fmt.Fprintf(os.Stderr, "tenantscope-lint: %d handler(s) read a tenant-scoped c.Params(...) key without invoking LoadOwned/LoadOwnedViaAgent:\n\n", len(violations))
+			for _, v := range violations {
+				fmt.Fprintf(os.Stderr, "  %s:%d  %s\n", v.File, v.Line, v.Handler)
+			}
+			fmt.Fprintln(os.Stderr, `
 To fix each violation:
   1. Add RequireOrganizationID(c) at the top of the handler.
   2. Wrap the resource load in LoadOwned or LoadOwnedViaAgent before
@@ -264,9 +323,54 @@ To fix each violation:
      name (HandlerStructName.MethodName) to the allowlist in
      cmd/tenantscope-lint/main.go with a one-line justification.
 
-See apps/backend/internal/interfaces/http/handlers/tenant_scope.go for the
-helper documentation and the SECURITY rationale for 404-not-403.`)
-	os.Exit(1)
+See apps/backend/internal/interfaces/http/handlers/tenant_scope.go for
+the helper documentation and the SECURITY rationale for 404-not-403.`)
+		} else {
+			fmt.Printf("tenantscope-lint: ok (%d allowlist entries; scanned %s)\n", len(allowlist), handlersDir)
+		}
+	}
+
+	if servicesDir != "" {
+		serviceViolations, err := scanServiceDirectory(servicesDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tenantscope-lint: %v\n", err)
+			os.Exit(2)
+		}
+		if len(serviceViolations) > 0 {
+			failed = true
+			sort.Slice(serviceViolations, func(i, j int) bool {
+				if serviceViolations[i].File != serviceViolations[j].File {
+					return serviceViolations[i].File < serviceViolations[j].File
+				}
+				return serviceViolations[i].Line < serviceViolations[j].Line
+			})
+			fmt.Fprintf(os.Stderr, "\nserviceparam-lint: %d service method(s) accept an orgID/organizationID parameter but never reference it in the body (class-#3 IDOR — likely repository call runs WHERE id = $1 system-wide):\n\n", len(serviceViolations))
+			for _, v := range serviceViolations {
+				fmt.Fprintf(os.Stderr, "  %s:%d  %s\n", v.File, v.Line, v.Handler)
+			}
+			fmt.Fprintln(os.Stderr, `
+To fix each violation:
+  1. Use orgID in the repository call's WHERE clause (e.g. add it to
+     a "WHERE id = $1 AND organization_id = $2" query).
+  2. If the orgID parameter is genuinely unused (e.g. legacy callsite
+     that no longer needs it), REMOVE the parameter — do not add to
+     the allowlist.
+  3. If the orgID is used through a struct field accessor (e.g. it
+     was unpacked into a local), refactor to reference orgID directly
+     OR add the method to serviceParamAllowlist in
+     cmd/tenantscope-lint/main.go with a one-line justification.
+
+See feedback_tenantscope_lint_three_blindspot_classes (memory) for
+the broader taxonomy. False-negative class: orgID referenced only in
+logging without flowing to the repo call still passes this check.`)
+		} else {
+			fmt.Printf("serviceparam-lint: ok (%d allowlist entries; scanned %s)\n", len(serviceParamAllowlist), servicesDir)
+		}
+	}
+
+	if failed {
+		os.Exit(1)
+	}
 }
 
 func scanDirectory(dir string) ([]violation, error) {
@@ -434,6 +538,189 @@ func bodyReadsTenantParam(fset *token.FileSet, body *ast.BlockStmt) (bool, int) 
 		return true
 	})
 	return found, line
+}
+
+// orgParamNames are the parameter names recognized as carrying a
+// caller-org UUID into a service method. These are the names we expect
+// to appear in the body if the method is genuinely tenant-scoped.
+//
+// Spelling variants reflect the codebase's current mix; the lint should
+// tolerate any reasonable casing. Names not in this set (e.g. `tenantID`)
+// are excluded because they introduce false-positive risk on unrelated
+// methods.
+var orgParamNames = map[string]bool{
+	"orgID":          true,
+	"OrgID":          true,
+	"organizationID": true,
+	"OrganizationID": true,
+	"adminOrgID":     true,
+	"callerOrgID":    true,
+}
+
+// scanServiceDirectory walks the application/services directory and
+// returns class-#3 violations: function declarations whose signature
+// includes an `orgID`-shaped parameter (per orgParamNames) that the
+// body never references. This catches methods like the historical
+// `AlertService.AcknowledgeAlert(ctx, alertID, orgID, userID uuid.UUID)`
+// where orgID is accepted in the signature but the repo call ran
+// `WHERE id = $1` with no tenant filter — making it a system-wide IDOR.
+//
+// Allowlist is `serviceParamAllowlist` (qualified by ReceiverType.Method).
+//
+// False-negative class to be aware of: a method that references orgID
+// only inside a log statement (without flowing it to a repo call) will
+// pass this check. The narrower "is orgID actually used in the repo
+// query?" check requires cross-function flow analysis beyond what the
+// AST scan provides here. Reviewers should still verify, but the
+// structural pattern catches the common case where orgID is forgotten
+// outright.
+func scanServiceDirectory(dir string) ([]violation, error) {
+	var violations []violation
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		violations = append(violations, scanServiceFile(fset, file, path)...)
+	}
+	return violations, nil
+}
+
+// scanServiceFile walks one parsed Go file for class-#3 service-method
+// violations. A method qualifies for inspection when:
+//   - It has a receiver (i.e. it's a method, not a free function).
+//   - It has at least one parameter whose name is in orgParamNames and
+//     whose type is uuid.UUID.
+//
+// For each qualifying parameter, the body is searched for any *ast.Ident
+// matching the parameter name. Zero matches → violation.
+func scanServiceFile(fset *token.FileSet, file *ast.File, path string) []violation {
+	var out []violation
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		// Service-layer methods always have a receiver. Skip free
+		// functions (constructors, helpers).
+		if fn.Recv == nil {
+			continue
+		}
+		methodName := receiverTypeName(fn) + "." + fn.Name.Name
+		if _, allowed := serviceParamAllowlist[methodName]; allowed {
+			continue
+		}
+		if fn.Type == nil || fn.Type.Params == nil {
+			continue
+		}
+		for _, field := range fn.Type.Params.List {
+			if !isUUIDType(field.Type) {
+				continue
+			}
+			for _, name := range field.Names {
+				if !orgParamNames[name.Name] {
+					continue
+				}
+				if bodyReferencesIdent(fn.Body, name.Name) {
+					continue
+				}
+				out = append(out, violation{
+					File:    path,
+					Line:    fset.Position(name.Pos()).Line,
+					Handler: methodName + " (param " + name.Name + ")",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// isUUIDType returns true if the parameter type expression is a
+// `uuid.UUID` selector. Recognizes the typical `uuid.UUID` spelling;
+// does NOT match pointer types or slices (callers passing a *uuid.UUID
+// or []uuid.UUID are not in scope for this lint — those are
+// non-canonical and rare in this codebase).
+func isUUIDType(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "uuid" && sel.Sel != nil && sel.Sel.Name == "UUID"
+}
+
+// bodyReferencesIdent returns true if any *ast.Ident in the function
+// body — EXCLUDING selector right-hand sides (`Sel`) — matches the
+// given parameter name. Parameter declarations are outside the body,
+// so the lookup is purely usage-based.
+//
+// SECURITY: a naive `ast.Inspect` walk visits the `Sel` field of every
+// `*ast.SelectorExpr`. If we didn't skip it, expressions like
+// `agent.OrganizationID` or `req.OrgID` would match parameter names
+// `OrganizationID`/`OrgID`, silently making the lint pass for any
+// method that touches a domain object with the same field name. This
+// is the exact class-of-bug the lint was designed to catch on the
+// OPPOSITE side — Phase 4.5 review caught it as a HIGH (H1) before
+// landing.
+//
+// Implementation: a custom `ast.Visitor` intercepts `*ast.SelectorExpr`
+// and recurses only into the LHS (`X`) — `Sel` is never visited as
+// an ident match candidate.
+func bodyReferencesIdent(body *ast.BlockStmt, name string) bool {
+	var found bool
+	ast.Walk(identMatchVisitor{name: name, found: &found}, body)
+	return found
+}
+
+// identMatchVisitor walks a Go AST node tree counting how many times a
+// top-level (non-selector-RHS) identifier matches a given name. It
+// short-circuits as soon as a match is found.
+type identMatchVisitor struct {
+	name  string
+	found *bool
+}
+
+func (v identMatchVisitor) Visit(n ast.Node) ast.Visitor {
+	if *v.found || n == nil {
+		return nil
+	}
+	switch x := n.(type) {
+	case *ast.SelectorExpr:
+		// Walk the LHS (e.g. `agent` in `agent.OrganizationID`).
+		// Sel is intentionally NOT walked: a field name match on
+		// `OrganizationID` should not be mistaken for a param match.
+		ast.Walk(v, x.X)
+		return nil
+	case *ast.KeyValueExpr:
+		// Struct literal: `domain.Alert{OrganizationID: orgID}`. The
+		// Key is a field name (skip); the Value is a real expression
+		// (walk). Treating Key as a potential ident match would
+		// produce the same false-negative as the selector case.
+		ast.Walk(v, x.Value)
+		return nil
+	case *ast.Ident:
+		if x.Name == v.name {
+			*v.found = true
+		}
+		return nil
+	}
+	return v
 }
 
 // bodyInvokesHelper returns true if any call inside the function body has

--- a/apps/backend/cmd/tenantscope-lint/main_test.go
+++ b/apps/backend/cmd/tenantscope-lint/main_test.go
@@ -88,3 +88,75 @@ func equal(a, b []string) bool {
 	}
 	return true
 }
+
+// TestScanServiceDirectoryFlagsAcceptedButUnusedOrgID runs the new
+// class-#3 service-param scan against the testdata fixtures. The
+// violating fixture (service_violating.go) MUST be flagged; the clean
+// fixtures (service_clean.go and the handler files) MUST NOT.
+func TestScanServiceDirectoryFlagsAcceptedButUnusedOrgID(t *testing.T) {
+	violations, err := scanServiceDirectory("testdata")
+	if err != nil {
+		t.Fatalf("scanServiceDirectory(testdata): %v", err)
+	}
+
+	gotMethods := make([]string, 0, len(violations))
+	for _, v := range violations {
+		gotMethods = append(gotMethods, v.Handler)
+	}
+	sort.Strings(gotMethods)
+
+	wantMethods := []string{
+		"LintTestViolatingSelectorService.AcknowledgeAlert (param OrganizationID)",
+		"LintTestViolatingService.AcknowledgeAlert (param orgID)",
+	}
+
+	if !equal(gotMethods, wantMethods) {
+		t.Fatalf("scanServiceDirectory(testdata) flagged %v, want %v",
+			gotMethods, wantMethods)
+	}
+
+	for _, v := range violations {
+		if !strings.HasSuffix(v.File, "service_violating.go") &&
+			!strings.HasSuffix(v.File, "service_violating_selector.go") {
+			t.Errorf("violation in unexpected file: %s", v.File)
+		}
+		if v.Line == 0 {
+			t.Errorf("violation has zero line number: %+v", v)
+		}
+	}
+}
+
+// TestOrgParamNamesCoversCommonSpellings is a structural guard against
+// silently dropping a parameter-name spelling. If callsites in this
+// codebase introduce a new spelling, add it here AND walk the existing
+// service surface for references.
+func TestOrgParamNamesCoversCommonSpellings(t *testing.T) {
+	mustHave := []string{"orgID", "OrgID", "organizationID", "OrganizationID", "adminOrgID", "callerOrgID"}
+	for _, name := range mustHave {
+		if !orgParamNames[name] {
+			t.Errorf("orgParamNames is missing %q", name)
+		}
+	}
+}
+
+// TestClassifyServiceDirRouting confirms the path-classifier sends
+// `./internal/application` to the service scanner and any other path
+// (including the default handlers path) to the handler scanner.
+func TestClassifyServiceDirRouting(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"./internal/application", true},
+		{"internal/application", true},
+		{"/abs/path/to/internal/application", true},
+		{"./internal/interfaces/http/handlers", false},
+		{"./cmd/tenantscope-lint", false},
+		{".", false},
+	}
+	for _, c := range cases {
+		if got := classifyServiceDir(c.path); got != c.want {
+			t.Errorf("classifyServiceDir(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/apps/backend/cmd/tenantscope-lint/testdata/service_clean.go
+++ b/apps/backend/cmd/tenantscope-lint/testdata/service_clean.go
@@ -1,0 +1,34 @@
+// Test fixture for the class-#3 service-param scan: a service method
+// that accepts orgID uuid.UUID AND uses it in the body. The lint
+// must NOT flag this method.
+//
+//go:build ignore_lint_testdata
+
+package testdata
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type LintTestCleanService struct {
+	repo interface {
+		AcknowledgeByOrg(id, orgID uuid.UUID) error
+	}
+}
+
+// AcknowledgeAlert uses orgID in the repository call. Body references
+// the param, so the lint passes.
+func (s *LintTestCleanService) AcknowledgeAlert(ctx context.Context, alertID uuid.UUID, orgID uuid.UUID) error {
+	return s.repo.AcknowledgeByOrg(alertID, orgID)
+}
+
+// CheckByOrg uses organizationID (alternate spelling) in a conditional;
+// any reference in the body counts as "used."
+func (s *LintTestCleanService) CheckByOrg(ctx context.Context, alertID uuid.UUID, organizationID uuid.UUID) error {
+	if organizationID == uuid.Nil {
+		return nil
+	}
+	return s.repo.AcknowledgeByOrg(alertID, organizationID)
+}

--- a/apps/backend/cmd/tenantscope-lint/testdata/service_violating.go
+++ b/apps/backend/cmd/tenantscope-lint/testdata/service_violating.go
@@ -1,0 +1,28 @@
+// Test fixture for the class-#3 service-param scan: a service method
+// that accepts orgID uuid.UUID but NEVER references it in the body.
+// The lint MUST flag this method (the downstream repo call likely
+// runs WHERE id = $1 system-wide and is a cross-tenant IDOR).
+//
+//go:build ignore_lint_testdata
+
+package testdata
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type LintTestViolatingService struct {
+	repo interface {
+		AcknowledgeByID(id uuid.UUID) error
+	}
+}
+
+// AcknowledgeAlert accepts orgID but never references it. The repo
+// call `AcknowledgeByID(alertID)` runs system-wide. The lint MUST
+// flag this.
+func (s *LintTestViolatingService) AcknowledgeAlert(ctx context.Context, alertID uuid.UUID, orgID uuid.UUID, userID uuid.UUID) error {
+	// Note: no reference to `orgID` anywhere below this line.
+	return s.repo.AcknowledgeByID(alertID)
+}

--- a/apps/backend/cmd/tenantscope-lint/testdata/service_violating_selector.go
+++ b/apps/backend/cmd/tenantscope-lint/testdata/service_violating_selector.go
@@ -1,0 +1,41 @@
+// Test fixture for the class-#3 service-param scan, H1 regression case:
+// a service method that accepts orgID uuid.UUID, never references it
+// at the top level, but contains a selector expression
+// `s.repo.OrganizationID` that mentions a STRUCT FIELD with the same
+// name. A naive ast.Inspect walk would incorrectly count the selector
+// RHS as a param match and pass the method. The lint MUST flag this
+// method.
+//
+//go:build ignore_lint_testdata
+
+package testdata
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Resource is a mock domain type with an OrganizationID field. The
+// field name deliberately matches one of the orgParamNames in the
+// lint so the selector-shadow false-negative can be exercised.
+type ResourceWithOrgIDField struct {
+	OrganizationID uuid.UUID
+}
+
+type LintTestViolatingSelectorService struct {
+	repo interface {
+		Get() *ResourceWithOrgIDField
+		AcknowledgeByID(id uuid.UUID) error
+	}
+}
+
+// AcknowledgeAlert accepts OrganizationID as a param (PascalCase
+// variant) but never references it. The body contains a selector
+// `r.OrganizationID` that the lint's identMatchVisitor MUST NOT count
+// as a parameter reference.
+func (s *LintTestViolatingSelectorService) AcknowledgeAlert(ctx context.Context, alertID uuid.UUID, OrganizationID uuid.UUID) error {
+	r := s.repo.Get()
+	_ = r.OrganizationID // selector — must NOT satisfy the lint
+	return s.repo.AcknowledgeByID(alertID)
+}

--- a/scripts/lint-tenant-scoping.sh
+++ b/scripts/lint-tenant-scoping.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-# lint-tenant-scoping.sh — invokes the tenantscope-lint Go binary against the
-# HTTP handlers package. Wraps the binary so the CI workflow has a stable
-# entry point and so developers can run it locally without remembering the
-# `go run` path.
+# lint-tenant-scoping.sh — invokes the tenantscope-lint Go binary in
+# dual-scan mode: checks the HTTP handlers package for missing
+# LoadOwned guards (class #1 path-id IDORs) AND the application
+# services package for orgID-accepted-but-unused parameters (class #3
+# IDORs). Wraps the binary so the CI workflow has a stable entry point
+# and so developers can run it locally without remembering the `go run`
+# path.
 #
 # Usage:
 #   ./scripts/lint-tenant-scoping.sh
 #
-# Exit code: 0 on pass, 1 on any new violation, 2 on tool error.
+# Exit code: 0 on pass, 1 on any new violation in EITHER scan, 2 on
+# tool error.
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root/apps/backend"
 
-go run ./cmd/tenantscope-lint ./internal/interfaces/http/handlers
+# No-arg invocation runs the dual scan (handlers + application).
+# Both scans must pass; either failure exits non-zero.
+go run ./cmd/tenantscope-lint


### PR DESCRIPTION
## Summary

Extend `cmd/tenantscope-lint` to mechanize detection of class-#3 IDORs: service-layer methods that **accept `orgID` / `organizationID` as a `uuid.UUID` parameter but never reference it in the body**. The repo call almost always runs `WHERE id = $1` system-wide — so the signature looks tenant-aware but the caller can reach any tenant's resource by guessing the UUID.

Phase 4.5 has repeatedly surfaced this exact pattern across the A3d-* sweep (memory: `feedback_tenantscope_lint_three_blindspot_classes`). This PR mechanizes the detection so future regressions fail at lint time.

## Mechanism

- `scanServiceDirectory` walks `apps/backend/internal/application/*.go`.
- For each method, scan parameters for any name in `orgParamNames` (`orgID` / `OrgID` / `organizationID` / `OrganizationID` / `adminOrgID` / `callerOrgID`) whose type is `uuid.UUID`.
- Walk the body via a custom `identMatchVisitor` that intercepts `*ast.SelectorExpr` (recurses only into `X`) and `*ast.KeyValueExpr` (recurses only into `Value`) so `foo.OrganizationID` does NOT silently satisfy a param named `OrganizationID`.
- If the parameter is never referenced, flag.

## Baseline allowlist (4 entries at landing)

| Method | Reason |
|---|---|
| `AlertService.AcknowledgeAlert` | HIGH IDOR, already filed at `todo/2026-05-21-a3d-v-followup-alert-handler-idors.md` |
| `AlertService.ResolveAlert` | HIGH IDOR, same todo |
| `AlertService.CheckAPIKeyExpiry` | Stub no-op; `orgID` reserved for future API key tracking |
| `BehaviorAnalysisService.detectCapabilityDrift` | Pure function on the baseline arg; `orgID` vestigial, refactor candidate |

Reviewers fixing the underlying defect should remove the allowlist entry. The allowlist must NOT grow over time.

## Phase 4.5 findings applied in-PR

- **HIGH H1 — selector-shadow false-negative.** `ast.Inspect` descends into `*ast.SelectorExpr.Sel`, so a body containing `agent.OrganizationID` (selector) would silently match a parameter named `OrganizationID`. Fixed via a custom `ast.Walk` Visitor (`identMatchVisitor`) that intercepts `*ast.SelectorExpr` and `*ast.KeyValueExpr` to skip the field-name side. Regression fixture at `testdata/service_violating_selector.go`.
- **HIGH H2 — CI gate inert.** `scripts/lint-tenant-scoping.sh` invoked the binary with an explicit handlers-dir argument, which routed away from the service scanner — making the new class-#3 detection a no-op in CI. Updated the script to use the binary's no-arg dual-scan default. **Without this fix the lint would have shipped as ornamental.**

## Dual-scan invocation

```bash
go run ./cmd/tenantscope-lint                                  # both scans (default; CI uses this)
go run ./cmd/tenantscope-lint ./internal/interfaces/http/handlers  # handler scan only (legacy)
go run ./cmd/tenantscope-lint ./internal/application               # service scan only
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./cmd/tenantscope-lint/ -count=1 -v` — all 6 tests pass (3 new: service scanner, orgParamNames coverage, path-routing classifier)
- [x] `bash scripts/lint-tenant-scoping.sh` — passes the dual scan (83 handler entries + 4 service entries)
- [x] Phase 4.5 adversarial subagent review — 2 HIGH findings (H1 selector-shadow + H2 CI inert) both fixed in-PR; 2 MEDIUM/LOW are either resolved by H1 fix or accepted as allowlist-quality tradeoffs
- [ ] Reviewer: walk the 4 baseline allowlist entries and confirm none are easy fixes; surface anything that should be refactored instead of allowlisted

## Behavior changes worth noting

- Pre-push gate now also runs the service scan. New class-#3 IDORs will fail CI immediately. Existing service code is allowlisted by name.
- The lint output format is unchanged for the handler scan; a new section reports service violations with file:line + `ReceiverType.Method (param <name>)`.

## False-negative class to document

The lint passes when `orgID` is referenced ANYWHERE in the body. A method that uses `orgID` only inside a `log.Printf` without flowing it to the repo call still satisfies the heuristic. Narrowing to "orgID flows to a repo call" requires cross-function flow analysis beyond what the AST scan provides. Reviewers should still verify, but the structural pattern catches the common case where `orgID` is forgotten outright.

## References

- Memory: `feedback_tenantscope_lint_three_blindspot_classes` (class taxonomy)
- Memory: `feedback_cross_tenant_idor_sentinel_collapse_pattern` (the body-AgentID class #2 fix pattern from PR #188 AttestMCP)
- Memory: `feedback_loadowned_uuid_nil_zerovalue_match` (uuid.Nil defense-in-depth)
- Companion sweep PRs shipped this session: #187 (A3d-vii.b A2AHandler) and #188 (AttestMCP body-AgentID P0)