### PR TITLE
security: close AlertService.AcknowledgeAlert + ResolveAlert system-wide IDORs (HIGH)

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -216,16 +216,6 @@ var serviceParamAllowlist = map[string]string{
 	// future-API surface; no current callsite. (alert_service.go:108-117)
 	"AlertService.CheckAPIKeyExpiry": "stub no-op; orgID reserved for future API key expiry implementation",
 
-	// HIGH IDOR — already tracked. AlertService.AcknowledgeAlert and
-	// ResolveAlert both accept orgID but call alertRepo.Acknowledge
-	// without the tenant filter, so any caller can acknowledge/resolve
-	// any tenant's alert by guessing the UUID. Fix is filed at
-	// todo/2026-05-21-a3d-v-followup-alert-handler-idors.md
-	// (handler-layer LoadOwned via alertRepo.GetByID is the preferred
-	// shape). Remove these entries once the follow-up PR lands.
-	"AlertService.AcknowledgeAlert": "audit-baseline IDOR: see todo/2026-05-21-a3d-v-followup-alert-handler-idors.md",
-	"AlertService.ResolveAlert":     "audit-baseline IDOR: see todo/2026-05-21-a3d-v-followup-alert-handler-idors.md",
-
 	// Pure function on the passed-in baseline argument; no DB call.
 	// orgID is vestigial — kept because callers still pass it but the
 	// method's logic uses only `baseline.CapabilityUsage`. Not an IDOR

--- a/apps/backend/internal/application/alert_service.go
+++ b/apps/backend/internal/application/alert_service.go
@@ -3,12 +3,25 @@ package application
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
+
+// ErrAlertNotFound is returned by AlertService write paths
+// (AcknowledgeAlert / ResolveAlert) when the alert does not exist OR
+// exists in another organization. The two cases are deliberately
+// collapsed to preserve existence-secrecy across tenant boundaries —
+// without this collapse, the response distinguishes "wrong UUID" from
+// "right UUID, wrong org" and becomes a cross-tenant existence oracle
+// for alert IDs (also enabling the historical system-wide ack/resolve
+// IDOR closed here). Handler maps this sentinel to 404 with a fixed
+// body; see tenant_scope.go:respondResourceNotFound for the matching
+// shape on the path-id helper side.
+var ErrAlertNotFound = errors.New("alert not found")
 
 // AlertService handles alert management
 type AlertService struct {
@@ -190,17 +203,32 @@ func (s *AlertService) GetAlerts(
 	return alerts, total, nil
 }
 
-// AcknowledgeAlert acknowledges an alert
+// AcknowledgeAlert acknowledges an alert.
+//
+// SECURITY (A3d-v R7 follow-up): before the prior fix, orgID was
+// accepted in the signature but never used — the repo call ran
+// `WHERE id = $1` system-wide, so any authenticated caller could
+// acknowledge any tenant's alert by guessing the UUID. The lint
+// extension shipped in PR #189 flagged this as class #3
+// (accepted-but-unused). The fix loads the alert via GetByID, compares
+// alert.OrganizationID to the caller's orgID, and collapses
+// not-found + cross-tenant + uuid.Nil mismatch to ErrAlertNotFound so
+// the handler returns a fixed 404 with no existence-oracle side
+// channel. Phase 4.5 defense-in-depth: the gate also rejects uuid.Nil
+// on either side (production rows are NOT NULL but defends against
+// future repo bugs returning zero-valued structs).
 func (s *AlertService) AcknowledgeAlert(
 	ctx context.Context,
 	alertID uuid.UUID,
 	orgID uuid.UUID,
 	userID uuid.UUID,
 ) error {
-	// Get alert first to have full data for webhook
 	alert, err := s.alertRepo.GetByID(alertID)
-	if err != nil {
-		return err
+	if err != nil || alert == nil {
+		return ErrAlertNotFound
+	}
+	if orgID == uuid.Nil || alert.OrganizationID == uuid.Nil || alert.OrganizationID != orgID {
+		return ErrAlertNotFound
 	}
 
 	if err := s.alertRepo.Acknowledge(alertID, userID); err != nil {
@@ -226,7 +254,16 @@ func (s *AlertService) BulkAcknowledgeAlerts(
 	return s.alertRepo.BulkAcknowledge(orgID, userID)
 }
 
-// ResolveAlert marks an alert as resolved
+// ResolveAlert marks an alert as resolved.
+//
+// SECURITY (A3d-v R7 follow-up): same orgID-accepted-but-unused IDOR
+// as AcknowledgeAlert above. Same Load → org-check → ErrAlertNotFound
+// collapse pattern. See AcknowledgeAlert comment for the rationale.
+//
+// Implementation note: the underlying ResolveAlert call still maps to
+// alertRepo.Acknowledge until the domain model gains a resolved
+// status (preserves pre-existing TODO behavior; not in scope of the
+// security fix).
 func (s *AlertService) ResolveAlert(
 	ctx context.Context,
 	alertID uuid.UUID,
@@ -234,8 +271,13 @@ func (s *AlertService) ResolveAlert(
 	userID uuid.UUID,
 	resolution string,
 ) error {
-	// For now, just acknowledge it
-	// TODO: Add a resolved status to the domain model
+	alert, err := s.alertRepo.GetByID(alertID)
+	if err != nil || alert == nil {
+		return ErrAlertNotFound
+	}
+	if orgID == uuid.Nil || alert.OrganizationID == uuid.Nil || alert.OrganizationID != orgID {
+		return ErrAlertNotFound
+	}
 	return s.alertRepo.Acknowledge(alertID, userID)
 }
 

--- a/apps/backend/internal/application/alert_service_test.go
+++ b/apps/backend/internal/application/alert_service_test.go
@@ -534,8 +534,10 @@ func TestAlertService_AcknowledgeAlert_NotFound(t *testing.T) {
 	ctx := context.Background()
 	err := service.AcknowledgeAlert(ctx, alertID, orgID, userID)
 
-	// Assert
-	assert.Error(t, err)
+	// Assert: not-found MUST collapse to the existence-secret sentinel
+	// — a regression that returned the raw GetByID error would silently
+	// pass `assert.Error` but is an existence-oracle leak.
+	assert.ErrorIs(t, err, ErrAlertNotFound)
 
 	mockAlertRepo.AssertExpectations(t)
 }
@@ -951,7 +953,14 @@ func TestAlertService_ResolveAlert_Success(t *testing.T) {
 	alertID := uuid.New()
 	orgID := uuid.New()
 	userID := uuid.New()
+	alert := createTestAlertForAlerts(orgID)
+	alert.ID = alertID
 
+	// A3d-v R7 follow-up: ResolveAlert now loads the alert via GetByID
+	// to enforce tenant ownership before mutating. Same-org test must
+	// set up the GetByID mock or the load fails and the call returns
+	// ErrAlertNotFound.
+	mockAlertRepo.On("GetByID", alertID).Return(alert, nil)
 	mockAlertRepo.On("Acknowledge", alertID, userID).Return(nil)
 
 	// Act
@@ -974,7 +983,10 @@ func TestAlertService_ResolveAlert_Error(t *testing.T) {
 	alertID := uuid.New()
 	orgID := uuid.New()
 	userID := uuid.New()
+	alert := createTestAlertForAlerts(orgID)
+	alert.ID = alertID
 
+	mockAlertRepo.On("GetByID", alertID).Return(alert, nil)
 	mockAlertRepo.On("Acknowledge", alertID, userID).Return(errors.New("database error"))
 
 	// Act
@@ -984,6 +996,84 @@ func TestAlertService_ResolveAlert_Error(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 
+	mockAlertRepo.AssertExpectations(t)
+}
+
+// A3d-v R7 follow-up: cross-tenant AcknowledgeAlert must collapse to
+// ErrAlertNotFound. Before the fix, the orgID parameter was accepted
+// but never used and ANY caller could acknowledge ANY tenant's alert
+// by guessing the UUID. The new behavior loads the alert, compares
+// alert.OrganizationID to the caller's orgID, and returns the
+// existence-secret sentinel on mismatch.
+func TestAlertService_AcknowledgeAlert_CrossTenantReturnsNotFound(t *testing.T) {
+	mockAlertRepo := new(MockAlertRepoForAlerts)
+	mockAgentRepo := new(MockAgentRepoForAlerts)
+
+	service := NewAlertService(mockAlertRepo, mockAgentRepo, nil)
+
+	alertID := uuid.New()
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	userID := uuid.New()
+	victimAlert := createTestAlertForAlerts(victimOrgID)
+	victimAlert.ID = alertID
+
+	// The repo returns the victim's alert. The service MUST reject
+	// before reaching Acknowledge — Acknowledge is intentionally NOT
+	// set up on the mock so a regression that calls it surfaces as a
+	// mock-unexpected-call failure.
+	mockAlertRepo.On("GetByID", alertID).Return(victimAlert, nil)
+
+	err := service.AcknowledgeAlert(context.Background(), alertID, callerOrgID, userID)
+
+	assert.ErrorIs(t, err, ErrAlertNotFound)
+	mockAlertRepo.AssertExpectations(t)
+}
+
+// A3d-v R7 follow-up: cross-tenant ResolveAlert must collapse to
+// ErrAlertNotFound. Same shape as AcknowledgeAlert above.
+func TestAlertService_ResolveAlert_CrossTenantReturnsNotFound(t *testing.T) {
+	mockAlertRepo := new(MockAlertRepoForAlerts)
+	mockAgentRepo := new(MockAgentRepoForAlerts)
+
+	service := NewAlertService(mockAlertRepo, mockAgentRepo, nil)
+
+	alertID := uuid.New()
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	userID := uuid.New()
+	victimAlert := createTestAlertForAlerts(victimOrgID)
+	victimAlert.ID = alertID
+
+	mockAlertRepo.On("GetByID", alertID).Return(victimAlert, nil)
+
+	err := service.ResolveAlert(context.Background(), alertID, callerOrgID, userID, "x")
+
+	assert.ErrorIs(t, err, ErrAlertNotFound)
+	mockAlertRepo.AssertExpectations(t)
+}
+
+// A3d-v R7 follow-up defense-in-depth: a uuid.Nil callerOrgID MUST
+// NOT match a uuid.Nil alert.OrganizationID. DB enforces NOT NULL on
+// alerts.organization_id, but defends against future repo bugs that
+// might return a zero-valued struct.
+func TestAlertService_AcknowledgeAlert_NilCallerOrgRejected(t *testing.T) {
+	mockAlertRepo := new(MockAlertRepoForAlerts)
+	mockAgentRepo := new(MockAgentRepoForAlerts)
+
+	service := NewAlertService(mockAlertRepo, mockAgentRepo, nil)
+
+	alertID := uuid.New()
+	userID := uuid.New()
+	// Both alert and caller have uuid.Nil orgID — a naive equality
+	// check would match. The guard MUST reject.
+	pathologicalAlert := &domain.Alert{ID: alertID, OrganizationID: uuid.Nil}
+
+	mockAlertRepo.On("GetByID", alertID).Return(pathologicalAlert, nil)
+
+	err := service.AcknowledgeAlert(context.Background(), alertID, uuid.Nil, userID)
+
+	assert.ErrorIs(t, err, ErrAlertNotFound)
 	mockAlertRepo.AssertExpectations(t)
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -1003,8 +1004,17 @@ func (h *AdminHandler) AcknowledgeAlert(c fiber.Ctx) error {
 	}
 
 	if err := h.getAlertService().AcknowledgeAlert(c.Context(), alertID, orgID, userID); err != nil {
+		// SECURITY (A3d-v R7 follow-up): cross-tenant and not-found
+		// collapse to ErrAlertNotFound. The 404 is intentional —
+		// existence-secrecy across tenants. err.Error() is NOT echoed
+		// so the SQL error / wrapped detail cannot leak through.
+		if errors.Is(err, application.ErrAlertNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "not found",
+			})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": err.Error(),
+			"error": "Failed to acknowledge alert",
 		})
 	}
 
@@ -1056,8 +1066,13 @@ func (h *AdminHandler) BulkAcknowledgeAlerts(c fiber.Ctx) error {
 
 	ackCount, err := h.getAlertService().BulkAcknowledgeAlerts(c.Context(), orgID, userID)
 	if err != nil {
+		// Parity with AcknowledgeAlert / ResolveAlert above: do not
+		// echo err.Error() (could carry SQL detail / wrapped state).
+		// Bulk path is tenant-scoped at the repo (WHERE organization_id
+		// = $3) so there is no IDOR, but the no-echo discipline keeps
+		// the file consistent.
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": err.Error(),
+			"error": "Failed to bulk acknowledge alerts",
 		})
 	}
 
@@ -1105,8 +1120,14 @@ func (h *AdminHandler) ResolveAlert(c fiber.Ctx) error {
 	}
 
 	if err := h.getAlertService().ResolveAlert(c.Context(), alertID, orgID, userID, req.Resolution); err != nil {
+		// SECURITY (A3d-v R7 follow-up): see AcknowledgeAlert above.
+		if errors.Is(err, application.ErrAlertNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "not found",
+			})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": err.Error(),
+			"error": "Failed to resolve alert",
 		})
 	}
 


### PR DESCRIPTION
## Summary

Closes the two HIGH IDORs surfaced by the class-#3 service-param scan I shipped in PR #189 and tracked at `todo/2026-05-21-a3d-v-followup-alert-handler-idors.md`.

Pre-fix, `AlertService.AcknowledgeAlert(ctx, alertID, orgID, userID)` and `ResolveAlert(...)` accepted `orgID` in the signature but the body never referenced it — the repo call ran `WHERE id = $1` system-wide. Any authenticated caller with a valid `user_id` could acknowledge/resolve **any tenant's** alert by guessing the UUID.

## Fix

**Service layer** (`alert_service.go`):
- New `ErrAlertNotFound` sentinel collapses not-found + cross-tenant + `uuid.Nil`-mismatch to a single existence-secret return.
- `AcknowledgeAlert`: load via `GetByID` → check `alert.OrganizationID == orgID` (with `uuid.Nil` defense-in-depth on both sides) → `alertRepo.Acknowledge`. Mismatch returns `ErrAlertNotFound`.
- `ResolveAlert`: same Load → org-check → sentinel pattern. Underlying call still routes to `alertRepo.Acknowledge` per the pre-existing TODO; handler-side audit-log distinction (`AuditActionAcknowledge` vs `AuditActionResolve`) is preserved.

**Handler layer** (`admin_handler.go`):
- `errors.Is(err, application.ErrAlertNotFound)` → 404 `{"error":"not found"}`. Non-sentinel errors → 500 with fixed `"Failed to (acknowledge|resolve) alert"`. **No `err.Error()` echo** — SQL errors / wrapped sentinel detail cannot leak through.
- Parity sweep: `BulkAcknowledgeAlerts` also stops echoing `err.Error()` (bulk SQL is tenant-scoped so not an IDOR, but the file is now consistent on the no-echo discipline). Phase 4.5 MEDIUM-1.

## Phase 4.5 findings applied in-PR

- **MEDIUM-1:** `BulkAcknowledgeAlerts` parity (no more `err.Error()` echo).
- **LOW-2:** Tightened `TestAlertService_AcknowledgeAlert_NotFound` to `assert.ErrorIs(t, err, ErrAlertNotFound)` — prevents silent regression if not-found collapse is ever reverted.

**Deferred (separate PRs):**
- **LOW-1:** Audit-log entry on cross-tenant rejection for SOC observability.
- **LOW-4:** Track `ApproveDrift` body-supplied `OrganizationID` shape as class-#2 IDOR if/when a handler wires it.

## Lint allowlist

`serviceparam-lint`: 4 → 2 entries.

- `AlertService.AcknowledgeAlert` removed.
- `AlertService.ResolveAlert` removed.
- Remaining: `AlertService.CheckAPIKeyExpiry` (stub no-op) + `BehaviorAnalysisService.detectCapabilityDrift` (pure baseline analysis). Both legitimately allowlisted; Phase 4.5 verified.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test \$(go list ./... | grep -v tests/integration) -count=1` — all green; added 3 new captured-flag tests, updated 3 existing
- [x] `go run ./cmd/tenantscope-lint/...` — passes (46 handler + 2 service entries)
- [x] **Negative-control verified:** reverting the guard surfaces as mock-unexpected-call panics in the cross-tenant tests — confirms regression tests are genuine, not no-ops
- [x] Phase 4.5 adversarial subagent review — NO HIGH findings; 1 MEDIUM + 1 LOW applied in-PR, 3 LOW deferred as follow-up observations
- [ ] Reviewer: walk \`alert_service.go:194-251\` to verify gate ordering precedes every alertRepo mutation call

## References

- Closes: \`todo/2026-05-21-a3d-v-followup-alert-handler-idors.md\`
- Memory: \`feedback_tenantscope_lint_three_blindspot_classes\` (class #3 — service-param accepted-but-unused)
- Memory: \`feedback_cross_tenant_idor_sentinel_collapse_pattern\` (sentinel + fixed-body 403/404 pattern from PR #188 AttestMCP)
- Memory: \`feedback_loadowned_uuid_nil_zerovalue_match\` (uuid.Nil defense-in-depth)