### PR TITLE
feat(#167): BEFORE UPDATE trigger sets verified_at on status transition

### DIFF
--- a/apps/backend/internal/application/verified_at_trigger_integration_test.go
+++ b/apps/backend/internal/application/verified_at_trigger_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifiedAtTrigger_SetsOnStatusTransition is the regression
+// test for issue #167's `verified_at` half. Migration 092 installs a
+// BEFORE UPDATE trigger on `agents` that sets `verified_at = NOW()`
+// when status transitions to 'verified' from any other state and
+// `verified_at` is still NULL.
+//
+// The audit doc § 10 observed agents whose dashboard rendered
+// "Verified at: never" because a direct-SQL UPDATE path flipped
+// status to 'verified' without setting `verified_at`. With the
+// trigger, no direct-SQL path can leave this gap.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL
+// with the AIM schema already applied (run migrations first).
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestVerifiedAtTrigger ./internal/application/...
+func TestVerifiedAtTrigger_SetsOnStatusTransition(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "verified-at-trigger-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed an agent in 'pending' state with NULL verified_at — the
+	// pre-flip state.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
+		                     verified_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'pending', 0.5, NULL, NOW(), NOW())`,
+		agentID, orgID, "verified-at-trigger-test-agent-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Direct-SQL status flip: this is the path the audit observed
+	// leaving verified_at NULL. With the trigger, verified_at must
+	// be set even though we did not touch it in the UPDATE.
+	beforeFlip := time.Now().UTC()
+	_, err = db.ExecContext(ctx,
+		`UPDATE agents SET status = 'verified' WHERE id = $1`,
+		agentID)
+	require.NoError(t, err)
+
+	var verifiedAt sql.NullTime
+	err = db.QueryRowContext(ctx,
+		`SELECT verified_at FROM agents WHERE id = $1`, agentID,
+	).Scan(&verifiedAt)
+	require.NoError(t, err)
+	require.True(t, verifiedAt.Valid,
+		"trigger must set verified_at when status transitions to 'verified'")
+	require.WithinDuration(t, beforeFlip, verifiedAt.Time.UTC(), 30*time.Second,
+		"trigger should stamp verified_at within the same UPDATE window")
+}
+
+// TestVerifiedAtTrigger_DoesNotOverwriteExisting asserts the trigger
+// is idempotent: an UPDATE that does not change status, or that
+// transitions FROM verified to something else and back, must not
+// clobber a verified_at that was already set by the application
+// layer (which would falsify the audit trail of when the agent was
+// first verified).
+func TestVerifiedAtTrigger_DoesNotOverwriteExisting(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "verified-at-noclobber-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed an agent already in 'verified' state with a known
+	// verified_at three days ago.
+	originalVerifiedAt := time.Now().UTC().Add(-72 * time.Hour).Truncate(time.Second)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
+		                     verified_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.8, $4, NOW(), NOW())`,
+		agentID, orgID, "verified-at-noclobber-test-agent-"+agentID.String()[:8],
+		originalVerifiedAt)
+	require.NoError(t, err)
+
+	// UPDATE that does NOT touch status. The trigger fires (BEFORE
+	// UPDATE FOR EACH ROW), but the guard `OLD.status <> 'verified'`
+	// must skip the assignment, preserving the original timestamp.
+	_, err = db.ExecContext(ctx,
+		`UPDATE agents SET trust_score = 0.7 WHERE id = $1`,
+		agentID)
+	require.NoError(t, err)
+
+	var verifiedAt sql.NullTime
+	err = db.QueryRowContext(ctx,
+		`SELECT verified_at FROM agents WHERE id = $1`, agentID,
+	).Scan(&verifiedAt)
+	require.NoError(t, err)
+	require.True(t, verifiedAt.Valid)
+	require.WithinDuration(t, originalVerifiedAt, verifiedAt.Time.UTC(), time.Second,
+		"trigger must NOT overwrite verified_at on unrelated UPDATEs")
+
+	// Re-verifying after a suspension: status flips verified -> suspended
+	// -> verified. The trigger's NULL guard means the second transition
+	// preserves the original verified_at (agent was first verified
+	// three days ago; re-verification does not reset that history).
+	_, err = db.ExecContext(ctx,
+		`UPDATE agents SET status = 'suspended' WHERE id = $1`, agentID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`UPDATE agents SET status = 'verified' WHERE id = $1`, agentID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		`SELECT verified_at FROM agents WHERE id = $1`, agentID,
+	).Scan(&verifiedAt)
+	require.NoError(t, err)
+	require.True(t, verifiedAt.Valid)
+	require.WithinDuration(t, originalVerifiedAt, verifiedAt.Time.UTC(), time.Second,
+		"re-verification must not clobber the first-verified timestamp")
+}

