### PR TITLE
fix(smoke): repair smoke-backend.sh broken since PR #141 + ATX rename

### DIFF
--- a/apps/backend/deployments/otel-demo/smoke-backend.sh
+++ b/apps/backend/deployments/otel-demo/smoke-backend.sh
@@ -101,7 +101,7 @@ cleanup() {
         kill "$BACKEND_PID" 2>/dev/null || true
         wait "$BACKEND_PID" 2>/dev/null || true
     fi
-    rm -f "$BACKEND_BIN"
+    rm -f "$BACKEND_BIN" "${BACKEND_BIN}.bootstrap"
     if [ "${KEEP_STACKS:-0}" != "1" ]; then
         docker compose down --remove-orphans >/dev/null 2>&1 || true
         docker rm -f "$SMOKE_PG_CONTAINER" >/dev/null 2>&1 || true
@@ -163,6 +163,7 @@ echo "==> [4/8] Build + run backend"
 (
     cd "$BACKEND_DIR"
     go build -o "$BACKEND_BIN" ./cmd/server
+    go build -o "${BACKEND_BIN}.bootstrap" ./cmd/bootstrap
 )
 
 # Run backend from $BACKEND_DIR — runMigrations() reads from the relative
@@ -213,6 +214,31 @@ if [ $attempt -ge 60 ]; then
     exit 3
 fi
 
+# 4b. Seed default admin via bootstrap binary.
+#
+# PR #141 (2cc5490, 2026-05-20) rewrote migration 013 to remove the hardcoded
+# admin INSERT (CWE-798 fix; AIM Cloud's Azure Postgres does not allow-list
+# pgcrypto, so SQL-side bcrypt is unavailable). The admin row is now seeded
+# by aim-bootstrap --default after migrations run. Without this step the
+# users table has no admin row and step 6 login returns 401.
+#
+# Idempotent: re-runs against an already-bootstrapped DB exit 0 with a "skip"
+# message. Pass --admin-password so the login in step 6 matches ADMIN_PASSWORD.
+echo
+echo "==> [4b/8] Seed default admin via bootstrap"
+(
+    cd "$BACKEND_DIR"
+    env \
+        DATABASE_URL="postgres://postgres:${SMOKE_PG_PASSWORD}@localhost:${SMOKE_POSTGRES_PORT}/${SMOKE_PG_DB}?sslmode=disable" \
+        "${BACKEND_BIN}.bootstrap" \
+            --default \
+            --admin-email="$ADMIN_EMAIL" \
+            --admin-password="$ADMIN_PASSWORD" \
+            --yes \
+            >>"$BACKEND_LOG" 2>&1
+) || { echo "FAIL: bootstrap --default did not seed admin"; tail -40 "$BACKEND_LOG"; exit 4; }
+echo "    admin seeded"
+
 # 5. Reset force_password_change.
 echo
 echo "==> [5/8] Reset admin force_password_change"
@@ -260,6 +286,7 @@ docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
         drift_score     DOUBLE PRECISION NOT NULL DEFAULT 0,
         active_alerts   INTEGER NOT NULL DEFAULT 0,
         atc_trust_level INTEGER NOT NULL DEFAULT 0,
+        atx_trust_level INTEGER,
         scan_verdict    TEXT NOT NULL DEFAULT 'UNKNOWN'
      );" >/dev/null
 docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \


### PR DESCRIPTION
## Summary

`apps/backend/deployments/otel-demo/smoke-backend.sh` (release-smoke matrix row 2) has been silently `exit 4` since 2026-05-20. Two distinct breaks, both surfaced by `/release-test` today:

1. **No admin row** — PR #141 (`2cc5490`, "security: random bootstrap admin UUIDs + password — CWE-798") rewrote migration 013 to remove the hardcoded admin INSERT (Azure Postgres doesn't allow-list pgcrypto, so SQL-side bcrypt is unavailable). The admin row is now seeded by `aim-bootstrap --default`. The smoke wasn't updated → `POST /api/v1/public/login` returned 401.

2. **`atx_trust_level` column missing** — `fga_engine.fetchASCRiskSummary` queries `COALESCE(atx_trust_level, atc_trust_level)` from `agent_security_contexts`. The smoke's `CREATE TABLE IF NOT EXISTS` predates the ATX column add. Postgres returned `column "atx_trust_level" does not exist`, the SELECT failed, `fetchASCRiskSummary` fail-open-returned nil, and the three ASC-derived parent-span attrs (`agent.drift_score`, `agent.scan_verdict`, `agent.active_alerts`) dropped off `fga.authorize` silently. This weakened the Slide-14 SemConv contract that PR #118 shipped — the smoke's own assertion in step `[7b/8]` caught it once break 1 was fixed.

## Changes (single file: `smoke-backend.sh`)

- Build `cmd/bootstrap` alongside `cmd/server` in step `[4/8]`.
- New step `[4b/8] Seed default admin via bootstrap` between backend-boot and force_password_change reset. Idempotent (bootstrap exits with "skip" on the bootstrap_completed marker).
- Add `atx_trust_level INTEGER` (nullable) to the smoke's ASC `CREATE TABLE` — matches the migration 231 default; `COALESCE` resolves to `atc_trust_level` until Phase 2 writers populate atx.
- Cleanup trap now removes both binaries.

## Test plan

- [x] Smoke FAILS on `main` at step `[6/8]` (login 401)
- [x] Smoke after fix 1 only: FAILS at step `[7b/8]` (3 of 9 SemConv attrs missing)
- [x] Smoke after both fixes: **PASS** (exit 0, all 9 attrs present, trace + 1 fga.* child landed in Tempo)
- [x] `go build ./...` clean on `apps/backend`

## Impact

- **No production impact.** Migration 013 + cmd/bootstrap continues to seed prod admin correctly. Only the test contract was broken.
- **Release-process impact.** The release-smoke matrix row 2 gate has been non-functional for 7 days. This PR restores it before any v1.0 cut.