### PR TITLE
security: fix RevokeAllAttestationsByAgent Fiber-v3 route binding (#237)

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go
@@ -647,13 +647,13 @@ func (h *MCPAttestationHandler) RevokeAttestation(c fiber.Ctx) error {
 // @Tags agents
 // @Accept json
 // @Produce json
-// @Param agent_id path string true "Agent ID"
+// @Param id path string true "Agent ID"
 // @Param request body RevokeAllAttestationsRequest true "Revocation reason"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} map[string]interface{}
 // @Failure 401 {object} map[string]interface{}
 // @Failure 500 {object} map[string]interface{}
-// @Router /api/v1/agents/{agent_id}/attestations/revoke-all [post]
+// @Router /api/v1/agents/{id}/attestations/revoke-all [post]
 func (h *MCPAttestationHandler) RevokeAllAttestationsByAgent(c fiber.Ctx) error {
 	// Get authenticated user ID from JWT middleware
 	userID, ok := c.Locals("user_id").(uuid.UUID)
@@ -671,8 +671,17 @@ func (h *MCPAttestationHandler) RevokeAllAttestationsByAgent(c fiber.Ctx) error 
 		})
 	}
 
-	// Parse agent ID from URL
-	agentID, err := uuid.Parse(c.Params("agent_id"))
+	// Parse agent ID from URL.
+	//
+	// ROUTE-BINDING FIX (#237): the production route in main.go binds this
+	// handler at `/api/v1/agents/:id/attestations/revoke-all`. Fiber v3 keys
+	// path params by the literal name after `:` — `c.Params("agent_id")`
+	// returns "" when the route uses `:id`, so every prod call returned 400
+	// "invalid UUID length: 0" before the LoadOwned cross-org gate below ever
+	// ran. The sibling handler RecordMCPConnection had the identical bug,
+	// fixed in PR #238. Using `"id"` here aligns this handler with the
+	// production route. Tests mount at `:id` to match.
+	agentID, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Invalid agent ID",

