### PR TITLE
security: close AuthorizeHandler.Authorize cross-tenant FGA decision leak (P0)

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1223,7 +1223,7 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 			services.Secrets,
 			repos.Agent, // A3d-iii: namespace-path-id handlers verify namespace.AgentID -> agent.OrganizationID via LoadOwnedViaAgent
 		),
-		Authorize: handlers.NewAuthorizeHandler(services.FGA),
+		Authorize: handlers.NewAuthorizeHandler(services.FGA, repos.Agent),
 	}
 }
 

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -87,7 +87,6 @@ var allowlist = map[string]string{
 	"AgentHandler.LogCapabilityResult":                      "audit-baseline: needs review",
 	"APIKeyHandler.DeleteAPIKey":                            "audit-baseline: needs review",
 	"APIKeyHandler.DisableAPIKey":                           "audit-baseline: needs review",
-	"AuthorizeHandler.Authorize":                            "audit-baseline: needs review",
 	"DetectionHandler.GetDetectionStatus":                   "audit-baseline: needs review",
 	"DetectionHandler.GetLatestCapabilityReport":            "audit-baseline: needs review",
 	"DetectionHandler.ReportCapabilities":                   "audit-baseline: needs review",

--- a/apps/backend/internal/interfaces/http/handlers/authorize_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/authorize_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
 // FGAAuthorizer is the slice of FGAEngine that AuthorizeHandler depends on.
@@ -20,20 +21,30 @@ type FGAAuthorizer interface {
 // AuthorizeHandler exposes FGAEngine.Authorize over HTTP. It is the entry
 // point that produces the parent `fga.authorize` span and its 5-step child
 // tree against the real backend (vs the synthetic gen-signal harness).
+//
+// SECURITY: FGAEngine is org-blind — FGARequest carries no caller-org
+// field, and FGAEngine.Authorize never reads any caller context.
+// The handler-layer agentRepo + LoadOwned is the SOLE tenant-scope
+// gate. Without it, any authenticated caller in org A could POST
+// /agents/<victim-agent-in-org-B>/authorize and receive the full
+// 5-step FGA decision against the victim's policies + trust score +
+// scan verdict, plus pollute the fga.authorize OTel span tree
+// against the victim org.
 type AuthorizeHandler struct {
-	fga FGAAuthorizer
+	fga       FGAAuthorizer
+	agentRepo domain.AgentRepository
 }
 
 // NewAuthorizeHandler constructs an AuthorizeHandler against a concrete
 // FGAEngine. Test code should use NewAuthorizeHandlerWithInterface.
-func NewAuthorizeHandler(fga *application.FGAEngine) *AuthorizeHandler {
-	return &AuthorizeHandler{fga: fga}
+func NewAuthorizeHandler(fga *application.FGAEngine, agentRepo domain.AgentRepository) *AuthorizeHandler {
+	return &AuthorizeHandler{fga: fga, agentRepo: agentRepo}
 }
 
 // NewAuthorizeHandlerWithInterface constructs an AuthorizeHandler against any
 // FGAAuthorizer implementation, for testability.
-func NewAuthorizeHandlerWithInterface(fga FGAAuthorizer) *AuthorizeHandler {
-	return &AuthorizeHandler{fga: fga}
+func NewAuthorizeHandlerWithInterface(fga FGAAuthorizer, agentRepo domain.AgentRepository) *AuthorizeHandler {
+	return &AuthorizeHandler{fga: fga, agentRepo: agentRepo}
 }
 
 // authorizeRequestBody mirrors application.FGARequest minus AgentID. The
@@ -87,6 +98,21 @@ func (h *AuthorizeHandler) Authorize(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 			Error: "capability is required",
 		})
+	}
+
+	// SECURITY: tenant-scope the agent before invoking FGAEngine.
+	// FGAEngine is org-blind (no CallerOrgID field on FGARequest;
+	// no caller-context reads in FGAEngine.Authorize), so the
+	// handler-layer LoadOwned is the only gate. Cross-tenant and
+	// not-found both collapse to a fixed 404, preventing
+	// cross-tenant FGA decision leaks and victim-org OTel span
+	// pollution.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+	if LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID) == nil {
+		return nil
 	}
 
 	req := &application.FGARequest{

--- a/apps/backend/internal/interfaces/http/handlers/authorize_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/authorize_handler_cross_tenant_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// crashingFGAAuthorizer is a sentinel that panics if Authorize is ever
+// invoked. Any path that reaches FGAEngine.Authorize on a cross-tenant
+// probe — i.e., a LoadOwned bypass — would call this and the test
+// would crash with a recognizable panic instead of silently returning
+// the FGA decision body.
+type crashingFGAAuthorizer struct{}
+
+func (crashingFGAAuthorizer) Authorize(ctx context.Context, req *application.FGARequest) (*application.FGAResult, error) {
+	panic("FGAAuthorizer.Authorize must not be called on a cross-tenant probe — LoadOwned gate failed")
+}
+
+// authorizeForeignOrgAgentRepo returns a victim-org agent for any UUID
+// the test asks about. The Name field carries a sentinel string the
+// test asserts is NEVER present in the response body.
+type authorizeForeignOrgAgentRepo struct {
+	domain.AgentRepository
+	victimOrgID uuid.UUID
+}
+
+func (r *authorizeForeignOrgAgentRepo) GetByID(id uuid.UUID) (*domain.Agent, error) {
+	return &domain.Agent{
+		ID:             id,
+		OrganizationID: r.victimOrgID,
+		Name:           "VICTIM_AGENT_NAME_MUST_NOT_LEAK",
+		TrustScore:     0.99, // high score — pre-fix leak would surface this in OTel span
+	}, nil
+}
+
+// ===========================
+// AuthorizeHandler.Authorize cross-tenant regression.
+//
+// Pre-fix shape: the handler did not read c.Locals("organization_id")
+// and FGAEngine itself is org-blind (FGARequest carries no caller-org
+// field, FGAEngine.Authorize never reads any caller context — verified
+// via grep across fga_engine.go: zero matches for OrganizationID /
+// CallerOrgID / orgID). Any authenticated caller in org A could POST
+// /agents/<victim-org-B-agent>/authorize and:
+//   - receive the full 5-step FGA decision (allowed / outcome /
+//     denied_by / denied_reason / steps_triggered) against the
+//     victim's policies + trust score + ASC scan verdict
+//   - pollute the fga.authorize OTel span tree with attributes from
+//     the victim agent (agent.public_key.algorithm, agent.trust_score,
+//     agent.scan_verdict per the SemConv slide-14 proposal)
+//
+// Post-fix: RequireOrganizationID + LoadOwned at the handler layer
+// collapses cross-tenant AND not-found to a fixed 404.
+//
+// Regression-proofing: FGAAuthorizer is the crashing sentinel above.
+// Any path that bypasses LoadOwned would panic in FGAEngine.Authorize
+// and the test would fail with a recognizable error rather than
+// silently returning the FGA decision.
+// ===========================
+
+func TestAuthorizeHandler_CrossOrgReturns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	victimOrgID := uuid.New()
+	victimAgentID := uuid.New()
+
+	repo := &authorizeForeignOrgAgentRepo{victimOrgID: victimOrgID}
+	h := NewAuthorizeHandlerWithInterface(crashingFGAAuthorizer{}, repo)
+
+	app := fiber.New()
+	app.Post("/api/v1/agents/:id/authorize", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return h.Authorize(c)
+	})
+
+	body := strings.NewReader(`{"capability":"file:read","resource":"/sensitive"}`)
+	req := httptest.NewRequest("POST", "/api/v1/agents/"+victimAgentID.String()+"/authorize", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"cross-tenant authorize must return 404, got %d", resp.StatusCode)
+	raw, _ := io.ReadAll(resp.Body)
+	bodyStr := string(raw)
+	assert.JSONEq(t, `{"error":"not found"}`, bodyStr,
+		"cross-tenant 404 body must be existence-secrecy shape, got %s", bodyStr)
+	// Defense-in-depth: none of the victim-agent's fields may appear in
+	// the response. (The OTel span pollution is harder to assert from a
+	// test, but if FGAEngine.Authorize is unreached we know the span
+	// tree was not emitted against the victim.)
+	assert.NotContains(t, bodyStr, "VICTIM_AGENT_NAME",
+		"response must not leak any victim-agent field")
+	assert.NotContains(t, bodyStr, "ALLOW",
+		"response must not contain any FGA outcome — FGAEngine must not have been invoked")
+	assert.NotContains(t, bodyStr, "DENY",
+		"response must not contain any FGA outcome — FGAEngine must not have been invoked")
+}
+
+// Companion test: when the caller's org DOES match the agent's org,
+// the gate passes through and the FGAEngine is invoked. This pins
+// the legitimate path — a regression that hardens the gate too far
+// (e.g., always returning 404) would be caught here.
+func TestAuthorizeHandler_SameOrgPassesThroughToFGA(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	fake := &fakeAuthorizer{
+		result: &application.FGAResult{
+			Allowed: true,
+			Outcome: "ALLOW",
+		},
+	}
+	repo := &permissiveAuthorizeAgentRepo{orgID: orgID}
+	h := NewAuthorizeHandlerWithInterface(fake, repo)
+
+	app := newAuthorizeTestApp(h, orgID)
+	body := strings.NewReader(`{"capability":"file:read"}`)
+	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.NotNil(t, fake.gotRequest,
+		"FGAEngine must be reached on the legitimate same-org path")
+	assert.Equal(t, agentID, fake.gotRequest.AgentID)
+}

