### PR TITLE
fix(sdk-py): refuse silent re-register; drop encrypted shadow (#178,#174)

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Stale agent credentials no longer trigger silent re-registration** (#178). When the
+  cached `~/.aim/agents/<name>.json` references an agent that no longer exists in the
+  backend, the SDK now raises `StaleCredentialsError` with the local file path and
+  recovery steps instead of deleting the file and registering a fresh agent under the
+  same name. Re-registering against admin-curated agent state (status, trust score,
+  granted capabilities, MCP grants) was wiping that state without notice; recovery is
+  now an explicit operator action.
+- **Bundled-SDK install path now prints a visible adoption warning** (#178). When the
+  SDK adopts credentials from a bundled `.aim/sdk_credentials.json` (e.g., a fresh
+  dashboard download in the working directory), the install prints which truncated
+  token ID it is adopting and the long-term home path so operators can see when stale
+  bundled tokens are entering the home store.
+
+### Changed
+- **Token rotation message names the prior refresh token as revoked** (#174). The
+  print after a successful rotation now reads `Token rotated successfully — old
+  refresh token revoked (new id: <8-char-prefix>...)` so the cause of out-of-band
+  copies failing on the next refresh is obvious.
+- **`print_token_expired_error` explains the root cause and surfaces the local
+  path** (#174). The error text names refresh-token rotation as the most common
+  cause, lists the four concrete situations that trigger it, and includes the exact
+  `rm <path>` command instead of pointing the user at the dashboard UI alone.
+
+### Removed
+- **Encrypted shadow credential file** (`~/.aim/sdk_credentials.encrypted`, audit
+  #12). The shadow file written alongside the JSON store became a write-only
+  secondary source that no other code path read, and operators had to delete it
+  manually to recover from corruption. `OAuthTokenManager` now treats
+  `~/.aim/sdk_credentials.json` (mode 0600) as the single source of truth and
+  performs a one-time migration on first instantiation: any leftover `.encrypted`
+  file is decrypted into the JSON store and removed, or — if decryption fails —
+  preserved in place so the operator can recover manually. The `use_secure_storage`
+  and `allow_plaintext_fallback` constructor parameters are preserved for ABI
+  stability and ignored.
+
+### Added
+- **`StaleCredentialsError`** (subclass of `ConfigurationError`). Raised from
+  `register_agent()` when cached agent credentials reference an agent missing from
+  the backend.
+
 ### Planned
 - JavaScript/TypeScript SDK
 - GraphQL API support

--- a/sdk/python/aim_sdk/__init__.py
+++ b/sdk/python/aim_sdk/__init__.py
@@ -75,7 +75,7 @@ from .decorators import aim_verify, aim_verify_database, aim_verify_api_call
 # Alias for enterprise security
 secure = register_agent
 
-from .exceptions import AIMError, AuthenticationError, VerificationError, ActionDeniedError
+from .exceptions import AIMError, AuthenticationError, VerificationError, ActionDeniedError, ConfigurationError, StaleCredentialsError
 from .secrets import SecretsClient, SecretsError
 from .detection import MCPDetector, auto_detect_mcps, track_mcp_call
 from .capability_detection import CapabilityDetector, auto_detect_capabilities, auto_detect_agent_type
@@ -162,6 +162,8 @@ __all__ = [
     "AuthenticationError",
     "VerificationError",
     "ActionDeniedError",
+    "ConfigurationError",
+    "StaleCredentialsError",
     "MCPDetector",
     "auto_detect_mcps",
     "CapabilityDetector",

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -24,7 +24,8 @@ from .exceptions import (
     AuthenticationError,
     VerificationError,
     ActionDeniedError,
-    ConfigurationError
+    ConfigurationError,
+    StaleCredentialsError,
 )
 
 # Get version - we need to compute it directly to avoid circular import
@@ -3531,11 +3532,14 @@ def register_agent(
             )
 
             if not is_valid:
-                # Credentials are stale - delete and re-register
-                console.warning(f"Cached credentials for '{name}' are stale: {validation_error}")
-                console.info("Deleting stale credentials and re-registering agent...")
+                # Stale credentials: the agent ID in the local file no longer
+                # exists in the backend. Silently re-registering would create a
+                # fresh agent row with default state, wiping any admin-curated
+                # status, trust score, granted capabilities, or MCP grants
+                # applied to the original agent under this name (#178).
+                from pathlib import Path as _Path
+                _creds_path = _Path.home() / ".aim" / "agents" / f"{name}.json"
 
-                # Log the stale credential detection
                 security_logger.log_agent_event(
                     AgentEventType.AGENT_STALE_CREDENTIALS,
                     agent_id=agent_id,
@@ -3543,16 +3547,30 @@ def register_agent(
                     details={
                         "error": "stale_credentials",
                         "reason": validation_error,
-                        "action": "re-registering"
+                        "action": "refused_silent_reregistration",
                     }
                 )
 
-                # Delete stale credentials
-                from .credentials import delete_agent_credentials
-                delete_agent_credentials(name)
-
-                # Fall through to re-registration below
-                existing_creds = None
+                raise StaleCredentialsError(
+                    f"\nCached agent credentials for '{name}' reference agent "
+                    f"{agent_id[:8]}... which is no longer present in the AIM "
+                    f"backend at {cached_aim_url}.\n"
+                    f"\n"
+                    f"Reason: {validation_error}\n"
+                    f"\n"
+                    f"The SDK will not silently re-register, because doing so "
+                    f"would create a fresh agent row and wipe any admin-set "
+                    f"state (status, trust score, granted capabilities, MCP "
+                    f"grants) applied to the previous agent under this name.\n"
+                    f"\n"
+                    f"TO RECOVER:\n"
+                    f"  1. Confirm the AIM URL is correct: {cached_aim_url}\n"
+                    f"  2. Check the dashboard to see if the agent was deleted.\n"
+                    f"  3. If you intend to register a new agent under this "
+                    f"name, remove the cached file explicitly:\n"
+                    f"       rm {_creds_path}\n"
+                    f"     then re-run your script.\n"
+                )
 
             else:
                 # Credentials are valid - use them

--- a/sdk/python/aim_sdk/credentials.py
+++ b/sdk/python/aim_sdk/credentials.py
@@ -275,8 +275,24 @@ def _find_sdk_package_credentials() -> Optional[Dict[str, Any]]:
 
 
 def _install_sdk_credentials(credentials: Dict[str, Any]) -> None:
-    """Install SDK credentials from package to home directory."""
+    """Install SDK credentials from package to home directory.
+
+    Bundled SDK credentials in the package or CWD are adopted as a
+    convenience for the first run after a fresh download. The home
+    location is the long-term source of truth; on subsequent runs the
+    SDK reads from there first and ignores the bundled file (#178).
+    """
     try:
+        token_id = credentials.get("sdkTokenId") or credentials.get("sdk_token_id") or ""
+        token_id_short = (token_id[:8] + "...") if token_id else "unknown"
+        # Visible warning so operators see when bundled (potentially stale)
+        # credentials are being adopted. Audit #37: the silent install path
+        # was how stale bundled tokens crept into the home file across
+        # demo prep runs.
+        print(
+            "INFO: Adopting SDK credentials from bundled package (token "
+            f"{token_id_short}). Long-term source: {SDK_CREDENTIALS_FILE}."
+        )
         save_sdk_credentials(credentials)
         print(f"✅ SDK credentials installed to {SDK_CREDENTIALS_FILE}")
     except Exception as e:
@@ -550,25 +566,40 @@ def print_wrong_credential_type_error(found_type: str, agent_name: str = None, a
 
 
 def print_token_expired_error(aim_url: str = "http://localhost:8080") -> None:
-    """Print a clear error message when SDK token has expired."""
+    """Print a clear error message when the SDK refresh token is rejected.
+
+    Audit #12: the prior wording told the user to "download a fresh SDK"
+    without explaining WHY the local token stopped working — the most
+    common cause is that another SDK installation rotated the refresh
+    token (server-side rotation invalidates prior copies). This version
+    names the cause and surfaces the local path so recovery is obvious.
+    """
     print()
     print("=" * 72)
-    print("⚠️  SDK TOKEN EXPIRED")
+    print("⚠️  SDK REFRESH TOKEN REJECTED")
     print("=" * 72)
     print()
-    print("Your SDK authentication token has expired or been revoked.")
+    print(f"The AIM server rejected the refresh token at {SDK_CREDENTIALS_FILE}.")
     print()
-    print("This can happen if:")
-    print("  • The token expired (90 days since last use)")
-    print("  • The token was revoked for security reasons")
-    print("  • Another SDK installation rotated the token")
+    print("WHAT HAPPENED:")
+    print("  The SDK rotates its refresh token on every successful refresh")
+    print("  and the server only honors the latest one. The token in your")
+    print("  local file is no longer the latest, which means one of these")
+    print("  happened:")
     print()
-    print("TO FIX:")
-    print(f"  1. Visit: {aim_url}")
-    print("  2. Go to Settings → SDK Downloads")
-    print("  3. Download a fresh Python SDK")
-    print("  4. Extract and install: pip install -e aim-sdk-python/")
+    print("  • Another SDK installation (different machine, different venv)")
+    print("    refreshed the token and now holds the current one.")
+    print("  • A previously bundled SDK download was used elsewhere.")
+    print("  • The token was revoked manually from the dashboard.")
+    print("  • The refresh token reached its 90-day expiry.")
     print()
-    print("Your agents and data are safe! Only SDK credentials need updating.")
+    print("TO RECOVER:")
+    print(f"  1. Remove the stale file:  rm {SDK_CREDENTIALS_FILE}")
+    print(f"  2. Download a fresh SDK from {aim_url} (Settings → SDK Downloads).")
+    print("  3. Extract and install: pip install -e aim-sdk-python/")
+    print()
+    print("Your registered agents are not affected; only the SDK auth")
+    print("credential is rotated. Agent Ed25519 keys are separate and remain")
+    print("valid.")
     print("=" * 72)
     print()

--- a/sdk/python/aim_sdk/exceptions.py
+++ b/sdk/python/aim_sdk/exceptions.py
@@ -28,6 +28,18 @@ class ConfigurationError(AIMError):
     pass
 
 
+class StaleCredentialsError(ConfigurationError):
+    """Raised when cached agent credentials reference an agent that no longer
+    exists in the AIM backend, and re-registration would silently wipe
+    admin-curated state (status, trust score, granted capabilities, MCPs).
+
+    The SDK refuses to auto-re-register; the operator must take an explicit
+    action to recover. The error message includes the local credential path
+    and the recovery steps.
+    """
+    pass
+
+
 class SecretsError(AIMError):
     """Raised when a secrets operation fails"""
     pass

--- a/sdk/python/aim_sdk/oauth.py
+++ b/sdk/python/aim_sdk/oauth.py
@@ -29,11 +29,7 @@ from .credentials import (
     save_sdk_credentials as _save_sdk_credentials_to_module,
     get_sdk_credentials_path,
     print_sdk_credentials_not_found_error,
-    print_wrong_credential_type_error,
     print_token_expired_error,
-    detect_credential_type,
-    CredentialType,
-    SDK_CREDENTIALS_FILE,
 )
 from .security_logging import security_logger, AuthnEventType, CredEventType
 
@@ -142,33 +138,85 @@ class OAuthTokenManager:
         self.access_token: Optional[str] = None
         self.access_token_expiry: Optional[float] = None
 
-        # Use secure storage if available and requested
-        self.use_secure_storage = use_secure_storage and SECURE_STORAGE_AVAILABLE
-        if self.use_secure_storage:
-            self.secure_storage = SecureCredentialStorage(str(self.credentials_path))
-        else:
-            self.secure_storage = None
-            # Handle plaintext fallback based on configuration
-            if use_secure_storage and not SECURE_STORAGE_AVAILABLE:
-                if not allow_plaintext_fallback:
-                    raise RuntimeError(
-                        "❌ SECURITY ERROR: Secure storage is required but not available.\n"
-                        "   Install required packages: pip install cryptography keyring\n"
-                        "   Or set allow_plaintext_fallback=True to use plaintext storage (not recommended)."
-                    )
-                elif SECURE_STORAGE_WARNING:
-                    # Warn user about plaintext storage
-                    import warnings
-                    warnings.warn(SECURE_STORAGE_WARNING, UserWarning, stacklevel=2)
+        # Audit #12: the encrypted shadow file (~/.aim/sdk_credentials.encrypted)
+        # used to be written alongside the JSON file by SecureCredentialStorage.
+        # Every other code path read the JSON only, so the encrypted file was a
+        # write-only secondary store that could drift from the JSON and that
+        # operators had to delete manually to recover from corruption. The JSON
+        # at SDK_CREDENTIALS_FILE (mode 0600) is now the single source of truth.
+        # `use_secure_storage` and `allow_plaintext_fallback` are kept for ABI
+        # stability and ignored; the storage layer is JSON in all configurations.
+        self.use_secure_storage = False
+        self.secure_storage = None
+
+        # One-time migration: if the deprecated encrypted shadow file exists,
+        # decrypt it into the JSON store and delete the orphan. Subsequent
+        # runs find no encrypted file and skip the migration.
+        self._migrate_encrypted_shadow_if_present()
 
         # Load credentials if they exist
         if self._credentials_exist():
             self.load_credentials()
 
+    def _migrate_encrypted_shadow_if_present(self) -> None:
+        """Migrate the deprecated encrypted shadow file (audit #12) to JSON.
+
+        Strategy:
+          - If no encrypted file exists, no-op.
+          - If the secure-storage libs are present, attempt to decrypt and
+            save the contents into the JSON store via the centralized module.
+          - If decryption fails (missing keyring entry, corrupted file), the
+            JSON file is authoritative — log and delete the orphan.
+          - Always delete the encrypted file at the end so subsequent runs
+            skip this branch entirely.
+        """
+        encrypted_path = self.credentials_path.with_suffix(".encrypted")
+        if not encrypted_path.exists():
+            return
+
+        migrated = False
+        decrypt_failed = False
+        if SECURE_STORAGE_AVAILABLE:
+            try:
+                legacy_storage = SecureCredentialStorage(str(self.credentials_path))
+                creds = legacy_storage.load_credentials()
+                if creds:
+                    # Persist BEFORE deleting the encrypted file. If the JSON
+                    # write fails, the encrypted file is left in place so the
+                    # next run can retry — we never delete the only copy of
+                    # credentials we still need.
+                    _save_sdk_credentials_to_module(creds)
+                    print(
+                        f"🔄 Migrated credentials from encrypted shadow file to JSON "
+                        f"single source of truth at {self.credentials_path}."
+                    )
+                    migrated = True
+            except Exception as e:
+                decrypt_failed = True
+                print(
+                    f"⚠️  Could not migrate legacy encrypted credentials at "
+                    f"{encrypted_path} ({e}); leaving the file in place."
+                )
+
+        # Only remove the encrypted file when we either migrated successfully
+        # or we know we cannot decrypt it at all (SECURE_STORAGE_AVAILABLE is
+        # False — the keyring + cryptography libs are gone). If decryption was
+        # attempted and failed (decrypt_failed=True), preserve the file so the
+        # operator can recover manually.
+        should_remove = migrated or (not SECURE_STORAGE_AVAILABLE and not decrypt_failed)
+        if should_remove:
+            try:
+                encrypted_path.unlink()
+                if not migrated:
+                    print(
+                        f"🧹 Removed deprecated encrypted credentials file at "
+                        f"{encrypted_path} (single-source-of-truth migration, audit #12)."
+                    )
+            except Exception:
+                pass
+
     def _credentials_exist(self) -> bool:
-        """Check if credentials exist (encrypted or plaintext)."""
-        if self.secure_storage:
-            return self.secure_storage.credentials_exist()
+        """Check if credentials exist on disk (JSON single source of truth)."""
         return self.credentials_path.exists()
 
     def load_credentials(self) -> bool:
@@ -184,35 +232,11 @@ class OAuthTokenManager:
             True if SDK credentials were loaded successfully
         """
         try:
-            # Try secure storage first
-            if self.secure_storage:
-                creds = self.secure_storage.load_credentials()
-                if creds:
-                    # Validate it's SDK credentials, not agent credentials
-                    cred_type = detect_credential_type(creds)
-                    if cred_type == CredentialType.SDK_OAUTH:
-                        self.credentials = creds
-                        return True
-                    elif cred_type == CredentialType.AGENT:
-                        # Wrong credential type in secure storage - this shouldn't happen
-                        # but handle it gracefully
-                        print_wrong_credential_type_error(cred_type)
-                        return False
-
-            # Use centralized credentials module for discovery and migration
             creds = _load_sdk_credentials_from_module()
             if creds:
                 self.credentials = creds
-                # Migrate to secure storage if available
-                if self.secure_storage:
-                    try:
-                        self.secure_storage.save_credentials(creds)
-                    except Exception:
-                        pass  # Continue even if secure storage fails
                 return True
-
             return False
-
         except Exception as e:
             print(f"⚠️  Warning: Failed to load credentials: {e}")
             return False
@@ -231,19 +255,9 @@ class OAuthTokenManager:
             True if saved successfully
         """
         try:
-            # Use centralized module for proper path and schema
             _save_sdk_credentials_to_module(credentials)
-
-            # Also save to secure storage if available
-            if self.secure_storage:
-                try:
-                    self.secure_storage.save_credentials(credentials)
-                except Exception:
-                    pass  # Continue even if secure storage fails
-
             self.credentials = credentials
             return True
-
         except Exception as e:
             print(f"⚠️  Warning: Failed to save credentials: {e}")
             return False
@@ -429,7 +443,13 @@ class OAuthTokenManager:
                         "new_token_id": new_token_id_full[:8] + "..." if new_token_id_full else None
                     }
                 )
-                print("🔄 Token rotated successfully")
+                # Audit #12: explicit that the prior refresh token is now revoked
+                # server-side so the user understands why an out-of-band copy
+                # (other machine, another venv, bundled SDK) would stop working.
+                print(
+                    "🔄 Token rotated successfully \u2014 old refresh token revoked "
+                    f"(new id: {new_token_id_full[:8] + '...' if new_token_id_full else 'unknown'})"
+                )
 
             # Decode token to get expiry using PyJWT
             if self.access_token:
@@ -500,9 +520,7 @@ class OAuthTokenManager:
             )
 
             # Delete local credentials regardless of server response
-            if self.secure_storage:
-                self.secure_storage.delete_credentials()
-            elif self.credentials_path.exists():
+            if self.credentials_path.exists():
                 self.credentials_path.unlink()
 
             self.credentials = None
@@ -515,43 +533,22 @@ class OAuthTokenManager:
         except Exception as e:
             print(f"⚠️  Warning: Token revocation failed: {e}")
             # Still delete local credentials for safety
-            if self.secure_storage:
-                self.secure_storage.delete_credentials()
-            elif self.credentials_path.exists():
+            if self.credentials_path.exists():
                 self.credentials_path.unlink()
 
             return False
 
 
 def load_sdk_credentials(use_secure_storage: bool = True) -> Optional[Dict[str, Any]]:
+    """Load SDK credentials from the JSON single source of truth.
+
+    Audit #12: the encrypted shadow file was removed as a credential store;
+    OAuthTokenManager performs a one-time migration from any leftover
+    `.encrypted` file. The `use_secure_storage` parameter is preserved for
+    ABI stability but ignored.
+
+    Returns SDK OAuth credentials (refreshToken, sdkTokenId) or None.
+    For agent credentials, use load_agent_credentials() from the
+    credentials module.
     """
-    Load SDK credentials with intelligent discovery and migration.
-
-    This function uses the centralized credentials module which:
-    1. Checks ~/.aim/sdk_credentials.json (new location)
-    2. Migrates from ~/.aim/credentials.json if it contains SDK credentials
-    3. Installs from SDK package if found (fresh download)
-
-    Note: This only returns SDK OAuth credentials (refreshToken, sdkTokenId).
-    For agent credentials, use load_agent_credentials() from the credentials module.
-
-    Args:
-        use_secure_storage: Try encrypted storage first (default: True)
-
-    Returns:
-        SDK credentials dict or None if not found
-    """
-    # Try secure storage first
-    if use_secure_storage and SECURE_STORAGE_AVAILABLE:
-        try:
-            storage = SecureCredentialStorage(str(SDK_CREDENTIALS_FILE))
-            credentials = storage.load_credentials()
-            if credentials:
-                cred_type = detect_credential_type(credentials)
-                if cred_type == CredentialType.SDK_OAUTH:
-                    return credentials
-        except Exception:
-            pass
-
-    # Fall back to centralized credentials module
     return _load_sdk_credentials_from_module()

--- a/sdk/python/tests/test_stale_creds_and_rotation.py
+++ b/sdk/python/tests/test_stale_creds_and_rotation.py
@@ -1,0 +1,236 @@
+"""Regression tests for issues #178 and #174.
+
+#178 (P0): Stale agent credentials must not trigger silent re-registration
+that wipes admin-curated agent state. The SDK raises StaleCredentialsError
+with recovery instructions instead.
+
+#174 (P2):
+  - Token rotation message names the prior token as revoked.
+  - Bundled-SDK install path prints a visible adoption warning.
+  - Encrypted shadow file is migrated to the JSON single source of truth
+    on first OAuthTokenManager instantiation and then deleted.
+  - print_token_expired_error explains the root cause (token rotation),
+    not just "download a fresh SDK".
+"""
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aim_sdk import StaleCredentialsError
+from aim_sdk.credentials import (
+    _install_sdk_credentials,
+    print_token_expired_error,
+)
+import aim_sdk.oauth as oauth_module
+from aim_sdk.oauth import OAuthTokenManager, load_sdk_credentials
+
+
+# ---------------------------------------------------------------------------
+# #178 — silent re-registration is refused
+# ---------------------------------------------------------------------------
+
+
+class TestStaleCredentialsRefusal:
+    """When cached credentials are stale, raise instead of wipe+re-register."""
+
+    def _patch_creds(self):
+        return {
+            "agent_id": "11111111-2222-3333-4444-555555555555",
+            "public_key": "pk",
+            "private_key": "sk",
+            "aim_url": "https://aim.example.com",
+            "status": "verified",
+            "trust_score": 0.92,
+        }
+
+    def test_stale_creds_raise_stale_credentials_error(self):
+        from aim_sdk import register_agent
+
+        with patch("aim_sdk.client._load_credentials", return_value=self._patch_creds()):
+            with patch(
+                "aim_sdk.client._validate_cached_credentials",
+                return_value=(False, "Agent 'demo-agent' (ID: 11111111...) not found in backend"),
+            ):
+                # Patch at the source module so any import path that tries
+                # to call it (lazy or top-level) is caught by mock_delete.
+                with patch("aim_sdk.credentials.delete_agent_credentials") as mock_delete:
+                    with pytest.raises(StaleCredentialsError) as exc_info:
+                        register_agent("demo-agent")
+
+                    mock_delete.assert_not_called()
+                    msg = str(exc_info.value)
+                    assert "demo-agent" in msg
+                    assert "11111111" in msg
+                    assert "wipe" in msg.lower() or "admin" in msg.lower()
+                    assert "rm" in msg
+                    assert "agents/demo-agent.json" in msg
+
+    def test_stale_credentials_error_subclasses_configuration_error(self):
+        from aim_sdk import ConfigurationError
+
+        assert issubclass(StaleCredentialsError, ConfigurationError)
+
+
+# ---------------------------------------------------------------------------
+# #174 — visible bundled-SDK install warning
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSdkCredentialsWarning:
+    def test_install_prints_adopting_warning_with_truncated_token(self, tmp_path):
+        creds = {
+            "aimUrl": "https://aim.example.com",
+            "sdkTokenId": "abcdefghij1234567890",
+            "refreshToken": "rt-xyz",
+            "email": "u@example.com",
+            "schemaVersion": "1.0",
+        }
+        with patch("aim_sdk.credentials.SDK_CREDENTIALS_FILE", tmp_path / "sdk_credentials.json"):
+            with patch("aim_sdk.credentials.save_sdk_credentials", return_value=True) as mock_save:
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    _install_sdk_credentials(creds)
+
+                out = buf.getvalue()
+                assert "Adopting SDK credentials from bundled package" in out
+                # Truncated token id (first 8 chars + ellipsis), full token not echoed.
+                assert "abcdefgh..." in out
+                assert "abcdefghij1234567890" not in out
+                mock_save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# #174 — print_token_expired_error explains root cause
+# ---------------------------------------------------------------------------
+
+
+class TestTokenExpiredErrorWording:
+    def test_error_names_rotation_and_shows_path(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_token_expired_error("https://aim.example.com")
+        out = buf.getvalue()
+
+        assert "REFRESH TOKEN REJECTED" in out
+        assert "rotates" in out.lower()
+        # Surfaces the local path so recovery is obvious instead of vague.
+        assert "sdk_credentials.json" in out
+        assert "rm " in out
+        # Still includes the dashboard URL for the re-download step.
+        assert "https://aim.example.com" in out
+
+
+# ---------------------------------------------------------------------------
+# #174 — encrypted shadow file is migrated and removed
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptedShadowMigration:
+    def test_orphan_encrypted_file_deleted_when_decrypt_unavailable(self, tmp_path, monkeypatch):
+        """If SECURE_STORAGE_AVAILABLE is False, the encrypted shadow file
+        is treated as an orphan and removed; the JSON store is untouched."""
+        json_path = tmp_path / "sdk_credentials.json"
+        encrypted_path = tmp_path / "sdk_credentials.encrypted"
+        encrypted_path.write_bytes(b"opaque-bytes-cant-decrypt-without-libs")
+
+        monkeypatch.setattr(oauth_module, "SECURE_STORAGE_AVAILABLE", False)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            mgr = OAuthTokenManager(credentials_path=str(json_path))
+
+        assert not encrypted_path.exists(), "encrypted shadow file must be removed"
+        assert mgr.secure_storage is None
+        out = buf.getvalue()
+        assert "Removed deprecated encrypted credentials file" in out
+        assert "audit #12" in out
+
+    def test_encrypted_file_preserved_when_decrypt_fails(self, tmp_path, monkeypatch):
+        """Safety: if the secure-storage libs are present but decryption
+        raises (corrupt file, missing keyring entry), the encrypted file is
+        LEFT IN PLACE so the operator can recover manually. Deleting it
+        would discard the only copy of the credentials."""
+        json_path = tmp_path / "sdk_credentials.json"
+        encrypted_path = tmp_path / "sdk_credentials.encrypted"
+        encrypted_path.write_bytes(b"corrupted-ciphertext")
+
+        monkeypatch.setattr(oauth_module, "SECURE_STORAGE_AVAILABLE", True)
+
+        class _ExplodingStorage:
+            def __init__(self, *_a, **_kw):
+                raise RuntimeError("keyring entry missing")
+
+        monkeypatch.setattr(oauth_module, "SecureCredentialStorage", _ExplodingStorage)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            OAuthTokenManager(credentials_path=str(json_path))
+
+        assert encrypted_path.exists(), (
+            "encrypted file must be preserved when decryption fails so the "
+            "operator can recover manually"
+        )
+        assert "leaving the file in place" in buf.getvalue()
+
+    def test_no_op_when_no_encrypted_file(self, tmp_path, monkeypatch):
+        json_path = tmp_path / "sdk_credentials.json"
+        # Pre-existing JSON should remain in place; migration is a no-op.
+        sample = {
+            "aimUrl": "https://aim.example.com",
+            "refreshToken": "rt-existing",
+            "sdkTokenId": "tokenid-1",
+            "schemaVersion": "1.0",
+        }
+        json_path.write_text(json.dumps(sample))
+
+        # Patch the module's loader so init's load_credentials() finds the JSON.
+        monkeypatch.setattr(
+            oauth_module,
+            "_load_sdk_credentials_from_module",
+            lambda: sample,
+        )
+        monkeypatch.setattr(oauth_module, "SECURE_STORAGE_AVAILABLE", False)
+
+        mgr = OAuthTokenManager(credentials_path=str(json_path))
+
+        assert json_path.exists()
+        assert mgr.credentials == sample
+
+
+# ---------------------------------------------------------------------------
+# #174 — module-level load_sdk_credentials ignores use_secure_storage
+# ---------------------------------------------------------------------------
+
+
+class TestModuleLevelLoaderIgnoresLegacyParam:
+    def test_param_is_a_no_op(self, monkeypatch):
+        sentinel = {"refreshToken": "rt", "sdkTokenId": "id", "schemaVersion": "1.0"}
+        monkeypatch.setattr(
+            oauth_module,
+            "_load_sdk_credentials_from_module",
+            lambda: sentinel,
+        )
+        assert load_sdk_credentials(use_secure_storage=True) == sentinel
+        assert load_sdk_credentials(use_secure_storage=False) == sentinel
+
+
+# ---------------------------------------------------------------------------
+# #174 — rotation message names the prior token as revoked
+# ---------------------------------------------------------------------------
+
+
+class TestRotationMessageWording:
+    """Driving the full refresh path requires mocking JWT decoding, server
+    responses, and credential persistence; the wording is a one-line
+    user-visible contract and asserting on the source guarantees it ships."""
+
+    def test_rotation_print_says_old_token_revoked(self):
+        oauth_src = Path(oauth_module.__file__).read_text()
+        assert "old refresh token revoked" in oauth_src, (
+            "Audit #12: rotation print must name the prior refresh token as revoked"
+        )


### PR DESCRIPTION
## Summary

Bundles two SDK credential-handling defects from the LF demo audit doc into a single PR (both fixes live in `sdk/python/aim_sdk/`).

- **#178 (P0)**: silent re-registration on stale agent credentials wiped admin-curated state (status, trust score, granted capabilities, MCP grants). `register_agent()` now raises `StaleCredentialsError` (subclass of `ConfigurationError`) with the local file path and an explicit `rm <path>` recovery step — re-registration becomes an explicit operator action. The bundled-SDK install path also now prints a visible "Adopting SDK credentials from bundled package" warning so operators see when stale bundled tokens enter the home store.
- **#174 (P2)**: the encrypted shadow file `~/.aim/sdk_credentials.encrypted` is removed as a storage layer. JSON at `SDK_CREDENTIALS_FILE` (mode 0600) is the single source of truth. `OAuthTokenManager` performs a one-time migration on first instantiation: leftover `.encrypted` files are decrypted into JSON and deleted, OR — if decryption fails — preserved in place so the operator can recover manually (never delete the only copy of credentials). Token rotation print now reads `Token rotated successfully — old refresh token revoked (new id: <prefix>...)`, and `print_token_expired_error` explains rotation as the root cause and surfaces the local path.

Source: `todo/2026-05-18-aim-defect-audit-from-lf-demo-prep.md` § 12 and § 37.

## API change

- New: `aim_sdk.StaleCredentialsError` (subclass of `ConfigurationError`).
- Re-exported: `aim_sdk.ConfigurationError`.
- `OAuthTokenManager(use_secure_storage=..., allow_plaintext_fallback=...)` — parameters preserved for ABI stability and ignored. The same applies to the module-level `load_sdk_credentials(use_secure_storage=...)`.

## Tests

9 new regression tests in `tests/test_stale_creds_and_rotation.py`:

- Stale creds raise `StaleCredentialsError` and do NOT call `delete_agent_credentials` from any import path.
- `StaleCredentialsError` subclasses `ConfigurationError`.
- `_install_sdk_credentials` prints the adoption warning with a truncated token id and never echoes the full token.
- `print_token_expired_error` names rotation as the cause, surfaces the local path, and gives a runnable `rm` command.
- Encrypted orphan file is deleted on init when the secure-storage libs are not available.
- **Safety**: encrypted file is PRESERVED when decryption fails (corrupt file / missing keyring entry) so the operator can recover manually.
- No-op when no encrypted file is present.
- Module-level `load_sdk_credentials` ignores the deprecated `use_secure_storage` parameter.
- Source-level assertion that the rotation print includes "old refresh token revoked".

Full SDK suite: **371 passing**, 3 pre-existing failures unrelated to this PR (documented in handoff: `test_load_sdk_credentials_returns_none_for_missing_file`, `test_register_agent_existing_credentials`, `test_secure_existing_credentials` — all about `oauth_token_manager` being non-None when tests expected None, confirmed present on `main` before this work).

## Pre-push gate

Full `/pre-push-review` ran:

- Phase 1 (sensitive files): PASS — no sensitive paths in diff.
- Phase 2 (build/test/lint): PASS — 371 + 9 new tests pass; remaining oauth.py lint warnings are pre-existing (json/os/AuthenticationError/print_sdk_credentials_not_found_error were already unused before this diff).
- Phase 3 (AI code review): PASS — self-review caught a data-loss window where the migration would delete the encrypted file after a successful decrypt even if the JSON write failed; the migration now persists JSON first and only removes the encrypted file when migration succeeds OR no decryption was possible. Added a regression test for the preserve-on-decrypt-failure path.
- Phase 4 (HMA scan): PASS for this diff. The initial scan flagged a CRITICAL `Invisible Unicode Codepoints Detected` (variation selector U+FE0F on `ℹ️` in the new install warning) — replaced with a plain `INFO:` prefix, which also aligns with the global "no emojis in code" rule. The two remaining HIGH findings (`Predictable /tmp path without mktemp` in `examples/flight-search-agent/prep-stage.sh`) are pre-existing carry-over noted in the prior session handoff — that file is untracked locally and outside this PR's scope (will be addressed in a follow-up "fix demo scripts" PR).
- Phase 4.5 (adversarial review): SKIP — no detection/scanner/scoring code touched.
- Phase 5 (hma-hunter): SKIP — SDK is a client library, not an API/server.
- Phase 6 (new-user walkthrough): PASS — new user-facing prints are specific, actionable, CISO-readable.
- Phase 7 (docs): PASS — CHANGELOG `[Unreleased]` updated; README current.

## Out of scope

- The deeper architectural fix (audit defect #1: route SDK registration through `CapabilityRequestService` so re-registration cannot mutate granted state) — explicitly deferred by the audit doc.
- No version bump; will batch with future SDK fixes per the 3-publishes/day cap noted in the handoff.

## Test plan

- [x] `cd sdk/python && pytest tests/test_stale_creds_and_rotation.py -v` — 9 new tests pass.
- [x] `cd sdk/python && pytest` — 371 pass, 34 skipped, 3 pre-existing failures deselected.
- [x] `npx hackmyagent secure --ci` — 82/100, zero CRITICAL/HIGH in this PR's scope.
- [ ] Reviewer: spot-check the `StaleCredentialsError` message text renders correctly with a real agent name + URL.
- [ ] Reviewer: confirm CHANGELOG `[Unreleased]` entries are accurate.

Closes #178
Closes #174