### PR TITLE
docs: replace weather:fetch with db:read in quick-start snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ from aim_sdk import secure
 
 agent = secure("my-first-agent")
 
-@agent.perform_action(capability="weather:fetch")
-def fetch_weather(city):
-    return f"Weather in {city}: Sunny"
+@agent.perform_action(capability="db:read")
+def get_customer(customer_id):
+    return db.query("SELECT * FROM customers WHERE id = ?", customer_id)
 ```
 
 `secure()` generates an Ed25519 keypair, registers the agent with the AIM backend, and stores credentials at `~/.aim/`. `@perform_action` signs every invocation, runs it through 5-step Fine-Grained Authorization, and records the outcome in the audit log.
@@ -76,9 +76,9 @@ Full example: [`examples/flight-search-agent/flight_agent.py`](examples/flight-s
 ```java
 AIMClient agent = AIMClient.secure("my-first-agent");
 
-@SecureAction(capability = "weather:fetch")
-public String fetchWeather(String city) {
-    return "Weather in " + city + ": Sunny";
+@SecureAction(capability = "db:read", resource = "users_table")
+public User getCustomer(String customerId) {
+    return userRepository.findById(customerId);
 }
 ```
 
@@ -90,7 +90,7 @@ Production-ready at v1.0.0. Same Ed25519 signing, same FGA flow, same audit trai
 import { AIMClient } from "@opena2a/aim-core";
 
 const agent = new AIMClient({ agentId: "my-first-agent" });
-await agent.verify({ capability: "weather:fetch", resource: city });
+await agent.verify({ capability: "db:read", resource: "users_table" });
 ```
 
 The only SDK that runs without a server today. Backs local mode. See [`sdk/typescript/README.md`](sdk/typescript/README.md).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -15,9 +15,9 @@ from aim_sdk import secure
 
 agent = secure("my-first-agent")
 
-@agent.perform_action(capability="weather:fetch")
-def fetch_weather(city):
-    return f"Weather in {city}: Sunny"
+@agent.perform_action(capability="db:read")
+def get_customer(customer_id):
+    return db.query("SELECT * FROM customers WHERE id = ?", customer_id)
 ```
 
 `secure()` generates an Ed25519 keypair, registers the agent with the AIM backend, and stores credentials at `~/.aim/`. `@perform_action` signs every invocation, runs it through 5-step Fine-Grained Authorization on the server, and records the outcome in the audit log.
@@ -74,10 +74,10 @@ Disable: `secure("my-agent", auto_hooks=False)`.
 When namespace and action disagree the higher risk wins. `SPECIFIC_CAPABILITY_MAP` overrides both for known patterns (for example `user:delete` escalates to critical).
 
 ```python
-@agent.perform_action(capability="db:read")               # low
+@agent.perform_action(capability="db:read")               # medium (db: medium, :read low → max = medium)
 def get_customer(customer_id): ...
 
-@agent.perform_action(capability="db:delete")             # high
+@agent.perform_action(capability="db:delete")             # high (SPECIFIC_CAPABILITY_MAP override)
 def delete_customer(customer_id): ...
 
 @agent.perform_action(capability="payment:refund",


### PR DESCRIPTION
## Why

The `weather:fetch` example in PR #201 and PR #202's quick-start snippets was the wrong opener:

- **Risk-tier mismatch.** Maps to the lowest risk per the auto-detector (`weather:` namespace = low, `:fetch` suffix = low). The snippet did not demonstrate the risk-detection feature shown immediately below it.
- **Capability shape ambiguity.** A reader's first question is "what kind of permission is `weather:fetch`?" The capability needs to be self-explanatory in the first 30 lines.
- **Cliché.** Every AI framework's tutorial uses weather. AIM is not generic AI infra.

## What changes

| File | Before | After |
|---|---|---|
| `README.md` (Python snippet) | `weather:fetch` / `fetch_weather(city)` | `db:read` / `get_customer(customer_id)` |
| `README.md` (Java snippet) | `weather:fetch` / `fetchWeather` | `db:read` / `getCustomer` |
| `README.md` (TypeScript snippet) | `weather:fetch` / `city` | `db:read` / `users_table` |
| `sdk/python/README.md` (quick start) | Same as above (Python) | Same as above (Python) |
| `sdk/python/README.md` (risk-level comment) | `# low` | `# medium` |

`db:read` is unambiguously a permission a reader wants to gate (database access against a user/customer table) and maps to medium risk per the auto-detector — so the risk-detection explanation below the snippet is grounded in the example above it.

## Bug fix bundled in

The Python SDK README's risk-level comments had a bug:
```python
@agent.perform_action(capability="db:read")               # low      <- WRONG
```

Per the same README's lookup table (`db:` namespace = medium, `:read` suffix = low, max wins), `db:read` is **medium**, not low. Fixed:
```python
@agent.perform_action(capability="db:read")               # medium (db: medium, :read low → max = medium)
```

`db:delete`'s `# high` comment was already correct (`SPECIFIC_CAPABILITY_MAP` override per `risk_detector.py:158`).

## Test plan

- [x] grep `weather` in README.md and sdk/python/README.md — only remaining hits are in the namespace-lookup-table documentation (correct context, not example snippets)
- [x] Verify db:delete → high per `sdk/python/aim_sdk/risk_detector.py:158` (`SPECIFIC_CAPABILITY_MAP`)
- [x] Verify db:read → medium per the namespace + suffix max rule (no SPECIFIC_CAPABILITY_MAP override)
- [x] Pre-push smoke pass

No other content changed.