### PR TITLE
security: close SDKTokenHandler.RevokeToken cross-user existence oracle

### DIFF
--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -99,7 +99,7 @@ var allowlist = map[string]string{
 	"MCPHandler.GetConnectedAgents":                         "audit-baseline: needs review",
 	"MCPHandler.VerifyMCPCapability":                        "audit-baseline: needs review",
 	"PublicMCPHandler.VerifyMCPAction":                      "audit-baseline: needs review",
-	"SDKTokenHandler.RevokeToken":                           "audit-baseline: needs review",
+	"SDKTokenHandler.RevokeToken": "service-layer scoping: SDKTokenService.RevokeToken collapses both not-found and cross-user mismatch into ErrSDKTokenNotFound; the handler maps the sentinel to a fixed 404. SDK tokens are user-scoped (not org-scoped), so the gate lives at the service layer.",
 	"TagHandler.UpdateTag": "audit-baseline: needs review (service-layer scoping exists but has existence side channel via error string; A3d-ii follow-up — see todo/2026-05-21-a3d-ii-tag-mcp-scoping.md)",
 	"VerificationHandler.GetVerification":                   "DEFECT #23 deferred: handler mounted on both public /api/v1/verifications/:id (no auth) and SDK-token /api/v1/sdk-api/verifications/:id (audit-cited); needs route split before tenant-scoping can apply.",
 	"VerificationHandler.SubmitVerificationResult":          "audit-baseline: needs review",

--- a/apps/backend/internal/application/sdk_token_service.go
+++ b/apps/backend/internal/application/sdk_token_service.go
@@ -2,11 +2,19 @@ package application
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
+
+// ErrSDKTokenNotFound is returned by SDKTokenService.RevokeToken for
+// both "token does not exist" and "token belongs to a different user"
+// — collapsing the two cases closes an existence-oracle side channel
+// that let an attacker enumerate SDK token UUIDs across users. The
+// handler maps this sentinel to a fixed 404 body.
+var ErrSDKTokenNotFound = errors.New("sdk token not found")
 
 // SDKTokenService handles SDK token business logic
 type SDKTokenService struct {
@@ -30,17 +38,26 @@ func (s *SDKTokenService) GetOrganizationTokens(ctx context.Context, organizatio
 	return s.sdkTokenRepo.GetByOrganizationID(organizationID, includeRevoked)
 }
 
-// RevokeToken revokes a specific SDK token
+// RevokeToken revokes a specific SDK token.
+//
+// SECURITY: both "not found" and "wrong user" return ErrSDKTokenNotFound.
+// The pre-fix implementation returned distinct error strings
+// ("token not found: …" vs "unauthorized: token belongs to different
+// user") which the handler then mapped to 500 vs 403 with distinct
+// bodies — an existence-oracle side channel that let an attacker
+// enumerate token UUIDs and distinguish "exists owned by another
+// user" from "doesn't exist". Both branches now collapse to the
+// sentinel and the handler emits a fixed 404 body.
 func (s *SDKTokenService) RevokeToken(ctx context.Context, tokenID uuid.UUID, userID uuid.UUID, reason string) error {
 	// Get token to verify ownership
 	token, err := s.sdkTokenRepo.GetByID(tokenID)
-	if err != nil {
-		return fmt.Errorf("token not found: %w", err)
+	if err != nil || token == nil {
+		return ErrSDKTokenNotFound
 	}
 
 	// Verify user owns this token
 	if token.UserID != userID {
-		return fmt.Errorf("unauthorized: token belongs to different user")
+		return ErrSDKTokenNotFound
 	}
 
 	// Revoke token

--- a/apps/backend/internal/application/sdk_token_service_test.go
+++ b/apps/backend/internal/application/sdk_token_service_test.go
@@ -287,7 +287,10 @@ func TestSDKTokenService_RevokeToken_NotFound(t *testing.T) {
 
 	err := service.RevokeToken(ctx, nonExistentID, userID, "test")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "token not found")
+	// SECURITY: not-found and wrong-user both collapse to the
+	// ErrSDKTokenNotFound sentinel (existence-oracle close).
+	assert.True(t, errors.Is(err, ErrSDKTokenNotFound),
+		"not-found revoke must return ErrSDKTokenNotFound sentinel, got %v", err)
 }
 
 func TestSDKTokenService_RevokeToken_WrongUser(t *testing.T) {
@@ -303,10 +306,14 @@ func TestSDKTokenService_RevokeToken_WrongUser(t *testing.T) {
 	err := repo.Create(token)
 	require.NoError(t, err)
 
-	// Try to revoke with different user
+	// Try to revoke with different user — must return the SAME
+	// sentinel as the not-found case so the handler-layer 404
+	// response is indistinguishable from the perspective of the
+	// caller. This is the existence-oracle close.
 	err = service.RevokeToken(ctx, token.ID, otherUserID, "unauthorized attempt")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unauthorized")
+	assert.True(t, errors.Is(err, ErrSDKTokenNotFound),
+		"cross-user revoke must collapse to ErrSDKTokenNotFound (same sentinel as not-found), got %v", err)
 }
 
 func TestSDKTokenService_RevokeByTokenHash(t *testing.T) {

--- a/apps/backend/internal/interfaces/http/handlers/sdk_token_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_token_handler.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"errors"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
@@ -132,9 +134,14 @@ func (h *SDKTokenHandler) RevokeToken(c fiber.Ctx) error {
 
 	err = h.sdkTokenService.RevokeToken(c.Context(), tokenID, userID, req.Reason)
 	if err != nil {
-		if err.Error() == "unauthorized: token belongs to different user" {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-				"error": "You don't have permission to revoke this token",
+		// SECURITY: the service collapses "not found" and
+		// "wrong user" to ErrSDKTokenNotFound. The handler maps
+		// the sentinel to a fixed 404, closing the existence
+		// oracle that previously distinguished 403 (cross-user)
+		// from 500 (not-found) with distinct body strings.
+		if errors.Is(err, application.ErrSDKTokenNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "not found",
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/apps/backend/internal/interfaces/http/handlers/sdk_token_handler_cross_user_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_token_handler_cross_user_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sdkTokenTestRepo is a minimal domain.SDKTokenRepository stub. Only
+// GetByID + Revoke are implemented (the methods RevokeToken touches);
+// every other interface method panics if reached.
+type sdkTokenTestRepo struct {
+	domain.SDKTokenRepository
+	getByID    func(id uuid.UUID) (*domain.SDKToken, error)
+	revokeCh   chan struct{}
+}
+
+func (r *sdkTokenTestRepo) GetByID(id uuid.UUID) (*domain.SDKToken, error) {
+	return r.getByID(id)
+}
+
+func (r *sdkTokenTestRepo) Revoke(id uuid.UUID, reason string) error {
+	// Bypass-detection signal: if a cross-user probe ever reaches
+	// the Revoke path, this fires and the test fails.
+	r.revokeCh <- struct{}{}
+	return nil
+}
+
+// ===========================
+// SDKTokenHandler.RevokeToken existence-oracle regression test.
+//
+// Pre-fix shape: service returned distinct error strings
+// ("token not found: …" vs "unauthorized: token belongs to different
+// user") which the handler mapped to 500 vs 403 with distinct body
+// messages — an existence side channel that let an attacker
+// enumerate token UUIDs and distinguish "exists owned by another
+// user" from "doesn't exist".
+//
+// Post-fix: both branches collapse to ErrSDKTokenNotFound at the
+// service layer, and the handler maps the sentinel to a fixed 404
+// {"error":"not found"}.
+//
+// Regression-proofing: captured-flag pattern (per memory
+// feedback_fiber_app_test_goroutine_t_fatalf_race). A real
+// SDKTokenService is constructed with the stub repo. The stub's
+// Revoke method pushes to a channel; the test asserts the channel
+// is empty after the cross-user call — proving the gate fires
+// BEFORE any mutation.
+// ===========================
+
+func TestSDKTokenHandler_RevokeToken_CrossUserReturns404(t *testing.T) {
+	callerUserID := uuid.New()
+	victimUserID := uuid.New()
+	victimTokenID := uuid.New()
+
+	// Buffer 1 so a bypass-write doesn't block; assert empty at end.
+	revokeCh := make(chan struct{}, 1)
+
+	repoStub := &sdkTokenTestRepo{
+		getByID: func(id uuid.UUID) (*domain.SDKToken, error) {
+			// Return a token owned by the VICTIM user, not the caller.
+			return &domain.SDKToken{
+				ID:     victimTokenID,
+				UserID: victimUserID,
+			}, nil
+		},
+		revokeCh: revokeCh,
+	}
+
+	svc := application.NewSDKTokenService(repoStub)
+	handler := &SDKTokenHandler{sdkTokenService: svc}
+
+	app := fiber.New()
+	app.Post("/users/me/sdk-tokens/:id/revoke", func(c fiber.Ctx) error {
+		c.Locals("user_id", callerUserID)
+		return handler.RevokeToken(c)
+	})
+
+	req := httptest.NewRequest("POST", "/users/me/sdk-tokens/"+victimTokenID.String()+"/revoke", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"cross-user revoke must return 404, got %d", resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	assert.JSONEq(t, `{"error":"not found"}`, bodyStr,
+		"cross-user 404 body must be existence-secrecy shape, got %s", bodyStr)
+	// Defense-in-depth: the pre-fix leak strings must not appear.
+	assert.NotContains(t, bodyStr, "unauthorized",
+		"response must not contain pre-fix cross-user leak string")
+	assert.NotContains(t, bodyStr, "permission",
+		"response must not contain pre-fix 403 'permission' wording")
+
+	// Bypass detection: the sentinel must fire BEFORE the repo's
+	// Revoke is called. An empty channel means the mutation never ran.
+	select {
+	case <-revokeCh:
+		t.Fatalf("SDKTokenService.RevokeToken called repo.Revoke on a cross-user probe — ErrSDKTokenNotFound sentinel did not fire")
+	default:
+		// expected: gate fired at service layer, no mutation
+	}
+}
+
+func TestSDKTokenHandler_RevokeToken_NotFoundReturns404(t *testing.T) {
+	callerUserID := uuid.New()
+	nonExistentTokenID := uuid.New()
+
+	revokeCh := make(chan struct{}, 1)
+
+	repoStub := &sdkTokenTestRepo{
+		getByID: func(id uuid.UUID) (*domain.SDKToken, error) {
+			return nil, assert.AnError
+		},
+		revokeCh: revokeCh,
+	}
+
+	svc := application.NewSDKTokenService(repoStub)
+	handler := &SDKTokenHandler{sdkTokenService: svc}
+
+	app := fiber.New()
+	app.Post("/users/me/sdk-tokens/:id/revoke", func(c fiber.Ctx) error {
+		c.Locals("user_id", callerUserID)
+		return handler.RevokeToken(c)
+	})
+
+	req := httptest.NewRequest("POST", "/users/me/sdk-tokens/"+nonExistentTokenID.String()+"/revoke", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"not-found revoke must return same 404 as cross-user revoke")
+	body, _ := io.ReadAll(resp.Body)
+	assert.JSONEq(t, `{"error":"not found"}`, string(body),
+		"not-found 404 body must match cross-user body byte-for-byte (no oracle)")
+
+	select {
+	case <-revokeCh:
+		t.Fatalf("repo.Revoke called for not-found token")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

`SDKTokenHandler.RevokeToken` echoed a distinct 403 body for cross-user probes (`"You don't have permission to revoke this token"`) and a generic 500 body for not-found (`"Failed to revoke token"`). The status + body split let an attacker enumerate SDK token UUIDs and distinguish "exists owned by another user" from "doesn't exist".

| Route | Handler | Pre-fix shape | Fix |
|---|---|---|---|
| `POST /api/v1/users/me/sdk-tokens/:id/revoke` | `RevokeToken` | Service returned distinct error strings → handler split into 403/500 with leak bodies | Service collapses both branches to `ErrSDKTokenNotFound`; handler maps sentinel to fixed 404 |

SDK tokens are **user-scoped**, not org-scoped — so the gate lives at the user-ownership layer in the service, not via LoadOwned. Mirror of PR #190's `AlertService.ErrAlertNotFound` sentinel pattern.

## The fix

1. Introduce `ErrSDKTokenNotFound` sentinel in `sdk_token_service.go` (mirrors `ErrAlertNotFound` in `alert_service.go`).
2. `SDKTokenService.RevokeToken` returns the sentinel for BOTH "GetByID error/nil" AND "token.UserID != userID". The two branches collapse so a downstream observer cannot distinguish them.
3. Handler matches `errors.Is(err, application.ErrSDKTokenNotFound)` and returns fixed 404 `{"error":"not found"}`. All other errors return generic 500.
4. `tenantscope-lint` allowlist: convert the entry from `audit-baseline: needs review` → `service-layer scoping: SDKTokenService.RevokeToken collapses both not-found and cross-user mismatch into ErrSDKTokenNotFound …` (hygiene-pattern mirror of PR #190's AcknowledgeAlert/ResolveAlert conversion).

## Lint allowlist

**42 entries unchanged** — the entry is converted, not removed (handler doesn't structurally use LoadOwned because the gate is at the service layer; SDK tokens are user-scoped, not org-scoped).

## Tests

Two pre-existing service tests updated (assertion changed from string-contains to `errors.Is`):
- `TestSDKTokenService_RevokeToken_NotFound`
- `TestSDKTokenService_RevokeToken_WrongUser` — now explicitly documents that cross-user collapses to the SAME sentinel as not-found.

New file `sdk_token_handler_cross_user_test.go`:
- `TestSDKTokenHandler_RevokeToken_CrossUserReturns404` — uses the **captured-flag pattern** (memory `feedback_fiber_app_test_goroutine_t_fatalf_race`). Real `SDKTokenService` with stub repo whose `Revoke` method pushes to a channel; test asserts channel is empty after the cross-user probe — **proving the sentinel fires BEFORE any mutation**. Body must not contain `"unauthorized"` or `"permission"` (pre-fix leak strings).
- `TestSDKTokenHandler_RevokeToken_NotFoundReturns404` — same pattern for not-found; body must match the cross-user body **byte-for-byte** (no oracle).

## Phase 4.5

Skipped — mechanical service-layer sentinel introduction mirroring PR #190 with no surprise scope expansion. The existence oracle was the only side-channel.

## Test plan

- [x] `go build ./...` — clean
- [x] `go run ./cmd/tenantscope-lint/` — 42 handler + 2 service entries (unchanged, entry converted)
- [x] `go test ./internal/application/ ./internal/interfaces/http/handlers/` — all pass
- [x] 2 new cross-user handler tests pass
- [x] 2 pre-existing service tests updated and pass
- [x] Pre-push smoke — pass

## Multi-session coordination

No file overlap with the 5 other open PRs (`#194` admin, `#195` audit-log, `#196` capability-request, `#197` agent-handler/security-endpoints, `#198` api-key). This PR touches `sdk_token_service.go`, `sdk_token_handler.go`, `sdk_token_service_test.go`, the new test file, and `tenantscope-lint/main.go` (1-line conversion — no conflict with other PRs' allowlist changes).