### PR TITLE
feat(#169): AFTER INSERT/UPDATE/DELETE trigger derives a2a_trust_scores aggregates from peer rows

### DIFF
--- a/apps/backend/internal/application/a2a_peer_trust_aggregates_trigger_integration_test.go
+++ b/apps/backend/internal/application/a2a_peer_trust_aggregates_trigger_integration_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestA2APeerTrustAggregatesTrigger_RecomputesOnInsert is the
+// regression test for issue #169. Migration 095 installs an
+// AFTER INSERT/UPDATE/DELETE trigger on a2a_peer_trust that
+// recomputes a2a_trust_scores.peer_trust_average and
+// unique_peers_count from the actual peer rows, replacing the
+// application-layer dual-write at a2a_repository.go:1700-1727.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestA2APeerTrustAggregatesTrigger ./internal/application/...
+func TestA2APeerTrustAggregatesTrigger_RecomputesOnInsert(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	agentID := uuid.New()
+	peerA := uuid.New()
+	peerB := uuid.New()
+	peerC := uuid.New()
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_peer_trust WHERE agent_id = $1 OR peer_agent_id IN ($2, $3, $4)`,
+			agentID, peerA, peerB, peerC)
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_trust_scores WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2, $3, $4)`,
+			agentID, peerA, peerB, peerC)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "a2a-aggr-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+
+	for _, id := range []uuid.UUID{agentID, peerA, peerB, peerC} {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
+			id, orgID, "a2a-aggr-agent-"+id.String()[:8])
+		require.NoError(t, err)
+	}
+
+	// INSERT three peer rows. The trigger must recompute the
+	// aggregates after each insert.
+	for i, peer := range []uuid.UUID{peerA, peerB, peerC} {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO a2a_peer_trust (agent_id, peer_agent_id, peer_trust_score, created_at, updated_at)
+			 VALUES ($1, $2, $3, NOW(), NOW())`,
+			agentID, peer, float64(i+1)*0.3)
+		require.NoError(t, err)
+	}
+
+	var avg sql.NullFloat64
+	var count sql.NullInt64
+	err = db.QueryRowContext(ctx,
+		`SELECT peer_trust_average, unique_peers_count FROM a2a_trust_scores WHERE agent_id = $1`,
+		agentID).Scan(&avg, &count)
+	require.NoError(t, err)
+	require.True(t, avg.Valid)
+	// 0.3, 0.6, 0.9 -> avg = 0.6
+	require.InDelta(t, 0.6, avg.Float64, 0.001,
+		"trigger must compute peer_trust_average from actual peer rows")
+	require.True(t, count.Valid)
+	require.Equal(t, int64(3), count.Int64,
+		"trigger must compute unique_peers_count from actual peer rows")
+}
+
+// TestA2APeerTrustAggregatesTrigger_DeleteShrinksAggregates asserts
+// that DELETEing a peer row recomputes the aggregates DOWNWARD —
+// the audit-doc concern about "deleted row -> aggregate lies."
+func TestA2APeerTrustAggregatesTrigger_DeleteShrinksAggregates(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	agentID := uuid.New()
+	peerA := uuid.New()
+	peerB := uuid.New()
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_peer_trust WHERE agent_id = $1 OR peer_agent_id IN ($2, $3)`,
+			agentID, peerA, peerB)
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_trust_scores WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2, $3)`, agentID, peerA, peerB)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "a2a-del-test-org-"+agentID.String()[:8])
+	require.NoError(t, err)
+	for _, id := range []uuid.UUID{agentID, peerA, peerB} {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
+			id, orgID, "a2a-del-agent-"+id.String()[:8])
+		require.NoError(t, err)
+	}
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO a2a_peer_trust (agent_id, peer_agent_id, peer_trust_score, created_at, updated_at)
+		 VALUES ($1, $2, 0.8, NOW(), NOW()), ($1, $3, 0.4, NOW(), NOW())`,
+		agentID, peerA, peerB)
+	require.NoError(t, err)
+
+	var avg sql.NullFloat64
+	var count sql.NullInt64
+	err = db.QueryRowContext(ctx,
+		`SELECT peer_trust_average, unique_peers_count FROM a2a_trust_scores WHERE agent_id = $1`,
+		agentID).Scan(&avg, &count)
+	require.NoError(t, err)
+	require.InDelta(t, 0.6, avg.Float64, 0.001)
+	require.Equal(t, int64(2), count.Int64)
+
+	// DELETE the higher-scoring peer row. Aggregate must shrink.
+	_, err = db.ExecContext(ctx,
+		`DELETE FROM a2a_peer_trust WHERE agent_id = $1 AND peer_agent_id = $2`, agentID, peerA)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		`SELECT peer_trust_average, unique_peers_count FROM a2a_trust_scores WHERE agent_id = $1`,
+		agentID).Scan(&avg, &count)
+	require.NoError(t, err)
+	require.InDelta(t, 0.4, avg.Float64, 0.001,
+		"DELETE must recompute peer_trust_average to reflect remaining rows")
+	require.Equal(t, int64(1), count.Int64,
+		"DELETE must recompute unique_peers_count downward")
+
+	// DELETE the last peer row.
+	_, err = db.ExecContext(ctx,
+		`DELETE FROM a2a_peer_trust WHERE agent_id = $1 AND peer_agent_id = $2`, agentID, peerB)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx,
+		`SELECT peer_trust_average, unique_peers_count FROM a2a_trust_scores WHERE agent_id = $1`,
+		agentID).Scan(&avg, &count)
+	require.NoError(t, err)
+	require.False(t, avg.Valid, "with no peer rows, peer_trust_average should be NULL")
+	require.Equal(t, int64(0), count.Int64, "with no peer rows, unique_peers_count should be 0")
+}

