### PR TITLE
docs(#176): clarify Audit Trail scope (lifecycle events; point to Recent Activity for verifications)

### DIFF
--- a/apps/web/app/dashboard/admin/compliance/page.tsx
+++ b/apps/web/app/dashboard/admin/compliance/page.tsx
@@ -1397,7 +1397,7 @@ export default function CompliancePage() {
                     Audit Trail
                   </h3>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Complete activity history for agents, MCP servers, and users
+                    Control-plane lifecycle events (agent create/update, MCP changes, user actions). For runtime verification activity on a specific agent, open that agent and use the <span className="font-medium">Recent Activity</span> timeline.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Closes #176. The compliance page's Audit Trail panel claimed "Complete activity history for agents, MCP servers, and users" but only fetches \`audit_log\` table rows via \`api.getAuditLogs(200, 0)\` — which excludes runtime verification events (those live in \`verification_events\` and surface on the per-agent Recent Activity timeline + in Alerts under "Capability Violation Detected").

A new user reading the old subtitle and finding only sparse \`agent.create\` rows reasonably concludes AIM isn't logging anything (audit doc § 14 / new-user observation).

## Approach

The issue offered two options: (a) fold verification events into the audit log feed, or (b) rename the panels so it's obvious where to look. The per-agent \`Recent Activity\` tab in \`apps/web/app/dashboard/agents/[id]/page.tsx\` (CardTitle "Activity Timeline", description "Unified view of trust score changes, security alerts, verifications, and agent actions") already unifies the four data sources, so option (a) is substantially in place for per-agent views.

What was missing is on the org-wide compliance page: the panel subtitle overpromised. This PR replaces it with an accurate one-liner that:
1. Names what this panel actually covers (control-plane lifecycle events).
2. Points users to the per-agent Recent Activity timeline for runtime verification activity.

## Change

\`apps/web/app/dashboard/admin/compliance/page.tsx\` — one-line subtitle rewrite under the "Audit Trail" \`h3\`:

BEFORE: \`Complete activity history for agents, MCP servers, and users\`

AFTER: \`Control-plane lifecycle events (agent create/update, MCP changes, user actions). For runtime verification activity on a specific agent, open that agent and use the **Recent Activity** timeline.\`

## Test plan

- [x] \`tsc --noEmit\` clean on the changed file
- [x] No data shape or fetch changes — only the descriptive subtitle changed

## Out of scope

- Folding verification events INTO the org-wide audit-log feed (option a from the issue). That'd require backend work (emit \`audit_log\` entries for verification submits and policy decisions, or join \`audit_log\` ∪ \`verification_events\` at the API layer). Per-agent timeline already covers the runtime view, so this is deferred.
- Live UI verification: blocked by the same docker-image-not-bind-mounted constraint noted in PR #210 — \`aim-frontend\` runs a pre-built dashboard image; local source changes don't show up against the running stack without restarting that container. This is a one-line copy change; the risk is bounded.