### PR TITLE
feat(#167): activity-touch middleware bumps agents.last_active on SDK-authed requests

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -316,6 +316,7 @@ func main() {
 	sdkAPI := app.Group("/api/v1/sdk-api")
 	sdkAPI.Use(middleware.PQCAgentMiddleware(services.Agent)) // Validates agent signatures (Ed25519, ML-DSA, or hybrid), passes through JWT
 	sdkAPI.Use(middleware.AuthMiddleware(jwtService))             // Fallback to JWT if Ed25519 not present
+	sdkAPI.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	sdkAPI.Use(middleware.RateLimitMiddleware())
 	sdkAPI.Get("/agents/:identifier", h.Agent.GetAgentByIdentifier)                                // Get agent by ID or name (SDK)
 	sdkAPI.Post("/agents/:id/capabilities", h.Capability.GrantCapability)                          // SDK capability reporting (legacy)
@@ -1331,6 +1332,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	detection := v1.Group("/detection")
 	detection.Use(middleware.PQCAgentMiddleware(services.Agent)) // ✅ Try Ed25519/ML-DSA/hybrid first (for SDK agents)
 	detection.Use(middleware.AuthMiddleware(jwtService))             // ✅ Fallback to JWT (for web UI)
+	detection.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	detection.Use(middleware.RateLimitMiddleware())
 	detection.Post("/agents/:id/report", h.Detection.ReportDetection)
 	detection.Get("/agents/:id/status", h.Detection.GetDetectionStatus) // ✅ Now accessible from web UI with JWT
@@ -1344,6 +1346,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Use(middleware.OptionalAPIKeyMiddleware(db))            // ✅ Try API key (for dashboard-generated keys)
 	agents.Use(middleware.PQCAgentMiddleware(services.Agent)) // ✅ Then try Ed25519/ML-DSA/hybrid (for SDK agents)
 	agents.Use(middleware.AuthMiddleware(jwtService))             // ✅ Fallback to JWT (for web UI)
+	agents.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	agents.Use(middleware.RateLimitMiddleware())
 	agents.Get("/", h.Agent.ListAgents)
 	agents.Post("/bulk-status", h.Lifecycle.BulkStatus) // Bulk agent status lookup
@@ -1543,6 +1546,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	// These endpoints use Ed25519 authentication (agent-to-backend) instead of JWT (user-to-backend)
 	mcpServersAgentAuth := v1.Group("/mcp-servers")
 	mcpServersAgentAuth.Use(middleware.PQCAgentMiddleware(services.Agent)) // PQC signature verification (Ed25519, ML-DSA, or hybrid)
+	mcpServersAgentAuth.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	mcpServersAgentAuth.Use(middleware.RateLimitMiddleware())
 	mcpServersAgentAuth.Get("/:id/challenge", h.MCPAttestation.GetAttestationChallenge)  // 🔐 Get challenge for proof of key possession (MUST be called before /attest)
 	mcpServersAgentAuth.Post("/:id/attest", h.MCPAttestation.AttestMCP)                  // ✅ Submit agent attestation (Ed25519 signed, with challenge)

--- a/apps/backend/internal/interfaces/http/middleware/agent_activity_touch.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_activity_touch.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+// AgentActivityToucher is the narrow surface this middleware needs
+// from the agent service. Defined here (not imported from
+// application) so the middleware can be unit-tested without pulling
+// the full service graph.
+type AgentActivityToucher interface {
+	UpdateLastActive(ctx context.Context, agentID uuid.UUID) error
+}
+
+// AgentActivityTouchMiddleware bumps agents.last_active on every
+// request that authenticated as an agent. Mount AFTER the agent-auth
+// middlewares (PQC / API key / ATC) so c.Locals("agent_id") is
+// populated by the time this runs.
+//
+// Discriminator: c.Locals("agent_id") presence. Every agent-auth
+// middleware in this repo sets agent_id on success (PQC sets
+// ed25519/mldsa/hybrid, api_key.go sets api_key, atc_auth.go sets
+// atc). JWT user-auth does NOT set agent_id, so admin requests
+// viewing an agent detail panel via JWT are excluded by
+// construction.
+//
+// Behavior:
+//   - Runs the handler first via c.Next().
+//   - On handler success (no error AND status < 400), fires
+//     UpdateLastActive off-goroutine with a background context so a
+//     cancelled request context does not abort the touch.
+//   - Errors from UpdateLastActive are swallowed: this is a
+//     fire-and-forget activity touch, not a transactional write.
+//     If it fails, the next request will retry it.
+//
+// Closes the last_active half of #167. The verified_at half is
+// closed by the migration 092 trigger.
+func AgentActivityTouchMiddleware(svc AgentActivityToucher) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		err := c.Next()
+
+		// Only touch on successful agent-auth responses. A 4xx/5xx
+		// agent request should not extend liveness.
+		if err != nil || c.Response().StatusCode() >= 400 {
+			return err
+		}
+
+		// JWT-only paths have no agent_id; skip them silently.
+		agentIDValue := c.Locals("agent_id")
+		if agentIDValue == nil {
+			return err
+		}
+		agentID, ok := agentIDValue.(uuid.UUID)
+		if !ok {
+			return err
+		}
+
+		// Fire-and-forget with background context: do NOT block the
+		// response on a counter UPDATE, and do not let the
+		// (already-completed) request context cancel the write.
+		go func(id uuid.UUID) {
+			_ = svc.UpdateLastActive(context.Background(), id)
+		}(agentID)
+
+		return err
+	}
+}

