### PR TITLE
chore(release): align docker-publish.yml tag trigger with convention

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,13 @@ name: Docker Publish
 on:
   push:
     tags:
-      - 'v*'
+      # Per CONTRIBUTING.md "Tag conventions" (PR #249). Bare `v*` tags
+      # are retired for new releases — they matched the legacy Python SDK
+      # path but never matched `platform-v*` which is the actual platform
+      # release tag prefix today. SDK tags (`sdk-py-v*`, `sdk-ts-v*`,
+      # `sdk-java-v*`) don't ship the platform images; their publish
+      # workflows live in release.yml.
+      - 'platform-v*'
     branches:
       - main
     paths:


### PR DESCRIPTION
## Summary

The `docker-publish.yml` workflow already does the full image-release pipeline — GHCR + Docker Hub, multi-arch (amd64 + arm64), cosign keyless signing, SBOM, and build-provenance attestation. The only piece misaligned with the per-package tag convention from PR #249 is its tag trigger.

| | Before | After |
|---|---|---|
| `on.push.tags` | `'v*'` | `'platform-v*'` |
| Fires on `platform-v1.0.0`? | ❌ (starts with `p`, not `v`) | ✅ |
| Fires on `sdk-py-v*` etc.? | ❌ (correct — SDKs publish from release.yml) | ❌ (correct) |
| Fires on legacy bare `v*` tags? | ✅ (those tags are retired per CONTRIBUTING.md) | ❌ (correct) |

The main-branch + path-filter trigger still publishes `:latest` and `:edge` on commits that touch backend / frontend / Dockerfile paths — unchanged.

## What's NOT in scope

- No image content changes — Dockerfiles, image names (`ghcr.io/opena2a-org/aim-server`, `aim-dashboard`, plus Docker Hub mirrors), signing, attestation all untouched.
- No `release.yml` changes — SDK publish workflows stay there; platform images stay here.
- No new secrets — `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` are already configured for this workflow.

## Test plan

- [x] YAML parse of `.github/workflows/docker-publish.yml`
- [x] Comment at the trigger declaration points at CONTRIBUTING.md so future maintainers see the convention up-front
- [ ] After merge: `platform-v1.0.0` tag-push triggers `docker-publish.yml` end-to-end (build + push + sign + attest on both registries); this becomes part of the v1.0 cut validation

## Sequence position

After this PR merges, all four publish paths are aligned with the per-package tag convention:

| Artifact | Workflow | Tag prefix | Notes |
|---|---|---|---|
| Backend + frontend container images | `docker-publish.yml` | `platform-v*` | this PR |
| SBOM bundle | `release.yml` (sbom job) | `platform-v*` | wired in #249 |
| Python `aim-sdk` (PyPI) | `release.yml` (publish-python) | `sdk-py-v*` | #251 + #253 |
| TypeScript `@opena2a/aim-sdk` (npm) | `release.yml` (publish-npm) | `sdk-ts-v*` | #253 |
| Java `org.opena2a:aim-sdk` (Maven Central) | `release.yml` (publish-java) | `sdk-java-v*` | #254 |

The remaining v1.0 cut work after this lands is purely: STATUS.md beta → stable, then `platform-v1.0.0` tag.
