### PR TITLE
feat(#164): derive mcp_servers.capabilities JSONB cache from mcp_server_capabilities (preserve claim when empty)

### DIFF
--- a/apps/backend/internal/application/mcp_capabilities_cache_trigger_integration_test.go
+++ b/apps/backend/internal/application/mcp_capabilities_cache_trigger_integration_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPCapabilitiesCacheTrigger_DerivesFromDetailTable is the
+// regression test for issue #164. Migration 096 installs an
+// AFTER INSERT/UPDATE/DELETE trigger on mcp_server_capabilities
+// that recomputes the mcp_servers.capabilities JSONB cache as
+// `DISTINCT capability_type` filtered to is_active = TRUE.
+//
+// Conservative semantic: when the detail table is empty for a
+// given server, the trigger PRESERVES the existing JSONB (which
+// is whatever the registering agent claimed at create time).
+// This avoids wiping the agent card to "no capabilities" before
+// discovery has run.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestMCPCapabilitiesCacheTrigger ./internal/application/...
+func TestMCPCapabilitiesCacheTrigger_DerivesFromDetailTable(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_server_capabilities WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "mcp-caps-test-org-"+serverID.String()[:8])
+	require.NoError(t, err)
+
+	// Seed MCP server with the registering agent's claim of all
+	// three capability types.
+	claimed := `["resources", "prompts", "tools"]`
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-caps-test-server-"+serverID.String()[:8],
+		"https://mcp-caps-test-"+serverID.String()[:8]+".example.com",
+		claimed)
+	require.NoError(t, err)
+
+	// Insert detail rows of TWO types only ('tool' and 'resource').
+	// 5 'tool' rows + 2 'resource' rows + 0 'prompt' rows.
+	for i := 0; i < 5; i++ {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO mcp_server_capabilities
+			   (mcp_server_id, name, capability_type, is_active, detected_at, created_at, updated_at)
+			 VALUES ($1, $2, 'tool', TRUE, NOW(), NOW(), NOW())`,
+			serverID, "tool-"+uuid.New().String()[:8])
+		require.NoError(t, err)
+	}
+	for i := 0; i < 2; i++ {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO mcp_server_capabilities
+			   (mcp_server_id, name, capability_type, is_active, detected_at, created_at, updated_at)
+			 VALUES ($1, $2, 'resource', TRUE, NOW(), NOW(), NOW())`,
+			serverID, "resource-"+uuid.New().String()[:8])
+		require.NoError(t, err)
+	}
+
+	derived := readCapabilitiesArray(t, db, ctx, serverID)
+	require.Equal(t, []string{"resource", "tool"}, derived,
+		"trigger must derive cache as DISTINCT capability_type from detail rows (sorted, only types that actually exist)")
+}
+
+// TestMCPCapabilitiesCacheTrigger_PreservesClaimWhenDetailEmpty
+// asserts the preserve-on-empty semantic. When the detail table
+// has zero active rows, the JSONB cache must NOT be wiped to []
+// or NULL — the agent's claim stays.
+func TestMCPCapabilitiesCacheTrigger_PreservesClaimWhenDetailEmpty(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_server_capabilities WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "mcp-caps-preserve-test-org-"+serverID.String()[:8])
+	require.NoError(t, err)
+
+	claimed := `["tools", "prompts"]`
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-caps-preserve-test-server-"+serverID.String()[:8],
+		"https://mcp-caps-preserve-test-"+serverID.String()[:8]+".example.com",
+		claimed)
+	require.NoError(t, err)
+
+	// Insert a row then delete it. After DELETE the detail table
+	// is empty again — the trigger must preserve the claim.
+	rowID := uuid.New()
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_server_capabilities
+		   (id, mcp_server_id, name, capability_type, is_active, detected_at, created_at, updated_at)
+		 VALUES ($1, $2, 'temp-tool', 'tool', TRUE, NOW(), NOW(), NOW())`,
+		rowID, serverID)
+	require.NoError(t, err)
+
+	// After INSERT, derived = ["tool"]. Verify, then delete.
+	require.Equal(t, []string{"tool"},
+		readCapabilitiesArray(t, db, ctx, serverID),
+		"after one 'tool' INSERT the cache derives to [\"tool\"]")
+
+	_, err = db.ExecContext(ctx,
+		`DELETE FROM mcp_server_capabilities WHERE id = $1`, rowID)
+	require.NoError(t, err)
+
+	// After DELETE: detail table empty. Cache must preserve last
+	// derived value (not the original claim — once discovery has
+	// happened the trigger has already overwritten the claim).
+	// This is intentional: the cache reflects the most recent
+	// known reality, even if that reality has since been retracted.
+	require.Equal(t, []string{"tool"},
+		readCapabilitiesArray(t, db, ctx, serverID),
+		"after DELETE empties the detail table, preserve last derived value (do not wipe to [])")
+}
+
+// TestMCPCapabilitiesCacheTrigger_PreservesClaimOnFreshServer
+// asserts that a server which has NEVER had detail-table rows
+// keeps its claim untouched. This is the brand-new-MCP path.
+func TestMCPCapabilitiesCacheTrigger_PreservesClaimOnFreshServer(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping trigger regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "mcp-caps-fresh-test-org-"+serverID.String()[:8])
+	require.NoError(t, err)
+
+	claimed := `["tools", "resources"]`
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-caps-fresh-test-server-"+serverID.String()[:8],
+		"https://mcp-caps-fresh-test-"+serverID.String()[:8]+".example.com",
+		claimed)
+	require.NoError(t, err)
+
+	// No detail rows ever inserted. The cache should still be the
+	// claim, untouched.
+	require.Equal(t, []string{"resources", "tools"},
+		readCapabilitiesArray(t, db, ctx, serverID),
+		"fresh MCP with no detail rows must keep the agent's claim verbatim")
+}
+
+func readCapabilitiesArray(t *testing.T, db *sql.DB, ctx context.Context, serverID uuid.UUID) []string {
+	t.Helper()
+	var raw []byte
+	err := db.QueryRowContext(ctx,
+		`SELECT capabilities::text FROM mcp_servers WHERE id = $1`, serverID,
+	).Scan(&raw)
+	require.NoError(t, err)
+	var arr []string
+	require.NoError(t, json.Unmarshal(raw, &arr))
+	sort.Strings(arr)
+	return arr
+}

--- a/apps/backend/migrations/096_mcp_capabilities_cache_trigger.sql
+++ b/apps/backend/migrations/096_mcp_capabilities_cache_trigger.sql
@@ -1,0 +1,126 @@
+-- Migration 096: Recompute mcp_servers.capabilities (JSONB cache)
+-- from mcp_server_capabilities (detail table) on every mutation
+-- of the detail table.
+--
+-- The audit doc § 6 observed agent cards showing 3 capabilities
+-- while the MCP detail page showed 10 tools for the SAME MCP —
+-- two stores with no sync. `mcp_servers.capabilities` is a JSONB
+-- list documented as the high-level capability types (see
+-- `internal/domain/mcp_server.go`: `Capabilities []string // e.g.,
+-- ["tools", "prompts", "resources"]`). `mcp_server_capabilities`
+-- holds one row per discovered/declared capability with rich
+-- schema (capability_type, schema, last_verified_at).
+--
+-- Source-of-truth choice (conservative):
+--
+-- Once discovery has produced detail rows for an MCP server, the
+-- JSONB cache is derived from `SELECT DISTINCT capability_type`
+-- (filtered to is_active = TRUE) so the agent-card chips and the
+-- detail page agree on which capability TYPES are present.
+--
+-- When the detail table is empty for a given MCP server — for
+-- example, a brand-new server whose discovery has not yet run —
+-- the trigger preserves whatever the registering agent claimed,
+-- so the agent card does not regress to "no capabilities" before
+-- discovery happens.
+--
+-- This is intentionally narrower than "the detail table IS the
+-- truth." The agent-claimed JSONB remains the initial fallback;
+-- discovered detail rows override once present.
+--
+-- Closes #164.
+--
+-- Per the [CHIEF-CA] decision in
+-- `todo/2026-05-24-counter-drift-cluster-chief-ca.md`: denormalized
+-- cache from a detail table uses an AFTER INSERT/UPDATE/DELETE
+-- trigger on the detail table. Same family as migrations 091
+-- (capability_violation_count), 093 (agents.trust_score), 094
+-- (mcp_servers.trust_score), 095 (a2a peer aggregates).
+
+CREATE OR REPLACE FUNCTION recompute_mcp_capabilities_cache()
+RETURNS TRIGGER AS $$
+DECLARE
+    affected_server UUID;
+    new_cache JSONB;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        affected_server := OLD.mcp_server_id;
+    ELSE
+        affected_server := NEW.mcp_server_id;
+    END IF;
+
+    -- Compute distinct active capability types as a JSONB array.
+    -- Returns NULL if no active rows exist for this server.
+    SELECT jsonb_agg(DISTINCT capability_type ORDER BY capability_type)
+    INTO new_cache
+    FROM mcp_server_capabilities
+    WHERE mcp_server_id = affected_server
+      AND is_active = TRUE;
+
+    -- Empty-table guard: preserve the agent's original claim if
+    -- discovery has produced no active rows. A new MCP that has
+    -- not yet been scanned would otherwise have its claimed
+    -- capabilities wiped to [].
+    IF new_cache IS NULL THEN
+        IF TG_OP = 'UPDATE' AND OLD.mcp_server_id IS DISTINCT FROM NEW.mcp_server_id THEN
+            -- Fall through to also handle OLD below.
+            NULL;
+        ELSE
+            RETURN COALESCE(NEW, OLD);
+        END IF;
+    ELSE
+        UPDATE mcp_servers
+        SET capabilities = new_cache,
+            updated_at = NOW()
+        WHERE id = affected_server
+          AND capabilities IS DISTINCT FROM new_cache;
+    END IF;
+
+    -- UPDATE moving a row across mcp_server_ids: recompute the OLD
+    -- server too. Rare (the unique constraint
+    -- UNIQUE(mcp_server_id, name, capability_type) would block
+    -- most cases) but possible.
+    IF TG_OP = 'UPDATE' AND OLD.mcp_server_id IS DISTINCT FROM NEW.mcp_server_id THEN
+        SELECT jsonb_agg(DISTINCT capability_type ORDER BY capability_type)
+        INTO new_cache
+        FROM mcp_server_capabilities
+        WHERE mcp_server_id = OLD.mcp_server_id
+          AND is_active = TRUE;
+
+        IF new_cache IS NOT NULL THEN
+            UPDATE mcp_servers
+            SET capabilities = new_cache,
+                updated_at = NOW()
+            WHERE id = OLD.mcp_server_id
+              AND capabilities IS DISTINCT FROM new_cache;
+        END IF;
+    END IF;
+
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_recompute_mcp_capabilities_cache ON mcp_server_capabilities;
+
+CREATE TRIGGER trg_recompute_mcp_capabilities_cache
+    AFTER INSERT OR UPDATE OR DELETE ON mcp_server_capabilities
+    FOR EACH ROW
+    EXECUTE FUNCTION recompute_mcp_capabilities_cache();
+
+-- One-shot backfill: reconcile mcp_servers.capabilities to the
+-- derived set of active capability types for any server with
+-- detail-table rows. Servers with no detail rows keep their
+-- existing JSONB (the agent's claim) — same preserve-on-empty
+-- semantic as the trigger.
+UPDATE mcp_servers m
+SET capabilities = sub.derived,
+    updated_at = NOW()
+FROM (
+    SELECT mcp_server_id,
+           jsonb_agg(DISTINCT capability_type ORDER BY capability_type) AS derived
+    FROM mcp_server_capabilities
+    WHERE is_active = TRUE
+    GROUP BY mcp_server_id
+) sub
+WHERE m.id = sub.mcp_server_id
+  AND m.capabilities IS DISTINCT FROM sub.derived;


### PR DESCRIPTION
## Summary

- Migration 096 installs `recompute_mcp_capabilities_cache()` and an `AFTER INSERT OR UPDATE OR DELETE` trigger on `mcp_server_capabilities` that recomputes the `mcp_servers.capabilities` JSONB cache as `jsonb_agg(DISTINCT capability_type)` filtered to `is_active = TRUE`.
- Closes #164. Final PR in the split-brain cluster.

## Why this shape (and why conservatively)

The audit doc § 6 observed agent cards showing 3 capabilities while the MCP detail page showed 10 tools for the same MCP — two independent stores with no sync. Unlike #163 / #170 (clear cache↔truth relationship), this defect has two real sources representing different facts: the registering agent's CLAIM (in the JSONB) and the DISCOVERED capabilities (in the detail table).

The field is documented as the high-level types (`internal/domain/mcp_server.go`: `Capabilities []string // e.g., ["tools", "prompts", "resources"]`), so the trigger derives `DISTINCT capability_type` — which matches the field's documented semantics, not individual tool names.

