### PR TITLE
security: close 4 AdminHandler user-lifecycle existence-oracle IDORs (A3d-viii)

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -80,10 +80,8 @@ var allowlist = map[string]string{
 	// from-lf-demo-prep.md (defect #18-25 follow-up section to be added).
 	// ---------------------------------------------------------------
 	"A2AHandler.DeleteSkill": "stub-handler: returns 204 No Content with no service dispatch. Path :id is a skill UUID; once a DeleteSkill service method exists, scope at handler layer (A3d-vii.c follow-up). Not exploitable today.",
-	"AdminHandler.AcknowledgeAlert":                         "audit-baseline: needs review",
-	"AdminHandler.DeactivateUser":                           "audit-baseline: needs review",
-	"AdminHandler.ResolveAlert":                             "audit-baseline: needs review",
-	"AdminHandler.UpdateUserRole":                           "audit-baseline: needs review",
+	"AdminHandler.AcknowledgeAlert": "service-layer scoping: AlertService.AcknowledgeAlert performs Load → caller-org check → ErrAlertNotFound (collapses cross-tenant + not-found + uuid.Nil mismatch) and the handler maps the sentinel to a fixed 404 body (A3d-v R7 closed in PR #190).",
+	"AdminHandler.ResolveAlert":     "service-layer scoping: AlertService.ResolveAlert mirrors AcknowledgeAlert — Load → caller-org check → ErrAlertNotFound → fixed 404 handler mapping (A3d-v R7 closed in PR #190).",
 	"DetectionHandler.GetDetectionStatus":                   "audit-baseline: needs review",
 	"DetectionHandler.GetLatestCapabilityReport":            "audit-baseline: needs review",
 	"DetectionHandler.ReportCapabilities":                   "audit-baseline: needs review",

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler.go
@@ -327,6 +327,16 @@ func (h *AdminHandler) UpdateUserRole(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (A3d-viii): verify the target user belongs to the caller's
+	// org before invoking the update flow. The service-layer check returns
+	// a distinct error string for cross-tenant vs not-found, which the
+	// handler then serialises as 500 with the error in the body — an
+	// existence side channel that lets an attacker enumerate user UUIDs
+	// across tenants. Handler-layer LoadOwned collapses both to 404.
+	if LoadOwned(c, h.userRepo.GetByID, targetUserID, orgID, userOrgID) == nil {
+		return nil
+	}
+
 	// Update user role
 	user, err := h.getAuthService().UpdateUserRole(c.Context(), targetUserID, orgID, role, adminID)
 	if err != nil {
@@ -374,6 +384,15 @@ func (h *AdminHandler) DeactivateUser(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Cannot deactivate your own account",
 		})
+	}
+
+	// SECURITY (A3d-viii): verify the target user belongs to the caller's
+	// org BEFORE the super-admin lookup and the service call. The service
+	// echoes a distinct error string for cross-tenant vs not-found, which
+	// the handler then surfaces as 500 with the body — an existence side
+	// channel. LoadOwned collapses both to 404.
+	if LoadOwned(c, h.userRepo.GetByID, targetUserID, orgID, userOrgID) == nil {
+		return nil
 	}
 
 	// Check if target user is the super admin (first admin user in the organization)
@@ -427,18 +446,13 @@ func (h *AdminHandler) ActivateUser(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify user belongs to the same organization
-	user, err := h.getAuthService().GetUserByID(c.Context(), targetUserID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "User not found",
-		})
-	}
-
-	if user.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "User not found in organization",
-		})
+	// SECURITY (A3d-viii): replace the pre-fix existence oracle (404
+	// "User not found" vs 403 "User not found in organization") with the
+	// LoadOwned helper. Both branches now collapse to a fixed 404 body,
+	// closing the side channel that let an attacker distinguish "no such
+	// user system-wide" from "user exists in another org".
+	if LoadOwned(c, h.userRepo.GetByID, targetUserID, orgID, userOrgID) == nil {
+		return nil
 	}
 
 	// Activate user using admin service
@@ -479,25 +493,21 @@ func (h *AdminHandler) PermanentlyDeleteUser(c fiber.Ctx) error {
 		})
 	}
 
