### PR TITLE
security: close 2 APIKeyHandler existence-oracle IDORs (Disable + Delete)

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1061,6 +1061,7 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 		APIKey: handlers.NewAPIKeyHandler(
 			services.APIKey,
 			services.Audit,
+			repos.APIKey,
 		),
 		TrustScore: handlers.NewTrustScoreHandler(
 			services.Trust,

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -84,8 +84,6 @@ var allowlist = map[string]string{
 	"AdminHandler.DeactivateUser":                           "audit-baseline: needs review",
 	"AdminHandler.ResolveAlert":                             "audit-baseline: needs review",
 	"AdminHandler.UpdateUserRole":                           "audit-baseline: needs review",
-	"APIKeyHandler.DeleteAPIKey":                            "audit-baseline: needs review",
-	"APIKeyHandler.DisableAPIKey":                           "audit-baseline: needs review",
 	"DetectionHandler.GetDetectionStatus":                   "audit-baseline: needs review",
 	"DetectionHandler.GetLatestCapabilityReport":            "audit-baseline: needs review",
 	"DetectionHandler.ReportCapabilities":                   "audit-baseline: needs review",

--- a/apps/backend/internal/interfaces/http/handlers/api_key_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/api_key_handler.go
@@ -10,15 +10,26 @@ import (
 type APIKeyHandler struct {
 	apiKeyService *application.APIKeyService
 	auditService  *application.AuditService
+
+	// Repository handle for handler-layer tenant scoping. Used by
+	// DisableAPIKey / DeleteAPIKey to LoadOwned the target key
+	// before invoking the service. The service-layer check exists
+	// (api_key_service.go:102, 117) but returns a distinct error
+	// string for cross-tenant vs not-found which the handler echoes
+	// via err.Error() — existence side channel. Handler-layer
+	// LoadOwned collapses both to a fixed 404.
+	apiKeyRepo domain.APIKeyRepository
 }
 
 func NewAPIKeyHandler(
 	apiKeyService *application.APIKeyService,
 	auditService *application.AuditService,
+	apiKeyRepo domain.APIKeyRepository,
 ) *APIKeyHandler {
 	return &APIKeyHandler{
 		apiKeyService: apiKeyService,
 		auditService:  auditService,
+		apiKeyRepo:    apiKeyRepo,
 	}
 }
 
@@ -213,9 +224,23 @@ func (h *APIKeyHandler) DisableAPIKey(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY: verify the key belongs to the caller's org BEFORE
+	// invoking the revoke flow. The service-layer check returns a
+	// distinct error string for cross-tenant vs not-found which the
+	// pre-fix handler echoed via err.Error() — existence side
+	// channel for API key UUID enumeration across tenants.
+	// LoadOwned collapses both branches to a fixed 404.
+	if LoadOwned(c, h.apiKeyRepo.GetByID, keyID, orgID, apiKeyOrgID) == nil {
+		return nil
+	}
+
 	if err := h.apiKeyService.RevokeAPIKey(c.Context(), keyID, orgID); err != nil {
+		// Cross-tenant + not-found already collapsed to 404 above; any
+		// remaining service error is operational. Use a generic body
+		// rather than echoing err.Error() to avoid leaking server-side
+		// detail.
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": err.Error(),
+			"error": "Failed to revoke API key",
 		})
 	}
 
@@ -273,7 +298,18 @@ func (h *APIKeyHandler) DeleteAPIKey(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY: see DisableAPIKey for rationale. LoadOwned collapses
+	// cross-tenant and not-found to a fixed 404.
+	if LoadOwned(c, h.apiKeyRepo.GetByID, keyID, orgID, apiKeyOrgID) == nil {
+		return nil
+	}
+
 	if err := h.apiKeyService.DeleteAPIKey(c.Context(), keyID, orgID); err != nil {
+		// The "key must be disabled before deletion" rule is the only
+		// remaining service-level rejection here (the cross-tenant and
+		// not-found cases were collapsed by LoadOwned above). Echo
+		// err.Error() to surface that specific guard message — it
+		// carries no cross-tenant information.
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": err.Error(),
 		})

--- a/apps/backend/internal/interfaces/http/handlers/api_key_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/api_key_handler_cross_tenant_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiKeyTestRepo is a domain.APIKeyRepository stub. Only GetByID is
+// implemented; other methods inherit from the nil-embedded interface
+// and will panic if reached — regression-proofing signal for handlers
+// that read fields beyond OrganizationID.
+type apiKeyTestRepo struct {
+	domain.APIKeyRepository
+	getByID func(id uuid.UUID) (*domain.APIKey, error)
+}
+
+func (r *apiKeyTestRepo) GetByID(id uuid.UUID) (*domain.APIKey, error) {
+	return r.getByID(id)
+}
+
+// ===========================
+// Cross-tenant access on the 2 APIKeyHandler routes
+// (DisableAPIKey + DeleteAPIKey) must return 404 with the
+// existence-secrecy body.
+//
+// Pre-fix shape: handler called h.apiKeyService.{RevokeAPIKey,
+// DeleteAPIKey}(keyID, orgID). The service-layer check returned a
+// distinct error string ("API key does not belong to organization"
+// vs the generic GetByID error). Handler echoed err.Error() in the
+// response — existence side channel that lets an attacker enumerate
+// API key UUIDs across tenants by status + body string.
+//
+// Regression-proofing: apiKeyService and auditService are nil. A
+// bypass on either handler would nil-deref on the service call →
+// fiber 500, distinguishable from the secure 404.
+// ===========================
+
+func TestAPIKeyHandler_CrossOrgReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	differentOrgID := uuid.New()
+	victimKeyID := uuid.New()
+
+	apiKeyRepoForeignOrg := &apiKeyTestRepo{
+		getByID: func(id uuid.UUID) (*domain.APIKey, error) {
+			return &domain.APIKey{
+				ID:             victimKeyID,
+				OrganizationID: differentOrgID,
+				Name:           "victim-key",
+				IsActive:       true,
+			}, nil
+		},
+	}
+
+	// apiKeyService + auditService intentionally nil — a bypass on
+	// either handler reaches h.apiKeyService.{RevokeAPIKey,
+	// DeleteAPIKey} which nil-derefs → fiber 500 ≠ 404.
+	handler := &APIKeyHandler{
+		apiKeyService: nil,
+		auditService:  nil,
+		apiKeyRepo:    apiKeyRepoForeignOrg,
+	}
+
+	tests := []struct {
+		name        string
+		method      string
+		requestPath string
+		setup       func(*fiber.App, *APIKeyHandler)
+	}{
+		{
+			name:        "DisableAPIKey",
+			method:      "POST",
+			requestPath: "/api-keys/" + victimKeyID.String() + "/disable",
+			setup: func(app *fiber.App, h *APIKeyHandler) {
+				app.Post("/api-keys/:id/disable", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", uuid.New())
+					return h.DisableAPIKey(c)
+				})
+			},
+		},
+		{
+			name:        "DeleteAPIKey",
+			method:      "DELETE",
+			requestPath: "/api-keys/" + victimKeyID.String(),
+			setup: func(app *fiber.App, h *APIKeyHandler) {
+				app.Delete("/api-keys/:id", func(c fiber.Ctx) error {
+					c.Locals("organization_id", callerOrgID)
+					c.Locals("user_id", uuid.New())
+					return h.DeleteAPIKey(c)
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			tt.setup(app, handler)
+
+			req := httptest.NewRequest(tt.method, tt.requestPath, nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+				"%s: cross-tenant request must return 404, got %d", tt.name, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+			assert.JSONEq(t, `{"error":"not found"}`, bodyStr,
+				"%s: cross-tenant 404 body must be existence-secrecy shape, got %s", tt.name, bodyStr)
+			// Defense-in-depth: confirm no fragment of the pre-fix
+			// service error string leaks through.
+			assert.NotContains(t, bodyStr, "does not belong to organization",
+				"%s: response must not contain pre-fix service-layer cross-tenant message", tt.name)
+			assert.NotContains(t, bodyStr, "victim-key",
+				"%s: response must not leak victim key name", tt.name)
+		})
+	}
+
+	// Suppress unused import warning for net/http when test changes
+	// in the future (kept here for table-driven body support).
+	_ = http.MethodPost
+}

--- a/apps/backend/internal/interfaces/http/handlers/api_key_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/api_key_handler_test.go
@@ -16,7 +16,7 @@ import (
 // ===========================
 
 func TestNewAPIKeyHandler_NilDeps(t *testing.T) {
-	handler := NewAPIKeyHandler(nil, nil)
+	handler := NewAPIKeyHandler(nil, nil, nil)
 	assert.NotNil(t, handler)
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
+++ b/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
@@ -30,6 +30,15 @@ func mcpServerOrgID(m *domain.MCPServer) uuid.UUID { return m.OrganizationID }
 // reject on a target user before the service is invoked.
 func userOrgID(u *domain.User) uuid.UUID { return u.OrganizationID }
 
+// apiKeyOrgID extracts OrganizationID from a *domain.APIKey. Used by
+// APIKeyHandler.DisableAPIKey + DeleteAPIKey to gate cross-tenant
+// API-key revoke + delete BEFORE the service is invoked. The
+// service-layer check (api_key_service.go:102, 117) already returns
+// a "does not belong to organization" error for cross-tenant, but
+// the handler echoes err.Error() in the response body — an
+// existence side channel.
+func apiKeyOrgID(k *domain.APIKey) uuid.UUID { return k.OrganizationID }
+
 // securityPolicyOrgID extracts OrganizationID from a
 // *domain.SecurityPolicy. Used by SecurityPolicyHandler's
 // Get/Update/Delete/Toggle paths to gate cross-tenant policy reads +


### PR DESCRIPTION
## Summary

Close 2 existence-oracle IDORs on `APIKeyHandler`. `DisableAPIKey` and `DeleteAPIKey` echoed `err.Error()` from the service, surfacing the cross-tenant message `"API key does not belong to organization"` vs the generic not-found error. Attacker enumerates API key UUIDs across tenants.

| Route | Handler | Pre-fix shape | Fix |
|---|---|---|---|
| `POST /api/v1/api-keys/:id/disable` | `DisableAPIKey` | Service returned cross-tenant string; handler echoed `err.Error()` in 500 body | LoadOwned + generic 500 |
| `DELETE /api/v1/api-keys/:id` | `DeleteAPIKey` | Same shape; handler echoed `err.Error()` in 400 body | LoadOwned + keep `err.Error()` only for the legitimate "must be disabled before deletion" guard |

Same defect class as PR #184 (ApproveUser/RejectUser) and PR #194 (admin user-lifecycle). Service-level org check is correct; the leak is the error-string passthrough.

## Lint allowlist hygiene

2 entries removed (`APIKeyHandler.DeleteAPIKey`, `APIKeyHandler.DisableAPIKey`).

**Handler scan: 42 → 40 entries** (off origin/main baseline).

## The fix

1. Add `apiKeyOrgID(*domain.APIKey) → uuid.UUID` to `tenant_scope.go` (mirror of `userOrgID` / `mcpServerOrgID`).
2. Add `apiKeyRepo domain.APIKeyRepository` field to `APIKeyHandler` and extend `NewAPIKeyHandler` signature.
3. Update `cmd/server/main.go` to pass `repos.APIKey` through (one new arg).
4. Wrap both handlers with `LoadOwned(c, h.apiKeyRepo.GetByID, keyID, orgID, apiKeyOrgID)` BEFORE the service call.
5. Replace `err.Error()` echo on `DisableAPIKey` with generic `"Failed to revoke API key"`. `DeleteAPIKey` retains the echo on the remaining guard ("API key must be disabled before deletion") — that message carries no cross-tenant info since LoadOwned already handled the tenant case.

## Tests

New file `api_key_handler_cross_tenant_test.go`:
- `TestAPIKeyHandler_CrossOrgReturns404` — 2 subtests, table-driven, **nil-deref-as-proof** (`apiKeyService = nil`, `auditService = nil`). A bypass on either handler nil-derefs on the service call → fiber 500 → distinct from 404.
- Defense-in-depth assertions: the 404 body must NOT contain `"does not belong to organization"` (pre-fix leak string) or the victim key's name (`victim-key`).

One pre-existing test updated:
- `TestNewAPIKeyHandler_NilDeps` — constructor sig change (2 → 3 args).

## Phase 4.5

Skipped for this slice — mechanical 2-handler fix following the established PR #184 / PR #197 pattern with no surprise scope expansion. The existence oracle was the only side-channel; no body-supplied UUID or service-param blindspot to investigate. Full `./internal/...` test sweep passes.

## Test plan

- [x] `go build ./...` — clean
- [x] `go run ./cmd/tenantscope-lint/` — 40 handler + 2 service entries
- [x] `go test ./internal/...` — all packages pass
- [x] 2 new cross-tenant regression subtests pass
- [x] Pre-existing `TestNewAPIKeyHandler_NilDeps` updated and passes
- [x] Pre-push smoke — pass

## Multi-session coordination

No file overlap with open PRs:
- PR #194 (admin_handler.go) — different file
- PR #195 (audit-log domain + repo + service + 9 mocks) — different files
- PR #196 (capability_request_handler.go) — different file
- PR #197 (agent_handler.go + agent_security_endpoints.go) — different files

This PR touches `api_key_handler.go`, `api_key_handler_test.go`, `tenant_scope.go` (one accessor added — PR #197 also didn't touch this file), `tenantscope-lint/main.go` (2-line removal), `cmd/server/main.go` (1-line arg addition), and the new test file. No conflicts.