### PR TITLE
feat(#168): AFTER INSERT trigger keeps capability_violation_count consistent

### DIFF
--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -1065,12 +1065,9 @@ func (s *AgentService) VerifyCapability(
 				agent.Name, capability, enforcementMode)
 		}
 
-		// Increment violation count
-		if err := s.agentRepo.IncrementViolationCount(agentID); err != nil {
-			fmt.Printf("⚠️  Warning: failed to increment violation count: %v\n", err)
-		} else {
-			fmt.Printf("✅ Violation count incremented for agent %s\n", agent.Name)
-		}
+		// capability_violation_count is bumped by an AFTER INSERT trigger
+		// on capability_violations (migration 091); no application-layer
+		// increment needed.
 
 		return false, fmt.Sprintf(
 			"Agent has no granted capabilities - action denied by %s mode (admin must grant capabilities first)",
@@ -1198,10 +1195,9 @@ func (s *AgentService) VerifyCapability(
 			fmt.Printf("⚠️  Warning: failed to update trust_scores table: %v\n", err)
 		}
 
-		// Increment violation count on agent record
-		if err := s.agentRepo.IncrementViolationCount(agentID); err != nil {
-			fmt.Printf("⚠️  Warning: failed to increment violation count: %v\n", err)
-		}
+		// capability_violation_count is bumped by an AFTER INSERT trigger
+		// on capability_violations (migration 091); no application-layer
+		// increment needed.
 
 		// Evaluate trust score policy enforcement (alerts and suspension)
 		previousScore := agent.TrustScore  // Store before updating

--- a/apps/backend/internal/application/capability_service.go
+++ b/apps/backend/internal/application/capability_service.go
@@ -120,12 +120,12 @@ func (s *CapabilityService) VerifyAction(
 			newTrustScore = 0
 		}
 
-		// Update violation count and trust score
+		// capability_violation_count is bumped by an AFTER INSERT trigger
+		// on capability_violations (migration 091); the local
+		// newViolationCount mirrors what the trigger just wrote and is
+		// used below for the compromised-threshold check.
 		newViolationCount := agent.CapabilityViolationCount + 1
 		if err := s.agentRepo.UpdateTrustScore(agentID, newTrustScore); err != nil {
-			return nil, err
-		}
-		if err := s.agentRepo.IncrementViolationCount(agentID); err != nil {
 			return nil, err
 		}
 

--- a/apps/backend/internal/application/capability_violation_trigger_integration_test.go
+++ b/apps/backend/internal/application/capability_violation_trigger_integration_test.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCapabilityViolationTrigger_BumpsCounter is the regression test
+// for issue #168 (and the dashboard half, #166). Migration 091 installs
+// an AFTER INSERT trigger on `capability_violations` that bumps the
+// agent's `capability_violation_count`. Before the trigger, the
+// application-layer pattern paired `CreateViolation` with
+// `IncrementViolationCount` at only 2-3 of 5+ call sites; the others
+// silently let the counter stale.
+//
+// This test asserts the counter ticks ONLY via the trigger, with no
+// application-layer increment call.
+//
+// Build-tag gated: requires a Postgres reachable via TEST_DATABASE_URL
+// with the AIM schema already applied (run migrations first). Skip if
+// absent so the unit-test pipeline stays self-contained. Run via
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestCapabilityViolationTrigger ./internal/application/...
+func TestCapabilityViolationTrigger_BumpsCounter(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+
+	// Setup: create a throwaway organization + agent so the test does
+	// not depend on any seeded row and cleans up after itself.
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM capability_violations WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "trigger-test-org-"+agentID.String()[:8],
+	)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
+		                     capability_violation_count, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.9, 0, NOW(), NOW())`,
+		agentID, orgID, "trigger-test-agent-"+agentID.String()[:8],
+	)
+	require.NoError(t, err)
+
+	// Insert 3 violations directly, bypassing the application layer
+	// entirely. The trigger is the ONLY thing that should bump the
+	// counter.
+	for i := 0; i < 3; i++ {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO capability_violations
+			   (agent_id, attempted_capability, severity, trust_score_impact, is_blocked, created_at)
+			 VALUES ($1, $2, 'medium', -2, false, NOW())`,
+			agentID, "test:capability",
+		)
+		require.NoError(t, err)
+	}
+
+	// Verify the counter ticked to 3 via the trigger, not 0 (counter
+	// never bumped) or 6 (trigger AND a manual increment double-bump).
+	var count int
+	err = db.QueryRowContext(ctx,
+		`SELECT capability_violation_count FROM agents WHERE id = $1`,
+		agentID,
+	).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 3, count,
+		"trigger must bump capability_violation_count once per insert; got %d after 3 inserts", count)
+
+	// Also confirm the trigger was the writer by checking updated_at
+	// moved within the last 30s.
+	var updatedAt time.Time
+	err = db.QueryRowContext(ctx,
+		`SELECT updated_at FROM agents WHERE id = $1`, agentID,
+	).Scan(&updatedAt)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().UTC(), updatedAt.UTC(), 30*time.Second,
+		"trigger should set updated_at on each bump")
+}
+
+// TestCapabilityViolationTrigger_BackfillReconcilesDrift covers the
+// one-shot backfill that ships in migration 091. The backfill resyncs
+// agents.capability_violation_count to the actual row count for any
+// agent whose counter drifted prior to the trigger being installed.
+//
+// This test does NOT re-run migration 091 (the backfill is a one-shot
+// at-migrate-time UPDATE). It asserts the invariant the backfill
+// maintains by inserting violations BEFORE relying on the trigger and
+// then re-running the same reconciling UPDATE shape inline.
+func TestCapabilityViolationTrigger_BackfillReconcilesDrift(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping backfill regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM capability_violations WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "backfill-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed an agent whose counter is INTENTIONALLY drifted: 7 actual
+	// rows, but the counter says 2 (simulating pre-trigger state where
+	// 5 violations were inserted without an accompanying increment).
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
+		                     capability_violation_count, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, 2, NOW(), NOW())`,
+		agentID, orgID, "backfill-test-agent-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Disable the trigger for the next inserts to simulate pre-091
+	// drift. We are testing the backfill, not the trigger.
+	_, err = db.ExecContext(ctx,
+		`ALTER TABLE capability_violations DISABLE TRIGGER trg_bump_capability_violation_count`)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.ExecContext(ctx,
+			`ALTER TABLE capability_violations ENABLE TRIGGER trg_bump_capability_violation_count`)
+	}()
+
+	for i := 0; i < 7; i++ {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO capability_violations
+			   (agent_id, attempted_capability, severity, trust_score_impact, is_blocked, created_at)
+			 VALUES ($1, $2, 'medium', -2, false, NOW())`,
+			agentID, "test:capability")
+		require.NoError(t, err)
+	}
+
+	// At this point: 7 rows, counter still 2. Re-run the backfill
+	// SQL shape from migration 091.
+	_, err = db.ExecContext(ctx, `
+		UPDATE agents a
+		SET capability_violation_count = sub.cnt,
+		    updated_at = NOW()
+		FROM (
+			SELECT agent_id, COUNT(*)::INTEGER AS cnt
+			FROM capability_violations
+			WHERE agent_id = $1
+			GROUP BY agent_id
+		) sub
+		WHERE a.id = sub.agent_id
+		  AND a.capability_violation_count IS DISTINCT FROM sub.cnt`,
+		agentID)
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx,
+		`SELECT capability_violation_count FROM agents WHERE id = $1`, agentID,
+	).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 7, count, "backfill must reconcile counter to actual row count; got %d", count)
+}