-	// Verify user belongs to the same organization
-	user, err := h.getAuthService().GetUserByID(c.Context(), targetUserID)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "User not found",
-		})
-	}
-
-	if user.OrganizationID != orgID {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-			"error": "User not found in organization",
-		})
-	}
-
 	// Cannot delete yourself
 	if targetUserID == adminID {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Cannot delete your own account",
 		})
+	}
+
+	// SECURITY (A3d-viii): replace the pre-fix existence oracle (404
+	// "User not found" vs 403 "User not found in organization") with the
+	// LoadOwned helper. Both branches now collapse to a fixed 404 body,
+	// closing the side channel. The returned user is reused below for
+	// the audit-log email/name capture.
+	user := LoadOwned(c, h.userRepo.GetByID, targetUserID, orgID, userOrgID)
+	if user == nil {
+		return nil
 	}
 
 	// Check if target user is the super admin (first admin user in the organization)

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler_a3dviii_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler_a3dviii_test.go
@@ -1,0 +1,219 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ===========================
+// A3d-viii: cross-tenant access on the 4 admin user-lifecycle routes
+// must return 404 with the existence-secrecy body. Each row exercises
+// the new LoadOwned guard wired in this PR (or, for ActivateUser /
+// PermanentlyDeleteUser, the LoadOwned guard that REPLACES the pre-fix
+// explicit 404/403 existence oracle).
+//
+// Regression-proofing pattern: AdminServicer and AuthServicer are
+// intentionally nil. A bypass of the LoadOwned guard would reach
+//   - h.getAuthService().UpdateUserRole / DeactivateUser, or
+//   - h.getAdminService().ActivateUser / PermanentlyDeleteUser, or
+//   - h.isSuperAdmin -> h.getAuthService().GetUserByID
+// All four nil-deref → fiber 500 → assert.Equal(404) below fires.
+//
+// PermanentlyDeleteUser has an additional dimension: the LoadOwned
+// returned user is reused for the audit log; a bypass also surfaces as
+// a nil-pointer panic on `user.Email` even before any service call.
+// ===========================
+
+func TestAdminHandler_UserLifecycle_CrossOrgReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	differentOrgID := uuid.New()
+	adminID := uuid.New()
+	targetUserID := uuid.New()
+
+	userRepoForeignOrg := &adminTestUserRepo{
+		getByID: func(id uuid.UUID) (*domain.User, error) {
+			return &domain.User{
+				ID:             targetUserID,
+				OrganizationID: differentOrgID,
+				Status:         domain.UserStatusActive,
+				Email:          "victim@other-org.example",
+				Name:           "Victim Other-Org",
+			}, nil
+		},
+	}
+
+	// authServicer + adminServicer intentionally nil — a bypass on any
+	// of the four handlers nil-derefs (either on the service call
+	// directly, or via isSuperAdmin) and fiber returns 500.
+	handler := NewAdminHandlerWithInterfaces(nil, nil, nil, nil, nil, nil, nil, nil, userRepoForeignOrg)
+
+	tests := []struct {
+		name        string
+		method      string
+		requestPath string
+		body        string
+		setup       func(*fiber.App, *AdminHandler)
+	}{
+		{
+			name:        "UpdateUserRole",
+			method:      "PUT",
+			requestPath: "/admin/users/" + targetUserID.String() + "/role",
+			// Valid role required — role validation happens BEFORE the
+			// LoadOwned gate (the gate is the last check before the
+			// service call), so an invalid role would short-circuit to
+			// 400 and the test would not exercise the gate.
+			body: `{"role":"member"}`,
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Put("/admin/users/:id/role", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", adminID)
+					return h.UpdateUserRole(c)
+				})
+			},
+		},
+		{
+			name:        "DeactivateUser",
+			method:      "POST",
+			requestPath: "/admin/users/" + targetUserID.String() + "/deactivate",
+			body:        "",
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Post("/admin/users/:id/deactivate", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", adminID)
+					return h.DeactivateUser(c)
+				})
+			},
+		},
+		{
+			name:        "ActivateUser",
+			method:      "POST",
+			requestPath: "/admin/users/" + targetUserID.String() + "/activate",
+			body:        "",
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Post("/admin/users/:id/activate", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", adminID)
+					return h.ActivateUser(c)
+				})
+			},
+		},
+		{
+			name:        "PermanentlyDeleteUser",
+			method:      "DELETE",
+			requestPath: "/admin/users/" + targetUserID.String(),
+			body:        "",
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Delete("/admin/users/:id", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", adminID)
+					return h.PermanentlyDeleteUser(c)
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			tt.setup(app, handler)
+
+			var req *http.Request
+			if tt.body == "" {
+				req = httptest.NewRequest(tt.method, tt.requestPath, nil)
+			} else {
+				req = httptest.NewRequest(tt.method, tt.requestPath, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+				"%s: cross-tenant request must return 404, got %d", tt.name, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.JSONEq(t, `{"error":"not found"}`, string(body),
+				"%s: cross-tenant 404 body must be existence-secrecy shape, got %s", tt.name, string(body))
+		})
+	}
+}
+
+// Self-target short-circuits MUST still fire BEFORE the LoadOwned gate
+// for DeactivateUser and PermanentlyDeleteUser. The handlers reject
+// "deactivate / delete your own account" with 400 before any DB load,
+// because the attacker provides their own userID — no cross-tenant
+// information is leaked by the 400 response.
+//
+// This test pins the ordering: if a future refactor moves LoadOwned
+// before the self-check, the test would still pass (404 is the
+// existence-secrecy outcome). But if a refactor REMOVES the self-check
+// entirely, the test fails (handler proceeds to service call with
+// targetUserID == adminID and either succeeds or nil-derefs).
+func TestAdminHandler_UserLifecycle_SelfTargetReturns400(t *testing.T) {
+	orgID := uuid.New()
+	adminID := uuid.New()
+	// userRepo returns a same-org user so LoadOwned would pass if reached.
+	userRepo := &adminTestUserRepo{
+		getByID: func(id uuid.UUID) (*domain.User, error) {
+			return &domain.User{ID: id, OrganizationID: orgID, Status: domain.UserStatusActive}, nil
+		},
+	}
+	// All services nil — only the 400 self-target branch is meant to
+	// fire. A regression that reaches the service crashes (500) or
+	// returns 200, distinguishable from 400.
+	handler := NewAdminHandlerWithInterfaces(nil, nil, nil, nil, nil, nil, nil, nil, userRepo)
+
+	cases := []struct {
+		name        string
+		method      string
+		requestPath string
+		setup       func(*fiber.App, *AdminHandler)
+	}{
+		{
+			name:        "DeactivateUser",
+			method:      "POST",
+			requestPath: "/admin/users/" + adminID.String() + "/deactivate",
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Post("/admin/users/:id/deactivate", func(c fiber.Ctx) error {
+					c.Locals("organization_id", orgID)
+					c.Locals("user_id", adminID)
+					return h.DeactivateUser(c)
+				})
+			},
+		},
+		{
+			name:        "PermanentlyDeleteUser",
+			method:      "DELETE",
+			requestPath: "/admin/users/" + adminID.String(),
+			setup: func(app *fiber.App, h *AdminHandler) {
+				app.Delete("/admin/users/:id", func(c fiber.Ctx) error {
+					c.Locals("organization_id", orgID)
+					c.Locals("user_id", adminID)
+					return h.PermanentlyDeleteUser(c)
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			tc.setup(app, handler)
+			req := httptest.NewRequest(tc.method, tc.requestPath, nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode,
+				"%s: self-target must return 400, got %d", tc.name, resp.StatusCode)
+		})
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler_integration_test.go
@@ -589,6 +589,7 @@ func TestAdminHandler_UpdateUserRole_Success(t *testing.T) {
 		nil,
 		nil,
 	)
+	handler.userRepo = &adminTestUserRepo{getByID: sameOrgUserStub(targetUserID, orgID)} // A3d-viii
 
 	app := fiber.New()
 	app.Put("/admin/users/:id/role", func(c fiber.Ctx) error {
@@ -694,6 +695,7 @@ func TestAdminHandler_DeactivateUser_Success(t *testing.T) {
 		nil,
 		nil,
 	)
+	handler.userRepo = &adminTestUserRepo{getByID: sameOrgUserStub(targetUserID, orgID)} // A3d-viii
 
 	app := fiber.New()
 	app.Delete("/admin/users/:id/deactivate", func(c fiber.Ctx) error {
@@ -769,6 +771,7 @@ func TestAdminHandler_ActivateUser_Success(t *testing.T) {
 		nil,
 		nil,
 	)
+	handler.userRepo = &adminTestUserRepo{getByID: sameOrgUserStub(targetUserID, orgID)} // A3d-viii
 
 	app := fiber.New()
 	app.Post("/admin/users/:id/activate", func(c fiber.Ctx) error {
@@ -790,22 +793,16 @@ func TestAdminHandler_ActivateUser_NotFound(t *testing.T) {
 	adminID := uuid.New()
 	targetUserID := uuid.New()
 
-	mockAuthService := &MockAuthServiceImpl{
-		GetUserByIDFunc: func(ctx context.Context, id uuid.UUID) (*domain.User, error) {
+	// A3d-viii: existence/not-found is now decided by the userRepo
+	// lookup inside LoadOwned, not AuthService.GetUserByID. The pre-fix
+	// 404 expectation is preserved because LoadOwned writes the same
+	// fixed body on loader error.
+	handler := createAdminHandlerWithMocks(nil, nil, nil, nil, nil, nil, nil, nil)
+	handler.userRepo = &adminTestUserRepo{
+		getByID: func(id uuid.UUID) (*domain.User, error) {
 			return nil, assert.AnError
 		},
 	}
-
-	handler := createAdminHandlerWithMocks(
-		mockAuthService,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-	)
 
 	app := fiber.New()
 	app.Post("/admin/users/:id/activate", func(c fiber.Ctx) error {
@@ -828,25 +825,17 @@ func TestAdminHandler_ActivateUser_WrongOrg(t *testing.T) {
 	adminID := uuid.New()
 	targetUserID := uuid.New()
 
-	mockAuthService := &MockAuthServiceImpl{
-		GetUserByIDFunc: func(ctx context.Context, id uuid.UUID) (*domain.User, error) {
-			return &domain.User{
-				ID:             id,
-				OrganizationID: otherOrgID, // Different org
-			}, nil
+	// A3d-viii: the cross-org branch is now decided by LoadOwned + the
+	// userRepo lookup. The pre-fix 403 with the "User not found in
+	// organization" body was an existence side channel; the post-fix
+	// response is a fixed 404 indistinguishable from "no such user
+	// system-wide".
+	handler := createAdminHandlerWithMocks(nil, nil, nil, nil, nil, nil, nil, nil)
+	handler.userRepo = &adminTestUserRepo{
+		getByID: func(id uuid.UUID) (*domain.User, error) {
+			return &domain.User{ID: id, OrganizationID: otherOrgID}, nil
 		},
 	}
-
-	handler := createAdminHandlerWithMocks(
-		mockAuthService,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-	)
 
 	app := fiber.New()
 	app.Post("/admin/users/:id/activate", func(c fiber.Ctx) error {
@@ -860,7 +849,7 @@ func TestAdminHandler_ActivateUser_WrongOrg(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
 // ===========================
@@ -908,6 +897,21 @@ func TestAdminHandler_PermanentlyDeleteUser_Success(t *testing.T) {
 		nil,
 		nil,
 	)
+	// A3d-viii: LoadOwned now uses userRepo (not AuthService.GetUserByID)
+	// for the existence+ownership check. The returned user is also reused
+	// for the audit-log Email/Name capture, so the stub must populate
+	// those fields.
+	handler.userRepo = &adminTestUserRepo{
+		getByID: func(id uuid.UUID) (*domain.User, error) {
+			return &domain.User{
+				ID:             id,
+				Email:          "user@test.com",
+				Name:           "Test User",
+				OrganizationID: orgID,
+				Role:           "member",
+			}, nil
+		},
+	}
 
 	app := fiber.New()
 	app.Delete("/admin/users/:id/permanent", func(c fiber.Ctx) error {


### PR DESCRIPTION
## Summary

Close 4 cross-tenant defects on AdminHandler user-lifecycle flows plus 2 lint allowlist hygiene conversions following PR #190's service-layer AlertService fix.

| Route | Handler | Pre-fix shape | Fix |
|---|---|---|---|
| `PUT /api/v1/admin/users/:id/role` | `UpdateUserRole` | Service-layer org check returned 500 with `err.Error()` distinct strings | LoadOwned wrap |
| `POST /api/v1/admin/users/:id/deactivate` | `DeactivateUser` | Same shape as UpdateUserRole | LoadOwned wrap |
| `POST /api/v1/admin/users/:id/activate` | `ActivateUser` | **Explicit** existence oracle: `GetUserByID` → 404 "User not found"; then `OrganizationID != orgID` → 403 "User not found in organization" | Replaced oracle with LoadOwned |
| `DELETE /api/v1/admin/users/:id` | `PermanentlyDeleteUser` | Same shape as ActivateUser | Replaced oracle with LoadOwned; returned user reused for audit-log Email/Name capture |

`ActivateUser` and `PermanentlyDeleteUser` passed `tenantscope-lint` only because they mention `OrganizationID` for the victim-side lookup — the documented `bodyMentionsOrganizationID` blindspot.

## Lint allowlist hygiene

- Removed (handler now structurally LoadOwned-scoped): `AdminHandler.UpdateUserRole`, `AdminHandler.DeactivateUser`
- Converted from `audit-baseline: needs review` to `service-layer scoping` rationale citing PR #190: `AdminHandler.AcknowledgeAlert`, `AdminHandler.ResolveAlert`

**Handler scan: 42 → 40 entries. Service-param scan: 2 unchanged.**

## Phase 4.5 adversarial subagent review

10 risk categories reviewed. **One HIGH sibling defect surfaced** on the same handler file:

- `AdminHandler.GetAuditLogs` accepts `entity_id` and `user_id` query params that bypass the service-layer org filter. `AuditService.GetAuditLogs` drops `orgID` on the entity-filter and user-filter branches; underlying repo methods (`AuditLogRepository.GetByUser`, `GetByResource`, `GetByAgent`) all run SQL with **no `organization_id` filter**. Any admin in org A can read audit rows for org B's MCP servers, agents, or users by supplying their UUIDs as query params.
- Same defect **class** as A3d-viii but a different functional surface (audit query, not user lifecycle). **Filed as P0 follow-up** at `todo/2026-05-21-a3d-viii-followup-audit-log-query-idor.md` with full repo signature changes and SQL fix outlined. Defers consistent with PR #184 → PR #190 precedent.
- **UPDATE 2026-05-23:** PR #195 (`security: close audit-log query IDOR — orgID required on GetByUser, GetByResource, GetByAgent`) merged to `main` as `36a4748` and closes the deferred sibling — `AuditLogRepository.GetByUser/GetByResource/GetByAgent` now require `orgID` and filter SQL by `organization_id`. The Phase 4.5 follow-up listed above is resolved; no separate PR needed.

Three MEDIUM / P2 follow-ups also noted:
1. Audit-log emission on cross-tenant 404 responses (currently no trail for slow-enumeration probes). Consistent with PR #184 deferral.
2. `AgentHandler.GetAgentAuditLogs` has its own 404-vs-403 existence oracle — same class, different handler.
3. `DeactivateUser` `isSuperAdmin` re-fetches the user via authService after LoadOwned already loaded it. Redundant DB hit.

## Tests

New file `admin_handler_a3dviii_test.go`:
- `TestAdminHandler_UserLifecycle_CrossOrgReturns404` — 4 subtests, table-driven, **nil-deref-as-proof** for all 4 handlers (bypass surfaces as fiber 500, distinct from the 404 the gate enforces).
- `TestAdminHandler_UserLifecycle_SelfTargetReturns400` — confirms the self-deactivate / self-delete business-logic 400 still fires before LoadOwned.

Six pre-existing integration tests updated to wire `handler.userRepo`:
- `UpdateUserRole_Success`, `DeactivateUser_Success`, `ActivateUser_Success`, `PermanentlyDeleteUser_Success` — same-org user stub.
- `ActivateUser_NotFound` — switched from authService GetUserByID error to userRepo loader error; LoadOwned writes the same 404.
- `ActivateUser_WrongOrg` — **expectation 403 → 404 with fixed body** (intentional: the 403 was the pre-fix existence side channel).

## Test plan

- [x] `go build ./...` — clean
- [x] `go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers` — 40 allowlist entries
- [x] `go run ./cmd/tenantscope-lint/ ./internal/application` — 2 allowlist entries
- [x] `go test ./internal/interfaces/http/handlers/ -run TestAdminHandler` — all pass
- [x] `go test ./internal/interfaces/http/handlers/ ./internal/application/` — all pass
- [x] Phase 4.5 adversarial subagent review — 1 HIGH sibling deferred to P0 follow-up todo, 3 MEDIUM deferred
- [x] Pre-push smoke (lint, build, tests) — pass