--- a/apps/backend/migrations/095_a2a_peer_trust_aggregates_trigger.sql
+++ b/apps/backend/migrations/095_a2a_peer_trust_aggregates_trigger.sql
@@ -1,0 +1,123 @@
+-- Migration 095: Derive a2a_trust_scores.peer_trust_average and
+-- unique_peers_count from a2a_peer_trust rows via an AFTER
+-- INSERT/UPDATE/DELETE trigger.
+--
+-- The audit doc § 29 observed that a2a_repository.go:1700-1727
+-- writes peer_trust_average and unique_peers_count directly to
+-- a2a_trust_scores instead of computing them from the actual
+-- a2a_peer_trust rows. If any peer-trust row is deleted, modified,
+-- or fails to persist, the aggregates lie.
+--
+-- This trigger makes the aggregates a derived view of the peer
+-- rows. Application writes to those columns become a hint; the
+-- trigger recomputes them from ground truth after every peer row
+-- mutation.
+--
+-- Closes #169.
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: aggregate
+-- of child rows uses an AFTER INSERT/UPDATE/DELETE trigger on the
+-- child table. Same family as migration 091
+-- (capability_violation_count) — that one was a COUNT, this one is
+-- COUNT(DISTINCT) + AVG.
+
+CREATE OR REPLACE FUNCTION recompute_a2a_peer_aggregates()
+RETURNS TRIGGER AS $$
+DECLARE
+    affected_agent UUID;
+    new_avg FLOAT;
+    new_count INT;
+BEGIN
+    -- INSERT and UPDATE expose NEW; DELETE only OLD. UPDATE that
+    -- moves a row between agent_ids (rare but possible) is handled
+    -- by recomputing for BOTH the old and the new agent.
+    IF TG_OP = 'DELETE' THEN
+        affected_agent := OLD.agent_id;
+    ELSE
+        affected_agent := NEW.agent_id;
+    END IF;
+
+    SELECT
+        AVG(peer_trust_score) FILTER (WHERE peer_trust_score IS NOT NULL),
+        COUNT(DISTINCT peer_agent_id)
+    INTO new_avg, new_count
+    FROM a2a_peer_trust
+    WHERE agent_id = affected_agent;
+
+    -- Upsert: a2a_trust_scores has UNIQUE(agent_id) per the table
+    -- definition (see application code at lines 1709-1725 which
+    -- uses ON CONFLICT (agent_id)). If no row exists yet, create
+    -- one with only the aggregate fields set.
+    INSERT INTO a2a_trust_scores (
+        agent_id, peer_trust_average, unique_peers_count,
+        created_at, updated_at
+    )
+    VALUES (affected_agent, new_avg, COALESCE(new_count, 0), NOW(), NOW())
+    ON CONFLICT (agent_id) DO UPDATE SET
+        peer_trust_average = EXCLUDED.peer_trust_average,
+        unique_peers_count = EXCLUDED.unique_peers_count,
+        updated_at = NOW()
+    WHERE a2a_trust_scores.peer_trust_average IS DISTINCT FROM EXCLUDED.peer_trust_average
+       OR a2a_trust_scores.unique_peers_count   IS DISTINCT FROM EXCLUDED.unique_peers_count;
+
+    -- For UPDATE that moves a row across agents, recompute the
+    -- OLD agent too.
+    IF TG_OP = 'UPDATE' AND OLD.agent_id IS DISTINCT FROM NEW.agent_id THEN
+        SELECT
+            AVG(peer_trust_score) FILTER (WHERE peer_trust_score IS NOT NULL),
+            COUNT(DISTINCT peer_agent_id)
+        INTO new_avg, new_count
+        FROM a2a_peer_trust
+        WHERE agent_id = OLD.agent_id;
+
+        INSERT INTO a2a_trust_scores (
+            agent_id, peer_trust_average, unique_peers_count,
+            created_at, updated_at
+        )
+        VALUES (OLD.agent_id, new_avg, COALESCE(new_count, 0), NOW(), NOW())
+        ON CONFLICT (agent_id) DO UPDATE SET
+            peer_trust_average = EXCLUDED.peer_trust_average,
+            unique_peers_count = EXCLUDED.unique_peers_count,
+            updated_at = NOW()
+        WHERE a2a_trust_scores.peer_trust_average IS DISTINCT FROM EXCLUDED.peer_trust_average
+           OR a2a_trust_scores.unique_peers_count   IS DISTINCT FROM EXCLUDED.unique_peers_count;
+    END IF;
+
+    -- AFTER triggers return value is ignored for table modification;
+    -- conventional to return NEW/OLD anyway.
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_recompute_a2a_peer_aggregates ON a2a_peer_trust;
+
+CREATE TRIGGER trg_recompute_a2a_peer_aggregates
+    AFTER INSERT OR UPDATE OR DELETE ON a2a_peer_trust
+    FOR EACH ROW
+    EXECUTE FUNCTION recompute_a2a_peer_aggregates();
+
+-- One-shot backfill: reconcile any agents whose a2a_trust_scores
+-- aggregates differ from the actual peer rows.
+INSERT INTO a2a_trust_scores (
+    agent_id, peer_trust_average, unique_peers_count,
+    created_at, updated_at
+)
+SELECT
+    p.agent_id,
+    AVG(p.peer_trust_score) FILTER (WHERE p.peer_trust_score IS NOT NULL),
+    COUNT(DISTINCT p.peer_agent_id),
+    NOW(),
+    NOW()
+FROM a2a_peer_trust p
+GROUP BY p.agent_id
+ON CONFLICT (agent_id) DO UPDATE SET
+    peer_trust_average = EXCLUDED.peer_trust_average,
+    unique_peers_count = EXCLUDED.unique_peers_count,
+    updated_at = NOW()
+WHERE a2a_trust_scores.peer_trust_average IS DISTINCT FROM EXCLUDED.peer_trust_average
+   OR a2a_trust_scores.unique_peers_count   IS DISTINCT FROM EXCLUDED.unique_peers_count;


