### PR TITLE
fix(sdk-tests): isolate three credential tests from real user state

### DIFF
--- a/sdk/python/tests/test_credentials.py
+++ b/sdk/python/tests/test_credentials.py
@@ -162,11 +162,16 @@ class TestLoadSdkCredentials:
 
     def test_load_sdk_credentials_returns_none_for_missing_file(self):
         """Loading from non-existent file should return None."""
+        # _find_sdk_package_credentials walks parent .aim dirs and adopts any
+        # bundled or developer-installed sdk_credentials.json it finds. Without
+        # mocking it, this test fails on any machine whose parent dirs contain
+        # real SDK credentials (the OpenA2A workspace tree does).
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch('aim_sdk.credentials.SDK_CREDENTIALS_FILE', Path(tmpdir) / "nonexistent.json"):
                 with patch('aim_sdk.credentials.LEGACY_CREDENTIALS_FILE', Path(tmpdir) / "legacy.json"):
-                    result = load_sdk_credentials()
-                    assert result is None
+                    with patch('aim_sdk.credentials._find_sdk_package_credentials', return_value=None):
+                        result = load_sdk_credentials()
+                        assert result is None
 
     def test_load_sdk_credentials_from_file(self):
         """Should load credentials from file."""

--- a/sdk/python/tests/test_register_agent.py
+++ b/sdk/python/tests/test_register_agent.py
@@ -183,19 +183,24 @@ class TestRegisterAgent:
             "trust_score": 80.0
         }
 
+        # Patch load_sdk_credentials to None so the cached-agent path does not
+        # attach a real OAuthTokenManager built from the developer's actual
+        # SDK credentials (or from credentials adopted out of the installed
+        # package by _find_sdk_package_credentials walking parent .aim dirs).
         with patch('aim_sdk.client._load_credentials', return_value=existing_creds):
-            with patch('aim_sdk.client.AIMClient') as mock_client:
-                agent = register_agent("existing-agent")
+            with patch('aim_sdk.client.load_sdk_credentials', return_value=None):
+                with patch('aim_sdk.client.AIMClient') as mock_client:
+                    agent = register_agent("existing-agent")
 
-                # Should create client with existing credentials
-                mock_client.assert_called_once_with(
-                    agent_id=existing_creds["agent_id"],
-                    public_key=existing_creds["public_key"],
-                    private_key=existing_creds["private_key"],
-                    aim_url=existing_creds["aim_url"],
-                    api_key=None,
-                    oauth_token_manager=None
-                )
+                    # Should create client with existing credentials
+                    mock_client.assert_called_once_with(
+                        agent_id=existing_creds["agent_id"],
+                        public_key=existing_creds["public_key"],
+                        private_key=existing_creds["private_key"],
+                        aim_url=existing_creds["aim_url"],
+                        api_key=None,
+                        oauth_token_manager=None
+                    )
 
     def test_register_agent_force_new_registration(self):
         """Test forcing new registration even when credentials exist"""

--- a/sdk/python/tests/test_secure_alias.py
+++ b/sdk/python/tests/test_secure_alias.py
@@ -169,19 +169,24 @@ class TestSecureAlias:
             "trust_score": 80.0
         }
 
+        # Patch load_sdk_credentials to None so the cached-agent path does not
+        # attach a real OAuthTokenManager built from the developer's actual
+        # SDK credentials (or from credentials adopted out of the installed
+        # package by _find_sdk_package_credentials walking parent .aim dirs).
         with patch('aim_sdk.client._load_credentials', return_value=existing_creds):
-            with patch('aim_sdk.client.AIMClient') as mock_client:
-                agent = secure("existing-agent")
+            with patch('aim_sdk.client.load_sdk_credentials', return_value=None):
+                with patch('aim_sdk.client.AIMClient') as mock_client:
+                    agent = secure("existing-agent")
 
-                # Should create client with existing credentials
-                mock_client.assert_called_once_with(
-                    agent_id=existing_creds["agent_id"],
-                    public_key=existing_creds["public_key"],
-                    private_key=existing_creds["private_key"],
-                    aim_url=existing_creds["aim_url"],
-                    api_key=None,
-                    oauth_token_manager=None
-                )
+                    # Should create client with existing credentials
+                    mock_client.assert_called_once_with(
+                        agent_id=existing_creds["agent_id"],
+                        public_key=existing_creds["public_key"],
+                        private_key=existing_creds["private_key"],
+                        aim_url=existing_creds["aim_url"],
+                        api_key=None,
+                        oauth_token_manager=None
+                    )
 
     def test_secure_force_new_registration(self):
         """Test secure() forcing new registration"""


### PR DESCRIPTION
## Summary

Three pre-existing SDK test failures fixed (called out in the 2026-05-24 docs-cleanup handoff as "worth a focused PR"):

| Test | Failure mode |
|---|---|
| `tests/test_credentials.py::test_load_sdk_credentials_returns_none_for_missing_file` | Patched `SDK_CREDENTIALS_FILE` + `LEGACY_CREDENTIALS_FILE` to tmp paths, but `_find_sdk_package_credentials` walked parent `.aim/` dirs and adopted real workspace credentials, so the function returned a dict instead of `None`. |
| `tests/test_register_agent.py::test_register_agent_existing_credentials` | Asserted `AIMClient(..., oauth_token_manager=None)` on the cached-credentials path. `aim_sdk/client.py:3599-3621` reads `load_sdk_credentials()` and attaches a real `OAuthTokenManager` whenever an SDK refreshToken exists on disk. The captured stdout showed a real token rotation against the developer's actual refresh-token endpoint during the test run. |
| `tests/test_secure_alias.py::test_secure_existing_credentials` | Same shape as the `test_register_agent` failure. |

All three failures stem from the same root cause: SDK credential discovery walks parent directories and the OpenA2A workspace tree contains real SDK credentials.

## Fix

Test-side, hermetic:

- `test_credentials.py` — add `patch('aim_sdk.credentials._find_sdk_package_credentials', return_value=None)` inside the existing `with` block.
- `test_register_agent.py` and `test_secure_alias.py` — add `patch('aim_sdk.client.load_sdk_credentials', return_value=None)` inside the existing `with` block.

No production code changes. The bundled-adoption behaviour (`Adopting SDK credentials from bundled package`) is a deliberate first-run UX and stays intact; only the tests are updated to assert against explicit, hermetic state instead of leaking the developer's real credentials into mock-call assertions.

## Result

```
Before: 372 passed, 3 failed
After:  375 passed, 0 failed
```

## Test plan

- [x] `pytest tests/test_register_agent.py::TestRegisterAgent::test_register_agent_existing_credentials` passes
- [x] `pytest tests/test_secure_alias.py::TestSecureAlias::test_secure_existing_credentials` passes
- [x] `pytest tests/test_credentials.py::TestLoadSdkCredentials::test_load_sdk_credentials_returns_none_for_missing_file` passes
- [x] Full SDK suite — 375 passed, 34 skipped, 0 failed
- [x] No production code touched; HMA / API / CLI surfaces unaffected