--- a/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler_test.go
@@ -333,7 +333,9 @@ func TestMCPAttestationHandler_RevokeAttestation_MissingReason(t *testing.T) {
 func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_InvalidAgentID(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Delete("/agents/:agent_id/attestations", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
+	// Route binds `:id` to match production main.go (#237). Fiber v3 keys
+	// params by the literal name after `:`; a mismatch silently returns "".
+	app.Delete("/agents/:id/attestations", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
 
 	req := httptest.NewRequest("DELETE", "/agents/not-a-uuid/attestations", nil)
 
@@ -347,7 +349,7 @@ func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_InvalidAgentID(t *te
 func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_NoUserContext(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Delete("/agents/:agent_id/attestations/revoke-all", handler.RevokeAllAttestationsByAgent)
+	app.Delete("/agents/:id/attestations/revoke-all", handler.RevokeAllAttestationsByAgent)
 
 	body := `{"reason":"test reason"}`
 	req := httptest.NewRequest("DELETE", "/agents/"+uuid.New().String()+"/attestations/revoke-all", strings.NewReader(body))
@@ -363,7 +365,7 @@ func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_NoUserContext(t *tes
 func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_NoOrgContext(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Delete("/agents/:agent_id/attestations/revoke-all", func(c fiber.Ctx) error {
+	app.Delete("/agents/:id/attestations/revoke-all", func(c fiber.Ctx) error {
 		c.Locals("user_id", uuid.New())
 		// No organization_id set
 		return handler.RevokeAllAttestationsByAgent(c)
@@ -383,7 +385,7 @@ func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_NoOrgContext(t *test
 func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_InvalidJSON(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Delete("/agents/:agent_id/attestations/revoke-all", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
+	app.Delete("/agents/:id/attestations/revoke-all", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
 
 	req := httptest.NewRequest("DELETE", "/agents/"+uuid.New().String()+"/attestations/revoke-all", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -398,7 +400,7 @@ func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_InvalidJSON(t *testi
 func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_MissingReason(t *testing.T) {
 	handler := &MCPAttestationHandler{}
 	app := fiber.New()
-	app.Delete("/agents/:agent_id/attestations/revoke-all", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
+	app.Delete("/agents/:id/attestations/revoke-all", withMCPAttestationContext(handler.RevokeAllAttestationsByAgent))
 
 	body := `{}`
 	req := httptest.NewRequest("DELETE", "/agents/"+uuid.New().String()+"/attestations/revoke-all", strings.NewReader(body))
@@ -409,6 +411,38 @@ func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_MissingReason(t *tes
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+// Regression test for #237: RevokeAllAttestationsByAgent must read the URL
+// agent ID via c.Params("id") to match the production route binding in
+// main.go (`agents.Post("/:id/attestations/revoke-all", ...)`). Fiber v3
+// keys path params by the literal name after `:`; a mismatch silently
+// returns "", and uuid.Parse("") fails with "invalid UUID length: 0",
+// short-circuiting every prod call to 400 before auth or LoadOwned run.
+// This test mounts at `:id` with a valid UUID and asserts the handler
+// progresses past the parse stage to the JWT user-context check. If a
+// future change reverts the param key back to "agent_id" or any other
+// non-matching string, this test fails.
+func TestMCPAttestationHandler_RevokeAllAttestationsByAgent_RouteBindingParamKey(t *testing.T) {
+	handler := &MCPAttestationHandler{}
+	app := fiber.New()
+	app.Post("/agents/:id/attestations/revoke-all", handler.RevokeAllAttestationsByAgent)
+
+	body := `{"reason":"x"}`
+	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/attestations/revoke-all", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// With a wrong param key, the handler would return 400 with body
+	// {"error":"Invalid agent ID","message":"invalid UUID length: 0"}.
+	// With the correct param key the parse succeeds and the JWT
+	// user-context check returns 401.
+	assert.NotEqual(t, fiber.StatusBadRequest, resp.StatusCode,
+		"#237 regression: handler read wrong param key (UUID didn't make it past parse). Check c.Params(...) matches the :id binding in main.go")
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
 }
 
 // ===========================
@@ -887,7 +921,7 @@ func TestMCPAttestationHandler_CrossOrgReturns404(t *testing.T) {
 			name:   "RevokeAllAttestationsByAgent_CrossOrgAgent",
 			method: "POST",
 			mount: func(app *fiber.App) {
-				app.Post("/agents/:agent_id/attestations/revoke-all", func(c fiber.Ctx) error {
+				app.Post("/agents/:id/attestations/revoke-all", func(c fiber.Ctx) error {
 					setLocals(c)
 					return handler.RevokeAllAttestationsByAgent(c)
 				})


### PR DESCRIPTION
## Summary

P0 prod bug. Every call to `POST /api/v1/agents/<uuid>/attestations/revoke-all` returned 400 `{"error":"Invalid agent ID","message":"invalid UUID length: 0"}` before any auth or `LoadOwned` cross-org gate ran. A privileged Manager who needed to revoke attestations for a compromised agent could not do so via the API.

`apps/backend/cmd/server/main.go:1380` binds `:id`:

```go
agents.Post("/:id/attestations/revoke-all", middleware.ManagerMiddleware(), h.MCPAttestation.RevokeAllAttestationsByAgent)
```

`apps/backend/internal/interfaces/http/handlers/mcp_attestation_handler.go:675` was reading `c.Params("agent_id")`. Fiber v3 keys path params by the literal name after `:`, so the read returned `""` and `uuid.Parse("")` failed with `invalid UUID length: 0`.

This is the sibling case of the `RecordMCPConnection` Fiber-v3 mismatch fixed in PR #238 (defect #41 / `audit-baseline #162`). Surfaced by sweeping the same handler file for the same pattern.

## Changes

- `mcp_attestation_handler.go:675` — `c.Params("agent_id")` → `c.Params("id")`
- Swagger doc lines 650 / 656 aligned to `id`
- 5 existing tests flipped from `/agents/:agent_id/...` to `/agents/:id/...` (RevokeAllAttestationsByAgent test sites only; unrelated handlers untouched)
- **New lock-in regression test** `TestMCPAttestationHandler_RevokeAllAttestationsByAgent_RouteBindingParamKey` mounts at `:id` (prod-shape) with a valid UUID and asserts the parse stage is reached (401 from JWT user-context check, not 400). If a future change reverts the param key, this test fails.

## Pre-push gate

| Phase | Status |
|---|---|
| 1 Sensitive file scan | PASS |
| 2 build / go test -race / go vet | PASS |
| 3 AI code review | PASS — no CRITICAL/HIGH; no auth surface, no race conditions, no resource leaks |
| 4 HMA secure --ci | 4 HIGH on \`.env:1\` (gitignored, untracked, not in diff) — pre-existing infra noise |
| 4.5 Adversarial self-review | SKIP — no detection / scanner / scoring logic in diff |
| 5 hma-hunter | SKIP — surgical 1-line param-key fix with dedicated regression test; defer to CI |
| 6 New-user walkthrough | SKIP — no CLI/UX changes |
| 7 Cross-repo version sweep | SKIP — no version bump / count changes |

Cross-class sweep also done: `grep ':agent_id' apps/backend/cmd/server/main.go` returns no hits, so there are no inverse-class bugs (handlers reading `c.Params("id")` whose route binds `:agent_id`).

## Test plan

- [x] `go test -race ./internal/interfaces/http/handlers/...` (1.505s, OK)
- [x] `go vet ./internal/interfaces/http/handlers/...` (clean)
- [x] `go build ./...` (clean)
- [x] New regression test reaches `StatusUnauthorized` (parse stage cleared) with prod-shape `:id` binding
- [ ] Required CI checks
- [ ] Manager-role smoke against staging after merge: `POST /api/v1/agents/<uuid>/attestations/revoke-all` returns 200/403/404 — not 400 with `"invalid UUID length: 0"`

Closes #237