### PR TITLE
docs(#134): document MCP attestation lifecycle; disclaim 7-day re-scan claim

### DIFF
--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -379,6 +379,36 @@ View all MCP servers with:
 
 ---
 
+## Attestation Lifecycle and Expiry
+
+The attestation lifecycle has three timeframes, none of which trigger an automatic vulnerability re-scan. Re-attestation is **client-driven on use**, not server-cron-driven.
+
+### Server-side TTLs
+
+| Object | TTL | Behavior at expiry |
+|---|---|---|
+| Attestation challenge nonce | 5 minutes | Rejected as `attestation expired` to prevent replay attacks (`mcp_attestation_service.go:483`) |
+| SDK MCP attestation record | 30 days from `verified_at` | Record stays in `mcp_attestations` for history; `is_valid` returns false; the server does NOT automatically queue a re-scan (`mcp_attestation_service.go:504`) |
+| Manual MCP attestation record | 90 days from `verified_at` | Same — history retained, `is_valid` false, no auto re-scan (`mcp_attestation_service.go:1247`) |
+
+No background goroutine in `cmd/server/main.go` walks `mcp_attestations` to mark expired rows or to invoke a re-scan against HackMyAgent. The only periodic cleanup job (`startExpirationCleanupJob`, runs every 5 minutes) operates on `verification_events`, not MCP attestations.
+
+### Client-side refresh interval
+
+The SDK's `AttestationCache` (`sdk/python/aim_sdk/attestation_cache.py:48`) uses `DEFAULT_TTL_HOURS = 24`. On every MCP tool invocation through `use_mcp_tool()`, the SDK checks the cache and re-attests if the cached attestation is older than 24 hours. This is what makes an ACTIVELY USED MCP server effectively re-attested every day; an MCP server that is registered but not invoked sits at its last attestation until the server-side TTL above lapses.
+
+### The 7-day window in the confidence score
+
+A 7-day window does appear in the attestation code, but it is a **recency factor in the confidence-score calculation**, not an expiry trigger. The "recency" component awards points based on the fraction of an MCP server's attestations that fall within the last 7 days (`mcp_attestation_service.go:617`). A server whose most recent attestations are all older than 7 days simply scores lower on the recency axis; it is not invalidated, and no scan is queued.
+
+### Vulnerability discovery is independent of the attestation lifecycle
+
+The attestation flow asserts that an agent currently holds a private key matching an MCP server's public key — it does not, by itself, scan the MCP server for new CVEs in its dependencies. CVE discovery against an MCP server is the job of HackMyAgent / the supply-chain scanner; the attestation lifecycle does not currently invoke it. Treat "re-attestation" and "re-scan" as separate primitives, not as the same cycle.
+
+If your operational requirement is "every MCP server gets a fresh vulnerability scan every N days," that needs to be a separate scheduled job that calls into HackMyAgent — it is not implied by the attestation TTLs above.
+
+---
+
 ## Auto-Attestation
 
 The SDK can automatically create attestations when you use MCP tools, requiring zero manual intervention:


### PR DESCRIPTION
## Summary

#134 asked to verify whether the deck's claim that "continuous re-attestation: 7-day credential expiry forces re-scan as a hygiene primitive" is backed by code, and to document the actual behavior or soften the claim if it is not.

A code walk found that none of the three sub-claims match what the backend actually does:

| Claim | Reality |
|---|---|
| "7-day credential expiry" | SDK attestations expire 30 days from `verified_at`; manual attestations 90 days. No 7-day TTL exists. The only 7-day window is the recency factor in the confidence-score calc. |
| "forces re-scan" | No background goroutine walks `mcp_attestations` or invokes HackMyAgent. The only periodic job in `cmd/server/main.go` is `startExpirationCleanupJob` (5-min ticker) and it operates on `verification_events`, not MCP attestations. |
| "new CVEs surface within the cycle" | The attestation flow proves current possession of an MCP server's private key. It does not scan for CVEs in the server's dependencies — that is HackMyAgent's job and is not chained to the attestation lifecycle. |

Adds a new "Attestation Lifecycle and Expiry" section to `docs/integrations/mcp.md` documenting the actual mechanism: 5-minute challenge TTL, 30-day SDK attestation TTL, 90-day manual TTL, the 7-day recency factor's actual role in scoring, the SDK's 24-hour client-driven re-attestation interval (`DEFAULT_TTL_HOURS = 24`), and an explicit disclaimer that vulnerability discovery is not implied by the attestation lifecycle.

Every claim in the new section is anchored to a file:line citation that was verified against current code at commit time.

## Out of scope (deferred)

Building a real 7-day server-side re-scan cron (the implementation that would make the deck claim true) would require:

- A new background goroutine in `cmd/server/main.go` modeled on `startExpirationCleanupJob`
- A new MCP rescan API path that calls into HackMyAgent
- A policy for what to do when a scan finds new CVEs (alert? auto-degrade trust? auto-revoke attestation?)
- Org-scoped configurability of the cycle length

That is feature work and a `[CHIEF-CA]` decision (policy on degrade/revoke). This PR is the honest documentation of current state.

## Test plan

- [x] All four `mcp_attestation_service.go:<line>` citations in the new section were verified against current `main` (post-#214) and resolve to the claimed code.
- [x] `npx hackmyagent secure --ci` → 100/100.
- [x] SDK test suite remains at 372 passing.
- [ ] Reviewer: confirm the slide deck text should ALSO be revised (the deck lives in a separate repo / asset and is out of scope for this PR).
- [ ] Reviewer: if you want the cron built rather than the claim documented, flag it and I'll open a `[CHIEF-CA]` proposal as a follow-up.

Closes #134