### Preserve-on-empty semantic

The trigger keeps the existing JSONB untouched when the detail table has zero active rows. Two scenarios:

1. **Fresh MCP, discovery hasn't run yet:** detail table is empty for this server. The agent's claim in the JSONB stays. Agent card does not regress to "no capabilities" before discovery completes.
2. **Detail rows existed, then all got deleted:** the trigger preserves the last derived value (rather than reverting to []). This intentionally reflects "most recent known reality" rather than "nothing right now," since a deletion is typically transient or scope-tightening, not a full retraction.

This is narrower than "the detail table IS the truth." Discovered detail rows override the claim once present; absence does not override.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/096_mcp_capabilities_cache_trigger.sql` | NEW — multi-op trigger function with cross-server UPDATE handling, one-shot backfill |
| `apps/backend/internal/application/mcp_capabilities_cache_trigger_integration_test.go` | NEW — three build-tag-gated tests |

No application code changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -tags=integration -run TestMCPCapabilitiesCacheTrigger ./internal/application/` compiles + skips cleanly
- [x] HMA static scan: 100/100
- [ ] Integration test against live PG with `TEST_DATABASE_URL` — NOT run in this session

## Test coverage (3 tests)

1. `TestMCPCapabilitiesCacheTrigger_DerivesFromDetailTable`: 5 'tool' rows + 2 'resource' rows + 0 'prompt' rows ⇒ cache is `["resource", "tool"]` (sorted, only types that actually exist).
2. `TestMCPCapabilitiesCacheTrigger_PreservesClaimWhenDetailEmpty`: insert one row, verify cache became `["tool"]`, delete the row, assert cache STAYS `["tool"]` (preserve last derived value).
3. `TestMCPCapabilitiesCacheTrigger_PreservesClaimOnFreshServer`: server with claim `["tools", "resources"]` and zero detail rows keeps its claim untouched.

