### PR TITLE
fix(#175): drop stale status + trust score from SDK existing-credentials banner

### DIFF
--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -3569,12 +3569,13 @@ def register_agent(
                     }
                 )
 
-                # Use beautiful console output
+                # Use beautiful console output. Note: cached status + trust
+                # score from existing_creds are intentionally NOT passed —
+                # they are stale snapshots from registration time and would
+                # mislead operators (#175). Live values live on the dashboard.
                 console.agent_found(
                     name=name,
                     agent_id=existing_creds['agent_id'],
-                    status=existing_creds.get('status', 'active'),
-                    trust_score=existing_creds.get('trust_score', 0.85)
                 )
 
                 # Create OAuth token manager - prefer SDK credentials (which have refresh_token)

--- a/sdk/python/aim_sdk/console.py
+++ b/sdk/python/aim_sdk/console.py
@@ -194,28 +194,26 @@ class AIMConsole:
         self,
         name: str,
         agent_id: str,
-        status: str,
-        trust_score: float
     ):
-        """Display message when existing agent credentials are found."""
+        """Display message when existing agent credentials are found.
+
+        Status and trust score are deliberately NOT shown here — the cached
+        credentials file on disk only captures the snapshot at registration
+        time and never refreshes, so anything printed would lie (#175: a
+        promoted agent at status=verified, trust=0.92 server-side would
+        still print pending / 0% from cache). The dashboard is the
+        authoritative source for live status; the CLI banner sticks to
+        identity (name + ID) which is stable.
+        """
         if self.quiet:
             return
 
-        trust_score = self._normalize_trust_score(trust_score)
+        id_short = f"{agent_id[:8]}...{agent_id[-4:]}"
 
         if RICH_AVAILABLE:
-            # Status indicator
-            status_color = "green" if status in ["active", "verified"] else "yellow"
-            status_icon = "●" if status in ["active", "verified"] else "○"
-
-            # Compact output
             self.console.print()
             self.console.print(f"[bold blue]↻[/] [bold]Using existing credentials:[/] [cyan]{name}[/]")
-
-            id_short = f"{agent_id[:8]}...{agent_id[-4:]}"
-            trust_str = self._format_trust_score_inline(trust_score)
-
-            self.console.print(f"  [dim]ID:[/] {id_short}  [dim]Status:[/] [{status_color}]{status_icon} {status}[/]  [dim]Trust:[/] {trust_str}")
+            self.console.print(f"  [dim]ID:[/] {id_short}")
             self.console.print(f"  [dim]Use force_new=True to register a new agent[/]")
             self.console.print()
         else:
@@ -223,10 +221,8 @@ class AIMConsole:
             print("╭─────────────────────────────────────────────────╮")
             print("│  ↻ Using Existing Credentials                   │")
             print("├─────────────────────────────────────────────────┤")
-            print(f"│  Agent:       {name:<32} │")
-            print(f"│  ID:          {agent_id[:8]}...{agent_id[-4:]:<20} │")
-            print(f"│  Status:      {status:<32} │")
-            print(f"│  Trust Score: {trust_score:.0%}{'':>28} │")
+            print(f"│  Agent: {name:<40} │")
+            print(f"│  ID:    {id_short:<40} │")
             print("╰─────────────────────────────────────────────────╯")
             print("  Use force_new=True to register a new agent")
             print()

