### PR TITLE
feat(#179): backfill a2a_consent_records.organization_id from grantor agent + add NOT NULL

### DIFF
--- a/apps/backend/internal/application/a2a_consent_backfill_integration_test.go
+++ b/apps/backend/internal/application/a2a_consent_backfill_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestA2AConsentBackfill_ConstraintEnforced is the regression test
+// for issue #179. Migration 097 backfilled
+// a2a_consent_records.organization_id from grantor agent and added
+// a NOT NULL constraint. After migration, inserting a consent row
+// without organization_id must be rejected.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL
+// with migration 097 already applied.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestA2AConsentBackfill ./internal/application/...
+func TestA2AConsentBackfill_ConstraintEnforced(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping constraint regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	grantorID := uuid.New()
+	recipientID := uuid.New()
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx,
+			`DELETE FROM a2a_consent_records WHERE grantor_agent_id IN ($1, $2)`,
+			grantorID, recipientID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2)`,
+			grantorID, recipientID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "consent-backfill-test-org-"+grantorID.String()[:8])
+	require.NoError(t, err)
+
+	for _, id := range []uuid.UUID{grantorID, recipientID} {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
+			id, orgID, "consent-backfill-agent-"+id.String()[:8])
+		require.NoError(t, err)
+	}
+
+	// Attempt to INSERT a consent record WITHOUT organization_id.
+	// Must fail with a not-null violation.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO a2a_consent_records
+		   (user_id, grantor_agent_id, recipient_agent_id,
+		    scope, purpose, data_types, consent_method)
+		 VALUES ($1, $2, $3, '[]'::jsonb, $4, '[]'::jsonb, 'api')`,
+		"test-user-"+grantorID.String()[:8], grantorID, recipientID,
+		"backfill constraint test")
+	require.Error(t, err,
+		"INSERT without organization_id must fail post-migration; got nil error")
+	require.Contains(t, err.Error(), "organization_id",
+		"error must reference the not-null column; got: %v", err)
+
+	// Sanity check: same INSERT WITH organization_id succeeds.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO a2a_consent_records
+		   (user_id, organization_id, grantor_agent_id, recipient_agent_id,
+		    scope, purpose, data_types, consent_method)
+		 VALUES ($1, $2, $3, $4, '[]'::jsonb, $5, '[]'::jsonb, 'api')`,
+		"test-user-"+grantorID.String()[:8], orgID, grantorID, recipientID,
+		"backfill positive test")
+	require.NoError(t, err)
+}
+
+// TestA2AConsentBackfill_OrgIDDerivesFromGrantor asserts the
+// backfill semantic: an existing NULL-org row's organization_id
+// gets stamped with the grantor agent's organization_id. This is
+// done by simulating the pre-migration state (insert with NULL,
+// then re-run the backfill SQL inline since the actual migration
+// is one-shot at migrate-time).
+func TestA2AConsentBackfill_OrgIDDerivesFromGrantor(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping backfill semantic test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	grantorID := uuid.New()
+	recipientID := uuid.New()
+	consentID := uuid.New()
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_consent_records WHERE id = $1`, consentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2)`,
+			grantorID, recipientID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at, updated_at)
+		 VALUES ($1, $2, NOW(), NOW())`,
+		orgID, "consent-derive-test-org-"+grantorID.String()[:8])
+	require.NoError(t, err)
+	for _, id := range []uuid.UUID{grantorID, recipientID} {
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
+			id, orgID, "consent-derive-agent-"+id.String()[:8])
+		require.NoError(t, err)
+	}
+
+	// Simulate the pre-migration shape: temporarily drop the NOT
+	// NULL constraint, insert a NULL-org row, then re-apply the
+	// constraint to reset state. We test only the backfill SELECT;
+	// the constraint itself is covered by the previous test.
+	_, err = db.ExecContext(ctx,
+		`ALTER TABLE a2a_consent_records ALTER COLUMN organization_id DROP NOT NULL`)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.ExecContext(ctx,
+			`ALTER TABLE a2a_consent_records ALTER COLUMN organization_id SET NOT NULL`)
+	}()
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO a2a_consent_records
+		   (id, user_id, organization_id, grantor_agent_id, recipient_agent_id,
+		    scope, purpose, data_types, consent_method)
+		 VALUES ($1, $2, NULL, $3, $4, '[]'::jsonb, $5, '[]'::jsonb, 'api')`,
+		consentID, "test-user-"+grantorID.String()[:8], grantorID, recipientID,
+		"pre-migration NULL-org row")
+	require.NoError(t, err)
+
+	// Run the same UPDATE shape that migration 097 ships.
+	_, err = db.ExecContext(ctx, `
+		UPDATE a2a_consent_records c
+		SET organization_id = a.organization_id,
+		    updated_at = NOW()
+		FROM agents a
+		WHERE c.grantor_agent_id = a.id
+		  AND c.id = $1
+		  AND c.organization_id IS NULL`, consentID)
+	require.NoError(t, err)
+
+	var derived uuid.UUID
+	err = db.QueryRowContext(ctx,
+		`SELECT organization_id FROM a2a_consent_records WHERE id = $1`, consentID,
+	).Scan(&derived)
+	require.NoError(t, err)
+	require.Equal(t, orgID, derived,
+		"backfill must derive organization_id from the grantor agent")
+}

--- a/apps/backend/migrations/097_backfill_a2a_consent_organization_id.sql
+++ b/apps/backend/migrations/097_backfill_a2a_consent_organization_id.sql
@@ -1,0 +1,57 @@
+-- Migration 097: Backfill a2a_consent_records.organization_id for
+-- rows written before PR #149's RecordConsent fix, then add a
+-- NOT NULL constraint so future writes are guaranteed org-scoped.
+--
+-- Background (audit doc § 50):
+--
+-- PR #149 added `WHERE user_id = $1 AND organization_id = $2` to
+-- A2AConsentRepository.ListByUser to close the cross-tenant
+-- userId enumeration IDOR (audit #42). The companion fix to
+-- RecordConsent now stamps caller orgID on every new write, so
+-- future rows are always org-scoped. But existing NULL-org rows
+-- from the pre-fix write path remain dark to the user's view
+-- because the new WHERE clause filters them out.
+--
+-- This migration:
+-- 1. Derives organization_id from the grantor agent (the agent that
+--    granted the consent; its organization_id is the canonical owner
+--    of the consent record per the cross-tenant model).
+-- 2. Adds a NOT NULL constraint so the schema enforces what the
+--    application now guarantees.
+--
+-- Closes #179.
+
+-- Step 1: Backfill from grantor agent's organization.
+UPDATE a2a_consent_records c
+SET organization_id = a.organization_id,
+    updated_at = NOW()
+FROM agents a
+WHERE c.grantor_agent_id = a.id
+  AND c.organization_id IS NULL
+  AND a.organization_id IS NOT NULL;
+
+-- Step 2: Defensive cleanup. If any rows still have NULL
+-- organization_id after backfill (e.g., grantor agent rows where
+-- the agent itself has NULL organization_id, which should be
+-- impossible per the agents schema but is checked defensively),
+-- they are orphaned and the NOT NULL constraint below would
+-- otherwise fail to add. Delete them — they are unrecoverable
+-- consent records that no tenant can claim, and per audit doc
+-- they have been invisible to all tenants since PR #149 anyway.
+DELETE FROM a2a_consent_records
+WHERE organization_id IS NULL;
+
+-- Step 3: Enforce the invariant. RecordConsent now always sets
+-- organization_id; this constraint guarantees the schema agrees.
+ALTER TABLE a2a_consent_records
+    ALTER COLUMN organization_id SET NOT NULL;
+
+-- Step 4: The original partial index
+-- `idx_a2a_consent_org ON a2a_consent_records(organization_id)
+-- WHERE organization_id IS NOT NULL` was correct under the
+-- nullable schema. Now that the column is NOT NULL, the WHERE
+-- predicate is redundant. Replace with a full index so PostgreSQL
+-- can use it for the org-scoped read path that ListByUser now
+-- requires.
+DROP INDEX IF EXISTS idx_a2a_consent_org;
+CREATE INDEX IF NOT EXISTS idx_a2a_consent_org ON a2a_consent_records(organization_id);


### PR DESCRIPTION
## Summary

- Migration 097 backfills `a2a_consent_records.organization_id` from each row's grantor agent, deletes any orphan rows where the grantor agent has no org, then adds `NOT NULL` to the column. Also replaces the now-redundant partial index with a full one.
- Closes #179. Audit doc § 50: pre-PR-#149 rows with NULL `organization_id` were rendered invisible by #149's new `WHERE organization_id = $2` filter on `ListByUser`. This is the cleanup PR that the original #149 left out of scope.

## Why this shape

The grantor agent is the canonical owner of a consent record (it's the agent that issued the consent). The recipient is across a trust boundary and cannot claim the record. So the derivation is `c.grantor_agent_id → a.id → a.organization_id`.

Defensive DELETE for residual NULL rows: if any consent record's grantor agent has NULL organization_id (should be impossible per the agents schema), the row is unrecoverable and has been invisible to all tenants since #149 anyway. Better to DELETE than to let the `ALTER COLUMN ... SET NOT NULL` fail.

## Files

| File | Change |
|---|---|
| `apps/backend/migrations/097_backfill_a2a_consent_organization_id.sql` | NEW — backfill UPDATE, orphan DELETE, NOT NULL constraint, index replace |
| `apps/backend/internal/application/a2a_consent_backfill_integration_test.go` | NEW — build-tag-gated test: post-migration INSERT without `organization_id` rejected; backfill SQL derives correctly from grantor agent |

No application code changes. RecordConsent already stamps orgID on every new write per #149.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -tags=integration -run TestA2AConsentBackfill ./internal/application/` compiles + skips cleanly without `TEST_DATABASE_URL`
- [x] HMA static scan: 100/100
- [ ] Integration test against live PG — NOT run in this session

## Cross-tenant safety

The backfill makes hidden consent records visible to their grantor agent's owning org. This is RESTORING the org's own data that's been invisible since #149, not crossing a tenant boundary. The audit explicitly flagged this as required cleanup.

## Skipped pre-push phases

- Phase 4.5 adversarial: data backfill, no scoring/detection logic.
- Phase 5 hma-hunter: no endpoint/auth changes.
- Phase 6 new-user walkthrough: backend-only data migration.