### PR TITLE
security: close defect #41 status-code oracle + RecordMCPConnection route binding (#162)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -756,15 +756,26 @@ func (h *MCPAttestationHandler) RevokeAllAttestationsByAgent(c fiber.Ctx) error 
 // @Tags sdk-api
 // @Accept json
 // @Produce json
-// @Param agent_id path string true "Agent ID"
+// @Param id path string true "Agent ID"
 // @Param request body map[string]interface{} true "Connection data"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
 // @Failure 500 {object} map[string]interface{}
-// @Router /api/v1/sdk-api/agents/{agent_id}/mcp-connections [post]
+// @Router /api/v1/sdk-api/agents/{id}/mcp-connections [post]
 func (h *MCPAttestationHandler) RecordMCPConnection(c fiber.Ctx) error {
-	// Get agent ID from URL path (already authenticated by SDK middleware)
-	agentID, err := uuid.Parse(c.Params("agent_id"))
+	// Get agent ID from URL path (already authenticated by SDK middleware).
+	//
+	// ROUTE-BINDING FIX: the production route in main.go binds this handler
+	// at `/api/v1/sdk-api/agents/:id/mcp-connections`. Fiber v3 keys path
+	// params by the literal name after `:` — `c.Params("agent_id")` returns
+	// "" when the route uses `:id`, so every prod call returned 400
+	// "invalid UUID length: 0" before the security checks below ever ran.
+	// The sibling handler RecordMCPUsageReport already reads `c.Params("id")`
+	// and is wired correctly. Using `"id"` here aligns this handler with the
+	// production route + the sibling handler. Tests use the same route
+	// shape so the param key change is the entire fix.
+	agentID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Invalid agent ID",
@@ -802,21 +813,25 @@ func (h *MCPAttestationHandler) RecordMCPConnection(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY (defect #41): a malformed body-supplied mcpServerId
+	// returns the same 404 {"error":"not found"} as a well-formed
+	// cross-org or nonexistent mcpServerId. Returning a distinct 400
+	// here would be a status-code oracle: an attacker holding a
+	// legitimate same-org SDK token could distinguish "valid-format-
+	// but-cross-org UUID" from "garbage UUID" via response shape,
+	// narrowing UUID enumeration to well-formed-only space. The
+	// security boundary is the LoadOwned call below; this branch
+	// collapses to the same response surface as that helper.
 	mcpServerID, err := uuid.Parse(req.MCPServerID)
 	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error":   "Invalid MCP server ID",
-			"message": err.Error(),
-		})
+		respondResourceNotFound(c)
+		return nil
 	}
 
 	// SECURITY (defect #19): verify the agent in the URL belongs to the
 	// caller's organization before recording the MCP connection. Without
 	// this check, an SDK token for org A can record fake MCP connections
-	// for any agent in any org by guessing UUIDs. Placed AFTER the body
-	// validation so that malformed-input tests retain their 400-shape
-	// contract; the security boundary is the service call below, not the
-	// JSON parse.
+	// for any agent in any org by guessing UUIDs.
 	orgID, err := RequireOrganizationID(c)
 	if err != nil {
 		return err
@@ -945,19 +960,25 @@ func (h *MCPAttestationHandler) RecordMCPUsageReport(c fiber.Ctx) error {
 		})
 	}
 
-	// SECURITY (defect #19b, body-class #2): pre-validation pass over
-	// every parseable mcpServerId in the body. Any cross-org UUID
-	// anywhere in the batch aborts the entire request with 404 BEFORE
-	// any service call — otherwise an attacker could plant a
+	// SECURITY (defect #19b + #41, body-class #2): pre-validation pass
+	// over every mcpServerId in the body. Any malformed or cross-org
+	// UUID anywhere in the batch aborts the entire request with 404
+	// BEFORE any service call.
+	//
+	// (#19b) Without the cross-org check, an attacker could plant a
 	// fictitious usage report against a victim org's MCP server,
