### PR TITLE
docs(v1.0): flip STATUS.md beta -> stable + remove pre-1.0 framing

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -1,14 +1,14 @@
 # Hardening
 
-AIM is pre-1.0 software in active hardening. This page tracks the work that needs to land before we recommend production deployment.
+AIM 1.0 ships with every Roadmap-to-1.0 gate criterion met (see below). This page tracks the work that landed to get here, and continues to track the next horizon of hardening work after 1.0.
 
 **Last updated:** 2026-05-28. Every enforcement stream and gate criterion is now closed in code, including the CI-integrated Playwright empty-state suite (PR #247 + #248). AIM is open source under Apache-2.0, so community review of the codebase is welcome before and after 1.0 per [SECURITY.md](SECURITY.md); a paid third-party engagement is a worthwhile post-1.0 investment for regulated deployments but is not a binding 1.0 gate.
 
 ## Current status
 
-**Pre-production.** AIM's architecture, threat model, and core enforcement primitives (capability authorization, trust scoring, monitoring/strict modes, cryptographic identity, audit logging) are in place. The integration layer between the SDK, the backend services, and the dashboard has been audited and the contract enforcement gaps are largely closed.
+**Stable (1.0).** AIM's architecture, threat model, and core enforcement primitives (capability authorization, trust scoring, monitoring/strict modes, cryptographic identity, audit logging) are in place and the integration layer between the SDK, the backend services, and the dashboard has been audited with contract-enforcement gaps closed.
 
-We are documenting this openly because pretending a pre-1.0 system is production-ready is more harmful than saying it is not. AIM is suitable today for evaluation, development, internal testing, and demonstration. It is not suitable for production deployments handling untrusted tenants or sensitive data — see the **Roadmap to 1.0** section below for the specific remaining blockers.
+We documented the road to 1.0 openly because pretending an unfinished system is production-ready is more harmful than saying it is not. With every gate criterion below now closed, AIM is suitable for production deployments — including environments with untrusted tenants or sensitive data — within the deployment posture documented in [SECURITY.md](SECURITY.md). New hardening work (middleware-level tenant scoping, the partial / aspirational items in SECURITY.md compliance section, etc.) continues post-1.0 and is tracked openly in this page.
 
 ## What we are working on
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Identity Management (AIM)
 
-[![Status: beta](https://img.shields.io/badge/status-beta-yellow)](./STATUS.md)
+[![Status: stable](https://img.shields.io/badge/status-stable-brightgreen)](./STATUS.md)
 
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
@@ -13,7 +13,7 @@ Cryptographic identity, capability authorization, and audit trails for AI agents
 
 [Website](https://opena2a.org) · [Demos](https://opena2a.org/demos) · [Discord](https://discord.gg/uRZa3KXgEn)
 
-> **Pre-1.0.** AIM is suitable today for evaluation, development, and internal testing. Production deployment with untrusted tenants or sensitive data is not yet recommended. Active hardening work is tracked in [HARDENING.md](HARDENING.md).
+> **AIM 1.0.** Every gate criterion in [HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" is met as of 2026-05-28. Semver is honored from this release forward; security patches are triaged within 24 hours per [SECURITY.md](SECURITY.md). A paid third-party security review is appropriate when a regulated customer requires formal attestation but is not a binding gate (AIM is open source under Apache-2.0 and the codebase is publicly auditable).
 
 ## Quick start
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-> **Pre-1.0 status.** AIM is in active hardening. The capabilities described in this document reflect target behavior. Several streams of work are open before we recommend production deployment, and we track them publicly in [HARDENING.md](HARDENING.md). Use AIM today for evaluation, development, and internal testing. Do not deploy it to environments handling untrusted tenants or sensitive data until the items in HARDENING.md are closed.
+> **AIM 1.0.** Every Roadmap-to-1.0 gate criterion in [HARDENING.md](HARDENING.md) is met as of 2026-05-28. The capabilities described in this document reflect shipped behavior; items still tracked as "Partial" or "Roadmap" in the Enterprise Compliance section below are flagged inline so consumers can plan around the actual enforcement boundary. Semver is honored from 1.0 forward, and security patches are triaged within 24 hours per the reporting flow below.
 
 ## Reporting Security Vulnerabilities
 
@@ -129,7 +129,7 @@ We conduct regular security assessments:
 
 ## Enterprise Compliance
 
-AIM is pre-1.0 (see the disclosure at the top of this file). This section maps each compliance claim to the code that backs it today, and flags claims that are partial or aspirational so consumers can plan around the actual enforcement boundary. Items marked **Partial** or **Roadmap** are tracked openly in [HARDENING.md](HARDENING.md).
+AIM ships at 1.0 with the gate criteria above closed. This section maps each compliance claim to the code that backs it today, and flags claims that are partial or aspirational so consumers can plan around the actual enforcement boundary. Items marked **Partial** or **Roadmap** are tracked openly in [HARDENING.md](HARDENING.md) and continue post-1.0.
 
 ### SOC 2 Type II Alignment
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,14 @@
-# Status: beta
+# Status: stable
 
-**Stage:** beta
+**Stage:** stable
 **Maintenance horizon:** actively maintained through 2026-12-31, status reviewed quarterly
 **Maintainer wanted:** no
 
 ## Stage rationale
 
-AIM is pre-1.0. Suitable for evaluation, development, and internal testing. Production deployment with untrusted tenants or sensitive data is not yet recommended. Active hardening work is tracked in [HARDENING.md](HARDENING.md).
+AIM 1.0. Every gate criterion in [HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" is met as of 2026-05-28 (last criterion — the CI-integrated Playwright empty-state suite — closed in PR #247 + PR #248 + PR #250). Semver is honored from this release forward; breaking changes go through a deprecation cycle and ship in a major bump. Security patches are triaged within 24 hours per the policy in [SECURITY.md](SECURITY.md).
+
+A paid third-party security review was previously listed as a 1.0 criterion but has been [rescoped to a post-1.0 investment](HARDENING.md#third-party-security-review) (CHIEF-CSR decision 2026-05-28): AIM is open source under Apache-2.0, so the codebase itself is the audit surface, and a community-review path through SECURITY.md is welcome before and after 1.0. A paid engagement is appropriate when a regulated customer requires formal attestation.
 
 ## Stage definitions
 
@@ -20,3 +22,4 @@ AIM is pre-1.0. Suitable for evaluation, development, and internal testing. Prod
 | Date | Stage | Reason |
 |---|---|---|
 | 2026-05-24 | beta | initial STATUS.md (org lifecycle introduction). Maps to existing pre-1.0 disclaimer in README. |
+| 2026-05-28 | stable | every Roadmap to 1.0 gate criterion in HARDENING.md met. Empty-state suite landed (#247) and CI-integrated (#248); HARDENING.md ☐ → ☑ in #250. Per-package SDK publish wiring complete (#251, #253, #254). Container image publish wiring aligned to convention (#255). Ready for `platform-v1.0.0` tag. |


### PR DESCRIPTION
## Summary

Final docs change before the v1.0 platform tag. Every Roadmap-to-1.0 gate criterion in `HARDENING.md` is closed (#250); the four publish paths — SBOM (#249), container images (#255), Python SDK (#251+#253), TypeScript SDK (#253), Java SDK (#254) — are wired and aligned with the per-package tag convention from `CONTRIBUTING.md`.

## What flips

| File | Before | After |
|---|---|---|
| `STATUS.md` | Stage: beta · "AIM is pre-1.0" rationale | Stage: stable · "AIM 1.0" rationale with closed-gate evidence pointers · status changes table appended with 2026-05-28 row |
| `README.md` | `status-beta-yellow` badge · "**Pre-1.0.**" blockquote | `status-stable-brightgreen` badge · "**AIM 1.0.**" blockquote pointing at SECURITY.md disclosure |
| `HARDENING.md` | "AIM is pre-1.0 software in active hardening" intro · "Current status: Pre-production" header | "AIM 1.0 ships with every Roadmap-to-1.0 gate criterion met" intro · "Current status: Stable (1.0)" header. The closed-stream evidence pointers from #250 stay unchanged. |
| `SECURITY.md` | "Pre-1.0 status" disclosure at top · "AIM is pre-1.0" Enterprise Compliance preamble | "AIM 1.0" disclosure with semver + 24-hour-triage commitment · "AIM ships at 1.0" Compliance preamble, same Partial/Roadmap caveats inline |

## What stays

- The Roadmap-to-1.0 table in `HARDENING.md` — every row is now `[x]` and the table itself is the audit trail.
- The 2026-05-24 row in `STATUS.md`'s status-changes log — accurate historical entry, not the current state.
- Every existing stream in `HARDENING.md` ("What we are working on") — those describe shipped work; new hardening continues in the same format post-1.0.
- Every Partial/Roadmap call-out in `SECURITY.md`'s Enterprise Compliance section — those are still accurate flags for items the codebase doesn't fully back yet, and they continue to track in `HARDENING.md`.

## What's NOT in scope

- Creating the `platform-v1.0.0` tag. After this PR merges, the operator step is:
  - Run `/release-test` from within Claude Code to validate the platform cut path (creates the `.release-test-passed` marker the tag-push-gate consumes).
  - Then `git tag -a platform-v1.0.0 -m "AIM Platform 1.0.0"` followed by pushing the tag.
- Bumping any SDK version. The three SDK workflows ship on their own per-SDK tag prefixes (`sdk-py-v*`, `sdk-ts-v*`, `sdk-java-v*`); SDK release cuts can happen before, with, or after the platform 1.0 whenever you're ready.
- Configuring the registry-side Trusted Publishing for PyPI and npm, or sonatype.com + GPG for Maven Central. Those user actions are documented inline in #251 / #253 / #254 and can happen at any cadence.

## Test plan

- [x] No grep hits for unflipped "Pre-1.0" / "pre-1.0" in top-level docs (`*.md` at repo root) or per-SDK READMEs.
- [x] The 2026-05-24 row in `STATUS.md`'s status-changes log is left as-is (accurate historical entry, not current state).
- [x] No code paths touched — only `STATUS.md`, `HARDENING.md`, `README.md`, `SECURITY.md`. No tests need to update; CI lint + build pass unchanged.
- [ ] After merge: `/release-test` walks the platform cut path, then the operator tags `platform-v1.0.0`.
