### PR TITLE
security: close A2AHandler.LogTask phantom-task body-AgentID IDOR (P2)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -600,10 +600,39 @@ func (h *A2AHandler) LogTask(c fiber.Ctx) error {
 		}
 	}
 
+	// SECURITY (body-class #2): the ClientAgentID has been resolved
+	// from one of three paths (SDK body, internal body, or Locals
+	// context). All three are attacker-controlled in the body-supplied
+	// cases — without this check, an attacker holding any valid
+	// A2A token can plant a phantom A2ATask row claiming the VICTIM's
+	// agent initiated a task against the attacker's RemoteAgentID,
+	// polluting the victim org's analytics + peer-trust history.
+	// RemoteAgentID is intentionally NOT scoped (A2A tasks are
+	// cross-org by protocol design — the remote side may legitimately
+	// belong to another organization).
+	//
+	// Filed as defect in
+	// todo/2026-05-21-a3d-logtask-phantom-task-idor.md (P2). Fix uses
+	// the existing agentService.GetAgent loader closure mirroring
+	// GetSkillAttestations:1226 and UpdateTaskState (A3d-vii.b).
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	agentLoader := func(id uuid.UUID) (*domain.Agent, error) {
+		return h.agentService.GetAgent(c.Context(), id)
+	}
+	if LoadOwned(c, agentLoader, req.ClientAgentID, orgID, agentOrgID) == nil {
+		return nil
+	}
+
 	task, err := h.a2aService.LogA2ATask(c.Context(), req)
 	if err != nil {
+		// err.Error() is NOT echoed — could carry victim agent state
+		// via wrapped service errors (mirrors A3d-vii.b PR #187 +
+		// AttestMCP PR #188 no-echo discipline).
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "failed to log task: " + err.Error(),
+			"error": "Failed to log task",
 		})
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler_cross_tenant_test.go
@@ -467,3 +467,49 @@ func TestA2AHandler_AgentScoped_CrossOrgReturns404(t *testing.T) {
 		})
 	}
 }
+
+// SECURITY (body-class #2, LogTask phantom-task IDOR): a POST
+// /api/v1/a2a/tasks with body `{"_clientAgentId": "<victim-org-agent>",
+// "remoteAgentId": "<attacker-org-agent>"}` from a token in the
+// attacker's org must return 404, NOT create a phantom A2ATask row
+// in the victim org. RemoteAgentID is intentionally NOT scoped (A2A
+// tasks are cross-org by protocol design). a2aService is nil — any
+// bypass would 500-panic rather than returning the asserted 404.
+func TestA2AHandler_LogTask_CrossOrgClientAgentReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	clientAgentID := uuid.New() // victim's agent UUID (body-supplied)
+	remoteAgentID := uuid.New() // attacker's own agent (legit cross-org)
+
+	agentLoaded := false
+	mockAgentService := &MockAgentServiceImpl{
+		GetAgentFunc: func(_ context.Context, id uuid.UUID) (*domain.Agent, error) {
+			agentLoaded = true
+			return &domain.Agent{ID: id, OrganizationID: victimOrgID}, nil
+		},
+	}
+
+	handler := &A2AHandler{agentService: mockAgentService}
+
+	app := fiber.New()
+	app.Post("/a2a/tasks", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		c.Locals("agent_id", uuid.New()) // attacker's own agent in Locals
+		return handler.LogTask(c)
+	})
+
+	body := `{"externalTaskId":"phantom-1","_clientAgentId":"` + clientAgentID.String() +
+		`","remoteAgentId":"` + remoteAgentID.String() + `","skillId":"exfiltrate"}`
+	req := httptest.NewRequest("POST", "/a2a/tasks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(bodyBytes))
+	assert.True(t, agentLoaded, "agentService.GetAgent must be called to verify ClientAgentID ownership")
+	assert.NotContains(t, string(bodyBytes), clientAgentID.String(), "response must not echo the supplied ClientAgentID")
+	assert.NotContains(t, string(bodyBytes), victimOrgID.String(), "response must not echo the victim's org UUID")
+}


### PR DESCRIPTION
## Summary

Closes the LogTask phantom-task IDOR filed at `todo/2026-05-21-a3d-logtask-phantom-task-idor.md` (P2). Phase 4.5 of the A3d-vii.b PR #187 surfaced it — same body-class #2 shape, inverse of the UpdateTaskState fix.

**Exploit (pre-fix):** `POST /api/v1/a2a/tasks` with `{"_clientAgentId": "<victim-org-agent>", "remoteAgentId": "<attacker-org-agent>"}` from a token in the attacker's org plants a phantom A2ATask row claiming the victim's agent initiated a task. Polluting the victim org's analytics and peer-trust history.

## Fix

`a2a_handler.go:603-628`: after the ClientAgentID is resolved (from any of the three body/context paths the handler already supports), wrap in `LoadOwned` against `agentService.GetAgent` using the existing `agentLoader` closure pattern from `GetSkillAttestations:1226` and `UpdateTaskState` (A3d-vii.b).

`RemoteAgentID` is intentionally **NOT** scoped — A2A tasks are cross-org by protocol design (the remote may legitimately belong to another organization).

Service-call error path now returns fixed `"Failed to log task"` instead of echoing `err.Error()`, mirroring the no-echo discipline established in PR #187 (RevokeConsent + UpdateTaskState) and PR #188 (AttestMCP).

## Test

`TestA2AHandler_LogTask_CrossOrgClientAgentReturns404` in `a2a_handler_cross_tenant_test.go`. Captured-flag pattern: `agentService.GetAgent` returns a victim-org agent; `a2aService` is nil. A bypass would 500-panic on the nil service; the test asserts 404 + no UUID echo.

## Lint allowlist

No change — body-class IDORs aren't detected by current `tenantscope-lint` (class-#2 detection is on the roadmap).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test \$(go list ./... | grep -v tests/integration) -count=1` — all green
- [x] `go run ./cmd/tenantscope-lint/...` — passes (46 handler + 2 service entries)
- [x] Pattern review: matches the A3d-vii.b `UpdateTaskState` fix exactly (same Loader closure, same `LoadOwned` shape). Phase 4.5 skipped — Phase 4.5 of PR #187 already validated this shape, and the LogTask body-class is structurally a mirror of UpdateTaskState's path-class fix.

## References

- Source: `todo/2026-05-21-a3d-logtask-phantom-task-idor.md` (closes)
- Pattern from PR #187 (A3d-vii.b): `UpdateTaskState` two-step ownership
- Memory: `feedback_tenantscope_lint_three_blindspot_classes` (class #2)