--- a/sdk/python/tests/test_console_agent_found.py
+++ b/sdk/python/tests/test_console_agent_found.py
@@ -1,0 +1,75 @@
+"""Regression coverage for #175: AIMConsole.agent_found() must not print
+the cached status or trust score. Those values live in the local credentials
+file from registration time and never refresh, so anything printed would lie
+once the agent is promoted or its trust score changes server-side."""
+
+import io
+from contextlib import redirect_stdout
+
+from aim_sdk.console import AIMConsole
+
+
+class TestAgentFoundBannerDoesNotLeakStaleFields:
+    """The banner shown when SDK loads cached credentials must stick to
+    identity (agent name + ID). Status and trust score belong on the
+    dashboard, which is authoritative."""
+
+    def _capture_banner(self) -> str:
+        """Render the existing-credentials banner with both rich and plain
+        backends captured. Each backend writes to a different stream, so we
+        join the stdout-printed plain branch (RICH_AVAILABLE=False) and the
+        rich console's recorded output (RICH_AVAILABLE=True)."""
+        console = AIMConsole(quiet=False)
+        buf = io.StringIO()
+
+        # Rich backend (if available) writes to its own Console; redirect by
+        # swapping the underlying file handle to our buffer.
+        if console.console is not None:
+            console.console.file = buf
+
+        with redirect_stdout(buf):
+            console.agent_found(
+                name="flight-search-agent",
+                agent_id="391be6bf-0b21-4b63-979d-d53d03f0deae",
+            )
+
+        return buf.getvalue()
+
+    def test_does_not_print_status_label(self):
+        out = self._capture_banner()
+        assert "Status:" not in out, (
+            "Banner must not show cached Status (#175): credentials file "
+            "only has the registration-time snapshot. Got:\n" + out
+        )
+
+    def test_does_not_print_trust_score_label(self):
+        out = self._capture_banner()
+        assert "Trust Score:" not in out and "Trust:" not in out, (
+            "Banner must not show cached Trust Score (#175). Got:\n" + out
+        )
+
+    def test_does_not_print_percent_sign(self):
+        # The cached trust score was rendered as a percentage. If '%' appears
+        # in the banner, something is leaking it back in.
+        out = self._capture_banner()
+        assert "%" not in out, (
+            "Banner must not render any percentage (#175 — was cached "
+            "trust). Got:\n" + out
+        )
+
+    def test_still_shows_name_and_id(self):
+        out = self._capture_banner()
+        assert "flight-search-agent" in out
+        assert "391be6bf" in out, "Short-form ID prefix must still appear"
+
+    def test_quiet_mode_suppresses_everything(self):
+        console = AIMConsole(quiet=True)
+        buf = io.StringIO()
+        if console.console is not None:
+            console.console.file = buf
+        with redirect_stdout(buf):
+            console.agent_found(
+                name="any",
+                agent_id="00000000-0000-0000-0000-000000000000",
+            )
+        assert buf.getvalue() == ""


### PR DESCRIPTION
## Summary

Closes #175. When the SDK loads cached credentials from \`~/.aim/agents/<name>.json\`, \`AIMConsole.agent_found()\` printed a banner with \`Status:\` and \`Trust Score:\` lines populated from that file. The file is only written at initial registration and never refreshes, so an agent promoted to \`verified, trust 0.92\` server-side still shows \`pending / 0%\` from the cache — exactly what the audit reported.

## Approach

The issue offered two options: (a) round-trip the values from the server before rendering, or (b) drop them from the banner entirely. Option (b) is the lower-disruption, lower-latency choice: status and trust score belong on the dashboard (live, authoritative), not in a CLI startup banner that fires before any network call. The banner now sticks to identity (\`name\` + short-form \`agent_id\`), which is the stable part of cached credentials.

## Changes

- \`sdk/python/aim_sdk/console.py\` — \`agent_found()\` signature drops \`status\` and \`trust_score\` parameters. Both the rich-rendered and plain-text branches now only show name + ID. Inline docstring explains why those fields were removed (avoid lying when cached snapshot diverges from server state).
- \`sdk/python/aim_sdk/client.py:3573\` — single internal caller updated to match the new signature. Comment block explains the staleness contract.
- \`sdk/python/tests/test_console_agent_found.py\` — new regression tests (5):
  - \`test_does_not_print_status_label\` — banner must not contain \`Status:\`
  - \`test_does_not_print_trust_score_label\` — banner must not contain \`Trust:\` or \`Trust Score:\`
  - \`test_does_not_print_percent_sign\` — no \`%\` (was the cached trust score)
  - \`test_still_shows_name_and_id\` — what we DO want to show
  - \`test_quiet_mode_suppresses_everything\` — quiet flag still wins

## Test plan

- [x] 5 new regression tests pass
- [x] All 8 existing \`test_console_trust_score.py\` tests still pass
- [x] Full SDK suite: 363 passed, 3 pre-existing failures (all about \`oauth_token_manager\` construction in \`client.py\` — verified present on \`main\` before this PR, unrelated to this change)

## Out of scope

- The cache file format on disk is unchanged. The \`status\` / \`trust_score\` fields are still written at registration time; they're just no longer surfaced in the banner. Future work could trim the cache file too, but that's a separate concern (other code paths may read those keys).
- The 3 pre-existing OAuth test failures in \`test_credentials.py\` / \`test_register_agent.py\` / \`test_secure_alias.py\` are not addressed here — they predate this PR.