--- a/apps/backend/internal/interfaces/http/middleware/agent_activity_touch_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_activity_touch_test.go
@@ -1,0 +1,180 @@
+package middleware
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingToucher struct {
+	mu      sync.Mutex
+	calls   []uuid.UUID
+	called  atomic.Int32
+	err     error
+}
+
+func (c *capturingToucher) UpdateLastActive(_ context.Context, agentID uuid.UUID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, agentID)
+	c.called.Add(1)
+	return c.err
+}
+
+// waitForCalls blocks until the toucher has been invoked `n` times
+// or the deadline elapses. The middleware fires UpdateLastActive on
+// a separate goroutine, so the test goroutine must synchronize.
+func (c *capturingToucher) waitForCalls(n int32, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if c.called.Load() >= n {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+func TestAgentActivityTouchMiddleware_FiresOnSdkAuth(t *testing.T) {
+	toucher := &capturingToucher{}
+	agentID := uuid.New()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		// Simulate an upstream agent-auth middleware (PQC, API key, ATC).
+		c.Locals("agent_id", agentID)
+		c.Locals("auth_method", "ed25519")
+		return c.Next()
+	})
+	app.Use(AgentActivityTouchMiddleware(toucher))
+	app.Get("/test", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	require.True(t, toucher.waitForCalls(1, 200*time.Millisecond),
+		"middleware should call UpdateLastActive once after SDK-authed request")
+	assert.Equal(t, []uuid.UUID{agentID}, toucher.calls)
+}
+
+func TestAgentActivityTouchMiddleware_SkipsJwtOnlyRequests(t *testing.T) {
+	toucher := &capturingToucher{}
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		// Simulate JWT user auth: only user_id and organization_id, no agent_id.
+		c.Locals("user_id", uuid.New())
+		c.Locals("organization_id", uuid.New())
+		return c.Next()
+	})
+	app.Use(AgentActivityTouchMiddleware(toucher))
+	app.Get("/test", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// Give any stray goroutine time to fire if the gate is broken.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), toucher.called.Load(),
+		"JWT-only requests must not touch last_active")
+}
+
+func TestAgentActivityTouchMiddleware_SkipsErrorResponses(t *testing.T) {
+	toucher := &capturingToucher{}
+	agentID := uuid.New()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals("agent_id", agentID)
+		return c.Next()
+	})
+	app.Use(AgentActivityTouchMiddleware(toucher))
+	app.Get("/test", func(c fiber.Ctx) error {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "denied"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), toucher.called.Load(),
+		"4xx responses must not extend last_active")
+}
+
+func TestAgentActivityTouchMiddleware_SkipsWhenAgentIDWrongType(t *testing.T) {
+	toucher := &capturingToucher{}
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		// Defensive: an upstream bug stores agent_id as a string. The
+		// touch should not panic or fire.
+		c.Locals("agent_id", "not-a-uuid")
+		return c.Next()
+	})
+	app.Use(AgentActivityTouchMiddleware(toucher))
+	app.Get("/test", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), toucher.called.Load(),
+		"non-UUID agent_id must not fire the touch")
+}
+
+func TestAgentActivityTouchMiddleware_SwallowsServiceErrors(t *testing.T) {
+	toucher := &capturingToucher{err: assertedError("db unavailable")}
+	agentID := uuid.New()
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals("agent_id", agentID)
+		return c.Next()
+	})
+	app.Use(AgentActivityTouchMiddleware(toucher))
+	app.Get("/test", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Handler must return success even if the touch fails. The
+	// touch is fire-and-forget; an UPDATE error never escapes.
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	require.True(t, toucher.waitForCalls(1, 200*time.Millisecond),
+		"middleware should have attempted the touch even though it will fail")
+}
+
+type assertedError string
+
+func (e assertedError) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

