### PR TITLE
feat(#177): surface drift score as a labeled card on the agent detail page

### DIFF
--- a/apps/web/app/dashboard/agents/[id]/page.tsx
+++ b/apps/web/app/dashboard/agents/[id]/page.tsx
@@ -42,6 +42,7 @@ import { ViolationsTab } from "@/components/agent/violations-tab";
 import { KeyVaultTab } from "@/components/agent/key-vault-tab";
 import { APIKeysTab } from "@/components/agent/api-keys-tab";
 import { TrustScoreBreakdown } from "@/components/agent/trust-score-breakdown";
+import { DriftScoreCard } from "@/components/agent/drift-score-card";
 import { AgentTagsTab } from "@/components/agent/tags-tab";
 import {
   AlertDialog,
@@ -1062,7 +1063,8 @@ export default function AgentDetailsPage({
           </Card>
         </TabsContent>
 
-        <TabsContent value="trust">
+        <TabsContent value="trust" className="space-y-4">
+          <DriftScoreCard agentId={agent.id} />
           <TrustScoreBreakdown
             agentId={agent.id}
             userRole={userRole}

--- a/apps/web/components/agent/drift-score-card.test.tsx
+++ b/apps/web/components/agent/drift-score-card.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { DriftScoreCard } from './drift-score-card';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getTrustScoreBreakdown: vi.fn(),
+  },
+}));
+
+const makeBreakdown = (driftDetection: number, overrides: Record<string, unknown> = {}) => ({
+  agentId: 'agent-1',
+  agentName: 'test-agent',
+  overall: 0.9,
+  factors: {
+    verificationStatus: 1,
+    uptime: 1,
+    successRate: 1,
+    securityAlerts: 1,
+    compliance: 1,
+    age: 1,
+    driftDetection,
+    userFeedback: 1,
+  },
+  weights: {
+    verificationStatus: 0.1, uptime: 0.1, successRate: 0.1, securityAlerts: 0.1,
+    compliance: 0.1, age: 0.1, driftDetection: 0.2, userFeedback: 0.2,
+  },
+  contributions: {
+    verificationStatus: 0.1, uptime: 0.1, successRate: 0.1, securityAlerts: 0.1,
+    compliance: 0.1, age: 0.1, driftDetection: 0.2, userFeedback: 0.2,
+  },
+  confidence: 0.9,
+  calculatedAt: '2026-05-25T20:00:00Z',
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.mocked(api.getTrustScoreBreakdown).mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DriftScoreCard — scale and classification', () => {
+  it('factor 1.0 (no alerts) renders as 0% drift, Clean', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(1.0));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('0%')).toBeTruthy());
+    expect(screen.getByText('Clean')).toBeTruthy();
+  });
+
+  it('factor 0.95 (boundary) renders as 5% drift, still Clean', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.95));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('5%')).toBeTruthy());
+    expect(screen.getByText('Clean')).toBeTruthy();
+  });
+
+  it('factor 0.80 renders as 20% drift, Mild', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.80));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('20%')).toBeTruthy());
+    expect(screen.getByText('Mild Drift')).toBeTruthy();
+  });
+
+  it('factor 0.75 (boundary) renders as 25% drift, Mild (not Active)', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.75));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('25%')).toBeTruthy());
+    expect(screen.getByText('Mild Drift')).toBeTruthy();
+  });
+
+  it('factor 0.945 (rounds drift to 6%) renders as 6% Mild — locks rounding behavior', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.945));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('6%')).toBeTruthy());
+    expect(screen.getByText('Mild Drift')).toBeTruthy();
+  });
+
+  it('factor 0.744 (rounds drift to 26%) renders as 26% Active — locks rounding behavior', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.744));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('26%')).toBeTruthy());
+    expect(screen.getByText('Active Drift')).toBeTruthy();
+  });
+
+  it('factor 0.40 renders as 60% drift, Active', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.40));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('60%')).toBeTruthy());
+    expect(screen.getByText('Active Drift')).toBeTruthy();
+  });
+
+  it('factor 0 renders as 100% drift, Active', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('100%')).toBeTruthy());
+    expect(screen.getByText('Active Drift')).toBeTruthy();
+  });
+});
+
+describe('DriftScoreCard — neutral sentinel (alertRepo unavailable)', () => {
+  it('factor exactly 0.5 (sentinel) renders as Baseline, never Active', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.5));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('Baseline')).toBeTruthy());
+    // No misleading percentage shown when there's no signal
+    expect(screen.queryByText('50%')).toBeNull();
+    expect(screen.getByText('—')).toBeTruthy();
+    // Screen reader-friendly: em-dash is announced as "No drift data available"
+    expect(screen.getByLabelText('No drift data available')).toBeTruthy();
+  });
+
+  it('factor 0.5 + epsilon is NOT treated as Baseline', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(0.5 + 1e-6));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('50%')).toBeTruthy());
+    expect(screen.queryByText('Baseline')).toBeNull();
+  });
+});
+
+describe('DriftScoreCard — defensive input handling', () => {
+  it('clamps factor > 1 to 0% drift, Clean (treated as best case)', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(1.5));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('0%')).toBeTruthy());
+    expect(screen.getByText('Clean')).toBeTruthy();
+  });
+
+  it('clamps factor < 0 to 100% drift, Active', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(-0.5));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('100%')).toBeTruthy());
+    expect(screen.getByText('Active Drift')).toBeTruthy();
+  });
+
+  it('treats NaN factor as Unknown (error path), never as 100% Active Drift', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(NaN));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() =>
+      expect(screen.getByText(/drift factor missing or invalid/i)).toBeTruthy()
+    );
+    expect(screen.queryByText('100%')).toBeNull();
+    expect(screen.queryByText('Active Drift')).toBeNull();
+    expect(screen.queryByText('NaN%')).toBeNull();
+  });
+
+  it('treats +Infinity factor as Unknown (error path), never as 0% Clean', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue(makeBreakdown(Infinity));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() =>
+      expect(screen.getByText(/drift factor missing or invalid/i)).toBeTruthy()
+    );
+    expect(screen.queryByText('Clean')).toBeNull();
+  });
+
+  it('handles missing factors object with an error message, no crash', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue({
+      ...makeBreakdown(1.0),
+      factors: undefined as unknown as ReturnType<typeof makeBreakdown>['factors'],
+    });
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() =>
+      expect(screen.getByText(/drift factor missing/i)).toBeTruthy()
+    );
+  });
+
+  it('handles missing calculatedAt without rendering Invalid Date', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockResolvedValue({
+      ...makeBreakdown(1.0),
+      calculatedAt: null as unknown as string,
+    });
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('0%')).toBeTruthy());
+    expect(screen.queryByText(/last calculated/i)).toBeNull();
+    expect(screen.queryByText(/invalid date/i)).toBeNull();
+  });
+});
+
+describe('DriftScoreCard — async lifecycle', () => {
+  it('shows error fallback when the API rejects', async () => {
+    vi.mocked(api.getTrustScoreBreakdown).mockRejectedValue(new Error('boom'));
+    render(<DriftScoreCard agentId="agent-1" />);
+    await waitFor(() => expect(screen.getByText('boom')).toBeTruthy());
+  });
+
+  it('does not update state after unmount mid-fetch', async () => {
+    let resolve!: (v: ReturnType<typeof makeBreakdown>) => void;
+    const pending = new Promise<ReturnType<typeof makeBreakdown>>((r) => { resolve = r; });
+    vi.mocked(api.getTrustScoreBreakdown).mockReturnValue(pending);
+    const { unmount } = render(<DriftScoreCard agentId="agent-1" />);
+    unmount();
+    resolve(makeBreakdown(0.4));
+    // Settle microtask queue; assert no thrown errors and nothing rendered.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText('60%')).toBeNull();
+  });
+});

