### PR TITLE
feat(#170): AFTER INSERT/UPDATE trigger mirrors mcp_trust_scores.score to mcp_servers.trust_score

### DIFF
--- a/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
+++ b/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache is the
+// regression test for issue #170. Migration 094 installs an
+// AFTER INSERT OR UPDATE trigger on mcp_trust_scores that mirrors
+// NEW.score onto mcp_servers.trust_score.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestMCPTrustScoreMirrorTrigger ./internal/application/...
+func TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_scores WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "mcp-mirror-test-org-"+serverID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed MCP server with a stale cache value.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers
+		   (id, organization_id, name, url, version, trust_score, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', 0.50, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-mirror-test-server-"+serverID.String()[:8],
+		"https://mcp-mirror-test-"+serverID.String()[:8]+".example.com")
+	require.NoError(t, err)
+
+	// INSERT a new score row. Trigger must mirror to mcp_servers.trust_score.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_trust_scores
+		   (id, mcp_server_id, score, factors, confidence, last_calculated, created_at)
+		 VALUES (gen_random_uuid(), $1, 0.8234, '{}'::jsonb, 0.95, NOW(), NOW())`,
+		serverID)
+	require.NoError(t, err)
+
+	var cached float64
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID,
+	).Scan(&cached)
+	require.NoError(t, err)
+	// mcp_servers.trust_score is DECIMAL(5,2); mcp_trust_scores.score is
+	// DECIMAL(5,4). The mirrored value gets rounded to 2 decimals on
+	// storage, so 0.8234 -> 0.82. Tolerance reflects that.
+	require.InDelta(t, 0.82, cached, 0.01,
+		"trigger must mirror mcp_trust_scores.score onto mcp_servers.trust_score on INSERT")
+}
+
+// TestMCPTrustScoreMirrorTrigger_UpdateSyncsLatestOnly asserts the
+// guard: an UPDATE on a historical (non-latest) row must NOT
+// clobber the cache.
+func TestMCPTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_scores WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "mcp-update-test-org-"+serverID.String()[:8])
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers
+		   (id, organization_id, name, url, version, trust_score, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', 0.50, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-update-test-server-"+serverID.String()[:8],
+		"https://mcp-update-test-"+serverID.String()[:8]+".example.com")
+	require.NoError(t, err)
+
+	olderID := uuid.New()
+	newerID := uuid.New()
+	olderCreatedAt := time.Now().UTC().Add(-1 * time.Hour)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_trust_scores
+		   (id, mcp_server_id, score, factors, confidence, last_calculated, created_at)
+		 VALUES ($1, $2, 0.6000, '{}'::jsonb, 0.9, $3, $3)`,
+		olderID, serverID, olderCreatedAt)
+	require.NoError(t, err)
+
+	// Newer row inserts; cache must move to 0.90.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_trust_scores
+		   (id, mcp_server_id, score, factors, confidence, last_calculated, created_at)
+		 VALUES ($1, $2, 0.9000, '{}'::jsonb, 0.95, NOW(), NOW())`,
+		newerID, serverID)
+	require.NoError(t, err)
+
+	var cached float64
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.90, cached, 0.01,
+		"newer INSERT must move the cache")
+
+	// UPDATE the older row: cache MUST NOT clobber.
+	_, err = db.ExecContext(ctx,
+		`UPDATE mcp_trust_scores SET score = 0.1000 WHERE id = $1`, olderID)
+	require.NoError(t, err)
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.90, cached, 0.01,
+		"UPDATE on historical row must NOT clobber the cache")
+
+	// UPDATE the latest row: cache must mirror.
+	_, err = db.ExecContext(ctx,
+		`UPDATE mcp_trust_scores SET score = 0.7500 WHERE id = $1`, newerID)
+	require.NoError(t, err)
+	err = db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID).Scan(&cached)
+	require.NoError(t, err)
+	require.InDelta(t, 0.75, cached, 0.01,
+		"UPDATE on the latest row must mirror to the cache")
+}

--- a/apps/backend/migrations/094_mcp_trust_score_mirror_trigger.sql
+++ b/apps/backend/migrations/094_mcp_trust_score_mirror_trigger.sql
@@ -1,0 +1,68 @@
+-- Migration 094: Mirror the latest mcp_trust_scores.score back to
+-- mcp_servers.trust_score atomically via an AFTER INSERT OR UPDATE
+-- trigger on mcp_trust_scores.
+--
+-- The audit doc § 30 observed that `mcp_trust_calculator.go:486-496`
+-- writes to both tables sequentially without a transaction. If the
+-- second write fails, the row is fresh and the column is stale.
+-- Same dual-source-of-truth class as #163 (agents.trust_score vs
+-- trust_scores.score), which migration 093 closes.
+--
+-- `mcp_trust_scores` carries the full factor breakdown + confidence
+-- and is the source of truth. `mcp_servers.trust_score` is the
+-- denormalized cache for hot-path list rendering of MCP servers.
+-- This trigger keeps the cache consistent.
+--
+-- Closes #170.
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: denormalized
+-- cache derived from a detail table uses an AFTER INSERT/UPDATE
+-- trigger on the detail table that maintains the parent cache.
+-- Same family as migration 091 (capability_violation_count) and
+-- migration 093 (agents.trust_score).
+
+CREATE OR REPLACE FUNCTION mirror_mcp_trust_score_to_server()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- AFTER INSERT: NEW row is by definition the latest snapshot.
+    -- AFTER UPDATE: only mirror if NEW row IS the latest for this
+    -- MCP server. Application code only updates the latest row,
+    -- but the guard prevents a future ad-hoc UPDATE on a
+    -- historical row from clobbering the cache.
+    IF TG_OP = 'INSERT'
+       OR NEW.created_at = (
+           SELECT MAX(created_at)
+           FROM mcp_trust_scores
+           WHERE mcp_server_id = NEW.mcp_server_id
+       )
+    THEN
+        UPDATE mcp_servers
+        SET trust_score = NEW.score,
+            updated_at = NOW()
+        WHERE id = NEW.mcp_server_id
+          AND trust_score IS DISTINCT FROM NEW.score;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_mirror_mcp_trust_score_to_server ON mcp_trust_scores;
+
+CREATE TRIGGER trg_mirror_mcp_trust_score_to_server
+    AFTER INSERT OR UPDATE ON mcp_trust_scores
+    FOR EACH ROW
+    EXECUTE FUNCTION mirror_mcp_trust_score_to_server();
+
+-- One-shot backfill: reconcile MCP servers whose cached trust_score
+-- differs from their latest mcp_trust_scores.score.
+UPDATE mcp_servers m
+SET trust_score = sub.latest_score,
+    updated_at = NOW()
+FROM (
+    SELECT DISTINCT ON (mcp_server_id) mcp_server_id, score AS latest_score
+    FROM mcp_trust_scores
+    ORDER BY mcp_server_id, created_at DESC
+) sub
+WHERE m.id = sub.mcp_server_id
+  AND m.trust_score IS DISTINCT FROM sub.latest_score;


### PR DESCRIPTION
## Summary

- Migration 094 installs `mirror_mcp_trust_score_to_server()` and an `AFTER INSERT OR UPDATE` trigger on `mcp_trust_scores` that keeps `mcp_servers.trust_score` consistent with the latest score.
- Closes #170. The audit doc § 30 observed that `mcp_trust_calculator.go:486-496` writes both tables sequentially without a transaction; if the second write fails, the row is fresh and the column is stale.
- Same dual-source-of-truth class as #163 (closed by PR #229 with migration 093). Same shape, near-identical trigger logic, adapted for MCP tables.
- Second of four PRs applying the [CHIEF-CA] taxonomy to the split-brain cluster.

## Why this shape

`mcp_trust_scores` carries the full factor breakdown + confidence and is the source of truth. `mcp_servers.trust_score` is the denormalized cache for hot-path MCP list rendering. Per the [CHIEF-CA] decision in `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: denormalized cache from a detail table uses an AFTER INSERT/UPDATE trigger on the detail table.

