### PR TITLE
fix(#129): increment rotation_count on PQC key rotation

### DIFF
--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -2071,6 +2071,12 @@ func (s *AgentService) RotateAgentPQCKey(ctx context.Context, agentID uuid.UUID,
 	agent.PQCKeyCreatedAt = &now
 	agent.UpdatedAt = now
 
+	// Bump the rotation counter (#129) — matches RotateCredentials and
+	// UpdateAgentPublicKey, which both already increment. Without this, the
+	// dashboard's rotationCount field stays at 0 for any agent that has only
+	// rotated its PQC key, hiding rotation activity from operators.
+	agent.RotationCount++
+
 	if err := s.agentRepo.Update(agent); err != nil {
 		return fmt.Errorf("failed to rotate agent PQC key: %w", err)
 	}

--- a/apps/backend/internal/application/agent_service_test.go
+++ b/apps/backend/internal/application/agent_service_test.go
@@ -2365,3 +2365,62 @@ func TestAgentService_GetAgentCredentials_DecryptionFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decrypt")
 }
+
+// ===========================
+// RotateAgentPQCKey Tests (#129)
+// ===========================
+
+// TestAgentService_RotateAgentPQCKey_IncrementsRotationCount is the regression
+// test for #129: RotateAgentPQCKey persisted the new key but never bumped
+// agent.RotationCount, so the dashboard's "Rotation count" badge stayed at 0
+// for any agent that had only ever rotated its PQC key. The Ed25519 paths
+// (RotateCredentials and UpdateAgentPublicKey) already increment correctly;
+// this test pins the PQC path to the same contract.
+func TestAgentService_RotateAgentPQCKey_IncrementsRotationCount(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	service := &AgentService{agentRepo: mockAgentRepo}
+
+	existingPQCKey := "previous-pqc-public-key"
+	existingAlg := "ML-DSA-65"
+	agent := createTestAgentForService()
+	agent.PQCPublicKey = &existingPQCKey
+	agent.PQCKeyAlgorithm = &existingAlg
+	agent.RotationCount = 3 // starting value — any non-zero is fine
+
+	mockAgentRepo.On("GetByID", agent.ID).Return(agent, nil)
+	mockAgentRepo.On("Update", mock.AnythingOfType("*domain.Agent")).Return(nil)
+
+	ctx := context.Background()
+	err := service.RotateAgentPQCKey(ctx, agent.ID, "new-pqc-public-key", "ML-DSA-65")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, agent.RotationCount, "RotateAgentPQCKey must increment RotationCount")
+	assert.NotNil(t, agent.PreviousPQCPublicKey, "previous PQC key must be preserved for grace period")
+	assert.Equal(t, existingPQCKey, *agent.PreviousPQCPublicKey)
+	mockAgentRepo.AssertExpectations(t)
+}
+
+// TestAgentService_UpdateAgentPublicKey_IncrementsRotationCount pins the
+// existing Ed25519-SDK-registration increment so it can't regress alongside
+// the PQC fix. Issue #129 erroneously listed this path as broken (the grep
+// pattern `UPDATE agents SET rotation_count = ...` missed the parameterized
+// SQL `rotation_count = $22`); this test makes the working contract explicit.
+func TestAgentService_UpdateAgentPublicKey_IncrementsRotationCount(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	service := &AgentService{agentRepo: mockAgentRepo}
+
+	agent := createTestAgentForService()
+	agent.RotationCount = 7
+
+	mockAgentRepo.On("GetByID", agent.ID).Return(agent, nil)
+	mockAgentRepo.On("Update", mock.AnythingOfType("*domain.Agent")).Return(nil)
+
+	ctx := context.Background()
+	// authMethod="jwt" because the agent already has a key and the function
+	// rejects Ed25519/mldsa/hybrid auth in that branch.
+	err := service.UpdateAgentPublicKey(ctx, agent.ID, "fresh-public-key", "jwt")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 8, agent.RotationCount, "UpdateAgentPublicKey must increment RotationCount")
+	mockAgentRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Closes #129. The `agents.rotation_count` field was stale specifically on the **PQC rotation path** — \`RotateAgentPQCKey\` updated the new key and stashed the previous one for the grace period but never bumped \`agent.RotationCount\`. The Ed25519 paths (\`RotateCredentials\`, \`UpdateAgentPublicKey\`) already increment correctly; the issue's grep for \`UPDATE agents SET rotation_count = ...\` missed the parameterized form (\`rotation_count = \$22\`).

So the field was 0 for any agent that had only ever rotated its PQC key — which on a demo or PQC-first deployment is essentially every agent.

## Changes

- \`agent_service.go\`: 4-line increment + explanatory comment in \`RotateAgentPQCKey\`, placed before the existing \`agentRepo.Update(agent)\` call so the persisted row carries the new count.
- \`agent_service_test.go\`: two regression tests pinning the contract:
  - \`TestAgentService_RotateAgentPQCKey_IncrementsRotationCount\` — the actual fix
  - \`TestAgentService_UpdateAgentPublicKey_IncrementsRotationCount\` — locks in the Ed25519-SDK-registration path that was already correct, so it can't regress alongside future PQC changes

## Out of scope (deliberately)

- \`UpdateAgentPQCKey\` is the FIRST-time PQC registration path (the handler returns 409 if a key already exists). Registering an initial key isn't a rotation, so no increment is added there. The same first-registration UX quirk arguably applies to \`UpdateAgentPublicKey\` (it increments from 0 → 1 on initial SDK key registration), but that's a separate UX question and not part of #129's scope.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go run ./cmd/jsonarray-lint ./internal/interfaces/http/handlers ./internal/infrastructure/repository ./internal/application\` exits 0
- [x] New tests pass: \`go test -run 'TestAgentService_(RotateAgentPQCKey|UpdateAgentPublicKey)_IncrementsRotationCount' ./internal/application/\`
- [x] Full backend unit suite (excluding rate-limited \`tests/integration\`) passes
- [x] Pre-push gate (sensitive-file scan, build/test/lint) clean