### PR TITLE
chore(release): wire PyPI Trusted Publishing for aim-sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     tags:
+      # Platform tag — runs the SBOM job for the whole AIM platform.
       - "platform-v*"
+      # Per-package tag for the Python SDK — runs the publish-python job.
+      # Convention from PR #249. Other SDK tag patterns (npm aim-sdk-ts,
+      # Java) will be added when their publish wiring lands.
+      - "aim-sdk-v*"
 
 permissions:
   contents: write
@@ -11,6 +16,8 @@ permissions:
 jobs:
   sbom:
     name: Generate SBOMs
+    # SBOM job is platform-scoped; skip on per-SDK tag pushes.
+    if: startsWith(github.ref, 'refs/tags/platform-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,3 +50,92 @@ jobs:
           files: |
             sbom-backend.cdx.json
             sbom-frontend.cdx.json
+
+  # Publishes the Python aim-sdk to PyPI on an `aim-sdk-v<version>` tag
+  # push, using PyPI Trusted Publishing (OIDC). No long-lived token in
+  # the workflow or in repo secrets — the OIDC token issued to this job
+  # is exchanged at the registry, per global CLAUDE.md "npm Publish
+  # (MANDATORY — Trusted Publishing via OIDC)" applied to PyPI.
+  #
+  # First publish under this job requires PyPI Trusted Publishers to be
+  # configured for `aim-sdk` (Account → Publishing on pypi.org; owner=
+  # opena2a-org, repo=agent-identity-management, workflow=release.yml,
+  # environment=blank). Without that configuration the OIDC exchange
+  # fails cleanly with "OIDC token verification failed".
+  publish-python:
+    name: Publish aim-sdk to PyPI
+    if: startsWith(github.ref, 'refs/tags/aim-sdk-v')
+    runs-on: ubuntu-latest
+    permissions:
+      # id-token: write is the OIDC trust handshake the registry verifies.
+      # contents: read is enough — no commits or releases written from here.
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches VERSION
+        run: |
+          # The tag is aim-sdk-v<X.Y.Z>; the VERSION file is <X.Y.Z>.
+          TAG_VERSION="${GITHUB_REF_NAME#aim-sdk-v}"
+          FILE_VERSION="$(cat VERSION)"
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "✗ Tag version ($TAG_VERSION) does not match VERSION file ($FILE_VERSION)"
+            echo "  Either the tag was pushed without bumping VERSION, or VERSION was bumped"
+            echo "  but the tag uses a different value. Fix one before re-tagging."
+            exit 1
+          fi
+          echo "✓ Tag and VERSION agree on ${TAG_VERSION}"
+
+      - name: Skip if version already on PyPI
+        id: idempotence
+        run: |
+          # Per-publish idempotence: a re-tag (e.g. workflow re-run) must not
+          # error the job just because the version exists. The pypa publish
+          # action errors loudly on duplicate version uploads; we short-circuit
+          # cleanly here instead.
+          VERSION="$(cat VERSION)"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/aim-sdk/${VERSION}/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "ℹ️  aim-sdk ${VERSION} is already on PyPI — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✓ aim-sdk ${VERSION} not yet on PyPI; will publish."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build sdist + wheel
+        if: steps.idempotence.outputs.skip != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: steps.idempotence.outputs.skip != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist/
+
+      - name: Verify publish
+        if: steps.idempotence.outputs.skip != 'true'
+        run: |
+          VERSION="$(cat VERSION)"
+          # Brief retry — registry indexing can lag a few seconds after upload.
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/aim-sdk/${VERSION}/json")
+            if [ "$STATUS" = "200" ]; then
+              echo "✓ aim-sdk ${VERSION} is live on PyPI"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "✗ aim-sdk ${VERSION} not visible on PyPI after publish — investigate"
+          exit 1


### PR DESCRIPTION
## Summary

Adds a `publish-python` job to `.github/workflows/release.yml` that publishes the Python `aim-sdk` to PyPI via **OIDC Trusted Publishing** on an `aim-sdk-v<version>` tag-push. First per-package SDK publish path in this repo; npm `@opena2a/aim-sdk` and Java Maven Central are sequential follow-up PRs.

This unblocks one of the structural v1.0 prerequisites (`release.yml is SBOM-only`) for the Python target. The `aim-sdk` VERSION file is already at `1.22.0` (one ahead of the published `1.21.0`), so the first end-to-end validation tag will be `aim-sdk-v1.22.0`.

## Trigger split

- `platform-v*` tags continue running the existing SBOM job (now `if`-gated to platform tags).
- `aim-sdk-v*` tags trigger `publish-python` and skip SBOM.
- Other SDK tag patterns get added with their publish jobs.

## Publish wiring (per global CLAUDE.md "Trusted Publishing via OIDC")

- `id-token: write` permission for the OIDC handshake; no `PYPI_TOKEN` in workflow or repo secrets.
- Tag-vs-VERSION assertion: aborts if tag value and `sdk/python/VERSION` disagree.
- Idempotence: re-tag for a version already on PyPI short-circuits the build + upload steps cleanly (instead of `pypa/gh-action-pypi-publish` erroring on duplicate version).
- Build via `python -m build` (sdist + wheel).
- Upload via `pypa/gh-action-pypi-publish@release/v1` with `packages-dir=sdk/python/dist/`.
- Post-publish verification with a brief retry loop (PyPI indexing lags a few seconds after upload).

## User action required BEFORE the first publish

PyPI Trusted Publishing must be configured for `aim-sdk` on pypi.org BEFORE the first `aim-sdk-v*` tag-push:

1. Log in to pypi.org with the account that owns `aim-sdk`.
2. Project `aim-sdk` → **Publishing** tab → **Add a pending publisher** (or **Manage** if a token-based publisher exists).
3. Fields:
   - **Owner:** `opena2a-org`
   - **Repository name:** `agent-identity-management`
   - **Workflow name:** `release.yml`
   - **Environment name:** (blank)

Without this configuration the first publish fails cleanly at the OIDC verification step with no published artifact. Configure first, then tag.

If a long-lived API token is currently configured for `aim-sdk`, it can be revoked after the first TP-based publish succeeds.

## Test plan

- [x] YAML parse of `.github/workflows/release.yml`
- [ ] After merge: configure PyPI Trusted Publishing for `aim-sdk` (user action above)
- [ ] After config: tag `aim-sdk-v1.22.0` and watch the publish-python job run
- [ ] Verify the workflow run goes green and `curl https://pypi.org/pypi/aim-sdk/1.22.0/json` returns the new version
- [ ] Verify SLSA provenance attestations on the uploaded artifacts

## What is NOT in scope

- `@opena2a/aim-sdk` on npm (next PR — first publish ever, needs npmjs.com TP config + workflow step).
- Java SDK Maven Central publish (PR after that; GPG signing + OSSRH staging).
- Docker image publish for backend / frontend (tracked separately).
- Bumping `sdk/python/VERSION` (1.22.0 already there from a prior commit).
- Switching `STATUS.md` beta → stable (deferred to the v1.0 cut PR per the v1-cut prompt).
