### PR TITLE
security: close MCP body-supplied mcpServerId IDORs (defects #19 + #19b)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -825,6 +825,17 @@ func (h *MCPAttestationHandler) RecordMCPConnection(c fiber.Ctx) error {
 		return nil
 	}
 
+	// SECURITY (defect #19, body-class #2): also gate the body-supplied
+	// mcpServerID. PR #185 closed the URL-path MCP cross-org class; the
+	// body-supplied mcpServerId on this endpoint is a separate IDOR:
+	// an SDK token for org A could record a connection between A's own
+	// agent and ANY tenant's MCP server by guessing the MCP UUID.
+	// Without this LoadOwned, the analytics rollup attributes a
+	// fictitious connection-graph edge to the victim org's MCP.
+	if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
+		return nil
+	}
+
 	// Record the connection
 	connection, err := h.attestationService.RecordAgentMCPConnection(
 		c.Context(),
@@ -932,6 +943,25 @@ func (h *MCPAttestationHandler) RecordMCPUsageReport(c fiber.Ctx) error {
 			"error":   "Invalid request body",
 			"message": err.Error(),
 		})
+	}
+
+	// SECURITY (defect #19b, body-class #2): pre-validation pass over
+	// every parseable mcpServerId in the body. Any cross-org UUID
+	// anywhere in the batch aborts the entire request with 404 BEFORE
+	// any service call — otherwise an attacker could plant a
+	// fictitious usage report against a victim org's MCP server,
+	// poisoning their analytics + invocation counters. Malformed UUIDs
+	// preserve the existing silent-skip behavior in the main loop
+	// (the malformed-vs-cross-org reporting oracle is a separate
+	// follow-up); only well-formed cross-org UUIDs are blocking.
+	for serverIDStr := range req.MCPServers {
+		mcpServerID, parseErr := uuid.Parse(serverIDStr)
+		if parseErr != nil {
+			continue
+		}
+		if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
+			return nil
+		}
 	}
 
 	// Calculate totals for response

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
@@ -494,6 +494,55 @@ func TestMCPAttestationHandler_RecordMCPConnection_InvalidMCPServerIDFormat(t *t
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
+// SECURITY (defect #19, body-class #2): RecordMCPConnection accepts a
+// body-supplied mcpServerId. PR #185 closed the URL path's agent_id
+// cross-org class but the body-supplied mcpServerId remained an IDOR:
+// an attacker holding an SDK token for org A could record a fictitious
+// connection between A's own agent and ANY tenant's MCP server by
+// guessing the UUID, poisoning the victim org's connection-graph
+// analytics. The fix wraps mcpServerId in LoadOwned against
+// mcpServerRepo; the captured-flag test confirms the service is never
+// reached (attestationService is nil; a bypass would 500-panic
+// rather than returning the asserted 404).
+func TestMCPAttestationHandler_RecordMCPConnection_CrossOrgMCPServerID_Returns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	agentID := uuid.New()
+	mcpServerID := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: mcpServerID, OrganizationID: victimOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/agents/:agent_id/mcp-connections", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPConnection(c)
+	})
+
+	body := `{"mcpServerId":"` + mcpServerID.String() + `","toolName":"x"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-connections", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode, "cross-org body mcpServerId must return 404")
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, mcpServerID.String(), "response must not echo the supplied mcpServerId")
+	assert.NotContains(t, bodyStr, victimOrgID.String(), "response must not echo the cross-org organization UUID")
+}
+
 // ===========================
 // MCPAttestationHandler.RecordMCPUsageReport Tests
 // ===========================
@@ -527,6 +576,69 @@ func TestMCPAttestationHandler_RecordMCPUsageReport_InvalidAgentID(t *testing.T)
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// SECURITY (defect #19b, body-class #2): RecordMCPUsageReport accepts
+// a body containing a map of mcpServerId → usage stats. Any cross-org
+// UUID anywhere in the batch must abort the entire request with 404
+// before any service call — without the pre-validation pass, an
+// attacker could plant a fictitious usage report against a victim
+// org's MCP, poisoning their invocation counters / capability rollups.
+//
+// Captured-flag pattern: attestationService is nil. A bypass that
+// reached the service would surface as a panic / 500, observably
+// distinct from the 404 the test asserts. The first cross-org UUID
+// encountered during the pre-validation pass triggers the abort,
+// regardless of where it appears in the map.
+func TestMCPAttestationHandler_RecordMCPUsageReport_CrossOrgMCPServerID_Returns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	agentID := uuid.New()
+	sameOrgMCP := uuid.New()
+	crossOrgMCP := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				if id == sameOrgMCP {
+					return &domain.MCPServer{ID: id, OrganizationID: callerOrgID}, nil
+				}
+				return &domain.MCPServer{ID: id, OrganizationID: victimOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/agents/:id/mcp-usage-report", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPUsageReport(c)
+	})
+
+	// Batch with one same-org and one cross-org server. The whole
+	// request must abort with 404 — partial-acceptance would still
+	// poison the victim's analytics for the same-org entries while
+	// the lying-by-omission about the cross-org entry hides the
+	// probe.
+	body := `{"agentId":"` + agentID.String() + `","mcpServers":{` +
+		`"` + sameOrgMCP.String() + `":{"toolUsage":{},"capabilitiesAttested":[]},` +
+		`"` + crossOrgMCP.String() + `":{"toolUsage":{},"capabilitiesAttested":[]}` +
+		`},"reportedAt":"2024-01-01T00:00:00Z"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-usage-report", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode, "any cross-org body mcpServerId must abort the whole batch with 404")
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, crossOrgMCP.String(), "response must not echo the supplied cross-org mcpServerId")
+	assert.NotContains(t, bodyStr, victimOrgID.String(), "response must not echo the cross-org organization UUID")
 }
 
 // ===========================