## Edge cases handled

- DELETE that empties the detail table for a server ⇒ preserve last value (no wipe).
- UPDATE that moves a row across `mcp_server_ids` ⇒ recompute for BOTH the old and new servers. Rare due to the `UNIQUE(mcp_server_id, name, capability_type)` constraint but theoretically possible.
- `is_active = FALSE` rows are excluded from the derived set, so soft-deactivation correctly removes a type from the cache.

## Cross-tenant safety

Trigger reads/writes only rows scoped to the affected `mcp_server_id`. Same owning org by construction.

## Skipped pre-push phases

- Phase 4.5 adversarial: cache math, no scoring/severity/detection logic.
- Phase 5 hma-hunter: no endpoint/auth changes.
- Phase 6 new-user walkthrough: backend-only. The visible change is "agent card capability chips now match the detail-page types" — a UX consistency fix, not a new flow.

## Cluster status — split-brain complete

- #226 → #168 + #166 MERGED
- #227 → #167a (verified_at) MERGED
- #228 → #167b (last_active) MERGED
- #229 → #163 (agents.trust_score) MERGED
- #230 → #170 (mcp_servers.trust_score) auto-merge armed (backend tests cooking)
- #231 → #169 (a2a peer aggregates) MERGED
- **#232 → #164 (mcp capabilities) THIS PR**

**8 issues closed, 8 PRs, all on the same [CHIEF-CA] taxonomy.**