### PR TITLE
chore(release): wire Maven Central deploy for Java SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - "platform-v*"   # SBOM job (backend + frontend)
       - "sdk-py-v*"     # PyPI publish for aim-sdk (Python)
       - "sdk-ts-v*"     # npm publish for @opena2a/aim-sdk (TypeScript)
+      - "sdk-java-v*"   # Maven Central publish for org.opena2a:aim-sdk (Java)
 
 permissions:
   contents: write
@@ -244,4 +245,110 @@ jobs:
             sleep 5
           done
           echo "✗ @opena2a/aim-sdk@${VERSION} not visible on npm after publish — investigate"
+          exit 1
+
+  # Publishes the Java org.opena2a:aim-sdk to Maven Central on an
+  # `sdk-java-v<version>` tag push.
+  #
+  # Unlike PyPI and npm, Maven Central has no OIDC Trusted Publishing
+  # (as of 2026-05). Authentication uses a username/password token pair
+  # from central.sonatype.com, stored as repo secrets. Artifacts must
+  # be GPG-signed; the GPG private key + passphrase are also repo
+  # secrets. The central-publishing-maven-plugin (sdk/java/pom.xml
+  # release profile) talks to central.sonatype.com's portal API and
+  # auto-releases the staged bundle.
+  #
+  # Required repo secrets (see PR body for setup):
+  #   MAVEN_CENTRAL_USERNAME   sonatype portal token user (NOT JIRA login)
+  #   MAVEN_CENTRAL_PASSWORD   sonatype portal token value
+  #   MAVEN_GPG_PRIVATE_KEY    ASCII-armored GPG private key
+  #   MAVEN_GPG_PASSPHRASE     passphrase for the GPG key
+  publish-java:
+    name: Publish org.opena2a:aim-sdk to Maven Central
+    if: startsWith(github.ref, 'refs/tags/sdk-java-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/java
+    steps:
+      - uses: actions/checkout@v4
+
+      # setup-java@v4 wires up settings.xml with the `central` server
+      # credentials and imports the GPG key so the maven-gpg-plugin can
+      # sign every artifact in the verify phase. The server-id here must
+      # match <distributionManagement><repository><id> in pom.xml.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: maven
+
+      - name: Verify tag matches pom.xml version
+        run: |
+          # Tag is sdk-java-v<X.Y.Z>; pom.xml <version> is <X.Y.Z>.
+          TAG_VERSION="${GITHUB_REF_NAME#sdk-java-v}"
+          POM_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          if [ "$TAG_VERSION" != "$POM_VERSION" ]; then
+            echo "✗ Tag version ($TAG_VERSION) does not match pom.xml ($POM_VERSION)"
+            echo "  Either the tag was pushed without bumping pom.xml, or pom.xml"
+            echo "  was bumped but the tag uses a different value. Fix one before"
+            echo "  re-tagging."
+            exit 1
+          fi
+          echo "✓ Tag and pom.xml agree on ${TAG_VERSION}"
+
+      - name: Skip if version already on Maven Central
+        id: idempotence
+        run: |
+          # Per-publish idempotence: a re-tag must not error the job just
+          # because the version is already published. Central's
+          # central-publishing-maven-plugin errors loudly on duplicate
+          # uploads; this short-circuits cleanly instead. Check repo1
+          # (the production CDN) since central.sonatype.com is the upload
+          # endpoint, not the read endpoint.
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          URL="https://repo1.maven.org/maven2/org/opena2a/aim-sdk/${VERSION}/aim-sdk-${VERSION}.pom"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+          if [ "$STATUS" = "200" ]; then
+            echo "ℹ️  org.opena2a:aim-sdk:${VERSION} is already on Maven Central — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✓ org.opena2a:aim-sdk:${VERSION} not yet on Maven Central; will publish."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build + sign + deploy to Central
+        if: steps.idempotence.outputs.skip != 'true'
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        # -P release activates GPG signing + central-publishing-maven-plugin
+        # autoPublish handles staging+release in one shot.
+        run: mvn -B -P release deploy
+
+      - name: Verify publish
+        if: steps.idempotence.outputs.skip != 'true'
+        run: |
+          # Central's CDN sync can take several minutes after autoPublish.
+          # We give it a generous window before declaring failure.
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          URL="https://repo1.maven.org/maven2/org/opena2a/aim-sdk/${VERSION}/aim-sdk-${VERSION}.pom"
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+            if [ "$STATUS" = "200" ]; then
+              echo "✓ org.opena2a:aim-sdk:${VERSION} is live on Maven Central"
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "✗ org.opena2a:aim-sdk:${VERSION} not visible on Maven Central after 10min"
+          echo "  Bundle may be stuck in the portal — check central.sonatype.com"
           exit 1

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -202,12 +202,30 @@
         </plugins>
     </build>
 
+    <!--
+        Distribution to the modern Maven Central portal (central.sonatype.com).
+        The server id "central" must match the <servers><server><id> entry in
+        the GitHub-runner settings.xml (configured by actions/setup-java@v4
+        via the `server-id` input).
+    -->
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://central.sonatype.com/api/v1/publisher</url>
+        </repository>
+    </distributionManagement>
+
     <profiles>
         <!-- Profile for publishing to Maven Central -->
         <profile>
             <id>release</id>
             <build>
                 <plugins>
+                    <!-- GPG-sign every artifact in the release. The runner's
+                         settings.xml provides the passphrase via the
+                         MAVEN_GPG_PASSPHRASE environment variable, populated
+                         by setup-java@v4's gpg-passphrase input. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -221,6 +239,22 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <!-- Modern Maven Central uploader. Replaces the
+                         deprecated nexus-staging-maven-plugin (which targeted
+                         the legacy oss.sonatype.org host). Talks directly to
+                         central.sonatype.com's portal API and auto-releases
+                         the staged bundle when autoPublish=true. -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.5.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

Third (and last) SDK publish path. Adds `publish-java` to `.github/workflows/release.yml` and the supporting plugin + repository config to `sdk/java/pom.xml` so an `sdk-java-v<version>` tag-push GPG-signs and uploads `org.opena2a:aim-sdk` to Maven Central via the **central-publishing-maven-plugin**.

This wires the workflow path but does NOT actually publish anything until you do the one-time UI + GPG setup below. The `sdk/java` VERSION + pom.xml are both at 1.0.0 already, so the first end-to-end validation tag will be `sdk-java-v1.0.0`.

## Maven Central is meaningfully different from PyPI/npm

| Surface | npm/PyPI | Maven Central |
|---|---|---|
| Auth | OIDC handshake at the registry | username/password token pair from central.sonatype.com, repo secrets |
| Signing | not required | GPG signature on every artifact (pom + jar + sources jar + javadoc jar) |
| Staging | none | staged via portal API, auto-released when `<autoPublish>true</autoPublish>` |
| CDN sync | seconds | minutes |

## Workflow shape

- Triggered on `sdk-java-v*` tag-push (per CONTRIBUTING.md).
- `actions/setup-java@v4` with `server-id: central` wires up `settings.xml` and imports the GPG key.
- Tag-vs-`pom.xml` version assertion (aborts on mismatch).
- Idempotence: skips cleanly if the version is already on the Central CDN.
- `mvn -B -P release deploy` activates the release profile (GPG signing + central-publishing-maven-plugin).
- Post-publish verification polls the production CDN with a 10-min budget (20s × 30 attempts).

## pom.xml additions

- `<distributionManagement>` with `<id>central</id>` matching `setup-java@v4`'s `server-id` input.
- `central-publishing-maven-plugin` in the release profile with `autoPublish=true` and `waitUntil=published`, so a successful upload immediately auto-releases the staged bundle (no manual portal step in the operator's path).

## ⚠ User actions required BEFORE the first deploy

1. **central.sonatype.com account + namespace verification** for `org.opena2a`:
   - Sign up at central.sonatype.com.
   - Add namespace `org.opena2a` → choose a verification method.
   - DNS TXT record on `opena2a.org` is the standard path; takes minutes to propagate.
2. **Generate central.sonatype.com User Token** (Account → Generate User Token; NOT the JIRA login). Returns a username + password pair.
3. **Generate GPG key**:
   - `gpg --full-generate-key` (RSA 4096, 2-year expiry recommended).
   - Export private (ASCII-armored): `gpg --export-secret-keys --armor <key-id>`.
   - Set a passphrase.
   - Upload public to multiple keyservers: `gpg --keyserver keyserver.ubuntu.com --send-keys <key-id>`, also `keys.openpgp.org`, `pgp.mit.edu`.
4. **Add 4 repo secrets** (Settings → Secrets and variables → Actions):
   - `MAVEN_CENTRAL_USERNAME` — sonatype portal token user
   - `MAVEN_CENTRAL_PASSWORD` — sonatype portal token value
   - `MAVEN_GPG_PRIVATE_KEY` — ASCII-armored GPG private key
   - `MAVEN_GPG_PASSPHRASE` — passphrase for the GPG key

Without all four secrets the workflow fails at the deploy step. The signing failure mode is loud (`gpg: signing failed: Bad passphrase` or similar) but doesn't expose anything; the auth failure surfaces as `401 Unauthorized` from central.sonatype.com.

## Test plan

- [x] YAML parse of `.github/workflows/release.yml`
- [x] XML parse of `sdk/java/pom.xml`
- [x] `if:` filter, tag pattern, and tag-version parse string all use `sdk-java-v` consistently
- [x] `server-id: central` in setup-java matches `<distributionManagement><repository><id>central</id></repository>` in pom.xml
- [ ] After merge + 4 user actions above: tag `sdk-java-v1.0.0` and watch the deploy
- [ ] Verify the workflow run goes green, the bundle reaches `https://repo1.maven.org/maven2/org/opena2a/aim-sdk/1.0.0/`
- [ ] Verify GPG signatures are attached: `*-1.0.0.pom.asc`, `*-1.0.0.jar.asc`, `*-1.0.0-sources.jar.asc`, `*-1.0.0-javadoc.jar.asc`

## What is NOT in scope

- Bumping `sdk/java/VERSION` or `sdk/java/pom.xml <version>` (both stay at 1.0.0; bump happens at tag time).
- Docker image upload for backend / frontend (separate PR; lighter setup via GHCR).
- `STATUS.md` beta → stable (deferred to the v1.0 cut PR).

## Sequence position

With this PR merged, all three SDK publish paths are wired:

| SDK | Workflow | Tag prefix | Auth | PR |
|---|---|---|---|---|
| Python `aim-sdk` | publish-python | `sdk-py-v*` | PyPI OIDC TP | #251 (fixed tag in #253) |
| TypeScript `@opena2a/aim-sdk` | publish-npm | `sdk-ts-v*` | npm OIDC TP | #253 |
| Java `org.opena2a:aim-sdk` | publish-java | `sdk-java-v*` | sonatype token + GPG | this PR |

After this lands, the remaining v1.0 cut work is: container images (GHCR), `STATUS.md` flip, and the actual `platform-v1.0.0` tag.