### PR DESCRIPTION
## Summary

- Migration 095 installs `recompute_a2a_peer_aggregates()` and an `AFTER INSERT OR UPDATE OR DELETE` trigger on `a2a_peer_trust` that recomputes `a2a_trust_scores.peer_trust_average` and `unique_peers_count` from ground truth after every peer-row mutation.
- Closes #169. The audit doc § 29 observed that `a2a_repository.go:1700-1727` writes both aggregates directly instead of deriving them; the audit's primary concern was that a DELETED peer row leaves the aggregate lying upward.
- Third of four PRs applying the [CHIEF-CA] taxonomy to the split-brain cluster (#163 closed by #229, #170 in PR #230, #164 follows).

## Why this shape

Per the [CHIEF-CA] decision in `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: aggregate of child rows uses an AFTER INSERT/UPDATE/DELETE trigger on the child table. Same family as migration 091 (`capability_violation_count`) — that one was a COUNT, this one is `COUNT(DISTINCT) + AVG`.

Aggregates derived:
- `peer_trust_average = AVG(peer_trust_score) FILTER (WHERE peer_trust_score IS NOT NULL)` — NULL when no scored peers
- `unique_peers_count = COUNT(DISTINCT peer_agent_id)` — 0 when no peer rows exist

## Edge cases handled

- **DELETE**: aggregates shrink (the audit's primary concern). When the last peer row is removed, avg → NULL and count → 0.
- **UPDATE that moves a row across agent_ids** (rare but possible): the trigger recomputes for BOTH the old and the new agent.
- **No row yet in a2a_trust_scores**: `INSERT … ON CONFLICT (agent_id) DO UPDATE` upserts the aggregate columns only; existing fields like `total_tasks_as_client` are left alone.

## Backfill

One-shot at migration time, idempotent on re-run via `IS DISTINCT FROM` guards. Reconciles every agent whose aggregates differ from the actual peer rows.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/095_a2a_peer_trust_aggregates_trigger.sql` | NEW — trigger function (multi-op), trigger, one-shot backfill |
| `apps/backend/internal/application/a2a_peer_trust_aggregates_trigger_integration_test.go` | NEW — build-tag-gated integration test covering INSERT computes; DELETE shrinks (including last-peer-removed → NULL avg + 0 count) |

No application code changes. The trigger replaces the dual-write with derived state.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -tags=integration -run TestA2APeerTrustAggregatesTrigger ./internal/application/` compiles + skips cleanly
- [x] HMA static scan: 100/100
- [ ] Integration test against live PG with `TEST_DATABASE_URL` — NOT run in this session

## Cross-tenant safety

Trigger reads/writes only `a2a_peer_trust` and `a2a_trust_scores` rows scoped to the affected `agent_id`. Same tenant by construction.

## Skipped pre-push phases

- Phase 4.5 adversarial: aggregate math, no scoring/severity/detection logic.
- Phase 5 hma-hunter: no endpoint/auth changes.
- Phase 6 new-user walkthrough: backend-only.

## Cluster status

- #226 → #168 + #166 MERGED
- #227 → #167 (verified_at) MERGED
- #228 → #167 (last_active) MERGED
- #229 → #163 MERGED
- #230 → #170 OPEN (auto-merge SQUASH armed)
- **#231 → #169 THIS PR**
- next: #164 (mcp capabilities JSONB cache)