### PR TITLE
test(e2e): empty-state Playwright suite + CI integration for v1.0 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,126 @@ jobs:
       - name: Build
         working-directory: apps/web
         run: npm run build
+
+  # End-to-end Playwright suite covering empty-state rendering on every
+  # dashboard panel of the agent and MCP server detail pages — the binding
+  # ☐ in HARDENING.md#roadmap-to-1-0. Boots a real Postgres + Go backend
+  # so every test exercises a freshly-created resource through the
+  # actual API contract; no mocked routes, no pre-seeded fixtures.
+  e2e-empty-state:
+    name: E2E empty-state (Playwright)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aim
+          POSTGRES_PASSWORD: aim
+          POSTGRES_DB: aim_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U aim -d aim_test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 12
+    env:
+      # cmd/migrate + cmd/bootstrap consume DATABASE_URL directly.
+      DATABASE_URL: postgres://aim:aim@localhost:5432/aim_test?sslmode=disable
+      # cmd/server consumes discrete POSTGRES_* vars (see internal/config/config.go).
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: aim
+      POSTGRES_PASSWORD: aim
+      POSTGRES_DB: aim_test
+      POSTGRES_SSL_MODE: disable
+      ENVIRONMENT: ci
+      NEXT_PUBLIC_API_URL: http://localhost:8080
+      AIM_TEST_ADMIN_EMAIL: admin@opena2a.org
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/backend/go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install frontend deps
+        run: npm ci --legacy-peer-deps
+
+      - name: Generate ephemeral CI secrets
+        run: |
+          # Bootstrap config validator rejects known-dev values and requires
+          # ≥32 chars. Fresh per-run hex strings satisfy both. These never
+          # leave the runner.
+          {
+            echo "JWT_SECRET=$(openssl rand -hex 32)"
+            echo "KEYVAULT_MASTER_KEY=$(openssl rand -hex 32)"
+            ADMIN_PW=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+            echo "DEFAULT_ADMIN_PASSWORD=${ADMIN_PW}"
+            echo "AIM_TEST_ADMIN_PASSWORD=${ADMIN_PW}"
+          } >> "$GITHUB_ENV"
+
+      - name: Build backend binaries
+        working-directory: apps/backend
+        run: |
+          go build -o /tmp/aim-server ./cmd/server
+          go build -o /tmp/aim-migrate ./cmd/migrate
+          go build -o /tmp/aim-bootstrap ./cmd/bootstrap
+
+      - name: Run migrations
+        run: /tmp/aim-migrate
+
+      - name: Seed canonical admin
+        run: /tmp/aim-bootstrap --default
+
+      - name: Start backend
+        run: |
+          /tmp/aim-server > /tmp/aim-server.log 2>&1 &
+          echo "BACKEND_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for backend /health/ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/health/ready >/dev/null 2>&1; then
+              echo "✓ backend ready (after ${i}s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ backend did not become ready within 60s"
+          echo "=== backend log ==="
+          cat /tmp/aim-server.log || true
+          exit 1
+
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright empty-state suite
+        working-directory: apps/web
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 14
+
+      - name: Upload backend log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-log
+          path: /tmp/aim-server.log
+          retention-days: 14

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
-    "test": "vitest --passWithNoTests"
+    "test": "vitest --passWithNoTests",
+    "test:e2e": "playwright test",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@alloc/quick-lru": "^5.2.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }], ['github']]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // Only start `next dev` when not already running. In CI the workflow starts
+  // both the Go backend and `next dev` before invoking playwright, so the
+  // server is already up and reuseExistingServer takes effect.
+  webServer: {
+    command: 'npm run dev',
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/apps/web/tests/e2e/empty-state-agent.spec.ts
+++ b/apps/web/tests/e2e/empty-state-agent.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from './fixtures/aim-test-stack';
+import type { Page } from '@playwright/test';
+
+// Universal post-render assertions every empty-state test must satisfy:
+//   1. No element with role=alert (catches error boundaries + toast errors)
+//   2. No /error|failed|crashed/i text leaking into the rendered DOM
+//   3. Skeletons have resolved (animate-pulse cleared after networkidle)
+async function assertNoErrorState(page: Page) {
+  await expect(page.locator('[role="alert"]')).toHaveCount(0);
+  await expect(page.locator('text=/error|failed|crashed/i')).toHaveCount(0);
+  await expect(page.locator('.animate-pulse')).toHaveCount(0);
+}
+
+async function gotoAgentTab(page: Page, agentId: string, tab: string) {
+  await page.goto(`/dashboard/agents/${agentId}?tab=${tab}`);
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('Agent detail page — empty-state rendering on fresh agent', () => {
+  test('connections tab renders "No MCP Servers Detected"', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'connections');
+    await expect(authedPage.getByText('No MCP Servers Detected')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('capabilities tab renders "No Capabilities Detected"', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'capabilities');
+    await expect(authedPage.getByText('No Capabilities Detected')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('violations tab renders clean-record empty state', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'violations');
+    await expect(
+      authedPage.getByText('No violations found. This agent has a clean record!'),
+    ).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('key-vault tab indicates no PQC key registered', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'key-vault');
+    await expect(
+      authedPage.getByText(/No post-quantum public key registered/i),
+    ).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('api-keys tab renders "No API Keys"', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'api-keys');
+    await expect(authedPage.getByText('No API Keys', { exact: true })).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('tags tab renders "No tags assigned"', async ({ authedPage, registerAgent }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'tags');
+    await expect(authedPage.getByText('No tags assigned')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('activity tab renders "No activity recorded for this agent yet."', async ({
+    authedPage,
+    registerAgent,
+  }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'activity');
+    await expect(
+      authedPage.getByText('No activity recorded for this agent yet.'),
+    ).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('trust tab renders "No historical data available yet"', async ({
+    authedPage,
+    registerAgent,
+  }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'trust');
+    // A freshly-created agent has no trust history yet. The breakdown panel
+    // may render a default score, but the history sub-panel must surface
+    // the empty state — that's the contract this test pins.
+    await expect(
+      authedPage.getByText(/No historical data available yet/i),
+    ).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  // details tab is N/A-by-design for empty-state copy: the agent's own
+  // metadata (displayName, registration timestamps) is always populated.
+  // Contract for this panel: it RENDERS, no error boundary, no crash.
+  test('details tab renders agent metadata without error', async ({
+    authedPage,
+    registerAgent,
+  }) => {
+    const agent = await registerAgent();
+    await gotoAgentTab(authedPage, agent.id, 'details');
+    // The display name we registered the agent under must surface somewhere.
+    await expect(authedPage.getByText(new RegExp(agent.name, 'i')).first()).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+});

--- a/apps/web/tests/e2e/empty-state-mcp.spec.ts
+++ b/apps/web/tests/e2e/empty-state-mcp.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from './fixtures/aim-test-stack';
+import type { Page } from '@playwright/test';
+
+async function assertNoErrorState(page: Page) {
+  await expect(page.locator('[role="alert"]')).toHaveCount(0);
+  await expect(page.locator('text=/error|failed|crashed/i')).toHaveCount(0);
+  await expect(page.locator('.animate-pulse')).toHaveCount(0);
+}
+
+// MCP detail page uses Radix Tabs with defaultValue="details" and does not
+// persist the active tab in the URL search params (unlike the agent page).
+// Tests switch tabs by clicking the matching role=tab element.
+async function gotoMcpDetail(page: Page, serverId: string) {
+  await page.goto(`/dashboard/mcp/${serverId}`);
+  await page.waitForLoadState('networkidle');
+}
+
+async function selectTab(page: Page, label: string | RegExp) {
+  await page.getByRole('tab', { name: label }).click();
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('MCP server detail page — empty-state rendering on fresh server', () => {
+  // details is the default tab. metadata (name, url) is always populated;
+  // contract is "renders without error boundary".
+  test('details tab (default) renders server metadata without error', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await expect(authedPage.getByText(new RegExp(server.name, 'i')).first()).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('capabilities tab renders "No capabilities detected yet"', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /capabilities/i);
+    await expect(authedPage.getByText('No capabilities detected yet')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('agents tab renders "No agents connected yet"', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /connected agents/i);
+    await expect(authedPage.getByText('No agents connected yet')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  // Tab label is "Attestations"; underlying value is "activity".
+  test('attestations tab renders "No attestations yet"', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /attestations/i);
+    await expect(
+      authedPage.getByRole('heading', { name: 'No attestations yet' }),
+    ).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  test('tags tab renders "No tags assigned"', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /^tags$/i);
+    await expect(authedPage.getByText('No tags assigned')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  // Tab label is "Audit Trail"; underlying value is "audit". A freshly
+  // created MCP server has no audit_logs so the panel's empty branch
+  // renders.
+  test('audit trail tab renders "No activity recorded yet"', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /audit trail/i);
+    await expect(authedPage.getByText('No activity recorded yet')).toBeVisible();
+    await assertNoErrorState(authedPage);
+  });
+
+  // integration is N/A-by-design for empty-state copy: the panel renders
+  // a static setup guide that is the same regardless of resource history.
+  // Contract: it renders, no error boundary, no crash.
+  test('integration tab renders setup guide without error', async ({
+    authedPage,
+    registerMcpServer,
+  }) => {
+    const server = await registerMcpServer();
+    await gotoMcpDetail(authedPage, server.id);
+    await selectTab(authedPage, /integration/i);
+    await assertNoErrorState(authedPage);
+  });
+});

--- a/apps/web/tests/e2e/fixtures/aim-test-stack.ts
+++ b/apps/web/tests/e2e/fixtures/aim-test-stack.ts
@@ -1,0 +1,100 @@
+import { test as base, type APIRequestContext, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const ADMIN_EMAIL = process.env.AIM_TEST_ADMIN_EMAIL ?? 'admin@opena2a.org';
+const ADMIN_PASSWORD = process.env.AIM_TEST_ADMIN_PASSWORD ?? process.env.DEFAULT_ADMIN_PASSWORD ?? '';
+
+type Resource = { id: string; name: string };
+
+type Fixtures = {
+  adminAuth: { accessToken: string; refreshToken: string };
+  registerAgent: (overrides?: { displayName?: string }) => Promise<Resource>;
+  registerMcpServer: (overrides?: { url?: string }) => Promise<Resource>;
+  authedPage: Page;
+};
+
+// freshSuffix is unique per test invocation so parallel workers never collide
+// on the (organizationId, name) unique constraint on agents / mcp_servers.
+function freshSuffix(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 12);
+}
+
+async function login(request: APIRequestContext): Promise<{ accessToken: string; refreshToken: string }> {
+  if (!ADMIN_PASSWORD) {
+    throw new Error(
+      'AIM_TEST_ADMIN_PASSWORD (or DEFAULT_ADMIN_PASSWORD) must be set to the seeded admin password.',
+    );
+  }
+  const res = await request.post('/api/v1/auth/login/local', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+  });
+  if (!res.ok()) {
+    throw new Error(`login/local failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = await res.json();
+  return { accessToken: body.accessToken, refreshToken: body.refreshToken };
+}
+
+export const test = base.extend<Fixtures>({
+  adminAuth: async ({ request }, use) => {
+    const tokens = await login(request);
+    await use(tokens);
+  },
+
+  registerAgent: async ({ request, adminAuth }, use) => {
+    const created: string[] = [];
+    const register = async (overrides?: { displayName?: string }): Promise<Resource> => {
+      const name = `e2e-agent-${freshSuffix()}`;
+      const res = await request.post('/api/v1/agents/', {
+        headers: { Authorization: `Bearer ${adminAuth.accessToken}` },
+        data: {
+          name,
+          displayName: overrides?.displayName ?? `E2E Agent ${name}`,
+          description: 'Fixture-registered agent for empty-state e2e',
+          agentType: 'ai_agent',
+        },
+      });
+      if (!res.ok()) {
+        throw new Error(`create agent failed: ${res.status()} ${await res.text()}`);
+      }
+      const body = await res.json();
+      created.push(body.id);
+      return { id: body.id, name };
+    };
+    await use(register);
+  },
+
+  registerMcpServer: async ({ request, adminAuth }, use) => {
+    const created: string[] = [];
+    const register = async (overrides?: { url?: string }): Promise<Resource> => {
+      const name = `e2e-mcp-${freshSuffix()}`;
+      const res = await request.post('/api/v1/mcp-servers/', {
+        headers: { Authorization: `Bearer ${adminAuth.accessToken}` },
+        data: {
+          name,
+          description: 'Fixture-registered MCP server for empty-state e2e',
+          url: overrides?.url ?? `https://example.test/${name}`,
+        },
+      });
+      if (!res.ok()) {
+        throw new Error(`create mcp-server failed: ${res.status()} ${await res.text()}`);
+      }
+      const body = await res.json();
+      created.push(body.id);
+      return { id: body.id, name };
+    };
+    await use(register);
+  },
+
+  // authedPage seeds localStorage.auth_token (read by useAuth() via api.getToken())
+  // before any navigation, so dashboard routes render without redirecting to /login.
+  // Cookies set by /auth/login/local are already on the context via APIRequestContext.
+  authedPage: async ({ page, adminAuth }, use) => {
+    await page.addInitScript((token) => {
+      try { window.localStorage.setItem('auth_token', token); } catch {}
+    }, adminAuth.accessToken);
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Summary

Closes the single remaining binding `HARDENING.md` "Roadmap to 1.0" checkbox: *"A passing end-to-end Playwright suite covering empty-state rendering on every dashboard panel, integrated into CI."*

After this lands and the CI workflow goes green on `main`, HARDENING.md needs a follow-up flip (Dashboard rendering on empty state stream: `in progress` → `done`; Roadmap checkbox: ☐ → ✓). Doing that doc update in a separate small PR after this PR's CI confirms the suite passes against real infra.

## What lands

### Suite (apps/web/tests/e2e/)

- `empty-state-agent.spec.ts` — 9 tabs on the agent detail page: connections, capabilities, violations, key-vault, api-keys, tags, activity, trust, details.
- `empty-state-mcp.spec.ts` — 7 tabs on the MCP server detail page: details, capabilities, agents, attestations, tags, audit trail, integration. The MCP page uses Radix Tabs with `defaultValue="details"` and doesn't persist the active tab in the URL (the agent page does), so this spec switches tabs by clicking the matching `role=tab` element.
- `fixtures/aim-test-stack.ts` — `@playwright/test` extension with `registerAgent`, `registerMcpServer`, and `authedPage` fixtures. Each registration uses a `randomUUID`-suffixed name so parallel workers never collide on the `(organizationId, name)` unique constraint.

Every test runs `assertNoErrorState` after the visible-text assertion: no `role=alert`, no `/error|failed|crashed/i` text leak, no unresolved skeletons (`.animate-pulse`).

### Config

- `apps/web/playwright.config.ts` — chromium-only project, `reuseExistingServer` so local runs against a hand-started `next dev` work, CI-aware retries + reporters.
- `apps/web/package.json` — adds `test:e2e` and `test:e2e:report` scripts.

### CI integration

`.github/workflows/ci.yml` gains the `e2e-empty-state` job:

1. Postgres 16 service container with healthcheck.
2. Generates ephemeral `JWT_SECRET`, `KEYVAULT_MASTER_KEY`, `DEFAULT_ADMIN_PASSWORD` per run via `openssl rand` (the config validator rejects known-dev values and requires ≥32 chars; these never leave the runner).
3. Builds `cmd/server`, `cmd/migrate`, `cmd/bootstrap`.
4. Runs migrations, then `aim-bootstrap --default` to seed the canonical admin.
5. Starts the backend, waits on `/health/ready` (up to 60s; emits backend log on failure for triage).
6. `npx playwright install --with-deps chromium`.
7. `npm run test:e2e` from `apps/web`.
8. Uploads `playwright-report/` and `aim-server.log` as artifacts on failure (14-day retention).

Job only runs when `frontend` or `backend` paths change (per the existing `changes` job filter).

## Test plan

- [x] `apps/backend` `go build ./...` PASS
- [x] `apps/web` `npx tsc --noEmit` PASS (no type errors in the suite or fixture)
- [ ] `e2e-empty-state` job green on this PR's CI run — that's the meaningful verification
- [ ] On green: follow-up PR flips `HARDENING.md` Dashboard rendering on empty state to `done` + Roadmap checkbox to ✓

## Effect on the v1.0 gate

| Item | Before this PR | After |
|---|---|---|
| HARDENING.md Roadmap ☐ Playwright suite | open | closed pending CI green |
| Audit-baseline open count | 0 | 0 |
| /release-test | PASS | PASS |
| STATUS.md flip + release.yml publish wiring + tag convention | open (structural, separate scope) | unchanged |