### PR TITLE
refactor(fga): Phase 1 ATC to ATX, prefer atx_trust_level with fallback

### DIFF
--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -127,11 +127,18 @@ type FGAPolicy struct {
 }
 
 // ASCRiskSummary is the cached risk view from the Registry ASC.
+//
+// Phase 1 of the ATC to ATX rename: both ATCTrustLevel and
+// ATXTrustLevel carry the SAME value, populated from
+// COALESCE(atx_trust_level, atc_trust_level) on the database row.
+// New code should read ATXTrustLevel; legacy code reading ATCTrustLevel
+// continues to work. Phase 3 will drop ATCTrustLevel.
 type ASCRiskSummary struct {
 	OverallRisk   string  `json:"overallRisk"`
 	DriftScore    float64 `json:"driftScore"`
 	ActiveAlerts  int     `json:"activeAlerts"`
 	ATCTrustLevel int     `json:"atcTrustLevel"`
+	ATXTrustLevel int     `json:"atxTrustLevel"`
 	ScanVerdict   string  `json:"scanVerdict"`
 }
 
@@ -969,15 +976,24 @@ func (e *FGAEngine) loadPolicy(ctx context.Context, agentID uuid.UUID, capabilit
 // In production, this reads from a local Redis cache populated by the Registry.
 // If no local cache is available, returns nil (fail open -- context rules skip).
 func (e *FGAEngine) fetchASCRiskSummary(ctx context.Context, agentID uuid.UUID) *ASCRiskSummary {
-	// Read from local DB if available (the ASC table is replicated locally)
+	// Read from local DB if available (the ASC table is replicated locally).
+	// COALESCE(atx_trust_level, atc_trust_level) handles the Phase 1
+	// transition window: opena2a-registry migration 231 added the
+	// atx_trust_level column with NULL defaults, and Phase 2 writers
+	// will populate it. Until then atx_trust_level is NULL and the
+	// fallback to atc_trust_level keeps the FGA engine working.
 	if e.db != nil {
 		var summary ASCRiskSummary
+		var trustLevel int
 		err := e.db.QueryRowContext(ctx,
-			`SELECT overall_risk, drift_score, active_alerts, atc_trust_level, scan_verdict
+			`SELECT overall_risk, drift_score, active_alerts,
+			        COALESCE(atx_trust_level, atc_trust_level), scan_verdict
 			 FROM agent_security_contexts WHERE agent_id = $1`, agentID,
 		).Scan(&summary.OverallRisk, &summary.DriftScore, &summary.ActiveAlerts,
-			&summary.ATCTrustLevel, &summary.ScanVerdict)
+			&trustLevel, &summary.ScanVerdict)
 		if err == nil {
+			summary.ATCTrustLevel = trustLevel
+			summary.ATXTrustLevel = trustLevel
 			return &summary
 		}
 	}


### PR DESCRIPTION
## Summary

Sibling to **opena2a-registry PR #216** (Phase 1 of the ATC to ATX rename per `todo/2026-04-28-atc-to-atx-code-rename.md`). PR #216 ships migration 231 adding an `atx_trust_level` column to `agent_security_contexts` with NULL defaults; Phase 2 writers will populate it.

This PR updates the FGA engine's local-DB read so AIM works against both the pre-migration and post-migration database state.

## Changes

- `ASCRiskSummary` gains an `ATXTrustLevel int` field alongside the existing `ATCTrustLevel`. Both fields carry the same value, sourced from `COALESCE(atx_trust_level, atc_trust_level)`. New code should read `ATXTrustLevel`; legacy code reading `ATCTrustLevel` continues to work. Phase 3 drops `ATCTrustLevel`.
- `fetchASCRiskSummary` SELECT switches to `COALESCE(atx_trust_level, atc_trust_level)` so the engine reads the new column when populated and falls back to the legacy column otherwise.
- Doc comment on the struct + inline comment on the SQL explain the Phase 1 transition window for future maintainers.

## Deploy coordination

This PR is safe to land before, with, or after registry PR #216 because `COALESCE` handles every schema state transparently:

| Schema state | `atx_trust_level` column | `atc_trust_level` value | What COALESCE returns |
|---|---|---|---|
| Pre-migration 231 | does not exist | (whatever) | error before PR #216 deploys, but migration 231 lands with #216 so this state is transient |
| Post-migration 231, pre-Phase-2 writers | exists, NULL | populated | `atc_trust_level` (NULL falls through) |
| Post-Phase-2 writers populate both | exists, populated | populated | `atx_trust_level` (preferred) |
| Phase 3 drops `atc_trust_level` | exists, populated | does not exist | `atx_trust_level` |

The middle row is the steady state for the Phase 1 + Phase 2 window. The COALESCE means this PR does NOT need to deploy in any particular order relative to PR #216 once both are merged.

## Test plan

- [x] `go build ./...` (from `apps/backend/`) clean
- [x] `go vet ./internal/application/...` clean
- [x] `go test -race ./internal/application/...` green
- [ ] Reviewer sanity-check that the `MinTrustLevel` rule at `fga_engine.go:798` still reads `summary.ATCTrustLevel` deliberately — Phase 1 keeps the rule reading the legacy field; Phase 2 migrates the readers to `ATXTrustLevel` in lockstep with the registry-side writer migration

## What does NOT ship in Phase 1

- Renaming `ATCTrustLevel` → `ATXTrustLevel` in the `MinTrustLevel` rule and other consumers. Phase 2.
- Writing to `atx_trust_level` from any AIM-side path. Registry owns the writes; AIM is read-only on this column.