### PR TITLE
chore(prep-stage): read admin password from AIM_ADMIN_PASSWORD env var

### DIFF
--- a/examples/flight-search-agent/prep-stage.sh
+++ b/examples/flight-search-agent/prep-stage.sh
@@ -25,9 +25,15 @@ trap 'rm -rf "$WORKDIR"' EXIT
 ./reset-demo.sh
 
 echo "Minting a fresh SDK refresh token (the existing one may have been rotated)..."
+# Match the same env-var-with-fallback pattern used by scripts/test_a2a_e2e.py
+# and the docs (docs/quick-start.md, docs/guides/QUICK_START.md). Local-dev
+# default is the pre-B2 admin password; set AIM_ADMIN_PASSWORD in the operator
+# environment when the dev stack has been rotated.
+ADMIN_PASSWORD="${AIM_ADMIN_PASSWORD:-AIM2025!Secure}"
+LOGIN_PAYLOAD=$(ADMIN_PASSWORD="$ADMIN_PASSWORD" python3 -c "import json,os; print(json.dumps({'email':'admin@opena2a.org','password':os.environ['ADMIN_PASSWORD']}))")
 TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/public/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@opena2a.org","password":"AIM2025!Secure"}' \
+  -d "$LOGIN_PAYLOAD" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")
 if [ -z "$TOKEN" ]; then
   echo "ERROR: admin login failed. Check backend health on localhost:8080."


### PR DESCRIPTION
## Summary

Follow-up to #214. The hardened `prep-stage.sh` still inlined the well-known local-dev admin password `AIM2025!Secure` (the `aim-bootstrap --default` default on pre-B2 stacks — documented with "rotate immediately" annotations across 6 docs). This was intended to be part of #214 but the auto-merge fired on the first commit before the password fix landed.

Match the pattern already used by `scripts/test_a2a_e2e.py:196` (`os.environ.get("ADMIN_PASSWORD", "AIM2025!Secure")`) and `apps/backend/tests/integration/test_helper.go:33`:

```bash
ADMIN_PASSWORD="${AIM_ADMIN_PASSWORD:-AIM2025!Secure}"
```

JSON payload is built via `python3 -c` with the password in an env var rather than direct shell-string interpolation, so a future rotated password containing JSON-meaningful characters (quote, backslash) cannot corrupt the request body.

## Not a leaked-secret issue

`AIM2025!Secure` is a documented bootstrap default, not a production secret. Every reference in the repo is annotated with "rotate immediately." This PR is convention cleanup — bringing the only inline copy in line with the env-var-with-fallback pattern used elsewhere — not a credential rotation.

## Test plan

- [x] `bash -n examples/flight-search-agent/prep-stage.sh` — syntax OK.
- [x] `npx hackmyagent secure --ci` — 100/100.
- [ ] Reviewer: confirm the JSON-via-`python -c` indirection is preferred over `printf '{"password": "%s"}' "$ADMIN_PASSWORD"` (it survives passwords containing quote/backslash/control chars; the printf form does not).