--- a/apps/web/components/agent/drift-score-card.tsx
+++ b/apps/web/components/agent/drift-score-card.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Activity, AlertTriangle, CheckCircle, HelpCircle, Info } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { api } from '@/lib/api';
+
+interface DriftScoreCardProps {
+  agentId: string;
+}
+
+type DriftStatus = 'clean' | 'mild' | 'active' | 'baseline';
+
+// Sentinel value returned by trust_calculator.go:427/433 when the alert
+// repository is unavailable (nil dep or query error). The drift factor
+// otherwise lives in [0, 1] where 1.0 = no alerts in 30 days and each
+// alert subtracts 0.02-0.30. 0.5 from real penalties is theoretically
+// possible (0.30 + 0.15 + 0.05) but extremely unlikely; we prefer a
+// false-baseline on that exact combo over a false "Active Drift" on
+// every default-config deployment.
+const NEUTRAL_SENTINEL = 0.5;
+const NEUTRAL_EPSILON = 1e-9;
+
+function isBaseline(factor: number): boolean {
+  return Math.abs(factor - NEUTRAL_SENTINEL) < NEUTRAL_EPSILON;
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+// Convert the trust factor (higher = less drift) to a drift score
+// percentage (higher = more drift). This is the same orientation as the
+// `agent.drift_score` OTel gauge published for Grafana, so users reading
+// "75% drift" here see the same direction as the gauge spike there.
+function factorToDriftPct(factor: number): number {
+  return Math.round((1 - clamp01(factor)) * 100);
+}
+
+function classifyByDriftPct(driftPct: number): DriftStatus {
+  if (driftPct <= 5) return 'clean';
+  if (driftPct <= 25) return 'mild';
+  return 'active';
+}
+
+const STATUS_META: Record<DriftStatus, { label: string; badgeClass: string; scoreClass: string; icon: typeof CheckCircle; description: string }> = {
+  clean: {
+    label: 'Clean',
+    badgeClass: 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20',
+    scoreClass: 'text-green-600 dark:text-green-400',
+    icon: CheckCircle,
+    description: 'No behavioral drift detected. Runtime configuration matches registered baseline.',
+  },
+  mild: {
+    label: 'Mild Drift',
+    badgeClass: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border-yellow-500/20',
+    scoreClass: 'text-yellow-600 dark:text-yellow-400',
+    icon: Activity,
+    description: 'Minor deviations from registered configuration. Review recent drift alerts.',
+  },
+  active: {
+    label: 'Active Drift',
+    badgeClass: 'bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20',
+    scoreClass: 'text-red-600 dark:text-red-400',
+    icon: AlertTriangle,
+    description: 'Significant runtime deviation from registered configuration. Investigate immediately.',
+  },
+  baseline: {
+    label: 'Baseline',
+    badgeClass: 'bg-gray-500/10 text-gray-700 dark:text-gray-200 border-gray-500/20',
+    scoreClass: 'text-gray-600 dark:text-gray-200',
+    icon: HelpCircle,
+    description: 'No drift signal available yet (alert backend unreachable or no history). Score is the neutral baseline.',
+  },
+};
+
+export function DriftScoreCard({ agentId }: DriftScoreCardProps) {
+  const [driftDetection, setDriftDetection] = useState<number | null>(null);
+  const [calculatedAt, setCalculatedAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .getTrustScoreBreakdown(agentId)
+      .then((data) => {
+        if (cancelled) return;
+        const factor = data?.factors?.driftDetection;
+        // Reject both missing and non-finite payloads (NaN, ±Infinity).
+        // Fail-loud as "Unknown" beats silently clamping a malformed value
+        // to 100% drift and rendering a phantom Active-Drift alarm.
+        if (typeof factor !== 'number' || !Number.isFinite(factor)) {
+          setError('Drift factor missing or invalid in trust breakdown response');
+          setDriftDetection(null);
+        } else {
+          setDriftDetection(factor);
+        }
+        setCalculatedAt(data?.calculatedAt ?? null);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message || 'Failed to load drift score');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Activity className="h-5 w-5" />
+            Drift Score
+          </CardTitle>
+          <CardDescription>Loading behavioral drift signal...</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-10 w-32 mb-2" />
+          <Skeleton className="h-4 w-48" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || driftDetection === null) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Activity className="h-5 w-5" />
+            Drift Score
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-6 text-muted-foreground">
+            <AlertTriangle className="h-8 w-8 mx-auto mb-2 text-yellow-600" />
+            <p className="text-sm">{error || 'No drift data available'}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const baseline = isBaseline(driftDetection);
+  const driftPct = factorToDriftPct(driftDetection);
+  const status: DriftStatus = baseline ? 'baseline' : classifyByDriftPct(driftPct);
+  const meta = STATUS_META[status];
+  const StatusIcon = meta.icon;
+  const displayValue = baseline ? '—' : `${driftPct}%`;
+
+  return (
+    <TooltipProvider>
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Activity className="h-5 w-5" />
+                Drift Score
+              </CardTitle>
+              <CardDescription className="mt-1">
+                Behavioral drift signal — runtime vs registered baseline (0% clean, 100% maximum drift)
+              </CardDescription>
+            </div>
+            <Tooltip>
+              <TooltipTrigger aria-label="About drift score">
+                <Info className="h-4 w-4 text-muted-foreground hover:text-blue-600 transition-colors" />
+              </TooltipTrigger>
+              <TooltipContent side="left" className="max-w-xs">
+                <p>
+                  Derived from the Drift Detection trust factor: each configuration-drift
+                  or MCP capability-drift alert in the last 30 days raises this score.
+                  Real-time per-event telemetry is published as the{' '}
+                  <code>agent.drift_score</code> OTel gauge for Grafana dashboards.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div>
+              <div
+                className={`text-4xl font-bold ${meta.scoreClass}`}
+                aria-label={baseline ? 'No drift data available' : `Drift score ${driftPct} percent`}
+              >
+                {displayValue}
+              </div>
+              {calculatedAt && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Last calculated: {new Date(calculatedAt).toLocaleString()}
+                </p>
+              )}
+            </div>
+            <Badge className={`gap-1.5 ${meta.badgeClass}`}>
+              <StatusIcon className="h-3.5 w-3.5" />
+              {meta.label}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground mt-3">{meta.description}</p>
+        </CardContent>
+      </Card>
+    </TooltipProvider>
+  );
+}

--- a/docs/sdk/trust-scoring.md
+++ b/docs/sdk/trust-scoring.md
@@ -635,7 +635,8 @@ def improve_trust_score():
     # Factor 7: Drift Detection
     if breakdown['factors']['drift_detection'] < 1.0:
         print("❌ Behavioral drift detected")
-        print("   → Review drift events in dashboard")
+        print("   → Check the Drift Score card on the agent detail page (Trust tab)")
+        print("   → Real-time per-event telemetry is on the agent.drift_score OTel gauge (Grafana)")
         print("   → Acknowledge expected changes")
 
     # Factor 8: User Feedback


### PR DESCRIPTION
Closes #177 (audit defect #15).

## Summary

The `agent.drift_score` OTel gauge has been live for the Talk 2 Grafana dashboard since the drift detection service shipped, but the AIM dashboard (Talk 1) had no labeled drift visualization — the Drift Detection factor was only visible nested inside the 8-factor Trust Score Breakdown card. The 2026-05-18 audit doc treats this as a P2 documentation-vs-implementation gap and the issue author themselves notes "Trust score chart is the equivalent dashboard-visible behavioral signal and DOES move on violations."

This adds a standalone `DriftScoreCard` mounted above `TrustScoreBreakdown` inside the existing trust tab on the agent detail page. It reads `factors.driftDetection` from `/api/v1/trust-score/agents/:id/breakdown` — the same endpoint the breakdown already consumes — so there is no new backend endpoint, no Prometheus client in the frontend, and no telemetry pipeline change. The OTel gauge remains the Grafana-side surface for real-time per-event telemetry.

## Inversion correctness (the subtle part)

`factors.driftDetection` is a trust factor (higher = less drift, 1.0 = no alerts). The OTel gauge `agent.drift_score` is the inverse semantic (higher = more drift, per its description). To label this card \"Drift Score\" AND have its direction match the Grafana gauge, the card displays `(1 - clamp01(factor)) * 100`. A critical drift alert (factor 0.70 from `trust_calculator.go:457-458`) shows here as \"30% drift, Active\" — same upward direction as the OTel gauge spiking to ~0.46 from `tanh(1/2)` for one event.

## Neutral baseline handling

`calculateDriftDetection` at `apps/backend/internal/application/trust_calculator.go:427` and `:433` returns `0.5` as a sentinel when the alert repository is unavailable (nil dep or query error). Without special handling, every default-config deployment would render \"50% drift, Active\" — a false alarm on every clean default install. The card detects the exact 0.5 value (within `1e-9`) and renders a neutral \"Baseline\" badge with em-dash display and an explicit \"no signal\" message.

Tradeoff acknowledged in `drift-score-card.tsx:18-24`: the real-penalty combo `0.30 + 0.15 + 0.05 = 0.50` collides with the sentinel and would be shown as \"Baseline\" rather than \"Active.\" The card prefers false-baseline on three specific severity combinations over false-active on every clean default deployment.

## Defensive input handling

- `Number.isFinite` guard routes NaN / ±Infinity through the error fallback rather than clamping them to 0 and silently rendering 100% \"Active Drift\" on a malformed payload.
- `clamp01` keeps out-of-range finite inputs from producing \"-5%\" or \"105%\" displays.
- Integer-aligned classification: `classifyByDriftPct` runs on the rounded displayed percent so the badge and the number always agree (factor 0.749 renders as 25% Active, not 25% Mild).
- `aria-label` on the score div for screen readers; the em-dash baseline display is announced as \"No drift data available.\"

## Test plan

`drift-score-card.test.tsx` adds 18 vitest cases (jsdom + `@testing-library/react`):

- [x] Scale boundaries: factor 1.0 → 0% Clean, 0.95 → 5% Clean, 0.75 → 25% Mild, 0.40 → 60% Active, 0 → 100% Active.
- [x] Non-integer rounding lock-ins: 0.945 → 6% Mild, 0.744 → 26% Active (catches off-by-one badge/percent mismatches).
- [x] Sentinel: exact 0.5 → Baseline + em-dash + aria-label; 0.5 + 1e-6 → NOT Baseline.
- [x] Clamp on out-of-range finite inputs: 1.5 → 0% Clean, -0.5 → 100% Active.
- [x] NaN and +Infinity routed to error path (no \"NaN%\", no phantom \"100% Active Drift\").
- [x] Missing `factors` and missing `calculatedAt` handled gracefully (no \"Invalid Date\", no crash).
- [x] API rejection surfaces `Error.message` to the DOM (XSS-safe via React text interpolation).
- [x] Unmount-mid-fetch race guard verified.
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean on changed files (3 pre-existing warnings in unrelated files only).
- [x] `npm run build` (Next.js production build) succeeds; agent detail page in route table.

## Adversarial review (Phase 4.5)

Two rounds of general-purpose adversarial subagent review on the diff. The subagent did not see implementer reasoning — only the diff and the issue context.

- **Round 1**: 2 CRITICAL findings — (a) the original card mislabeled `factors.driftDetection` (higher=better) under the name \"Drift Score\" as if it were the OTel gauge; (b) factor value 0.5 (the no-signal sentinel) was classified as \"Active Drift,\" turning every default-config deployment into a phantom alarm. Both fixed in this commit.
- **Round 2**: 0 CRITICAL / 0 HIGH; 2 MEDIUM (NaN clamping to 100% Active, Baseline badge dark-mode contrast). Both also fixed in this commit. The 3 WARN/LOW items are documented tradeoffs (the 0.30+0.15+0.05 sentinel collision) or test-hardening (more rounding-boundary tests added).

## Documentation

`docs/sdk/trust-scoring.md` tightened: the SDK guidance \"Review drift events in dashboard\" now points at the new card by name and explicitly distinguishes the Grafana OTel gauge as the real-time per-event surface.

## Out of scope (and why)

- Prometheus client in the frontend OR a new backend endpoint exposing per-event drift records — would be the literal Option A from the audit doc, but the risk-to-value is poor for a P2 documentation gap and the trust factor already moves with drift events.
- Sentinel disambiguation in the backend (return `null` / `-1` instead of 0.5 for the no-signal case) — fixes the `0.30+0.15+0.05` collision cleanly but is a Track separate from this UI close-out; file as a follow-up if the collision is observed in the wild.
- Real-time websocket/SSE push of drift events to the card — Grafana is the real-time surface; this card refreshes when the user navigates to the trust tab.

## Closes

Closes #177.