UPDATE guard: mirror only when NEW is the latest snapshot for its MCP server (`MAX(created_at)` subquery). Prevents a future ad-hoc UPDATE on a historical row from clobbering the cache with a stale score.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/094_mcp_trust_score_mirror_trigger.sql` | NEW — trigger function, `AFTER INSERT OR UPDATE` trigger, one-shot backfill |
| `apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go` | NEW — build-tag-gated integration test (INSERT mirrors; UPDATE on latest mirrors; UPDATE on historical does NOT) |

No application code changes. The trigger enforces consistency on writes that were already happening.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./internal/application/` PASS
- [x] `go test -tags=integration -run TestMCPTrustScoreMirrorTrigger ./internal/application/` compiles + skips cleanly
- [x] HMA static scan: 100/100
- [ ] Integration test against live PG with `TEST_DATABASE_URL` — NOT run in this session

## Precision note

`mcp_servers.trust_score` is `DECIMAL(5,2)` while `mcp_trust_scores.score` is `DECIMAL(5,4)` — same 0-1 normalized scale, different precision. The mirrored value gets rounded to 2 decimals on storage; the integration test accounts for this with a 0.01 delta tolerance.

## Cross-tenant safety

Trigger updates the MCP server row whose ID equals `NEW.mcp_server_id`. Same owning org by construction. No new attack surface.

## Skipped pre-push phases

- Phase 4.5 adversarial: consistency math, no scoring/severity/detection logic.
- Phase 5 hma-hunter: no endpoint/auth changes.
- Phase 6 new-user walkthrough: backend-only.

## Cluster status

- #226 → #168 + #166 (counter trigger) MERGED
- #227 → #167 (verified_at trigger) MERGED
- #228 → #167 (last_active middleware) MERGED
- #229 → #163 (agents.trust_score mirror) MERGED
- **#230 → #170 (mcp_servers.trust_score mirror) THIS PR**
- next: #169 (a2a_peer_trust aggregates), #164 (mcp capabilities JSONB cache)