### PR TITLE
fix(#156): stop alerts from claiming bare resource values are types

### DIFF
--- a/apps/backend/internal/application/alert_service.go
+++ b/apps/backend/internal/application/alert_service.go
@@ -528,7 +528,7 @@ func (s *AlertService) checkUnusualResourceAccess(ctx context.Context, orgID, ag
 				AlertType:      domain.AlertUnusualActivity,
 				Severity:       domain.AlertSeverityInfo,
 				Title:          fmt.Sprintf("New Resource Access Pattern for '%s'", agentName),
-				Description:    fmt.Sprintf("Agent accessed resource type '%s' for the first time in 7 days. Review if this access is authorized.", resourceType.String),
+				Description:    firstTimeResourceAccessDescription(resourceType.String, "Agent accessed ", " for the first time in 7 days. Review if this access is authorized."),
 				ResourceType:   "agent",
 				ResourceID:     agentID,
 				AgentName:      agentName,

--- a/apps/backend/internal/application/behavior_analysis_service.go
+++ b/apps/backend/internal/application/behavior_analysis_service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -209,7 +210,7 @@ func (s *BehaviorAnalysisService) DetectAnomalies(
 				OrganizationID:    orgID,
 				AnomalyType:       domain.BehavioralAnomalyNewResource,
 				Severity:          domain.AnomalySeverityMedium,
-				Description:       fmt.Sprintf("First-time access to resource type '%s'", resourceType),
+				Description:       firstTimeResourceAccessDescription(resource, "First-time access to ", ""),
 				TriggerResource:   resource,
 				TriggerAction:     action,
 				TriggerCapability: capability,
@@ -473,36 +474,79 @@ func (s *BehaviorAnalysisService) detectCapabilityDrift(
 	return nil
 }
 
-// extractResourceType extracts a resource type from a resource string
-// e.g., "s3://bucket/key" -> "s3", "/api/users/123" -> "api"
+// firstTimeResourceAccessDescription returns the user-facing description
+// for an alert fired on a first-time resource access. It uses
+// resourceLabelForDisplay to drop the word "type" when the parser cannot
+// classify the input as a real resource type — that is what prevents
+// alerts like "resource type 'NYC'" where NYC is a bare value, not a
+// type.
+//
+// prefix and suffix wrap the noun + label so callers can vary the
+// phrasing (e.g. "Agent accessed " + " for the first time in 7 days..."
+// vs "First-time access to " + "").
+func firstTimeResourceAccessDescription(resource, prefix, suffix string) string {
+	label, isType := resourceLabelForDisplay(resource)
+	noun := "resource"
+	if isType {
+		noun = "resource type"
+	}
+	return fmt.Sprintf("%s%s '%s'%s", prefix, noun, label, suffix)
+}
+
+// resourceLabelForDisplay returns a display-friendly label for a resource
+// string and whether that label is a recognized resource TYPE (true) or
+// just a raw resource value the parser couldn't classify (false). Alert
+// rendering uses the second return value to choose between
+// "resource type 'X'" and "resource 'X'" so we don't falsely claim a
+// bare value is a type.
+//
+//	"destination:NYC"      → ("destination", true)
+//	"s3://bucket/key"      → ("s3",          true)
+//	"/api/users/123"       → ("api",         true)
+//	"users.ssn"            → ("users",       true)
+//	"alice@example.com"    → ("email",       true)
+//	"NYC"                  → ("NYC",         false)
+//	""                     → ("",            false)
+func resourceLabelForDisplay(resource string) (string, bool) {
+	if i := strings.Index(resource, ":"); i > 0 && i < len(resource)-1 {
+		return resource[:i], true
+	}
+	if strings.HasPrefix(resource, "/") {
+		rest := resource[1:]
+		if j := strings.Index(rest, "/"); j > 0 {
+			return rest[:j], true
+		}
+		if rest != "" {
+			return rest, true
+		}
+	}
+	if strings.Contains(resource, "@") {
+		return "email", true
+	}
+	if i := strings.Index(resource, "."); i > 0 {
+		return resource[:i], true
+	}
+	return resource, false
+}
+
+// extractResourceType extracts a resource type from a resource string for
+// use as a stable bucket key in behavior baselines (e.g. baseline.ResourcePatterns).
+// Returns "unknown" for bare values the parser cannot classify, so the map
+// doesn't accumulate one fake "type" entry per distinct bare value (e.g. a
+// flight-search agent that passes "NYC", "LAX", "SFO" as resources would
+// otherwise create three separate "types" — they all bucket as "unknown").
+//
+//	"s3://bucket/key"      → "s3"
+//	"/api/users/123"       → "api"
+//	"alice@example.com"    → "email"
+//	"NYC"                  → "unknown"
+//	""                     → "unknown"
 func extractResourceType(resource string) string {
-	if resource == "" {
+	label, isType := resourceLabelForDisplay(resource)
+	if !isType {
 		return "unknown"
 	}
-
-	// Handle protocol-style resources (s3://, dynamodb://, etc.)
-	for i, c := range resource {
-		if c == ':' && i > 0 {
-			return resource[:i]
-		}
-	}
-
-	// Handle path-style resources (/api/..., /admin/..., etc.)
-	if resource[0] == '/' && len(resource) > 1 {
-		end := 1
-		for ; end < len(resource) && resource[end] != '/'; end++ {
-		}
-		return resource[1:end]
-	}
-
-	// Default: use first segment
-	for i, c := range resource {
-		if c == '/' || c == ':' || c == '.' {
-			return resource[:i]
-		}
-	}
-
-	return resource
+	return label
 }
 
 // GetBaselineStatus returns the baseline status for an agent

--- a/apps/backend/internal/application/behavior_analysis_service_test.go
+++ b/apps/backend/internal/application/behavior_analysis_service_test.go
@@ -148,17 +148,32 @@ func TestExtractResourceType_EdgeCases(t *testing.T) {
 		{
 			name:     "just slash",
 			resource: "/",
-			expected: "", // Single slash returns empty string
+			expected: "unknown", // bare separator with no segment; was "" pre-#156, now "unknown"
 		},
 		{
-			name:     "no delimiter",
+			name:     "no delimiter (bare value)",
 			resource: "simpleresource",
-			expected: "simpleresource",
+			expected: "unknown", // bare values bucket as "unknown" per #156 fix — see resourceLabelForDisplay docstring
 		},
 		{
 			name:     "dot delimiter",
 			resource: "domain.example.com",
 			expected: "domain",
+		},
+		{
+			name:     "email address",
+			resource: "alice@example.com",
+			expected: "email", // #156: explicit email recognition, was "alice@example" pre-fix
+		},
+		{
+			name:     "colon at start (no prefix)",
+			resource: ":foo",
+			expected: "unknown",
+		},
+		{
+			name:     "colon at end (no suffix)",
+			resource: "foo:",
+			expected: "unknown",
 		},
 	}
 
@@ -166,6 +181,104 @@ func TestExtractResourceType_EdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := extractResourceType(tt.resource)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// ========================================
+// resourceLabelForDisplay Tests (issue #156)
+// ========================================
+
+func TestResourceLabelForDisplay(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       string
+		expectedLabel  string
+		expectedIsType bool
+	}{
+		// Real types (isType=true)
+		{"protocol prefix", "s3://bucket/key", "s3", true},
+		{"protocol prefix file", "file:///path", "file", true},
+		{"custom protocol", "destination:NYC", "destination", true},
+		{"path style", "/api/users/123", "api", true},
+		{"path with single segment", "/users", "users", true},
+		{"email shape", "alice@example.com", "email", true},
+		{"dot delimiter", "users.ssn", "users", true},
+
+		// Bare values (isType=false) — the bug class #156 closes
+		{"bare value all letters", "NYC", "NYC", false},
+		{"bare value with digits", "abc123", "abc123", false},
+		{"empty string", "", "", false},
+		{"colon at start", ":foo", ":foo", false},
+		{"colon at end", "foo:", "foo:", false},
+		{"just slash", "/", "/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			label, isType := resourceLabelForDisplay(tt.resource)
+			assert.Equal(t, tt.expectedLabel, label, "label mismatch")
+			assert.Equal(t, tt.expectedIsType, isType, "isType mismatch")
+		})
+	}
+}
+
+// TestFirstTimeResourceAccessDescription_NoFalseTypeClaim is the regression
+// test for issue #156. It guarantees that when the resource parser cannot
+// identify a real type (bare values like "NYC", malformed colon strings),
+// the alert description does NOT contain the literal phrase "resource type"
+// — which was the user-facing bug ("Agent accessed resource type 'NYC'"
+// falsely claimed NYC was a type).
+func TestFirstTimeResourceAccessDescription_NoFalseTypeClaim(t *testing.T) {
+	// Inputs that the parser cannot classify as types.
+	bareValues := []string{
+		"NYC",
+		"alice",
+		"abc123",
+		":foo",
+		"foo:",
+		"/",
+		"",
+	}
+
+	for _, resource := range bareValues {
+		t.Run(resource, func(t *testing.T) {
+			// Both call-site phrasings.
+			d1 := firstTimeResourceAccessDescription(resource, "Agent accessed ", " for the first time in 7 days.")
+			d2 := firstTimeResourceAccessDescription(resource, "First-time access to ", "")
+			assert.NotContains(t, d1, "resource type",
+				"alert_service phrasing must not claim a bare value is a type (input=%q, got=%q)", resource, d1)
+			assert.NotContains(t, d2, "resource type",
+				"behavior_analysis phrasing must not claim a bare value is a type (input=%q, got=%q)", resource, d2)
+			// Positive form: should use the "resource 'X'" phrasing (without "type").
+			assert.Contains(t, d1, "resource '",
+				"alert_service phrasing should fall back to \"resource 'X'\" (input=%q, got=%q)", resource, d1)
+			assert.Contains(t, d2, "resource '",
+				"behavior_analysis phrasing should fall back to \"resource 'X'\" (input=%q, got=%q)", resource, d2)
+		})
+	}
+}
+
+// TestFirstTimeResourceAccessDescription_ClaimsTypeWhenParsed ensures the
+// "resource type 'X'" phrasing is still used when the parser DOES identify
+// a real type. Negative-space partner to NoFalseTypeClaim above.
+func TestFirstTimeResourceAccessDescription_ClaimsTypeWhenParsed(t *testing.T) {
+	cases := []struct {
+		resource      string
+		expectedLabel string
+	}{
+		{"s3://bucket/key", "s3"},
+		{"destination:NYC", "destination"},
+		{"/api/users/123", "api"},
+		{"alice@example.com", "email"},
+		{"users.ssn", "users"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			d := firstTimeResourceAccessDescription(tc.resource, "Agent accessed ", " for the first time in 7 days.")
+			assert.Contains(t, d, "resource type '"+tc.expectedLabel+"'",
+				"parsed-type inputs must keep the \"resource type 'X'\" phrasing (input=%q, got=%q)", tc.resource, d)
 		})
 	}
 }


### PR DESCRIPTION
Closes #156.

## Why

`extractResourceType` correctly parses URL-shaped resources (`s3://...`, `/api/...`) for the type prefix. For bare strings like `NYC`, it fell through to "return the whole input." Then two alert sites rendered the result as "resource type 'NYC'" — falsely claiming NYC is a type:

- `alert_service.go:531` (was) — \`Sprintf(\"Agent accessed resource type '%s' for the first time in 7 days. Review if this access is authorized.\", resourceType.String)\` — reading the raw \`verification_events.resource_type\` column with no parsing.
- \`behavior_analysis_service.go:212\` (was) — \`Sprintf(\"First-time access to resource type '%s'\", resourceType)\` — using \`extractResourceType\`'s raw fallback.

Even \`destination:NYC\` rendered as \"resource type 'destination:NYC'\" because the first site never parsed at all.

## What changes

Three coupled changes:

1. **\`resourceLabelForDisplay(resource) (label, isType)\`** added in \`behavior_analysis_service.go\`. Returns the parsed prefix for recognized shapes (\`s3:\`, \`/api/\`, \`users.ssn\`, \`alice@example.com\`), otherwise returns the raw value with \`isType=false\` so the renderer knows to drop the word \"type\". Explicit email recognition; previously emails fell through to the dot-fallback and returned \`\"alice@example\"\`.

2. **\`extractResourceType\` rewritten** to return \`\"unknown\"\` for inputs the parser cannot classify. This stops \`agent_behavior_baselines.resource_patterns\` from accumulating one fake \"type\" entry per distinct bare value.

3. **\`firstTimeResourceAccessDescription(resource, prefix, suffix)\`** helper renders the alert text using \`resourceLabelForDisplay\`. Both call sites route through it so they cannot diverge in the future.

## Behavioral changes worth flagging

| Input | Before | After |
|---|---|---|
| \`\"alice@example.com\"\` | \`\"alice@example\"\` | \`\"email\"\` |
| \`\"/\"\` | \`\"\"\` | \`\"unknown\"\` |
| \`\"simpleresource\"\` | \`\"simpleresource\"\` | \`\"unknown\"\` |
| \`\":foo\"\` / \`\"foo:\"\` | (same input back) | \`\"unknown\"\` |

\"New resource type\" anomaly alerts: an agent accessing many distinct bare resource values (e.g. \`\"NYC\"\`, \`\"LAX\"\`, \`\"SFO\"\`) used to trigger an alert per unique value. They now bucket as a single \`\"unknown\"\` and trigger ONE alert. The audit doc author explicitly endorsed this — per-value alerts were false signal, not detection.

## Tests

- **\`TestExtractResourceType_EdgeCases\`** updated for the new defaults; extended with email-address, colon-at-start, colon-at-end.
- **\`TestResourceLabelForDisplay\`** (new) — 13 cases covering all (label, isType) branches.
- **\`TestFirstTimeResourceAccessDescription_NoFalseTypeClaim\`** (new) — the regression test issue #156 asked for. For 7 bare-value inputs (NYC, alice, abc123, :foo, foo:, /, \"\"), both call-site phrasings must NOT contain the literal \`\"resource type\"\`.
- **\`TestFirstTimeResourceAccessDescription_ClaimsTypeWhenParsed\`** (new) — negative-space partner: real types (s3, destination, api, email, users) STILL render as \`\"resource type 'X'\"\`.

\`go test ./internal/application/ -timeout 90s\` — pass (8.2s). Lint + build clean.

## Out of scope

- SDK docstring on \`verify_capability\` recommending \`<noun>:<id>\` resource shape (follow-up #2 in the issue) — separate PR, touches Python/Java/TypeScript SDKs.
- Backfill migration to clean existing bare-value entries from \`agent_behavior_baselines.resource_patterns\` JSONB — additive going forward, historical data stays.