- New `AgentActivityTouchMiddleware` that mounts after the agent-auth middlewares (PQC, API key, ATC) and fires `UpdateLastActive` from a background goroutine after each successful agent-authed request returns.
- Mounted on four SDK route groups in `cmd/server/main.go`: `/api/v1/sdk-api`, `/api/v1/detection`, `/api/v1/agents`, `/api/v1/mcp-servers` (the agent-auth subgroup).
- Closes #167. Phase A (#168 + #166) merged via #226; Phase B (verified_at trigger) merged via #227. Phase C completes the counter-drift cluster.

## Why this shape

Audit doc § 10 observed agents rendering "Last Active: never" because only one handler (`agent_handler.go:714`) was calling `UpdateLastActive`. Every other SDK-authed endpoint (capability verify, MCP attestation, detection report, etc.) left the timestamp stale.

A DB trigger does not fit this shape — there is no parent row to derive from. The activity itself is a method call, not a row insert. The right boundary is the request handler, and middleware ensures no handler can forget.

Per the [CHIEF-CA] decision: activity-touch timestamps use HTTP middleware at the auth boundary.

## Discriminator: `agent_id` presence

Every agent-auth middleware in this repo sets `c.Locals("agent_id")` on success:
- `PQCAgentMiddleware` (Ed25519, ML-DSA, hybrid)
- `OptionalAPIKeyMiddleware`
- `ATCAuthMiddleware`

JWT user auth (`AuthMiddleware`) does NOT set `agent_id`. Admin requests viewing an agent detail panel via JWT are excluded by construction — no route-list maintenance needed, no chance of double-firing.

## Behavior

- Fire-and-forget background goroutine using `context.Background()` so request cancellation does not abort the touch.
- Skips on handler error OR status >= 400. Failed auth does not extend liveness.
- Swallows UpdateLastActive errors silently. The touch is best-effort; the next request retries it. Errors never leak back to the handler response.
- Defensive: type-asserts `agent_id` to `uuid.UUID` with the `ok` check, so a future upstream bug that stores the wrong type cannot panic.

## Files

| File | Change |
|---|---|
| `apps/backend/internal/interfaces/http/middleware/agent_activity_touch.go` | NEW — 70 LoC, narrow `AgentActivityToucher` interface so the middleware is testable without the full service graph |
| `apps/backend/internal/interfaces/http/middleware/agent_activity_touch_test.go` | NEW — 5 unit tests under race detector |
| `apps/backend/cmd/server/main.go` | 4 mount points (one per SDK route group) |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./internal/interfaces/http/middleware/ ./internal/interfaces/http/handlers/ ./internal/application/` PASS, all 5 new tests pass under race
- [x] HMA static scan: 100/100
- [x] Adversarial review skipped per Phase 4.5 conditions (no scanner/scoring logic touched)
- [ ] Live integration test against running backend: agent registers, fires verify-action, dashboard shows `lastActive` updated within seconds. NOT run in this PR (no live stack in the session). Recommended before deploy.

## Test coverage (5 unit tests, all under race detector)

1. `TestAgentActivityTouchMiddleware_FiresOnSdkAuth` — when upstream sets `agent_id`, the touch fires with the right UUID.
2. `TestAgentActivityTouchMiddleware_SkipsJwtOnlyRequests` — when only `user_id` is set (JWT path), no touch fires.
3. `TestAgentActivityTouchMiddleware_SkipsErrorResponses` — a 403 response from the handler does NOT touch.
4. `TestAgentActivityTouchMiddleware_SkipsWhenAgentIDWrongType` — defensive: a non-UUID `agent_id` does not panic and does not fire.
5. `TestAgentActivityTouchMiddleware_SwallowsServiceErrors` — service returns an error; handler still responds 200; touch is attempted (proven by call counter).

## Cross-tenant safety

The middleware reads only `agent_id` from locals (set by the upstream auth middleware, which already validated the agent's identity) and writes only to that agent's `last_active`. No cross-tenant boundary touched.

## Skipped pre-push phases

- Phase 4.5 adversarial: liveness timestamp, not scanning/scoring/detection.
- Phase 5 hma-hunter: middleware fires AFTER auth, only reads locals, only writes `last_active`. Auth decision logic unchanged.
- Phase 6 new-user walkthrough: backend-only, no CLI/UI surface change.

## Cluster completion

After this merge:
- #168 closed (counter trigger)
- #166 closed (dashboard symptom of #168)
- #167 closed (verified_at via trigger, last_active via this middleware)

Counter-drift cluster: 3 issues closed, 3 PRs merged, no chief-cross-conflict, no escalation, on-pattern.