### PR DESCRIPTION
## Summary

Re-implementation of two of the three residuals from the closed PR #143 (`todo/2026-05-21-pr-143-body-uuid-scoping-residuals.md`). Also closes the original prompt's **Option B** (`todo/2026-05-21-mcp-usage-class2-idor.md`).

PR #185 closed the URL path's MCP `c.Params("id")` IDOR class. The body-supplied `mcpServerId` on two endpoints remained un-scoped:

### #19 — `RecordMCPConnection`

`POST /api/v1/agents/:agent_id/mcp-connections` body `{"mcpServerId": "<cross-org-mcp-uuid>", "toolName": "x"}`. Pre-fix: any SDK token for org A could record a fictitious connection between A's agent and ANY tenant's MCP server, polluting the victim org's connection-graph analytics.

**Fix:** new `LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID)` immediately after the existing URL-agent LoadOwned. `mcpServerRepo` is the field PR #185 added.

### #19b — `RecordMCPUsageReport`

`POST /api/v1/agents/:id/mcp-usage-report` body has `mcpServers: {uuid → usage stats}` map. Same body-class-#2 IDOR — any cross-org UUID in the batch poisons the victim org's invocation counters.

**Fix:** pre-validation pass walks every parseable `mcpServerId` and calls `LoadOwned`; first cross-org UUID aborts the entire batch with 404. Partial-acceptance is intentionally rejected (silent-success on same-org + silent-skip on cross-org would lie by omission). Malformed UUIDs preserve pre-existing silent-skip (separate `#41` follow-up).

### #18 — `CreateMCPServer` (no code change needed)

Re-investigated and determined to need no additional work:
- `mcp_handler.go:243-249` already silently drops cross-org agent links.
- `domain.MCPServer.RegisteredByAgent *uuid.UUID` marshals to `null` when dropped — body UUID never echoes.
- 409-conflict response echoes only same-org `existingId` / `name` from `mcpRepo.GetByURL(req.URL, orgID)`.

Phase 4.5 re-verified.

## Phase 4.5 findings

NO HIGH/MEDIUM. 3 LOW deferred (regression test for #18 silent-drop, pre-existing `uuid.Nil` actor_org_id in SDK audit logs, O(N) GetByID in batch pre-validation). All accepted as out-of-scope.

## Lint allowlist

No change — body-class IDORs are not detected by the current `tenantscope-lint` (it scans `c.Params(...)` only, not request structs). Class-#2 detection is on the lint roadmap.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test \$(go list ./... | grep -v tests/integration) -count=1` — all green; 2 new captured-flag tests
- [x] `go run ./cmd/tenantscope-lint/...` — passes (46 handler + 2 service)
- [x] **Negative-control:** Phase 4.5 verified the new tests fail when the new LoadOwned calls are reverted (mock-unexpected-call panic surfaces in place of the asserted 404).
- [ ] Reviewer: confirm `RecordMCPUsageReport` partial-batch rejection semantics are correct (whole batch → 404 if ANY entry is cross-org).

## References

- `todo/2026-05-21-pr-143-body-uuid-scoping-residuals.md` (closes #19 + #19b; #18 documented as no-action-needed)
- Memory: `feedback_tenantscope_lint_three_blindspot_classes` (this is class #2 — body-supplied tenant UUIDs)