### PR TITLE
feat(#163): AFTER INSERT/UPDATE trigger mirrors trust_scores.score to agents.trust_score

### DIFF
--- a/apps/backend/internal/application/trust_score_mirror_trigger_integration_test.go
+++ b/apps/backend/internal/application/trust_score_mirror_trigger_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrustScoreMirrorTrigger_InsertSyncsAgentCache asserts that
+// INSERTing into `trust_scores` automatically mirrors the score
+// onto the `agents.trust_score` denormalized cache. Closes #163.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestTrustScoreMirrorTrigger ./internal/application/...
+func TestTrustScoreMirrorTrigger_InsertSyncsAgentCache(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM trust_scores WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "trust-score-mirror-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Agent starts with a stale cache value of 0.500.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.500, NOW(), NOW())`,
+		agentID, orgID, "trust-score-mirror-test-agent-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// INSERT a new score row. The trigger must mirror to agents.trust_score.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO trust_scores
+		   (id, agent_id, score,
+		    verification_status, certificate_validity, repository_quality,
+		    documentation_score, community_trust, security_audit,
+		    update_frequency, age_score, confidence,
+		    last_calculated, created_at)
+		 VALUES (gen_random_uuid(), $1, 0.823,
+		         0.9, 0.8, 0.7, 0.6, 0.85, 0.9, 0.7, 0.8, 0.95,
+		         NOW(), NOW())`,
+		agentID)
+	require.NoError(t, err)
+
+	var agentScore float64
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM agents WHERE id = $1`, agentID,
+	).Scan(&agentScore)
+	require.NoError(t, err)
+	require.InDelta(t, 0.823, agentScore, 0.001,
+		"trigger must mirror trust_scores.score onto agents.trust_score on INSERT")
+}
+
+// TestTrustScoreMirrorTrigger_UpdateSyncsLatestOnly asserts the
+// guard: an UPDATE on the LATEST trust_scores row mirrors, but an
+// UPDATE on an OLDER historical row does NOT clobber the cache
+// (the cache should reflect the most recent measurement).
+func TestTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM trust_scores WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "trust-score-update-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.500, NOW(), NOW())`,
+		agentID, orgID, "trust-score-update-test-agent-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed two trust_scores rows: an older one and a newer one.
+	olderID := uuid.New()
+	newerID := uuid.New()
+	olderCreatedAt := time.Now().UTC().Add(-1 * time.Hour)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO trust_scores
+		   (id, agent_id, score, verification_status, certificate_validity, repository_quality,
+		    documentation_score, community_trust, security_audit, update_frequency, age_score,
+		    confidence, last_calculated, created_at)
+		 VALUES ($1, $2, 0.600, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.9, $3, $3)`,
+		olderID, agentID, olderCreatedAt)
+	require.NoError(t, err)
+
+	// Newer row inserts; trigger fires; cache moves to 0.900.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO trust_scores
+		   (id, agent_id, score, verification_status, certificate_validity, repository_quality,
+		    documentation_score, community_trust, security_audit, update_frequency, age_score,
+		    confidence, last_calculated, created_at)
+		 VALUES ($1, $2, 0.900, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.95, NOW(), NOW())`,
+		newerID, agentID)
+	require.NoError(t, err)
+
+	var cached float64
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM agents WHERE id = $1`, agentID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.900, cached, 0.001,
+		"after the newer INSERT, cache should reflect the newer score")
+
+	// Now UPDATE the OLDER historical row. The trigger must NOT
+	// clobber the cache, because the older row is not the latest.
+	_, err = db.ExecContext(ctx,
+		`UPDATE trust_scores SET score = 0.100 WHERE id = $1`, olderID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM agents WHERE id = $1`, agentID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.900, cached, 0.001,
+		"UPDATE on a historical (non-latest) row must NOT clobber the cache")
+
+	// UPDATE on the LATEST row must mirror.
+	_, err = db.ExecContext(ctx,
+		`UPDATE trust_scores SET score = 0.750 WHERE id = $1`, newerID)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM agents WHERE id = $1`, agentID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.750, cached, 0.001,
+		"UPDATE on the latest row must mirror to the cache")
+}

--- a/apps/backend/migrations/093_trust_score_mirror_trigger.sql
+++ b/apps/backend/migrations/093_trust_score_mirror_trigger.sql
@@ -1,0 +1,73 @@
+-- Migration 093: Mirror the latest trust_scores.score back to
+-- agents.trust_score atomically via an AFTER INSERT OR UPDATE
+-- trigger on trust_scores.
+--
+-- The audit doc § 5 observed the agents list showing 92% while the
+-- agent detail page showed 61.3% for the SAME agent at the SAME
+-- moment. Root cause: the dashboard list query reads
+-- `agents.trust_score` (a hot-path denormalized cache), the detail
+-- page reads the latest row from `trust_scores` (the factor
+-- breakdown). Application code syncs both on calculate / direct
+-- penalty paths, but any external writer that touches one without
+-- the other (admin tool, script, manual SQL) produces a visible
+-- split-brain.
+--
+-- The richer record is `trust_scores` (full 8-factor breakdown).
+-- That is the source of truth; `agents.trust_score` is a cache.
+-- This trigger keeps the cache consistent.
+--
+-- Closes #163.
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: denormalized
+-- cache derived from a detail table uses an AFTER INSERT/UPDATE
+-- trigger on the detail table that maintains the parent cache.
+-- Same family as migration 091 (capability_violation_count).
+
+CREATE OR REPLACE FUNCTION mirror_trust_score_to_agent()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- AFTER INSERT: NEW row is by definition the latest snapshot
+    -- (created_at defaults to NOW). Mirror unconditionally.
+    --
+    -- AFTER UPDATE: only mirror if NEW row IS the latest for this
+    -- agent. UpdateScore() in trust_score_repository.go targets
+    -- only the latest row, but a future ad-hoc UPDATE on a
+    -- historical row must not overwrite the agent cache with a
+    -- stale score.
+    IF TG_OP = 'INSERT'
+       OR NEW.created_at = (
+           SELECT MAX(created_at)
+           FROM trust_scores
+           WHERE agent_id = NEW.agent_id
+       )
+    THEN
+        UPDATE agents
+        SET trust_score = NEW.score,
+            updated_at = NOW()
+        WHERE id = NEW.agent_id
+          AND trust_score IS DISTINCT FROM NEW.score;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_mirror_trust_score_to_agent ON trust_scores;
+
+CREATE TRIGGER trg_mirror_trust_score_to_agent
+    AFTER INSERT OR UPDATE ON trust_scores
+    FOR EACH ROW
+    EXECUTE FUNCTION mirror_trust_score_to_agent();
+
+-- One-shot backfill: reconcile agents whose cached trust_score
+-- differs from their latest trust_scores.score.
+UPDATE agents a
+SET trust_score = sub.latest_score,
+    updated_at = NOW()
+FROM (
+    SELECT DISTINCT ON (agent_id) agent_id, score AS latest_score
+    FROM trust_scores
+    ORDER BY agent_id, created_at DESC
+) sub
+WHERE a.id = sub.agent_id
+  AND a.trust_score IS DISTINCT FROM sub.latest_score;


### PR DESCRIPTION
## Summary

- Migration 093 installs `mirror_trust_score_to_agent()` and an `AFTER INSERT OR UPDATE` trigger on `trust_scores` that keeps `agents.trust_score` consistent with the latest `trust_scores.score` for each agent.
- Closes #163. The audit doc § 5 observed the agents list showing 92% while the detail page showed 61.3% for the same agent at the same moment — list reads the cache, detail reads the latest factor-decomposed row; application code synced both but external writers (admin tools, scripts, manual SQL) could touch one without the other.
- First of four PRs that apply the [CHIEF-CA] taxonomy to the remaining split-brain cluster. #170 (MCP trust score, near-identical shape), #169 (a2a_peer_trust aggregates), #164 (mcp capabilities JSONB) follow.

## Why this shape

`trust_scores` carries the full 8-factor breakdown. `agents.trust_score` is the hot-path cache for list rendering. Source of truth is the richer table; the cache is derivable. Per the [CHIEF-CA] decision in `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: denormalized cache from a detail table uses an AFTER INSERT/UPDATE trigger on the detail table.