--- a/apps/backend/internal/domain/agent.go
+++ b/apps/backend/internal/domain/agent.go
@@ -121,7 +121,6 @@ type AgentRepository interface {
 	Delete(id uuid.UUID) error
 	List(limit, offset int) ([]*Agent, error)
 	UpdateTrustScore(id uuid.UUID, newScore float64) error
-	IncrementViolationCount(id uuid.UUID) error
 	MarkAsCompromised(id uuid.UUID) error
 	UpdateLastActive(ctx context.Context, agentID uuid.UUID) error
 	GetStaleAgents(ctx context.Context, staleSince time.Time) ([]*Agent, error)

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -609,17 +609,6 @@ func (r *AgentRepository) UpdateTrustScore(id uuid.UUID, newScore float64) error
 	return err
 }
 
-// IncrementViolationCount increments an agent's capability violation count
-func (r *AgentRepository) IncrementViolationCount(id uuid.UUID) error {
-	query := `
-		UPDATE agents
-		SET capability_violation_count = capability_violation_count + 1, updated_at = $1
-		WHERE id = $2
-	`
-	_, err := r.db.Exec(query, time.Now(), id)
-	return err
-}
-
 // MarkAsCompromised marks an agent as potentially compromised by setting status to suspended
 func (r *AgentRepository) MarkAsCompromised(id uuid.UUID) error {
 	query := `

--- a/apps/backend/internal/testutil/mocks/repositories.go
+++ b/apps/backend/internal/testutil/mocks/repositories.go
@@ -66,11 +66,6 @@ func (m *MockAgentRepository) UpdateTrustScore(id uuid.UUID, newScore float64) e
 	return args.Error(0)
 }
 
-func (m *MockAgentRepository) IncrementViolationCount(id uuid.UUID) error {
-	args := m.Called(id)
-	return args.Error(0)
-}
-
 func (m *MockAgentRepository) MarkAsCompromised(id uuid.UUID) error {
 	args := m.Called(id)
 	return args.Error(0)

--- a/apps/backend/migrations/091_capability_violation_count_trigger.sql
+++ b/apps/backend/migrations/091_capability_violation_count_trigger.sql
@@ -1,0 +1,53 @@
+-- Migration 091: AFTER INSERT trigger on capability_violations to keep
+-- agents.capability_violation_count consistent with the actual row count.
+--
+-- Replaces the application-layer `IncrementViolationCount` pattern, which
+-- was paired with only 2 of 5 `CreateViolation` call sites in
+-- `internal/application/agent_service.go`, leaving the counter stale on
+-- the monitoring-mode and SDK-LogActivity paths.
+--
+-- Closes #168 (capability_violation_count drift) and #166 (count not
+-- ticking on the dashboard, which was a symptom of #168).
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`:
+-- aggregate-of-child-rows fields use an AFTER INSERT trigger on the
+-- child table; this is the canonical fix pattern for that shape.
+
+CREATE OR REPLACE FUNCTION bump_capability_violation_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE agents
+    SET capability_violation_count = COALESCE(capability_violation_count, 0) + 1,
+        updated_at = NOW()
+    WHERE id = NEW.agent_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_bump_capability_violation_count ON capability_violations;
+
+CREATE TRIGGER trg_bump_capability_violation_count
+    AFTER INSERT ON capability_violations
+    FOR EACH ROW
+    EXECUTE FUNCTION bump_capability_violation_count();
+
+-- One-shot backfill: reconcile any existing drift between
+-- capability_violation_count and the actual row count.
+-- Safe to re-run; the UPDATE is idempotent.
+UPDATE agents a
+SET capability_violation_count = sub.cnt,
+    updated_at = NOW()
+FROM (
+    SELECT agent_id, COUNT(*)::INTEGER AS cnt
+    FROM capability_violations
+    GROUP BY agent_id
+) sub
+WHERE a.id = sub.agent_id
+  AND a.capability_violation_count IS DISTINCT FROM sub.cnt;
+
+-- Agents with zero violations: ensure the counter is 0, not NULL, so
+-- subsequent trigger fires increment from a known base.
+UPDATE agents
+SET capability_violation_count = 0
+WHERE capability_violation_count IS NULL;


### PR DESCRIPTION
## Summary

- Migration 091 installs `bump_capability_violation_count()` and an `AFTER INSERT` trigger on `capability_violations`, so the counter on `agents.capability_violation_count` ticks atomically with every violation row no matter which application path created it.
- One-shot backfill in the same migration reconciles any pre-existing drift (current agents whose counter does not match their actual row count get resynced in the same transaction the trigger is created).
- Removes the three application-layer `IncrementViolationCount` call sites (two in `agent_service.go`, one in `capability_service.go`) plus the now-dead repo method, domain-interface entry, and shared testutil mock entry.
- Phase A of the counter-drift cluster decision in `todo/2026-05-24-counter-drift-cluster-chief-ca.md`. Phase B (`verified_at`) and Phase C (`last_active`) ship in follow-up PRs.

Closes #168, closes #166.

## Why this shape

Before: five `CreateViolation` call sites; only two paired with `IncrementViolationCount` (lines 1069 and 1202 of `agent_service.go`). The other three (lines 877, 1005, 2249) and a fourth in `capability_service.go:128` silently let the counter drift. The "dashboard count not ticking" symptom in #166 was downstream of that — there was no separate dashboard cache bug.

Per the [CHIEF-CA] decision: denormalized aggregates of child rows use an AFTER INSERT trigger on the child table. This removes the choice from application code — any future `CreateViolation` call site is automatically correct.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/091_capability_violation_count_trigger.sql` | NEW — trigger function, `AFTER INSERT` trigger, one-shot backfill |
| `apps/backend/internal/application/agent_service.go` | Remove the two paired `IncrementViolationCount` calls (lines 1069, 1202) |
| `apps/backend/internal/application/capability_service.go` | Remove the third paired `IncrementViolationCount` call (line 128); local `newViolationCount` is unchanged and continues to drive the compromised-threshold check on line 134 |
| `apps/backend/internal/domain/agent.go` | Remove `IncrementViolationCount` from `AgentRepository` interface |
| `apps/backend/internal/infrastructure/repository/agent_repository.go` | Remove `IncrementViolationCount` postgres impl |
| `apps/backend/internal/testutil/mocks/repositories.go` | Remove the shared mock entry |
| `apps/backend/internal/application/capability_violation_trigger_integration_test.go` | NEW — build-tag-gated regression test (counter ticks via trigger only; backfill reconciles drift) |

Per-test mock structs in `*_test.go` files still define an orphan `IncrementViolationCount` method, since each test's local mock satisfied the interface independently. They no longer satisfy any interface but they don't break the build; a follow-up sweep can drop them.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/application/ ./internal/interfaces/http/handlers/ ./internal/domain/ ./internal/infrastructure/... -race` PASS (forced re-run, not cached)
- [x] `go test -tags=integration -run TestCapabilityViolationTrigger ./internal/application/` compiles and skips cleanly without `TEST_DATABASE_URL`
- [x] HMA static scan: 100/100, no findings
- [ ] Integration test against a live PG (`TEST_DATABASE_URL=postgres://… go test -tags=integration -run TestCapabilityViolationTrigger ./internal/application/`) — NOT run in this PR (no live DB in the dev session). Recommended before deploy.

## Cross-tenant safety

The trigger function updates the row in `agents` whose ID equals `NEW.agent_id`. The `capability_violations.agent_id` is set by the application when the violation is logged; same tenant by construction. No tenant boundary crossed inside the trigger.

## Skipped pre-push phases

- Phase 4.5 adversarial self-review: trigger logic is counter math, not scoring/severity/detection rules.
- Phase 5 hma-hunter: no new endpoints, no auth/routing changes.
- Phase 6 new-user walkthrough: backend-only; no CLI or user-facing output changed.

## Sequencing

Phase B (`verified_at` BEFORE UPDATE trigger on `agents`) and Phase C (SDK middleware for `last_active`) ship as separate PRs and close the rest of #167. Each is independent and small (~50 and ~80 LoC + tests).