### PR TITLE
docs(hardening): correct A2A invariant mechanism in trigger inventory

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,7 +30,7 @@ Coverage in main today: organization-scoped handlers for agents, MCP servers, ca
 
 ### Data model invariants
 
-**Status: done.** Each known data-model invariant — parent cache columns plus richer detail tables, and row-internal couplings where two columns on the same row must move together — is now enforced at the database layer rather than by application code. Six invariant-preserving triggers cover trust scores → agent cache, MCP trust scores → MCP server cache, capability violations → agent count, MCP server capabilities → cache, A2A consent organization scoping, and agent status → `verified_at` timestamp. Tests assert the trigger behavior under insert, update, and delete.
+**Status: done.** Each known data-model invariant — parent cache columns plus richer detail tables, and row-internal couplings where two columns on the same row must move together — is now enforced at the database layer rather than by application code. Six invariant-preserving triggers cover trust scores → agent cache, MCP trust scores → MCP server cache, capability violations → agent count, MCP server capabilities → cache, A2A peer trust aggregates, and agent status → `verified_at` timestamp. The A2A consent cross-tenant invariant is enforced by a complementary `NOT NULL` constraint on `a2a_consent_records.organization_id` (migration 097, backfilled from the grantor agent). Tests assert the trigger and constraint behavior under insert, update, and delete.
 
 ### Capability lifecycle
 


### PR DESCRIPTION
## Summary

Follow-up to PR #243 (`3cbc404`). The Data model invariants section listed six triggers but mislabeled the sixth slot.

**Issue:** The bullet `A2A consent organization scoping` referenced migration 097, which is a backfill plus `NOT NULL` constraint on `a2a_consent_records.organization_id` — not a trigger. The actual sixth trigger is migration 095 (`a2a_peer_trust_aggregates_trigger`), which was omitted.

**Fix:** Replace the misnamed bullet with `A2A peer trust aggregates` (the actual trigger), then add one sentence acknowledging migration 097's `NOT NULL` constraint so the A2A consent invariant remains documented as DB-layer-enforced.

The six triggers in `apps/backend/migrations/` 091-096 are:
- 091 capability_violation_count_trigger → agent count
- 092 verified_at_status_trigger → agent status
- 093 trust_score_mirror_trigger → agent cache
- 094 mcp_trust_score_mirror_trigger → MCP server cache
- 095 a2a_peer_trust_aggregates_trigger → a2a_trust_scores aggregates
- 096 mcp_capabilities_cache_trigger → MCP server capabilities cache

## Test plan

- [x] Spot-check trigger inventory against apps/backend/migrations/091*.sql through 096*.sql
- [x] Confirm migration 097 is a backfill + NOT NULL constraint, not a trigger
- [x] Confirm no other claims in HARDENING.md depend on the swapped wording