### UPDATE guard

The trigger fires `AFTER INSERT OR UPDATE`. INSERTs always reflect the latest snapshot (created_at = NOW), so mirror unconditionally. UPDATEs go through a `MAX(created_at)` guard — if the row being updated is the latest for that agent, mirror; otherwise leave the cache alone. `UpdateScore()` in `trust_score_repository.go` targets only the latest row by construction, but the guard prevents a future ad-hoc UPDATE on a historical row from clobbering the cache with a stale score.

### Backfill

`UPDATE agents SET trust_score = sub.latest_score FROM (SELECT DISTINCT ON (agent_id) ...) sub WHERE a.trust_score IS DISTINCT FROM sub.latest_score`. Idempotent. Restricted to drifted rows.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/093_trust_score_mirror_trigger.sql` | NEW — trigger function, `AFTER INSERT OR UPDATE` trigger, one-shot backfill |
| `apps/backend/internal/application/trust_score_mirror_trigger_integration_test.go` | NEW — build-tag-gated integration test (INSERT mirrors; UPDATE on latest mirrors; UPDATE on historical does NOT) |

No application code changes. The trigger keeps the existing write paths consistent without changing their semantics.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./internal/application/ ./internal/interfaces/http/handlers/` PASS
- [x] `go test -tags=integration -run TestTrustScoreMirrorTrigger ./internal/application/` compiles + skips cleanly without `TEST_DATABASE_URL`
- [x] HMA static scan: 100/100
- [ ] Integration test against live PG with `TEST_DATABASE_URL` — NOT run in this session. Recommended before deploy.

## Performance

The `MAX(created_at)` subquery on UPDATE is per-row, against an indexed column (`idx_trust_scores_agent_id`). `trust_scores` writes are infrequent (per-violation or per-calculation, not per-request). No measurable impact expected.

## Cross-tenant safety

The trigger updates the agent row whose ID equals `NEW.agent_id`, the same agent that owns the trust_scores row being written. Same tenant by construction. No new attack surface — the trigger only enforces consistency on writes that were already happening.

## Skipped pre-push phases

- Phase 4.5 adversarial: trigger is consistency math, not scoring/severity/detection logic.
- Phase 5 hma-hunter: no new endpoints, no auth/routing changes.
- Phase 6 new-user walkthrough: backend-only.