### PR TITLE
docs(#135): align SECURITY.md compliance claims to actual enforcement

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,16 +129,33 @@ We conduct regular security assessments:
 
 ## Enterprise Compliance
 
+AIM is pre-1.0 (see the disclosure at the top of this file). This section maps each compliance claim to the code that backs it today, and flags claims that are partial or aspirational so consumers can plan around the actual enforcement boundary. Items marked **Partial** or **Roadmap** are tracked openly in [HARDENING.md](HARDENING.md).
+
 ### SOC 2 Type II Alignment
 
-| Control Area | Implementation |
-|--------------|----------------|
-| CC6.1 Logical Access | RBAC, JWT authentication, API key scoping |
-| CC6.6 System Boundaries | Network segmentation, CORS, rate limiting |
-| CC6.7 Data Classification | Credential encryption, log sanitization |
-| CC6.8 Data Retention | Configurable retention, secure deletion |
-| CC7.1 Configuration Management | Environment variables, no hardcoded secrets |
-| CC7.2 Change Management | Git history, audit logs |
+| Control Area | Status | Implementation today | Notes |
+|---|---|---|---|
+| CC6.1 Logical Access | Enforced | RBAC, JWT authentication, API key scoping | |
+| CC6.3 Privileged Access | Partial | `RiskLevel` constants on capabilities (`apps/backend/internal/domain/capability.go` Low/Medium/High/Critical) gate approval requirements via `CapabilityRequestService` | The SDK registration path can still grant capabilities directly without routing through the approval workflow. See HARDENING.md "Capability lifecycle." |
+| CC6.6 System Boundaries | Enforced | Network segmentation, CORS, rate limiting | |
+| CC6.7 Data Classification | Partial | Credential encryption (Fernet + system keyring on the SDK side; AES-256-GCM at rest on the backend) | "Log sanitization" is per-event truncation of token IDs, not a tested PII redaction pipeline — treat as best-effort. |
+| CC6.8 Data Retention | Partial | `ComplianceService.GetDataRetentionStatus` exposes the configured retention policy (`apps/backend/internal/application/compliance_service.go:458`) | No background job currently enforces the policy via row-level deletion; values are reported, not yet swept. |
+| CC7.1 Configuration Management | Partial | Environment-variable-driven config | Several required secrets currently fall back to weak defaults when unset. Removing those defaults is HARDENING.md "Bootstrap secrets and configuration." |
+| CC7.2 Change Management | Enforced | Git history; `audit_logs` table records every privileged action | |
+
+### Frameworks beyond SOC 2
+
+The product narrative also references ISO 27001, NIST SP 800-53, FedRAMP, EU AI Act, and the OWASP Agentic Top 10. The honest status of those mappings is:
+
+| Framework / control | Status | What is true today |
+|---|---|---|
+| ISO 27001 A.9.2.3 (Privileged Access Management) | Partial | JIT capability grants exist (`apps/backend/internal/application/capability_request_service.go`, with `RiskLevel`-gated approval and TTLs). In **strict** enforcement mode, high-risk requests require admin approval. In **monitoring** mode (the default), the same requests auto-approve and emit an audit row — useful for visibility, not equivalent to PAM. The A.9.2.3 framing is accurate only when the org is in strict mode AND when the SDK registration path also routes through the approval workflow (HARDENING.md "Capability lifecycle"). |
+| NIST SP 800-53 AC-6 (Least Privilege) | Partial | FGA enforces capability allowlists with wildcard prefix matching (`apps/backend/internal/application/fga_engine.go`). The `capability_scope` JSONB column on `agent_capabilities` is persisted at grant time but not consumed by the matcher today, so attribute-level scoping ("read only these columns") is plumbed but not enforced. Tracked separately in #130. |
+| FedRAMP AC-2 / AU-9 (Account Management / Audit Protection) | Roadmap | The `audit_logs` table records actions and is access-controlled, but is not append-only at the database layer and is not cryptographically signed. AU-9's "protection of audit information" requirement is partially met by RBAC; it is not met by a tamper-evident signing scheme. We do not claim FedRAMP authorization. |
+| EU AI Act Article 14 (Human Oversight) | Partial | Approval gates exist for capability requests, and in **strict** enforcement mode high-risk operations require human review before grant. The Article 14 framing is accurate only in that mode; in monitoring mode the human-oversight gate is observational, not blocking. |
+| OWASP Agentic Top 10 | Roadmap | We are working with the OASB community on a per-scenario mapping document. The current AIM enforcement primitives (capability authorization, trust scoring, FGA, audit trail) cover the agentic-identity portion of the threat space; a published one-to-one OWASP-to-AIM mapping is not yet in this repo. |
+
+If you are evaluating AIM against a specific certification, please read [HARDENING.md](HARDENING.md) alongside this section. We do not claim certification under any of the frameworks above today; we describe where AIM's primitives align and where they do not.
 
 ### GDPR Compliance
 


### PR DESCRIPTION
## Summary

#135 asked us to cross-check every compliance claim in SECURITY.md and the broader product story against current implementation, keep cells that match (with citations), move partial cells to a roadmap with HARDENING.md cross-refs, and remove cells that have no implementation today.

This PR does that for SECURITY.md (the slide deck is in a separate asset and is out of scope here; flagged below for follow-up).

### Changes to SOC 2 table

Added a Status column with three values:

| Status | Meaning |
|---|---|
| **Enforced** | Implemented today; matches the control intent |
| **Partial** | Implemented today but with a known gap; HARDENING.md stream is open |
| **Roadmap** | Architecture supports it, no current enforcement; not yet a controlled commitment |

Result:

- **Enforced**: CC6.1, CC6.6, CC7.2
- **Partial**: CC6.3 (Capability lifecycle stream — SDK auto-grant bypasses approval), CC6.7 (log sanitization is best-effort), CC6.8 (retention reported but not yet swept), CC7.1 (Bootstrap secrets default-fallback stream)
- CC6.3 is newly explicit; it was implicit before but is one of the deck's most-load-bearing claims

### New "Frameworks beyond SOC 2" subsection

The product story references ISO 27001, NIST SP 800-53, FedRAMP, EU AI Act, and OWASP Agentic Top 10. Adds a small table with honest status for each:

- **ISO 27001 A.9.2.3 — Partial.** JIT/PAM is real, equivalent in **strict** mode + once HARDENING.md "Capability lifecycle" lands.
- **NIST AC-6 — Partial.** FGA allowlist enforcement works; `capability_scope` JSONB is plumbed but not consumed by the matcher (#130).
- **FedRAMP AC-2 / AU-9 — Roadmap.** `audit_logs` is access-controlled but not append-only at DB layer and not cryptographically signed; AU-9's tamper-evidence requirement is not met. Explicit "we do NOT claim FedRAMP authorization."
- **EU AI Act Article 14 — Partial.** Approval gates block only in strict mode; in monitoring mode they're observational.
- **OWASP Agentic Top 10 — Roadmap.** Per-scenario mapping document not yet in repo.

Closing line: **"We do not claim certification under any of the frameworks above today; we describe where AIM's primitives align and where they do not."**

### File:line citations verified

All references in the new content resolve against current main at commit time:

- `apps/backend/internal/domain/capability.go` (RiskLevel constants)
- `apps/backend/internal/application/capability_request_service.go`
- `apps/backend/internal/application/fga_engine.go`
- `apps/backend/internal/application/compliance_service.go:458` (`GetDataRetentionStatus`)
- `HARDENING.md` streams (Capability lifecycle, Bootstrap secrets)

### Out of scope

- **The slide deck itself.** The deck's specific control numbers (CC6.3, A.9.2.3, AC-6, AC-2/AU-9, Article 14) should be revised to match this section the next time the deck is edited. The deck is a separate asset and not in this repo.
- **Building any missing enforcement.** Cryptographic audit-log signing (FedRAMP AU-9), capability_scope evaluation in FGA (#130), capability lifecycle routing through the approval workflow (HARDENING.md), and a published OWASP Agentic Top 10 mapping each warrant separate decisions/PRs. Wiring them up is `[CHIEF-CA]` territory because the "what counts as enforcement" answer materially affects what we can claim.

## Test plan

- [x] All file:line citations in the new content resolve against current `main`.
- [x] `npx hackmyagent secure --ci` → 100/100.
- [x] SDK test suite 372 passing.
- [ ] Reviewer: confirm the Status column granularity (Enforced/Partial/Roadmap) is the right vocabulary, or rename uniformly.
- [ ] Reviewer: confirm the deck text should be revised to match (separate asset).
- [ ] Reviewer: if any of the Partial → Enforced upgrades should be a sprint commitment, flag and I'll open the `[CHIEF-CA]` proposal.

Closes #135