### PR TITLE
docs(hardening): correct A2A invariant mechanism in trigger inventory

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,7 +30,7 @@ Coverage in main today: organization-scoped handlers for agents, MCP servers, ca
 
 ### Data model invariants
 
-**Status: done.** Each known data-model invariant — parent cache columns plus richer detail tables, and row-internal couplings where two columns on the same row must move together — is now enforced at the database layer rather than by application code. Six invariant-preserving triggers cover trust scores → agent cache, MCP trust scores → MCP server cache, capability violations → agent count, MCP server capabilities → cache, A2A consent organization scoping, and agent status → `verified_at` timestamp. Tests assert the trigger behavior under insert, update, and delete.
+**Status: done.** Each known data-model invariant — parent cache columns plus richer detail tables, and row-internal couplings where two columns on the same row must move together — is now enforced at the database layer rather than by application code. Six invariant-preserving triggers cover trust scores → agent cache, MCP trust scores → MCP server cache, capability violations → agent count, MCP server capabilities → cache, A2A peer trust aggregates, and agent status → `verified_at` timestamp. The A2A consent cross-tenant invariant is enforced by a complementary `NOT NULL` constraint on `a2a_consent_records.organization_id` (migration 097, backfilled from the grantor agent). Tests assert the trigger and constraint behavior under insert, update, and delete.
 
 ### Capability lifecycle
 


### PR DESCRIPTION
## Summary

Follow-up correction to PR #243 (`HARDENING.md` reality refresh, merged as `3cbc404`).

PR #243's Data-model-invariants stream listed six triggers covering: trust scores → agent cache, MCP trust scores → MCP server cache, capability violations → agent count, MCP server capabilities → cache, **"A2A consent organization scoping"**, and agent status → `verified_at`.

That fifth slot was wrong:

- **Migration 095** (`a2a_peer_trust_aggregates_trigger.sql`) is the actual sixth trigger. It was omitted from the list.
- The A2A consent organization-scope invariant is real, but is enforced by a **`NOT NULL` constraint** on `a2a_consent_records.organization_id` (migration 097, a backfill plus the constraint), not by a trigger.

This PR replaces the misnamed slot with the actual trigger and adds one sentence acknowledging the NOT NULL constraint so the A2A consent invariant remains visible in the doc.

## Verification

```
$ ls apps/backend/migrations/095*.sql apps/backend/migrations/097*.sql
apps/backend/migrations/095_a2a_peer_trust_aggregates_trigger.sql
apps/backend/migrations/097_backfill_a2a_consent_organization_id.sql
```

## Test plan

- [x] Migration 095 exists and is the `a2a_peer_trust_aggregates` trigger
- [x] Migration 097 exists and is the consent-scoping backfill + NOT NULL constraint
- [x] No other claims in the Data-model-invariants section need correction
- [x] Doc-only diff; no code paths affected