### PR TITLE
ci(docker-publish): align with platform-v* tag convention

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,11 @@ name: Docker Publish
 on:
   push:
     tags:
-      - 'v*'
+      # Platform release tag convention — see CONTRIBUTING.md "Tag conventions".
+      # SDK tags (sdk-py-v*, sdk-ts-v*, sdk-java-v*) deliberately do not
+      # trigger this workflow; SDK publish workflows are separate per-package
+      # files (follow-up work).
+      - 'platform-v*'
     branches:
       - main
     paths:
@@ -57,9 +61,9 @@ jobs:
           images: ${{ env.REGISTRY }}/opena2a-org/aim-server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=edge,branch=main
 
       - name: Extract metadata (Docker Hub)
@@ -69,9 +73,9 @@ jobs:
           images: opena2a/aim-server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=edge,branch=main
 
       - name: Build and push image
@@ -148,9 +152,9 @@ jobs:
           images: ${{ env.REGISTRY }}/opena2a-org/aim-dashboard
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=edge,branch=main
 
       - name: Extract metadata (Docker Hub)
@@ -160,9 +164,9 @@ jobs:
           images: opena2a/aim-dashboard
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=edge,branch=main
 
       - name: Build and push image


### PR DESCRIPTION
## Summary

`docker-publish.yml` still filters on bare `v*` and uses `type=semver` to extract the version — both broken under the per-package tag convention shipped in PR #249. A `platform-v1.0.0` tag would (a) not trigger the workflow at all, and (b) even if it did, the metadata-action wouldn't be able to extract `1.0.0` from the prefixed tag. Fixing both so the v1.0.0 platform cut produces correctly-tagged Docker images.

This is the **last B.3 piece** needed for the v1.0.0 platform cut. SDK publish workflows (PyPI / npm / Maven Central) are deferred per `CONTRIBUTING.md` "Tag conventions" — they're per-package files that don't gate the platform cut.

## Changes

`.github/workflows/docker-publish.yml`:

- **Trigger filter:** `'v*'` → `'platform-v*'`, with a comment pointing at the convention doc and explicitly noting that SDK tags do not trigger this workflow.
- **Four `docker/metadata-action@v5` calls** (backend × GHCR + Docker Hub, frontend × GHCR + Docker Hub) replace their three `type=semver,pattern={{version|major.minor|major}}` lines with three `type=match,pattern=platform-v(\d+\.\d+\.\d+|\d+\.\d+|\d+),group=1` lines.

On a `platform-v1.0.0` tag push, the new patterns emit `1.0.0`, `1.0`, `1` — identical to what `type=semver` would have emitted on a bare `v1.0.0` tag.

## Verification

- [x] YAML parses cleanly.
- [x] Regex verified locally against `platform-v1.0.0`, `platform-v2.3.4`, `platform-v10.20.30`. All three patterns extract the expected `<X.Y.Z>`, `<X.Y>`, `<X>` substrings.
- [x] `main`-branch trigger with `paths:` filter is unchanged. `edge` tag still fires on main pushes.
- [x] Pre-push gate: phases 1 + 7a PASS; 2/3/4/4.5/5/6/7b SKIPPED per skill rules for workflow-only changes. Native pre-push hook PASSED (3 unrelated `<img>` lint warnings on `apps/web/**`).
- [ ] **Live verification will run when the platform release tag is cut after merge** — the workflow itself is the test.

## End-to-end on the v1.0.0 cut after this lands

Tagging the platform release then pushing the tag triggers in parallel:

- **`release.yml`** (filter already on `platform-v*` per PR #249): generates Go + Frontend SBOMs, creates the GitHub release for the tag with both SBOMs attached.
- **`docker-publish.yml`** (this PR's fix): builds + pushes `aim-server` and `aim-dashboard` to GHCR + Docker Hub tagged `1.0.0` / `1.0` / `1`, cosign-signs both images keylessly, attests build provenance.

## Out of scope

- SDK publish workflows. Documented as follow-up in `CONTRIBUTING.md` (per PR #249). Each SDK has its own readiness work (Python needs `pyproject.toml` for OIDC, Java needs OSSRH/GPG secrets, TypeScript needs npm Trusted Publisher setup on npmjs.com).