### PR TITLE
chore: per-package tag convention for v1.0.0 cut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "platform-v*"
 
 permissions:
   contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,33 @@ docs(readme): update installation instructions
 test(agents): add integration tests for agent registration
 ```
 
+## Tag conventions
+
+This repository ships multiple independently versioned artifacts (the platform itself and three language SDKs). Tags use per-package prefixes so each artifact has its own release timeline and so the release workflow can filter cleanly.
+
+| Artifact | Tag prefix | Example | Source of truth for version |
+|---|---|---|---|
+| Platform (backend + frontend release artifacts) | `platform-v` | `platform-v1.0.0` | release commit |
+| Python SDK | `sdk-py-v` | `sdk-py-v1.23.0` | `sdk/python/VERSION` |
+| TypeScript SDK | `sdk-ts-v` | `sdk-ts-v1.0.0` | `sdk/typescript/package.json` |
+| Java SDK | `sdk-java-v` | `sdk-java-v1.0.0` | `sdk/java/VERSION` and `sdk/java/pom.xml` |
+
+**Bare `v<X.Y.Z>` tags are retired for new releases.** Historical bare tags from `v0.2.0` through `v1.23.0` remain in the tag history as immutable artifacts — they were de-facto Python SDK releases despite the ambiguous naming, and removing them would break external references. Do not create new bare-`v*` tags.
+
+**Cutting a release:**
+
+```bash
+# Platform (example: cutting 1.0.0)
+git tag -a platform-v1.0.0 -m "Platform v1.0.0"
+git push origin platform-v1.0.0
+
+# Python SDK (example: cutting 1.23.0)
+git tag -a sdk-py-v1.23.0 -m "Python SDK v1.23.0"
+git push origin sdk-py-v1.23.0
+```
+
+The `.github/workflows/release.yml` workflow currently filters on `platform-v*` and generates SBOMs on each platform tag push. Per-SDK publishing workflows (PyPI, npm, Maven Central) will be added under their own tag prefixes in follow-up work; until those land, SDK tags only mark the release point in git history.
+
 ## 🔄 Pull Request Process
 
 1. **Create a Branch**


### PR DESCRIPTION
## Summary

Document a per-package tag convention for the platform and the three language SDKs, and change the Release workflow's tag filter from bare `v*` to `platform-v*`. This unblocks the v1.0.0 platform cut without colliding with the historical bare `v*` tag namespace.

This is item **B.2** in the v1.0 cut sequence (after A.1 and before B.3 publish wiring).

## [CHIEF-CA] DECISION

**Per-package tags for `agent-identity-management`**

- Platform release tag: `platform-v<X.Y.Z>` (e.g. `platform-v1.0.0`)
- Python SDK tag: `sdk-py-v<X.Y.Z>`
- TypeScript SDK tag: `sdk-ts-v<X.Y.Z>`
- Java SDK tag: `sdk-java-v<X.Y.Z>`
- Bare `v<X.Y.Z>` tags: **retired** for new releases. Historical bare tags `v0.2.0` through `v1.23.0` remain in tag history as immutable artifacts.

### Rationale

Historical bare `v*` is already polluted with what were de-facto Python SDK releases. `git log --grep="bump SDK version"` confirms `v1.5.0`, `v1.21.0`, `v1.23.0`, `v1.19.0`, and `v1.15.0` were all Python SDK version bumps (commits `319c934`, `e33377d`, `fce3633`, `d73a138`, et al.). Current `sdk/python/VERSION` reads `1.22.0`. A bare `v1.0.0` platform tag would lexically appear "older" than `v1.23.0` in semver-sorted release listings — UX win does not outweigh the confusion floor.

Per-package prefixes match the global ` ~/.claude/CLAUDE.md` "Per-package tag convention" rule and the `@opena2a/shared 0.1.2 → v0.1.2-shared-canary` precedent.

### Alternatives rejected

| Alternative | Why rejected |
|---|---|
| Keep bare `v*` for platform | `v1.0.0` < `v1.23.0` by semver — would render the platform 1.0 cut as visually "older" than three pre-1.0 SDK bumps in the GH releases UI |
| Retroactively retag `v1.21.0..v1.23.0` to `sdk-py-v*` | Destructive; tags are immutable promises; any external puller (clone-by-tag, archive URL referenced in changelogs, future Trusted Publishing audit trail) would break. Precedent across `dvaa`, `hackmyagent`, `homebrew-tap`: leave historical tags intact, prefix future tags only |
| Repo-short-name prefix `aim-v*` | "aim" is also the SDK product family name (`aim-sdk` on npm, `aim_sdk` on PyPI, `aim-sdk` on Maven). `aim-v1.0.0` reads ambiguously as "AIM SDK v1.0.0" |

### Escalation

None required. This is internal release plumbing — no user-facing CLI UX surface (CHIEF-CPO not consulted), no pipeline change (CHIEF-CDE not consulted), no security surface change (CHIEF-CSR not consulted).

## Changes

- **`CONTRIBUTING.md`**: append `## Tag conventions` section between `Commit Message Format` and `Pull Request Process`, with a per-artifact tag-prefix table, retired-bare-`v*` notice, and a cutting-a-release example.
- **`.github/workflows/release.yml`**: change `on.push.tags` filter from `"v*"` to `"platform-v*"`. SBOM job is otherwise unchanged. Per-SDK publishing workflows (PyPI, npm, Maven Central) are out of scope for this PR — they'll be added under their own tag prefixes in a follow-up.

## Test plan

- [x] YAML lint: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` succeeds
- [x] CONTRIBUTING.md: `## Tag conventions` appears exactly once; all five referenced files (`sdk/python/VERSION`, `sdk/typescript/package.json`, `sdk/java/VERSION`, `sdk/java/pom.xml`, `.github/workflows/release.yml`) exist
- [x] Pre-push gate phases 1, 2, 3, 7a: PASS (4 — HMA static, 4.5 — adversarial, 5 — hma-hunter, 6 — new-user, 7b — cross-repo version sweep: all SKIPPED per skill rules for docs/workflow-filter changes)
- [x] Native pre-push hook: build, tests, lint cache hits clean (3 unrelated pre-existing `<img>` lint warnings on `apps/web/**` not introduced by this PR)
- [ ] First exercise: the next platform release will cut `platform-v1.0.0` and the SBOM job will fire on that tag — proves the new filter works

## Follow-ups (separate sessions)

- B.3: add publish wiring to `release.yml` under Trusted Publishing for `sdk-py-v*`, `sdk-ts-v*`, `sdk-java-v*` (separate jobs per artifact, idempotent skip-if-already-published)
- B.1: STATUS.md stage flip `beta` → `stable` (lands IN the v1.0.0 cut PR, not before)
- A.1: empty-state Playwright suite (PR #248, owned by parallel session)

## Out of scope

- HARDENING.md "Roadmap to 1.0" checkbox flip — PR #248's parallel session owns the empty-state ☐→☑ update
- `git tag platform-v1.0.0` itself — the actual cut happens after all four v1.0 blockers (A.1, B.1, B.2, B.3) land
- Retroactive retagging of `v0.2.0..v1.23.0` — destructive, never doing this