-	// poisoning their analytics + invocation counters. Malformed UUIDs
-	// preserve the existing silent-skip behavior in the main loop
-	// (the malformed-vs-cross-org reporting oracle is a separate
-	// follow-up); only well-formed cross-org UUIDs are blocking.
+	// poisoning their analytics + invocation counters.
+	//
+	// (#41) Malformed UUIDs collapse to the same 404 as cross-org so
+	// the response shape does not betray "valid-format-but-cross-org"
+	// vs "garbage UUID". Treating malformed as silent-skip while
+	// cross-org returns 404 was a status-code oracle that narrowed
+	// UUID enumeration to well-formed-only space.
 	for serverIDStr := range req.MCPServers {
 		mcpServerID, parseErr := uuid.Parse(serverIDStr)
 		if parseErr != nil {
-			continue
+			respondResourceNotFound(c)
+			return nil
 		}
 		if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
 			return nil

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
@@ -433,7 +433,7 @@ func TestMCPAttestationHandler_RecordMCPConnection_InvalidJSON(t *testing.T) {
 func TestMCPAttestationHandler_RecordMCPConnection_InvalidAgentID(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Post("/agents/:agent_id/mcp-connections", handler.RecordMCPConnection)
+	app.Post("/agents/:id/mcp-connections", handler.RecordMCPConnection)
 
 	body := `{"mcpServerId":"` + uuid.New().String() + `","toolName":"test"}`
 	req := httptest.NewRequest("POST", "/agents/not-a-uuid/mcp-connections", strings.NewReader(body))
@@ -449,7 +449,7 @@ func TestMCPAttestationHandler_RecordMCPConnection_InvalidAgentID(t *testing.T) 
 func TestMCPAttestationHandler_RecordMCPConnection_MissingMCPServerID(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Post("/agents/:agent_id/mcp-connections", handler.RecordMCPConnection)
+	app.Post("/agents/:id/mcp-connections", handler.RecordMCPConnection)
 
 	body := `{"toolName":"test"}`
 	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/mcp-connections", strings.NewReader(body))
@@ -465,7 +465,7 @@ func TestMCPAttestationHandler_RecordMCPConnection_MissingMCPServerID(t *testing
 func TestMCPAttestationHandler_RecordMCPConnection_MissingToolName(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Post("/agents/:agent_id/mcp-connections", handler.RecordMCPConnection)
+	app.Post("/agents/:id/mcp-connections", handler.RecordMCPConnection)
 
 	body := `{"mcpServerId":"` + uuid.New().String() + `"}`
 	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/mcp-connections", strings.NewReader(body))
@@ -478,10 +478,21 @@ func TestMCPAttestationHandler_RecordMCPConnection_MissingToolName(t *testing.T)
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
-func TestMCPAttestationHandler_RecordMCPConnection_InvalidMCPServerIDFormat(t *testing.T) {
+// SECURITY (defect #41): malformed body mcpServerId returns the same
+// 404 {"error":"not found"} as a well-formed cross-org or nonexistent
+// mcpServerId. A distinct 400 here would be a status-code oracle: an
+// attacker holding a legitimate same-org SDK token could distinguish
+// "valid-format-but-cross-org UUID" from "garbage UUID" via response
+// shape, narrowing UUID enumeration to well-formed-only space.
+//
+// Pairs with TestMCPAttestationHandler_RecordMCPConnection_CrossOrgMCPServerID_Returns404
+// to pin both branches of the status-oracle collapse. The two tests
+// MUST return byte-identical 404 bodies; assertions below check the
+// status code and the body content explicitly.
+func TestMCPAttestationHandler_RecordMCPConnection_MalformedMCPServerID_Returns404(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Post("/agents/:agent_id/mcp-connections", handler.RecordMCPConnection)
+	app.Post("/agents/:id/mcp-connections", handler.RecordMCPConnection)
 
 	body := `{"mcpServerId":"not-a-uuid","toolName":"test"}`
 	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/mcp-connections", strings.NewReader(body))
@@ -491,7 +502,16 @@ func TestMCPAttestationHandler_RecordMCPConnection_InvalidMCPServerIDFormat(t *t
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"malformed body mcpServerId must return 404 to match cross-org response (defect #41 status-oracle)")
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, "Invalid MCP server ID",
+		"response must not echo the legacy 400 'Invalid MCP server ID' string (a parse-error signal would re-open the oracle)")
+	assert.NotContains(t, bodyStr, "not-a-uuid",
+		"response must not echo the attacker-supplied malformed string back")
+	assert.Contains(t, bodyStr, `"error":"not found"`,
+		"response body must match the cross-org 404 body produced by respondResourceNotFound")
 }
 
 // SECURITY (defect #19, body-class #2): RecordMCPConnection accepts a
@@ -524,7 +544,7 @@ func TestMCPAttestationHandler_RecordMCPConnection_CrossOrgMCPServerID_Returns40
 	}
 
 	app := fiber.New()
-	app.Post("/agents/:agent_id/mcp-connections", func(c fiber.Ctx) error {
+	app.Post("/agents/:id/mcp-connections", func(c fiber.Ctx) error {
 		c.Locals("organization_id", callerOrgID)
 		return handler.RecordMCPConnection(c)
 	})
@@ -639,6 +659,70 @@ func TestMCPAttestationHandler_RecordMCPUsageReport_CrossOrgMCPServerID_Returns4
 	bodyStr := string(bodyBytes)
 	assert.NotContains(t, bodyStr, crossOrgMCP.String(), "response must not echo the supplied cross-org mcpServerId")
 	assert.NotContains(t, bodyStr, victimOrgID.String(), "response must not echo the cross-org organization UUID")
+}
+
+// SECURITY (defect #41, batch variant): a malformed UUID anywhere in
+// the RecordMCPUsageReport batch map must abort the whole request with
+// the same 404 {"error":"not found"} as a cross-org entry. The
+// pre-fix silent-skip on parseErr produced a 200 OK with serversReported
+// = len(req.MCPServers) (the raw input count) — observably different
+// from the cross-org 404, which let an attacker probe "garbage UUID"
+// vs "well-formed cross-org UUID" via the response code AND via the
+// serversReported counter against a baseline.
+//
+// Captured-flag: attestationService is nil. Any bypass that reached
+// the service main loop would panic / 500 rather than surface the
+// asserted 404. The fix collapses parseErr to respondResourceNotFound
+// in the pre-validation pass, byte-identical to LoadOwned's 404.
+func TestMCPAttestationHandler_RecordMCPUsageReport_MalformedBatchEntry_Returns404(t *testing.T) {
+	callerOrgID := uuid.New()
+	agentID := uuid.New()
+	sameOrgMCP := uuid.New()
+
+	handler := &MCPAttestationHandler{
+		agentRepo: &MockAgentRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Agent, error) {
+				return &domain.Agent{ID: agentID, OrganizationID: callerOrgID}, nil
+			},
+		},
+		mcpServerRepo: &MockMCPServerRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.MCPServer, error) {
+				return &domain.MCPServer{ID: id, OrganizationID: callerOrgID}, nil
+			},
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/agents/:id/mcp-usage-report", func(c fiber.Ctx) error {
+		c.Locals("organization_id", callerOrgID)
+		return handler.RecordMCPUsageReport(c)
+	})
+
+	// Batch with one same-org UUID and one malformed string. Pre-fix:
+	// the malformed entry would silently skip in both pre-validation
+	// and the main loop, returning 200 OK with serversReported=2. The
+	// fix aborts on the first malformed UUID with 404 — matching the
+	// cross-org abort exactly.
+	body := `{"agentId":"` + agentID.String() + `","mcpServers":{` +
+		`"` + sameOrgMCP.String() + `":{"toolUsage":{},"capabilitiesAttested":[]},` +
+		`"not-a-uuid":{"toolUsage":{},"capabilitiesAttested":[]}` +
+		`},"reportedAt":"2024-01-01T00:00:00Z"}`
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/mcp-usage-report", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"malformed UUID in batch map must abort the whole batch with 404 to match cross-org response (defect #41)")
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyStr := string(bodyBytes)
+	assert.NotContains(t, bodyStr, "not-a-uuid",
+		"response must not echo the attacker-supplied malformed string back")
+	assert.NotContains(t, bodyStr, "serversReported",
+		"response must not include the 200-success serversReported counter (would re-open the oracle even at the same status code)")
+	assert.Contains(t, bodyStr, `"error":"not found"`,
+		"response body must match the cross-org 404 body produced by respondResourceNotFound")
 }
 
 // ===========================


### PR DESCRIPTION
## Summary

Closes audit-baseline **#162** (audit doc #41) and folds in a CRITICAL adversarial-review finding (route↔handler param mismatch) that turned PR #191's body-class IDOR fix into dead code in production.

| Class | Surface | File:Line (post-fix) |
|---|---|---|
| Status-code oracle | `POST /api/v1/sdk-api/agents/:id/mcp-connections` body `mcpServerId` | `mcp_attestation_handler.go:816-829` |
| Status-code oracle (batch) | `POST /api/v1/sdk-api/agents/:id/mcp-usage-report` body `mcpServers` map | `mcp_attestation_handler.go:963-979` |
| Route binding (CRITICAL, adversarial round 1) | `RecordMCPConnection` `c.Params("agent_id")` vs prod route `:id` | `mcp_attestation_handler.go:777` |

Closes #162

## #162 — Status-code oracle (audit doc #41)

Pre-fix on `RecordMCPConnection`:

```go
mcpServerID, err := uuid.Parse(req.MCPServerID)
if err != nil {
    return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
        "error":   "Invalid MCP server ID",
        "message": err.Error(),
    })
}
// ...
if LoadOwned(c, h.mcpServerRepo.GetByID, mcpServerID, orgID, mcpServerOrgID) == nil {
    return nil // -> 404 {"error":"not found"}
}
```

Malformed `mcpServerId` → 400 with parse-error echo. Well-formed cross-org → 404. An attacker holding a legitimate same-org SDK token could distinguish "valid-format-but-cross-org UUID" from "garbage UUID" via response shape, narrowing UUID enumeration to the well-formed space.

Post-fix: both branches collapse to the same `respondResourceNotFound(c)` helper that `LoadOwned` already uses. Response shape, status, and body are byte-identical between the malformed and cross-org paths.

The same change applies to `RecordMCPUsageReport`'s pre-validation pass: malformed UUIDs in the batch map now abort the whole batch with 404 (matching cross-org), instead of silently skipping (which would return 200 + serversReported=N — a counter-based oracle even if status converged).

### Regression tests

- `TestMCPAttestationHandler_RecordMCPConnection_MalformedMCPServerID_Returns404` — renamed from `_InvalidMCPServerIDFormat`. Asserts:
  - `404` status
  - body does NOT contain `"Invalid MCP server ID"` (the pre-fix 400 string would re-open the oracle)
  - body does NOT echo `not-a-uuid` (the attacker-supplied malformed string)
  - body DOES match `{"error":"not found"}` exactly — the same shape `LoadOwned` emits
- `TestMCPAttestationHandler_RecordMCPUsageReport_MalformedBatchEntry_Returns404` — new. Batch with one same-org valid + one malformed entry. Asserts:
  - `404` status
  - body does NOT contain `not-a-uuid` or `serversReported`
  - body DOES match `{"error":"not found"}`

Captured-flag pattern: `attestationService` is nil. Any bypass that reached the service main loop would surface as a panic / 500 — observably distinct from the 404 the tests assert.

## CRITICAL adversarial round-1 finding folded in (route binding)

`apps/backend/cmd/server/main.go:331` binds `RecordMCPConnection` at `/api/v1/sdk-api/agents/:id/mcp-connections`. The handler at `mcp_attestation_handler.go:767` (pre-fix) read `c.Params(\"agent_id\")`. Fiber v3 keys path params by the literal name after `:` — `c.Params(\"agent_id\")` returns `\"\"` when the route uses `:id`. `uuid.Parse(\"\")` errors. Every prod call returned **400 `{\"error\":\"Invalid agent ID\",\"message\":\"invalid UUID length: 0\"}`** before the `LoadOwned` body-class IDOR fix shipped in PR #191 could ever run.

Verified empirically with a minimal Fiber v3 program:

```
$ go run main.go     # route: /agents/:id/mcp-connections
status: 200
body: {"params_agent_id":"","params_id":"abc-123"}
```

Python SDK calls at `sdk/python/aim_sdk/integrations/mcp/registration.py:418` and `sdk/python/scripts/setup_agents_via_api.py:171` have been returning 400 for ~4 days. The sibling handler `RecordMCPUsageReport` already reads `c.Params(\"id\")` and was wired correctly — only `RecordMCPConnection` had the mismatch.

Fix: `c.Params(\"agent_id\")` → `c.Params(\"id\")` on the handler line. Swagger doc updated (`@Param id`, `@Router .../{id}/...`, added `@Failure 404`). Test routes at 5 sites updated from `/agents/:agent_id/mcp-connections` to `/agents/:id/mcp-connections` so tests exercise the actual prod route shape. **Without this commit, the #162 fix would also be dead code in production** — the malformed-vs-cross-org status oracle only matters once the endpoint actually executes.

## Sibling prod bug filed separately (#237)

Round 1 adversarial sweep caught the identical pattern in `RevokeAllAttestationsByAgent` (handler line 675 reads `c.Params(\"agent_id\")`, main.go:1380 binds `:id`). Out of #162 audit-doc scope; filed as P0 issue #237 for a separate hotfix. Both bugs share the same root cause (Fiber v3 param-name mismatch) and same one-line fix shape.

## Adversarial review (round 1)

Spawned a `general-purpose` adversarial subagent. Findings:

- **CRITICAL × 1** (fixed in this PR): route↔handler param mismatch.
- **HIGH × 2** (accepted residuals, see below): timing oracle on malformed-vs-cross-org; batch-map iteration timing variance.
- **MEDIUM × 2** (documented): parse-before-RequireOrganizationID order (actually a security improvement against unauth probes since the handler is behind auth middleware in prod); audit-log skip on abort (same behavior as pre-fix LoadOwned).
- **LOW × 2**: stale a2a_handler.go comments referencing \"RecordMCPConnection precedent\" — false alarm, those refer to JSON-parse 400 contract which is unchanged; `MissingMCPServerID` 400 with descriptive string — different threat class, not a UUID-enumeration oracle.

### Accepted residuals

**H1 / H2 — timing oracle.** Malformed parse is microseconds; cross-org `LoadOwned` is a DB roundtrip (~1-5ms in-region). Status + body are byte-identical (`404 {\"error\":\"not found\"}`), but wall-clock delta is ~3 orders of magnitude — detectable over N=50-200 probes. Audit doc #41 specifically called out the **status-code** oracle. A constant-time mitigation requires a stub DB call on every malformed request (DoS amplification trade-off) or a sleep-jitter scheme that complicates the response contract. Following the PR #147 / #191 precedent of documenting accepted residuals rather than gold-plating the threat model.

**M2 — audit-log skip on abort.** Pre-fix, `LoadOwned` cross-org aborts also skipped the audit log; my fix preserves that behavior on the malformed path. Adding audit-log-on-abort would expand attack noise and need rate-limiting. Out of scope; track separately if forensic visibility into probe traffic becomes required.

## Diff scope

| File | Δ | Purpose |
|---|---|---|
| `mcp_attestation_handler.go` | +44/-19 | (1) `c.Params(\"agent_id\")` → `c.Params(\"id\")` + comment + swagger; (2) `uuid.Parse` 400 → `respondResourceNotFound` 404 with security comment on `RecordMCPConnection`; (3) pre-validation `parseErr != nil { continue }` → `respondResourceNotFound; return nil` on `RecordMCPUsageReport` |
| `mcp_attestation_handler_test.go` | +89/-9 | renamed/updated `_MalformedMCPServerID_Returns404` test; new `_MalformedBatchEntry_Returns404` test; 5 route literals `:agent_id` → `:id` on this handler's test sites only |

**133 insertions, 28 deletions across 2 files.** No incidental drift. Stayed within the audit-baseline scope plus the load-bearing route fix.

## Verification

- `go build ./...` → clean.
- `go vet ./...` → clean.
- `go test -race -count=1 \$(go list ./... | grep -v tests/integration)` → all green.
- `go run ./cmd/tenantscope-lint/ ./internal/interfaces/http/handlers` → ok (32 allowlist entries).
- HMA `secure --ci apps/backend/internal/interfaces/http/handlers` → 98/100 (1 LOW pre-existing for missing `.gitignore` in subdir).
- Pre-push gate: PASS (Phase 1 sensitive files, Phase 2 build/test/lint, Phase 3 AI review, Phase 4 HMA, Phase 4.5 adversarial round 1, Phase 7a docs).

## Test plan

- [ ] CI: confirm `Backend (Go)`, `tenantscope-lint`, `Go Security Scan (SAST)`, `gosec` all green.
- [ ] Code review: confirm `c.Params(\"id\")` matches `main.go:331` route binding and that the swagger `@Router` line uses `{id}`.
- [ ] Manual integration: POST `/api/v1/sdk-api/agents/<valid-uuid>/mcp-connections` with `{\"mcpServerId\":\"not-a-uuid\",\"toolName\":\"x\"}` from an authenticated same-org SDK client → expect 404 `{\"error\":\"not found\"}`, NOT 400.
- [ ] Manual integration: POST same endpoint with `{\"mcpServerId\":\"<well-formed-cross-org-uuid>\",\"toolName\":\"x\"}` → expect 404 with identical body.
- [ ] Manual integration: POST `/api/v1/sdk-api/agents/<valid-uuid>/mcp-usage-report` with a batch containing one same-org + one malformed entry → expect 404, NOT 200 with `serversReported=2`.
- [ ] Manual integration: POST `RecordMCPConnection` from current Python SDK (registration.py:418) and confirm the call now reaches the security gates instead of the parse-fail 400.

## Audit-baseline launch-gate progress

Pre-session (2026-05-25 morning): 8 audit-baseline issues open.
This session: closed #160 (PR #236 merge), #161 (already-fixed in PR #147 retroactive close), #159 (already-fixed in PR #191), #158 (already-fixed in PR #191), and this PR closes #162.
Post-merge: **3 audit-baseline open** (#153, #157 CHIEF-CA defer, #177 dashboard viz).

## Related

- PR #147 (defect #40) — `MCPServerRepository.GetByURL` cross-tenant leak. Sibling closure shape (existence-secrecy via repo-layer scoping).
- PR #185 — closed URL-path agent_id IDOR class.
- PR #191 (defects #19 + #19b) — `RecordMCPConnection` + `RecordMCPUsageReport` body-class IDOR via `LoadOwned`. **Dead code in production until this PR** (route↔handler param mismatch).
- PR #236 (defect #160) — verification GET dual-mount IDOR.
- Issue #237 (filed in this session) — sibling Fiber-v3 param mismatch on `RevokeAllAttestationsByAgent`. Same one-line fix shape; separate PR.