### PR TITLE
fix(#165): show actual agent status in detail header (drop redundant Active pill)

### DIFF
--- a/apps/web/app/dashboard/agents/[id]/page.tsx
+++ b/apps/web/app/dashboard/agents/[id]/page.tsx
@@ -318,8 +318,24 @@ export default function AgentDetailsPage({
   // Check if agent is verified
   const isVerified = agent?.status === "verified";
 
-  // Check if agent is active
-  const isActive = agent?.status !== "suspended" && agent?.status !== "revoked";
+  // Status-badge color mapping (mirrors the agents list page so the detail
+  // header and the list page describe the same agent the same way — fixes
+  // #165, where the detail page rendered a generic "Active/Inactive" pill
+  // derived from status that read as a second, contradicting status next to
+  // the "Verified" badge).
+  const getStatusBadgeClass = (status: string): string => {
+    switch (status) {
+      case "verified":
+        return "bg-green-500/10 text-green-600";
+      case "pending":
+        return "bg-yellow-500/10 text-yellow-600";
+      case "suspended":
+      case "revoked":
+        return "bg-red-500/10 text-red-600";
+      default:
+        return "bg-gray-500/10 text-gray-600";
+    }
+  };
 
   // Create mapping from MCP server name to ID for clickable navigation
   const serverNameToId = new Map<string, string>();
@@ -465,13 +481,9 @@ export default function AgentDetailsPage({
               <p className="text-muted-foreground mb-2">{agent.description}</p>
               <div className="flex items-center gap-2 flex-wrap">
                 <Badge variant="outline">{agent.agentType}</Badge>
-                {isActive ? (
-                  <Badge className="bg-green-500/10 text-green-600">
-                    Active
-                  </Badge>
-                ) : (
-                  <Badge variant="secondary">Inactive</Badge>
-                )}
+                <Badge className={`capitalize ${getStatusBadgeClass(agent.status)}`}>
+                  {agent.status}
+                </Badge>
                 <Badge
                   className={getTrustColor((agent.trustScore ?? 0) * 100)}
                 >
@@ -1108,13 +1120,9 @@ export default function AgentDetailsPage({
                     Status:
                   </span>
                   <span className="col-span-2 text-sm">
-                    {isActive ? (
-                      <Badge className="bg-green-500/10 text-green-600">
-                        Active
-                      </Badge>
-                    ) : (
-                      <Badge variant="secondary">Inactive</Badge>
-                    )}
+                    <Badge className={`capitalize ${getStatusBadgeClass(agent.status)}`}>
+                      {agent.status}
+                    </Badge>
                   </span>
                 </div>
                 <Separator />


### PR DESCRIPTION
## Summary

Closes #165. The agent detail header rendered an "Active" / "Inactive" pill derived from \`status not in (suspended, revoked)\`, placed next to a green Shield icon for verified agents and a green "Verified" verify-action button. A verified agent's header therefore showed both an "Active" pill AND a "Verified" badge — two visual indicators describing the same state in different vocabulary.

This PR mirrors the working pattern already used by the agents list page (\`StatusBadge\` in \`apps/web/app/dashboard/agents/page.tsx\`): render the actual status string ("Pending" / "Verified" / "Suspended" / "Revoked") with color-coded styling so the header tells one consistent story.

## Changes

\`apps/web/app/dashboard/agents/[id]/page.tsx\`:

- Drop the local \`isActive\` derived boolean (was the source of the "Active/Inactive" copy).
- Add \`getStatusBadgeClass(status)\` — small status → tailwind class lookup, identical color logic to the agents list page's \`StatusBadge\`.
- Header badge row (line ~466): replace the binary \`isActive\` ternary with a single \`<Badge>\` showing \`{agent.status}\` styled by \`getStatusBadgeClass(agent.status)\`.
- Info panel "Status" row (line ~1105): same swap — drop the redundant Active/Inactive ternary, render the actual status badge.

The green Shield icon next to the agent name (visual affordance for trust at-a-glance) and the "Verify Agent" / "Verified" action button stay — those are an icon and an action, not a competing status label.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] ESLint clean
- [x] Pattern is structurally identical to the agents list page's \`StatusBadge\` which is verified working in the live dashboard

## Live-browser verification limitation

Tried to verify visually with Playwright but hit two blockers, both orthogonal to the change:

1. The user's local \`:3000\` is served by \`aim-frontend\` Docker container running \`ghcr.io/opena2a-org/aim-dashboard:latest\` — a pre-built published image that doesn't reflect local source edits and isn't bind-mounted to \`apps/web/\`. The image would need to be rebuilt to see this fix.
2. Starting a fresh \`next dev\` on \`:3010\` against the existing backend at \`:8080\` failed with CORS — the backend's allowed-origin config doesn't include alternate ports.

The change itself is a small JSX swap with no new behavior — same \`<Badge>\` component, same color values per status, only the rendered text and the source of those colors change. Confidence is high; the limitation is logged here for transparency per CLAUDE.md's "if you can't test the UI, say so explicitly" rule.

## Out of scope

- The \`isActive?: boolean\` field on the \`Agent\` interface (line 68) is untouched — it's a separate optional property on the type, not the derived const I removed.
- The "Verified" info-panel row remains — it's a focused verification-specific indicator, not a redundant status restatement.