--- a/apps/backend/internal/interfaces/http/handlers/authorize_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/authorize_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
 // fakeAuthorizer is a stand-in for FGAEngine that lets us drive the handler
@@ -30,9 +31,32 @@ func (f *fakeAuthorizer) Authorize(ctx context.Context, req *application.FGARequ
 	return f.result, f.err
 }
 
-func newAuthorizeTestApp(h *AuthorizeHandler) *fiber.App {
+// permissiveAuthorizeAgentRepo returns an agent whose OrganizationID
+// matches whatever the caller asks for via the orgID field. Used by
+// the happy-path tests in this file to satisfy the LoadOwned gate
+// added in the AuthorizeHandler tenant-scope fix; the cross-tenant
+// regression test in authorize_handler_cross_tenant_test.go uses a
+// separate stub that returns a foreign-org agent.
+type permissiveAuthorizeAgentRepo struct {
+	domain.AgentRepository
+	orgID uuid.UUID
+}
+
+func (r *permissiveAuthorizeAgentRepo) GetByID(id uuid.UUID) (*domain.Agent, error) {
+	return &domain.Agent{ID: id, OrganizationID: r.orgID}, nil
+}
+
+// newAuthorizeTestApp wires the handler under a Fiber app that sets
+// Locals("organization_id") on every request. callerOrgID is the
+// caller's tenant; the permissive agentRepo (constructed alongside
+// the handler) returns agents in this same org so LoadOwned passes
+// through to the FGAEngine branch the test wants to exercise.
+func newAuthorizeTestApp(h *AuthorizeHandler, callerOrgID uuid.UUID) *fiber.App {
 	app := fiber.New()
-	app.Post("/api/v1/agents/:id/authorize", h.Authorize)
+	app.Post("/api/v1/agents/:id/authorize", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return h.Authorize(c)
+	})
 	return app
 }
 
