### PR TITLE
docs(#133): document MCP pre-connection scan; disclaim what AIM does not do

### DIFF
--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -167,6 +167,42 @@ print(f"   Status: {result['status']}")
 
 ---
 
+## Registration Verification and Pre-Connection Scans
+
+What AIM does at MCP-server registration is a process check, not a vulnerability scan against the server itself.
+
+### Registration paths
+
+| Registered via | `status` | `is_verified` | `trust_score` | `verification_method` |
+|---|---|---|---|---|
+| SDK (agent-authenticated) | `verified` | `true` | `75` | `sdk_registration` |
+| Manual / dashboard | `pending` | `false` | `0` | `manual` (admin must click Verify) |
+
+The SDK-registration auto-verify is set in `mcp_service.go:208-239` and is not the result of an external scan — it is a trust assumption that the calling agent has already proved its own identity through OAuth. Manual registrations stay pending until an admin acts on them in the dashboard.
+
+### What AIM does NOT do at registration time
+
+- It does NOT invoke HackMyAgent against the MCP server URL. There are zero `hackmyagent` / `HackMyAgent` references anywhere under `apps/backend/`.
+- It does NOT pull the MCP server's own SOUL.md / agent-card.json / capabilities.json for static review.
+- It does NOT block subsequent calls based on `mcp_servers.is_verified = false`. The FGA engine (`apps/backend/internal/application/fga_engine.go`) has zero references to MCP-side `is_verified` / `isVerified` / `IsVerified` — authorization decisions read the AGENT's `agent_security_contexts.scan_verdict`, not the MCP's verification status.
+- It does NOT populate a `scanSummary` field on the agent or the MCP. `scanSummary` exists in exactly one place — `apps/backend/internal/domain/registry_contribution.go:11`, where it is part of the payload AIM publishes UPSTREAM to the public Registry via `registry_bridge_service.go`. It is registry export telemetry, not a per-call gate.
+
+### What "pre-connection" actually means in current AIM
+
+The closest current AIM gets to a pre-connection check is the cryptographic attestation flow described in [How Attestation Works](#how-attestation-works) — the agent proves it currently holds a private key that matches the MCP server's registered public key. That confirms the MCP is the same MCP, but it does not confirm anything about the MCP's own dependencies, vulnerabilities, or configuration.
+
+If your operational requirement is "no agent talks to an MCP that has not been scanned by HackMyAgent within the last N days," that needs to be a separate primitive that:
+
+1. Calls into HackMyAgent against the MCP's deployable surface (URL, repo, or container image).
+2. Writes the result to a new column (`mcp_servers.last_scan_verdict`, or a new `mcp_scan_results` table).
+3. Gates `agents.talks_to` or the FGA `verify_capability` path on that field.
+
+None of these exist today. Building them is a `[CHIEF-CA]` decision because it requires committing to a specific HMA-AIM integration surface and a policy for what to do when a scan finds new CVEs (alert? auto-degrade trust? auto-revoke verification?).
+
+Until then, the honest framing for the registration story is: **AIM verifies the agent that registers an MCP, not the MCP itself.**
+
+---
+
 ## Listing MCP Servers
 
 List all MCP servers registered with AIM for your organization.


### PR DESCRIPTION
## Summary

#133 asked whether the deck's claim that "AIM scans the MCP server before allowing the agent to connect, and scan results land in the agent's `scanSummary` field" is backed by code, and to document the actual behavior or soften the claim.

A code walk found that all three sub-claims are not what current AIM does:

| Claim | Reality |
|---|---|
| "AIM scans the MCP server" | Zero `hackmyagent` / `HackMyAgent` references anywhere under `apps/backend/`. The backend does not invoke HMA against MCP server URLs, repos, or images at any point. |
| "before allowing the agent to connect" | The FGA engine has zero references to MCP-side `is_verified`. Authorization reads the agent's `agent_security_contexts.scan_verdict`, not the MCP's verification status. An MCP with `is_verified = false` does not block `verify_capability`. |
| "scanSummary field on the agent" | `scanSummary` exists in exactly one location: `apps/backend/internal/domain/registry_contribution.go:11`. It is the payload AIM publishes UPSTREAM to the public Registry via `registry_bridge_service.go` — registry export telemetry, not a per-call gate. |

Adds a "Registration Verification and Pre-Connection Scans" section to `docs/integrations/mcp.md` documenting what actually happens at MCP registration:

- **SDK registration**: auto-verify with `status=verified`, `is_verified=true`, `trust_score=75`, `verification_method=sdk_registration` (`mcp_service.go:208-239`). This is a trust assumption — the calling agent has already proved its OAuth identity — not the result of a scan.
- **Manual registration**: stays `pending` / `is_verified=false` until an admin clicks Verify in the dashboard.

Plus an explicit disclaimer naming what AIM does NOT do (no HMA invocation, no `is_verified` gate at FGA, no per-agent `scanSummary` field), and the framing that the cryptographic attestation flow proves an MCP is the same MCP — not that it is safe.

Every claim is anchored to a file:line citation that was verified against current `main` at commit time.

## Out of scope (deferred)

Building real pre-connection scanning would require:

1. HMA → AIM scan invocation on registration (and presumably on a periodic refresh)
2. A new column (`mcp_servers.last_scan_verdict`) or a new `mcp_scan_results` table
3. FGA gate on the field
4. Policy for what to do when a scan finds new CVEs (alert? auto-degrade trust? auto-revoke verification?)

That is feature work and a `[CHIEF-CA]` decision because of the degrade/revoke policy. Same shape of follow-up as #134 (the 7-day re-attestation cron). Worth scoping together if either gets prioritized.

## Test plan

- [x] All file:line citations resolve against current `main`: `mcp_service.go:208`, `mcp_service.go:239`, `domain/registry_contribution.go:11`.
- [x] `grep -rln "hackmyagent\|HackMyAgent" apps/backend/ --include="*.go"` → empty.
- [x] `grep -n "is_verified\|isVerified\|IsVerified" apps/backend/internal/application/fga_engine.go` → empty.
- [x] `npx hackmyagent secure --ci` → 100/100.
- [x] SDK suite 372 passing.
- [ ] Reviewer: confirm the slide deck text should also be revised (deck is in a separate asset, out of scope for this PR).
- [ ] Reviewer: if you want HMA integration built instead of the claim documented, flag and I'll open a `[CHIEF-CA]` proposal alongside #134's twin.

Closes #133