### PR TITLE
docs: add STATUS.md (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agent Identity Management (AIM)
 
+[![Status: beta](https://img.shields.io/badge/status-beta-yellow)](./STATUS.md)
+
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
 Cryptographic identity, capability authorization, and audit trails for AI agents. Apache 2.0.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,22 @@
+# Status: beta
+
+**Stage:** beta
+**Maintenance horizon:** actively maintained through 2026-12-31, status reviewed quarterly
+**Maintainer wanted:** no
+
+## Stage rationale
+
+AIM is pre-1.0. Suitable for evaluation, development, and internal testing. Production deployment with untrusted tenants or sensitive data is not yet recommended. Active hardening work is tracked in [HARDENING.md](HARDENING.md).
+
+## Stage definitions
+
+- **stable**: production-ready, semver honored, breaking changes documented, security patches triaged within 24 hours.
+- **beta**: feature-complete or near, breaking changes possible with notice, actively developed.
+- **experimental**: early stage, breaking changes expected, use at your own risk.
+- **reference-only**: spec or reference implementation, not intended for production use.
+
+## Status changes
+
+| Date | Stage | Reason |
+|---|---|---|
+| 2026-05-24 | beta | initial STATUS.md (org lifecycle introduction). Maps to existing pre-1.0 disclaimer in README. |


### PR DESCRIPTION
## Summary

Adds a top-level `STATUS.md` and a status-line badge to the README header. Part of the org-wide STATUS sweep so downstream consumers can read repo lifecycle at a glance.

Stage: **beta**. This maps to the existing "Pre-1.0" disclaimer at the top of the README.

## What changed

- `STATUS.md` (new): stage, maintenance horizon, maintainer-wanted flag, stage definitions, status-change log
- `README.md` (line 3): status badge linking to STATUS.md

## Scope

Part of the 16-repo non-honey sweep. The four honey-fleet bait repos (agent-hardening-guide, mcp-security-checklist, ai-credential-safety, a2a-security-examples) are intentionally excluded.

## Test plan

- [x] Pre-push gate passed (turbo build cached, turbo test cached, docs-only phases skipped)
- [x] STATUS.md renders correctly on GitHub
- [x] Badge links to STATUS.md