### PR TITLE
docs(use-cases): lead register flow with SDK one-liner, drop dead links, clean weather refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,6 @@ Four runnable demos in [`examples/`](examples/):
 | [Enforce capabilities](docs/use-cases/enforce-capabilities.md) | 5 min |
 | [Embed in an app](docs/use-cases/embed-in-my-app.md) | 10 min |
 | [Fleet governance](docs/use-cases/fleet-governance.md) | 30 min |
-| [SIEM forwarding](docs/use-cases/siem-forwarding.md) | 15 min |
-| [CyberArk vault integration](docs/use-cases/cyberark-integration.md) | 20 min |
 
 Full index: [docs/USE-CASES.md](docs/USE-CASES.md).
 

--- a/docs/use-cases/audit-agent-actions.md
+++ b/docs/use-cases/audit-agent-actions.md
@@ -80,7 +80,7 @@ Audit Log: my-agent (aim_7f3a9c2e)
 Chain integrity: VALID (50 events shown of 128 total, 0 breaks)
 
 #    Timestamp                Action          Target         Outcome
-79   2026-03-16T10:00:12Z     api:call        weather-svc    allowed
+79   2026-03-16T10:00:12Z     db:read         customers      allowed
 80   2026-03-16T10:01:44Z     db:read         orders         allowed
 81   2026-03-16T10:02:03Z     file:write      /tmp/report    denied
 ...
@@ -107,7 +107,7 @@ aim.getIdentity();
 
 // Log events (plugin and result are required fields)
 aim.logEvent({ action: 'db:read', target: 'customers', result: 'allowed', plugin: 'my-agent' });
-aim.logEvent({ action: 'api:call', target: 'weather-svc', result: 'allowed', plugin: 'my-agent' });
+aim.logEvent({ action: 'db:write', target: 'customers', result: 'allowed', plugin: 'my-agent' });
 aim.logEvent({ action: 'file:write', target: '/tmp/report', result: 'denied', plugin: 'my-agent' });
 
 // Each event is appended to the local audit log with a SHA-256 hash chain.
@@ -130,10 +130,6 @@ agent = secure("my-agent")
 @agent.perform_action("db:read", resource="customers")
 def read_customers():
     return db.query("SELECT * FROM customers")
-
-@agent.perform_action("api:call", resource="weather-svc")
-def call_weather():
-    return requests.get("https://weather-svc.example.com/forecast")
 
 # Each decorated call is automatically logged with the agent's identity.
 # When connected to an AIM Server (via aim_url), events are also sent to the central database.

--- a/docs/use-cases/register-my-agent.md
+++ b/docs/use-cases/register-my-agent.md
@@ -1,11 +1,33 @@
-# Use Case: Register My AI Agent with a Cryptographic Identity
+# Use Case: Register an Agent (SDK or CLI)
 
 **Time:** 2 minutes
-**Prerequisites:** Node.js 18+, npm
+**Prerequisites:** Python 3.9+ (Option A) **or** Node.js 18+ and npm (Option B)
 
 ## Problem
 
 Your AI agent has no verifiable identity. Other systems cannot authenticate it, and there is no record of what it does.
+
+## Option A: Register from your application (SDK, recommended)
+
+If you are building an agent in Python, register it directly from your code. The SDK generates an Ed25519 keypair, registers the agent with the AIM backend, and writes credentials to `~/.aim/` — no separate CLI step.
+
+```bash
+pip install aim-sdk
+```
+
+```python
+from aim_sdk import secure
+
+agent = secure("my-first-agent")
+```
+
+That is the full registration. `secure()` is idempotent — subsequent calls with the same agent name return the existing identity. Skip to [Step 2](#step-2-check-initial-trust-score) below to verify the trust score.
+
+The TypeScript and Java SDKs offer equivalent one-line registration; see the per-language READMEs under `sdk/`.
+
+## Option B: Create a local-only identity (CLI)
+
+If you want an identity stored entirely on your machine with no backend dependency, use the CLI. This is useful for offline development, scripted provisioning, or fleets where the agent process is not the registrant.
 
 ## Step 1: Create an Identity
 


### PR DESCRIPTION
## Summary

Three small, independent doc fixes bundled into one PR (per the agreed scope handoff from the 2026-05-21..23 AIM sweep).

### 1. `docs/use-cases/register-my-agent.md` — lead with the SDK
- Retitled to **Register an Agent (SDK or CLI)**.
- New **Option A** at top: `from aim_sdk import secure; agent = secure(\"my-first-agent\")` — the on-ramp framing locked in by [[project_aim_local_first_design_doc]]. SDK generates the Ed25519 keypair, registers with the backend, writes credentials to `~/.aim/`.
- Existing CLI walkthrough kept verbatim as **Option B** (local-only path). Useful for offline dev, scripted provisioning, fleets where the agent process is not the registrant.

### 2. `docs/use-cases/audit-agent-actions.md` — finish the weather→db sweep
PR #204 swapped `weather:fetch` → `db:read` in the README and Python SDK README quick-start snippets, but did not touch this use-case doc. This file was in a partially-updated state: line 109's TS example and line 130's Python decorator had already been swapped to `db:read/customers`, but lines 83, 110, 134, 135, 136 still referenced `api:call weather-svc`.

Resolution:
- Line 83 (mock event in filter output): `api:call weather-svc` → `db:read customers`.
- Line 110 (TS): `api:call/weather-svc` → `db:write/customers`. A strict mapping to `db:read/customers` would have duplicated the line immediately above; `db:write` preserves the read/write/file:write variety the example was demonstrating.
- Python decorator: collapsed to one example (`read_customers`) since the second decorator would have duplicated the first under any non-weather replacement. Pedagogically, one well-named example is sufficient.

### 3. `README.md` — drop two broken use-cases links
- `docs/use-cases/siem-forwarding.md` — file does not exist.
- `docs/use-cases/cyberark-integration.md` — file does not exist.

Both are deferred to dedicated sessions per integration; they need a careful read of `internal/integrations/{siem,cyberark}/` before they can be written accurately. SIEM and CyberArk both still surface in the **Server features** section (lines 46, 126, 130), so they are not hidden — only the use-case walkthroughs are missing.

## Test plan

- [x] `grep -nE \"weather|api:call\" docs/use-cases/audit-agent-actions.md` returns zero matches.
- [x] `ls docs/use-cases/siem-forwarding.md docs/use-cases/cyberark-integration.md` confirms both files genuinely don't exist (removal is correct, not premature).
- [x] `grep -inE \"siem|cyberark\" README.md` confirms both still appear in the Server features section.
- [x] `secure = register_agent` alias exists in `sdk/python/aim_sdk/__init__.py:76` — the Option A example compiles against the actual SDK.
- [x] Pre-push smoke passed.

## Out of scope

- Writing the `siem-forwarding.md` and `cyberark-integration.md` walkthroughs (separate sessions, each needs deep code-read first).
- Reconciling the Python SDK's `register_agent()` vs `secure()` API surface — both are valid (the second is an alias of the first), and harmonizing the docs on one or the other is a separate, larger pass.