### PR TITLE
fix(#171): prod-guard on sentinel-UUID seed scripts

### DIFF
--- a/apps/backend/scripts/seed_complete.sql
+++ b/apps/backend/scripts/seed_complete.sql
@@ -1,5 +1,22 @@
 -- Complete Seed Data for AIM Testing (Matches Actual Schema)
 -- Run with: export PGPASSWORD=postgres && psql -h localhost -U postgres -d identity -f scripts/seed_complete.sql
+--
+-- TEST DATA ONLY. Uses sequential sentinel UUIDs (11111111-*, 22222222-*, ...).
+-- The guard below aborts if a production-shaped org is present so an accidental
+-- `psql -f` against a real cluster cannot create predictable enumerable rows
+-- (CWE-330). See issue #171.
+
+DO $guard$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM organizations
+        WHERE domain IN ('admin.opena2a.org', 'aim.oa2a.org', 'opena2a.org')
+           OR plan_type = 'enterprise'
+    ) THEN
+        RAISE EXCEPTION 'Refusing to seed test data: this database contains a production-shaped organization. Use a fresh test DB.';
+    END IF;
+END
+$guard$;
 
 -- Create test organization (all required fields)
 INSERT INTO organizations (id, name, domain, plan_type, max_agents, max_users, is_active, created_at, updated_at)

--- a/apps/backend/scripts/seed_data.sql
+++ b/apps/backend/scripts/seed_data.sql
@@ -1,5 +1,22 @@
 -- Seed Data for AIM Testing
 -- Run with: export PGPASSWORD=postgres && psql -h localhost -U postgres -d identity -f scripts/seed_data.sql
+--
+-- TEST DATA ONLY. Uses sequential sentinel UUIDs (11111111-*, 22222222-*, ...).
+-- The guard below aborts if a production-shaped org is present so an accidental
+-- `psql -f` against a real cluster cannot create predictable enumerable rows
+-- (CWE-330). See issue #171.
+
+DO $guard$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM organizations
+        WHERE domain IN ('admin.opena2a.org', 'aim.oa2a.org', 'opena2a.org')
+           OR plan_type = 'enterprise'
+    ) THEN
+        RAISE EXCEPTION 'Refusing to seed test data: this database contains a production-shaped organization. Use a fresh test DB.';
+    END IF;
+END
+$guard$;
 
 -- Create test organization
 INSERT INTO organizations (id, name, slug, created_at, updated_at)

--- a/apps/backend/scripts/seed_data_fixed.sql
+++ b/apps/backend/scripts/seed_data_fixed.sql
@@ -1,5 +1,22 @@
 -- Seed Data for AIM Testing (Schema-Correct Version)
 -- Run with: export PGPASSWORD=postgres && psql -h localhost -U postgres -d identity -f scripts/seed_data_fixed.sql
+--
+-- TEST DATA ONLY. Uses sequential sentinel UUIDs (11111111-*, 22222222-*, ...).
+-- The guard below aborts if a production-shaped org is present so an accidental
+-- `psql -f` against a real cluster cannot create predictable enumerable rows
+-- (CWE-330). See issue #171.
+
+DO $guard$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM organizations
+        WHERE domain IN ('admin.opena2a.org', 'aim.oa2a.org', 'opena2a.org')
+           OR plan_type = 'enterprise'
+    ) THEN
+        RAISE EXCEPTION 'Refusing to seed test data: this database contains a production-shaped organization. Use a fresh test DB.';
+    END IF;
+END
+$guard$;
 
 -- Create test organization
 INSERT INTO organizations (id, name, created_at, updated_at)


### PR DESCRIPTION
## Summary

Closes #171. The three \`apps/backend/scripts/seed_*.sql\` scripts insert sequential sentinel UUIDs (\`11111111-*\`, \`22222222-*\`, ...) as test fixtures. If accidentally pointed at a real cluster, they create predictable enumerable rows (CWE-330).

This PR adds a DO-block guard at the top of each script that aborts with a clear message when the database contains a production-shaped organization (matched by \`domain IN ('admin.opena2a.org', 'aim.oa2a.org', 'opena2a.org')\` OR \`plan_type = 'enterprise'\`). Stable UUIDs are preserved so existing deterministic test assertions still work; the only change is that an accidental \`psql -f scripts/seed_*.sql\` against the wrong cluster now aborts before inserting anything.

## Why this approach (not \`gen_random_uuid()\`)

The issue offered two options: (a) hard guard against prod runs, (b) replace with \`gen_random_uuid()\`. Replacing with random UUIDs would break every test fixture that asserts on a specific seeded ID (the existing tests do — e.g., \`scripts/jwt/generate_jwt.go\` uses \`11111111-...\` as the orgID for token generation). The guard is the lower-disruption fix.

## #154 is already fixed (separate)

Auditing the related issue #154 (sentinel UUIDs in migrations 013/072): both are already fixed by the B2 hardening work landed 2026-05-20. Migration 013 uses \`gen_random_uuid()\`; migration 072 is a documented no-op; migration 024 looks up the default org by domain instead of by sentinel UUID; the admin user is now seeded by the \`aim-bootstrap --default\` Go binary which generates a random UUID and password printed once. Will close #154 with a verification comment separately.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` clean (no Go changes anyway)
- [x] Guard DO-block is well-formed Postgres syntax (\$guard\$-delimited block)
- [x] Pre-push gate clean

## Out of scope

- Replacing sentinel UUIDs in test fixtures (\`verification_handler_integration_test.go\`, \`webhook_handler_integration_test.go\`, \`registry_bridge_service_test.go\`, \`scripts/jwt/generate_jwt.go\`) — these are test-internal stable fixtures, not enumerable production resources
- The \`examples/flight-search-agent/prep-stage.sh\` demo script still references the legacy \`a0000000-...\` org IDs and is untracked; that's a demo-script cleanup, separate from #171's scope