@@ -46,8 +70,9 @@ func TestAuthorize_AllowResult_Returns200WithBody(t *testing.T) {
 			LatencyMs:      7,
 		},
 	}
-	h := NewAuthorizeHandlerWithInterface(fake)
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(fake, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"capability":"file:read","resource":"/tmp/x","action":"read"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
@@ -83,8 +108,9 @@ func TestAuthorize_DenyResult_Returns200WithDenyBody(t *testing.T) {
 			LatencyMs:      812,
 		},
 	}
-	h := NewAuthorizeHandlerWithInterface(fake)
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(fake, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"capability":"file:write"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
@@ -105,8 +131,9 @@ func TestAuthorize_DenyResult_Returns200WithDenyBody(t *testing.T) {
 }
 
 func TestAuthorize_InvalidAgentID_Returns400(t *testing.T) {
-	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{})
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{}, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"capability":"file:read"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/not-a-uuid/authorize", body)
@@ -120,8 +147,9 @@ func TestAuthorize_InvalidAgentID_Returns400(t *testing.T) {
 
 func TestAuthorize_MissingCapability_Returns400(t *testing.T) {
 	agentID := uuid.New()
-	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{})
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{}, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"resource":"/tmp/x"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
@@ -136,8 +164,9 @@ func TestAuthorize_MissingCapability_Returns400(t *testing.T) {
 func TestAuthorize_BodyAgentIDMismatch_Returns400(t *testing.T) {
 	pathID := uuid.New()
 	bodyID := uuid.New()
-	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{})
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{}, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"agentId":"` + bodyID.String() + `","capability":"file:read"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+pathID.String()+"/authorize", body)
@@ -151,8 +180,9 @@ func TestAuthorize_BodyAgentIDMismatch_Returns400(t *testing.T) {
 
 func TestAuthorize_InvalidJSON_Returns400(t *testing.T) {
 	agentID := uuid.New()
-	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{})
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(&fakeAuthorizer{}, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{not-json`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
@@ -176,8 +206,9 @@ func TestAuthorize_EngineError_Returns500WithErrorResultBody(t *testing.T) {
 		},
 		err: errors.New("failed to load FGA policy: connection refused"),
 	}
-	h := NewAuthorizeHandlerWithInterface(fake)
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(fake, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"capability":"file:read"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)
@@ -202,8 +233,9 @@ func TestAuthorize_EngineErrorWithNilResult_Returns500WithErrorResponse(t *testi
 		result: nil, // defensive: handler should still return a clean 500
 		err:    errors.New("totally unexpected"),
 	}
-	h := NewAuthorizeHandlerWithInterface(fake)
-	app := newAuthorizeTestApp(h)
+	orgID := uuid.New()
+	h := NewAuthorizeHandlerWithInterface(fake, &permissiveAuthorizeAgentRepo{orgID: orgID})
+	app := newAuthorizeTestApp(h, orgID)
 
 	body := strings.NewReader(`{"capability":"file:read"}`)
 	req := httptest.NewRequest("POST", "/api/v1/agents/"+agentID.String()+"/authorize", body)


### PR DESCRIPTION
## Summary

**P0 cross-tenant FGA decision leak.** `AuthorizeHandler.Authorize` is the HTTP entry to FGAEngine's 5-step authorization flow. The handler never read `c.Locals("organization_id")` and `FGAEngine` is entirely org-blind (verified: zero matches for OrganizationID / CallerOrgID / orgID across fga_engine.go; FGARequest has no caller-org field). Any authenticated caller in the `/agents` quad-auth group could POST `/agents/<victim-org-agent>/authorize` and:

- Receive the full FGA decision against the victim's policies + trust score + ASC scan verdict (`allowed`, `outcome`, `denied_by`, `denied_reason`, `steps_triggered`)
- Pollute the `fga.authorize` OTel span tree with attributes from the victim agent (`agent.public_key.algorithm`, `agent.trust_score`, `agent.scan_verdict` per the SemConv slide-14 proposal)

Same defect class as PR #197's `VerifyCapability` fix.

## The fix

1. Add `agentRepo domain.AgentRepository` field to `AuthorizeHandler`; extend both constructors.
2. Wrap with `RequireOrganizationID(c)` + `LoadOwned(c, h.agentRepo.GetByID, agentID, orgID, agentOrgID)` before `FGAEngine.Authorize`. Cross-tenant + not-found collapse to fixed 404.
3. `cmd/server/main.go`: pass `repos.Agent` to the constructor.
4. Remove `AuthorizeHandler.Authorize` from lint allowlist.

**Lint: 42 → 41.**

## Tests

8 pre-existing `TestAuthorize_*` tests updated:
- `newAuthorizeTestApp` helper now takes `callerOrgID` and sets `Locals` via Fiber middleware.
- All call sites pass a `permissiveAuthorizeAgentRepo` stub matching the caller's org.

New file `authorize_handler_cross_tenant_test.go`:
- `TestAuthorizeHandler_CrossOrgReturns404` — **crashing-FGAAuthorizer sentinel pattern**: the test's FGAAuthorizer panics if `Authorize` is ever invoked. A bypass would reach the engine and crash with a recognizable message. agentRepo stub returns a foreign-org agent with sentinel fields (`VICTIM_AGENT_NAME_MUST_NOT_LEAK`, TrustScore 0.99); test asserts 404 body contains NONE of these and NONE of `ALLOW` / `DENY`.
- `TestAuthorizeHandler_SameOrgPassesThroughToFGA` — pins the legitimate path; an over-hardening regression would be caught here.

## Phase 4.5

Skipped — mechanical handler-layer LoadOwned wrap following the established PR #197 pattern. FGAEngine's org-blindness was confirmed by direct read + grep; no body-supplied UUID, service-param blindspot, or dual-mount in scope.

## Test plan

- [x] `go build ./...` — clean
- [x] `go run ./cmd/tenantscope-lint/` — 41 handler + 2 service entries
- [x] `go test ./internal/...` — all packages pass
- [x] 2 new + 8 updated AuthorizeHandler tests pass
- [x] Pre-push smoke — pass

## Multi-session coordination

No conflicts with the 6 other open PRs (#194–#199). Touches `authorize_handler.go`, `authorize_handler_test.go`, new test file, `tenantscope-lint/main.go` (1-line removal), `cmd/server/main.go` (1-line arg addition).