--- a/apps/backend/migrations/092_verified_at_status_trigger.sql
+++ b/apps/backend/migrations/092_verified_at_status_trigger.sql
@@ -1,0 +1,48 @@
+-- Migration 092: BEFORE UPDATE trigger on agents to set verified_at
+-- when status transitions to 'verified' and verified_at is still NULL.
+--
+-- The application-layer `VerifyAgent` service (agent_service.go:637)
+-- already sets `agent.VerifiedAt = now` before persisting. The gap
+-- this trigger closes is the direct-SQL path: ops scripts, manual
+-- admin DB sessions, future migrations, and any non-service writer
+-- that does `UPDATE agents SET status = 'verified' WHERE ...`. The
+-- audit doc § 10 observed agents with status='verified' but
+-- verified_at NULL on the dashboard for exactly this reason.
+--
+-- Closes the verified_at half of #167.
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`:
+-- row-internal coupling (two columns on the same row that must move
+-- together) uses a BEFORE UPDATE trigger on the parent table; this
+-- is the canonical fix pattern for that shape.
+
+CREATE OR REPLACE FUNCTION set_verified_at_on_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.status = 'verified'
+       AND (OLD.status IS NULL OR OLD.status <> 'verified')
+       AND NEW.verified_at IS NULL THEN
+        NEW.verified_at := NOW();
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_set_verified_at ON agents;
+
+CREATE TRIGGER trg_set_verified_at
+    BEFORE UPDATE ON agents
+    FOR EACH ROW
+    EXECUTE FUNCTION set_verified_at_on_status_change();
+
+-- One-shot backfill: for agents already in 'verified' state with a
+-- NULL verified_at (the drifted rows the audit observed), set
+-- verified_at to the row's updated_at as a best-available
+-- approximation. updated_at is the closest timestamp we have to when
+-- the status flip happened; we accept the approximation rather than
+-- leave the dashboard rendering "Verified at: never" indefinitely.
+UPDATE agents
+SET verified_at = COALESCE(updated_at, created_at, NOW())
+WHERE status = 'verified'
+  AND verified_at IS NULL;


### PR DESCRIPTION
## Summary

- Migration 092 installs `set_verified_at_on_status_change()` and a `BEFORE UPDATE` trigger on `agents` that stamps `verified_at = NOW()` when status transitions to 'verified' from any other state and `verified_at` is still NULL.
- Closes the verified_at half of #167. The application-layer `VerifyAgent` service (`agent_service.go:637`) already sets verified_at correctly; the trigger closes the direct-SQL path (ops scripts, manual admin DB sessions, future migrations) that the audit doc § 10 observed leaving "Verified at: never" on the dashboard.
- One-shot backfill in the same migration reconciles existing drift by stamping verified_at with the row's updated_at for any agent already in 'verified' state with NULL verified_at.
- Phase B of the counter-drift cluster decision in `todo/2026-05-24-counter-drift-cluster-chief-ca.md`. Phase A (#168 + #166) merged via #226. Phase C (`last_active` SDK middleware) ships next and closes the rest of #167.

## Why this shape

The audit observed agents whose `agents.status = 'verified'` but `agents.verified_at IS NULL` because some non-service writer flipped the status. Per the [CHIEF-CA] decision: row-internal coupling (two columns on the same row that must move together) uses a BEFORE UPDATE trigger on the parent table.

The trigger guard `OLD.status <> 'verified' AND NEW.verified_at IS NULL` keeps it idempotent:
- UPDATEs that do not change status are a no-op for verified_at.
- Re-verification after a suspension preserves the original first-verified timestamp, rather than clobbering it. The dashboard should show when the agent was first verified, not when it was last re-verified.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/092_verified_at_status_trigger.sql` | NEW — trigger function, `BEFORE UPDATE` trigger, one-shot backfill |
| `apps/backend/internal/application/verified_at_trigger_integration_test.go` | NEW — build-tag-gated regression test (direct-SQL flip stamps verified_at; unrelated UPDATE + re-verification preserve original timestamp) |

No application code changes. The existing `VerifyAgent` service still sets `agent.VerifiedAt` before persisting — the trigger is purely defensive against non-service writers.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/application/ ./internal/interfaces/http/handlers/ -race -count=1` PASS (forced re-run)
- [x] `go test -tags=integration -run TestVerifiedAtTrigger ./internal/application/` compiles and skips cleanly without `TEST_DATABASE_URL`
- [x] HMA static scan: 100/100
- [ ] Integration test against a live PG (`TEST_DATABASE_URL=postgres://… go test -tags=integration -run TestVerifiedAtTrigger ./internal/application/`) — NOT run in this PR (no live DB in the dev session). Recommended before deploy.

## Cross-tenant safety

The trigger operates on the row being UPDATEd. `verified_at` is a per-agent field; no foreign-tenant write path exists inside the trigger function.

## Skipped pre-push phases

- Phase 4.5 adversarial: no scoring/severity/detection logic.
- Phase 5 hma-hunter: no new endpoints, no auth/routing changes.
- Phase 6 new-user walkthrough: backend-only.