### PR TITLE
fix(#155,#172,#173): close null-array gap at application layer + extend lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,8 @@ jobs:
           go build -o "$LINT_TMP/jsonarray-lint" ./cmd/jsonarray-lint/
           "$LINT_TMP/jsonarray-lint" \
             internal/interfaces/http/handlers \
-            internal/infrastructure/repository
+            internal/infrastructure/repository \
+            internal/application
 
       - name: Test with coverage
         run: |

--- a/apps/backend/internal/application/a2a_service.go
+++ b/apps/backend/internal/application/a2a_service.go
@@ -214,7 +214,7 @@ func (s *A2AService) RegisterAgentCard(ctx context.Context, req RegisterAgentCar
 	}
 
 	// 7. Parse and save skills
-	var skillIDs []string
+	skillIDs := make([]string, 0)
 	for _, skillDef := range parsedCard.Skills {
 		skill := &domain.A2ASkill{
 			AgentID:     req.AgentID,
@@ -884,7 +884,7 @@ func (s *A2AService) EvaluateA2APolicy(ctx context.Context, req EvaluateA2APolic
 	}
 
 	// Evaluate policies (simplified - in production would use CEL or OPA)
-	var evaluatedPolicies []string
+	evaluatedPolicies := make([]string, 0)
 	for _, policy := range policies {
 		evaluatedPolicies = append(evaluatedPolicies, policy.Name)
 
@@ -1283,7 +1283,7 @@ func (s *A2AService) CheckA2ASecurity(ctx context.Context, req *domain.A2ASecuri
 
 	// Get security settings for the target agent's organization
 	settings, _ := s.GetSecuritySettings(ctx, targetAgent.OrganizationID)
-	var violations []domain.A2AViolationType
+	violations := make([]domain.A2AViolationType, 0)
 
 	// Check 1: Is requesting agent revoked?
 	revoked, _ := s.revokedRepo.IsRevoked(ctx, req.RequestingAgentID)

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -541,7 +541,7 @@ func (s *AgentService) UpdateAgent(ctx context.Context, id uuid.UUID, req *Creat
 		}
 
 		// Identify new capabilities (potential escalations)
-		var newCaps []string
+		newCaps := make([]string, 0)
 		for _, capType := range req.Capabilities {
 			if _, exists := currentCapTypes[capType]; !exists {
 				newCaps = append(newCaps, capType)
@@ -595,7 +595,7 @@ func (s *AgentService) UpdateAgent(ctx context.Context, id uuid.UUID, req *Creat
 		}
 
 		// Capability removal is always allowed (safe direction - reducing privileges)
-		var revokedCaps []string
+		revokedCaps := make([]string, 0)
 		for capType, cap := range currentCapTypes {
 			if !requestedCapTypes[capType] {
 				now := time.Now()

--- a/apps/backend/internal/application/alert_service.go
+++ b/apps/backend/internal/application/alert_service.go
@@ -321,7 +321,7 @@ func (s *AlertService) DetectUnusualAccessPatterns(ctx context.Context, orgID uu
 	}
 
 	config := DefaultUnusualAccessConfig()
-	var alerts []*domain.Alert
+	alerts := make([]*domain.Alert, 0)
 
 	fmt.Printf("📊 [ANOMALY-DETECTION] Starting checks for agent %s in org %s (config: volume=%d/%dmin, offHours=%d:00-%d:00)\n",
 		agentID, orgID, config.HighVolumeThreshold, config.TimeWindowMinutes, config.OffHoursStart, config.OffHoursEnd)
@@ -509,7 +509,7 @@ func (s *AlertService) checkUnusualResourceAccess(ctx context.Context, orgID, ag
 	}
 	defer rows.Close()
 
-	var alerts []*domain.Alert
+	alerts := make([]*domain.Alert, 0)
 	agent, _ := s.agentRepo.GetByID(agentID)
 	agentName := "Unknown Agent"
 	if agent != nil {

--- a/apps/backend/internal/application/community_intelligence_service.go
+++ b/apps/backend/internal/application/community_intelligence_service.go
@@ -163,7 +163,7 @@ func (s *CommunityIntelligenceService) GetCommunityBenchmarks(ctx context.Contex
 	}
 
 	totalAgents := 0
-	var allScores []float64
+	allScores := make([]float64, 0)
 	factorAggregates := make(map[string][]float64)
 	var scoreDist domain.ScoreDistribution
 
@@ -236,7 +236,7 @@ func (s *CommunityIntelligenceService) buildTrustDistribution(ctx context.Contex
 	}
 
 	// Collect trust scores for all agents
-	var scores []float64
+	scores := make([]float64, 0)
 	factorValues := map[string][]float64{
 		"verificationStatus": {},
 		"uptime":             {},

--- a/apps/backend/internal/application/compliance_service.go
+++ b/apps/backend/internal/application/compliance_service.go
@@ -198,7 +198,7 @@ func (s *ComplianceService) analyzeAuditActivity(logs []*domain.AuditLog) AuditA
 }
 
 func (s *ComplianceService) generateRecommendations(summary ComplianceSummary, agents []*domain.Agent) []string {
-	var recommendations []string
+	recommendations := make([]string, 0)
 
 	// Check for pending agents
 	if summary.PendingAgents > 0 {
@@ -246,7 +246,7 @@ func (s *ComplianceService) ExportAuditLog(
 	}
 
 	// Filter by date range
-	var filteredLogs []*domain.AuditLog
+	filteredLogs := make([]*domain.AuditLog, 0)
 	for _, log := range logs {
 		if log.Timestamp.After(startDate) && log.Timestamp.Before(endDate) {
 			filteredLogs = append(filteredLogs, log)
@@ -593,7 +593,7 @@ func (s *ComplianceService) evaluateCheckWithDetails(checkName string, agents []
 		Severity  string    `json:"severity,omitempty"`
 	}
 
-	var affectedAgents []affectedItem
+	affectedAgents := make([]affectedItem, 0)
 	var checkPassed bool
 	var checkDetails string
 	var actionURL string
@@ -1523,7 +1523,7 @@ func (s *ComplianceService) GetComplianceViolations(
 		return nil, err
 	}
 
-	var violations []*ComplianceViolation
+	violations := make([]*ComplianceViolation, 0)
 
 	// Check for unverified agents (compliance violation)
 	for _, agent := range agents {
@@ -2316,7 +2316,7 @@ func (s *ComplianceService) ExportComplianceReportFull(
 	}
 
 	// Get evidence
-	var evidenceItems []domain.ComplianceEvidence
+	evidenceItems := make([]domain.ComplianceEvidence, 0)
 	if s.evidenceRepo != nil {
 		evidence, err := s.evidenceRepo.GetByFramework(orgID, frameworkType)
 		if err == nil {
@@ -2327,7 +2327,7 @@ func (s *ComplianceService) ExportComplianceReportFull(
 	}
 
 	// Get trending data
-	var scoreTrend []domain.ComplianceSnapshot
+	scoreTrend := make([]domain.ComplianceSnapshot, 0)
 	if s.snapshotRepo != nil {
 		snapshots, err := s.snapshotRepo.GetTrending(orgID, frameworkType, startDate, endDate)
 		if err == nil {
@@ -2419,7 +2419,7 @@ func (s *ComplianceService) buildAgentInventory(agents []*domain.Agent, now time
 		}
 
 		// Identify compliance issues
-		var issues []string
+		issues := make([]string, 0)
 		if agent.Status != domain.AgentStatusVerified {
 			issues = append(issues, "Not verified")
 		}
@@ -2597,7 +2597,7 @@ func (s *ComplianceService) buildAuditActivityReport(logs []*domain.AuditLog, us
 		summary *domain.UserActivitySummary
 		count   int
 	}
-	var sortedUsers []userActivitySort
+	sortedUsers := make([]userActivitySort, 0)
 	for _, ua := range userActivity {
 		sortedUsers = append(sortedUsers, userActivitySort{summary: ua, count: ua.ActionCount})
 	}
@@ -2832,7 +2832,7 @@ func (s *ComplianceService) buildRecommendations(
 	riskAssessment domain.RiskAssessmentReport,
 	checkResults []domain.ComplianceCheckResult,
 ) []domain.RecommendationItem {
-	var recommendations []domain.RecommendationItem
+	recommendations := make([]domain.RecommendationItem, 0)
 
 	// Critical: Unacknowledged alerts
 	if securityAlerts.UnacknowledgedCount > 10 {
@@ -2974,7 +2974,7 @@ func (s *ComplianceService) ExportToCSV(
 	lowFindings := 0
 
 	var checkResults []map[string]interface{}
-	var domainCheckResults []domain.ComplianceCheckResult
+	domainCheckResults := make([]domain.ComplianceCheckResult, 0)
 	for _, checkName := range checks {
 		result := s.evaluateCheckWithDetails(checkName, agents, orgID)
 		checkResults = append(checkResults, map[string]interface{}{

--- a/apps/backend/internal/application/detection_service.go
+++ b/apps/backend/internal/application/detection_service.go
@@ -178,7 +178,7 @@ func (s *DetectionService) ReportDetections(
 				continue
 			}
 
-			var talksTo []string
+			talksTo := make([]string, 0)
 			if len(talksToJSON) > 0 {
 				json.Unmarshal(talksToJSON, &talksTo)
 			}
@@ -336,7 +336,7 @@ func (s *DetectionService) GetDetectionStatus(
 
 	for rows.Next() {
 		var mcp domain.DetectedMCPSummary
-		var methods []string
+		methods := make([]string, 0)
 		var firstDetectedNull, lastSeenNull sql.NullTime
 
 		err := rows.Scan(&mcp.Name, pq.Array(&methods), &mcp.ConfidenceScore,
@@ -545,7 +545,7 @@ func (s *DetectionService) GetLatestCapabilityReport(
 		return nil, fmt.Errorf("failed to parse environment: %w", err)
 	}
 
-	var aiModels []domain.AIModelUsage
+	aiModels := make([]domain.AIModelUsage, 0)
 	if err := json.Unmarshal(aiModelsJSON, &aiModels); err != nil {
 		return nil, fmt.Errorf("failed to parse ai models: %w", err)
 	}

--- a/apps/backend/internal/application/mcp_attestation_service.go
+++ b/apps/backend/internal/application/mcp_attestation_service.go
@@ -780,7 +780,7 @@ func (s *MCPAttestationService) GetConsensusStatus(
 	}
 
 	// Calculate progress and missing criteria
-	var missingCriteria []string
+	missingCriteria := make([]string, 0)
 	agentsProgress := float64(uniqueAgentCount) / float64(minAgents) * 100
 	if agentsProgress > 100 {
 		agentsProgress = 100
@@ -893,7 +893,7 @@ func (s *MCPAttestationService) GetMCPAttestations(
 	}
 
 	// Convert to response format with enriched metadata
-	var result []*domain.AttestationWithAgentDetails
+	result := make([]*domain.AttestationWithAgentDetails, 0)
 	var lastAttestedAt time.Time
 
 	for _, att := range attestations {
@@ -1027,7 +1027,7 @@ func (s *MCPAttestationService) GetConnectedAgentsForMCP(
 	}
 
 	// Fetch agent details
-	var agents []*domain.Agent
+	agents := make([]*domain.Agent, 0)
 	for _, conn := range connections {
 		if !conn.IsActive {
 			continue // Skip inactive connections
@@ -1056,7 +1056,7 @@ func (s *MCPAttestationService) GetMCPServersForAgent(
 	}
 
 	// Fetch MCP server details
-	var mcpServers []*domain.MCPServer
+	mcpServers := make([]*domain.MCPServer, 0)
 	for _, conn := range connections {
 		if !conn.IsActive {
 			continue // Skip inactive connections

--- a/apps/backend/internal/application/mcp_policy_evaluator.go
+++ b/apps/backend/internal/application/mcp_policy_evaluator.go
@@ -40,7 +40,7 @@ func (e *MCPPolicyEvaluator) EvaluateMCPServer(
 		return nil, fmt.Errorf("failed to get active policies: %w", err)
 	}
 
-	var results []*domain.MCPPolicyEvaluationResult
+	results := make([]*domain.MCPPolicyEvaluationResult, 0)
 
 	// Evaluate each MCP-related policy
 	for _, policy := range policies {

--- a/apps/backend/internal/application/registry_bridge_service.go
+++ b/apps/backend/internal/application/registry_bridge_service.go
@@ -118,7 +118,7 @@ func (s *RegistryBridgeService) buildOrgContribution(ctx context.Context, orgID 
 		return nil, nil
 	}
 
-	var events []domain.ContributionEvent
+	events := make([]domain.ContributionEvent, 0)
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	for _, agent := range agents {

--- a/apps/backend/internal/application/registry_bridge_service_test.go
+++ b/apps/backend/internal/application/registry_bridge_service_test.go
@@ -443,7 +443,8 @@ func TestBuildOrgContribution_NoAttestations(t *testing.T) {
 
 	events, err := svc.buildOrgContribution(context.Background(), orgID)
 	assert.NoError(t, err)
-	assert.Nil(t, events)
+	assert.NotNil(t, events, "must be non-nil empty slice (jsonarray-lint invariant)")
+	assert.Equal(t, 0, len(events))
 }
 
 func TestInferEcosystem(t *testing.T) {

--- a/apps/backend/internal/application/security_policy_service.go
+++ b/apps/backend/internal/application/security_policy_service.go
@@ -813,7 +813,7 @@ func (s *SecurityPolicyService) EvaluateConfigDrift(
 				}
 
 				// Detect new capabilities (not in baseline)
-				var addedCaps []string
+				addedCaps := make([]string, 0)
 				for cap := range currentCaps {
 					if !baseline[cap] {
 						addedCaps = append(addedCaps, cap)
@@ -821,7 +821,7 @@ func (s *SecurityPolicyService) EvaluateConfigDrift(
 				}
 
 				// Detect removed capabilities (in baseline but not current)
-				var removedCaps []string
+				removedCaps := make([]string, 0)
 				for cap := range baseline {
 					if !currentCaps[cap] {
 						removedCaps = append(removedCaps, cap)
@@ -896,7 +896,7 @@ func (s *SecurityPolicyService) EvaluateConfigDrift(
 			}
 
 			// Check if agent has any dangerous capabilities
-			var foundDangerousCaps []string
+			foundDangerousCaps := make([]string, 0)
 			for _, cap := range agent.Capabilities {
 				for _, dangerousCap := range dangerousCapabilities {
 					if dangerousCapStr, ok := dangerousCap.(string); ok {

--- a/apps/backend/internal/application/webhook_service.go
+++ b/apps/backend/internal/application/webhook_service.go
@@ -275,7 +275,7 @@ func (s *WebhookService) TriggerEvent(ctx context.Context, orgID uuid.UUID, even
 	}
 
 	// Filter webhooks that are active and subscribed to this event
-	var matchingWebhooks []*domain.Webhook
+	matchingWebhooks := make([]*domain.Webhook, 0)
 	for _, wh := range webhooks {
 		if !wh.IsActive {
 			continue

--- a/apps/backend/internal/interfaces/http/handlers/null_array_regression_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/null_array_regression_test.go
@@ -126,6 +126,61 @@ func TestAgentMCPServers_EmptyReturnsArrayNotNull(t *testing.T) {
 	assert.Equal(t, "[]", got, "mcpServers field must serialize as `[]` not `null` when empty")
 }
 
+// Regression for audit #27 (issue #173): `/agents/:id/alerts` must return
+// `"alerts": []` when the agent has zero alerts. Pre-fix, AlertService paths
+// declared `var alerts []*domain.Alert` and could return nil on the cold
+// path, which marshaled as `null` and crashed the dashboard alerts panel.
+func TestAgentAlerts_EmptyReturnsArrayNotNull(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+
+	agentMock := &MockAgentServiceImpl{
+		GetAgentFunc: func(_ context.Context, _ uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{
+				ID:             agentID,
+				OrganizationID: orgID,
+				Name:           "test-agent",
+			}, nil
+		},
+	}
+
+	alertMock := &MockAlertServiceImpl{
+		GetAlertsByAgentFunc: func(_ context.Context, _ uuid.UUID, _, _ int) ([]*domain.Alert, error) {
+			return make([]*domain.Alert, 0), nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		agentMock,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		alertMock,
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents/:id/alerts", handler.GetAgentAlerts)
+
+	req := httptest.NewRequest("GET", "/agents/"+agentID.String()+"/alerts", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body := make([]byte, resp.ContentLength)
+	_, _ = resp.Body.Read(body)
+
+	got := rawArrayField(t, body, "alerts")
+	assert.Equal(t, "[]", got, "alerts field must serialize as `[]` not `null` when empty")
+}
+
 // Marshal-layer contract: protects the test suite from a hypothetical future
 // stdlib change that would serialize `make([]T, 0)` as anything other than
 // `[]`. If this ever fails, the entire defect class above must be re-audited.


### PR DESCRIPTION
## Summary

Closes #155, #172, #173 — the residual null-array contract violation that PR #138 left in the application/service layer.

**Background.** PR #138 fixed the handler + repository layers and wired \`cmd/jsonarray-lint\` to scan those two dirs in CI. The service layer (\`internal/application/\`) was never wired. Running the lint there today reports 32 \`var xs []T\` declarations — including the exact source code behind the endpoints called out in #172 (\`mcp_attestation_service.go\` → MCP Attestations + MCP Servers For Agent) and #173 (\`alert_service.go\` → \`/agents/<id>/alerts\`, plus \`registry_bridge_service.go\`, etc.). When the function returns on the cold path with zero rows, the slice is nil and the Fiber JSON encoder writes \`null\`, which crashes the React dashboard's \`.forEach\` / \`.map\` / \`.filter\` consumers.

## Changes

- **32 sites fixed** across 11 service files: \`var xs []T\` → \`xs := make([]T, 0)\`
  - \`a2a_service.go\`, \`agent_service.go\`, \`alert_service.go\`, \`community_intelligence_service.go\`, \`compliance_service.go\`, \`detection_service.go\`, \`mcp_attestation_service.go\`, \`mcp_policy_evaluator.go\`, \`registry_bridge_service.go\`, \`security_policy_service.go\`, \`webhook_service.go\`
- **CI lint extended**: \`internal/application\` added to \`jsonarray-lint\` args in \`.github/workflows/ci.yml\`. Mechanical enforcement of the invariant from this PR forward.
- **New regression test**: \`TestAgentAlerts_EmptyReturnsArrayNotNull\` in \`null_array_regression_test.go\` proves the \`/agents/<id>/alerts\` contract for #173.
- **Test update**: \`TestBuildOrgContribution_NoAttestations\` previously asserted \`assert.Nil(events)\` — that assertion protected the bug. Updated to \`NotNil + len == 0\` to match the lint invariant.

Repo + handler layers already passed the lint before this PR; verified \`jsonarray-lint\` exits clean on all three dirs after the change.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go run ./cmd/jsonarray-lint ./internal/interfaces/http/handlers ./internal/infrastructure/repository ./internal/application\` exits 0
- [x] \`go test ./internal/application/... ./internal/interfaces/http/handlers/...\` all pass
- [x] Full backend unit suite (excluding \`tests/integration\` which is rate-limited by a running server, unrelated to this diff) passes
- [x] Four null-array regression tests (TrustScoreHistory, AgentMCPServers, AgentAlerts, EmptySliceMarshalContract) all pass
- [x] Pre-push gate (Phase 1 sensitive scan, Phase 2 build/test/lint) clean

## Out of scope

- Frontend defensive \`|| []\` coalescing (\`apps/web/\`)
- TS type generation from Go (#155 future work)
- HMA flagged 2 HIGH \`/tmp\` path findings in **untracked** demo prep scripts (\`examples/flight-search-agent/prep-stage.sh\`) that are not in this PR's diff, not in HEAD, and won't be pushed — handed off for a separate cleanup PR when those scripts are committed.