### PR TITLE
fix(sdk): stop doubling the 'Registration failed:' error prefix

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`register_agent` no longer doubles the error prefix.** When the backend
+  rejected a registration, the message read `Registration failed: Registration
+  failed: <reason>` because the outer handler re-wrapped a `ConfigurationError`
+  the inner helper had already raised. `AIMError` subclasses are now re-raised
+  unwrapped; generic exceptions are still wrapped exactly once. Regression tests
+  added in `tests/test_register_agent.py`.
+
 ## [1.22.0] - 2026-05-25
 
 ### Security

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -21,6 +21,7 @@ import re
 import warnings
 
 from .exceptions import (
+    AIMError,
     AuthenticationError,
     VerificationError,
     ActionDeniedError,
@@ -3886,6 +3887,12 @@ def register_agent(
 
     except requests.RequestException as e:
         raise ConfigurationError(f"Failed to connect to AIM server: {e}")
+    except AIMError:
+        # The inner helpers (_register_via_oauth / _register_via_api_key) already
+        # raise typed, well-messaged errors (e.g. "Registration failed: <reason>").
+        # Re-raise as-is — re-wrapping them here produced the doubled
+        # "Registration failed: Registration failed: ..." prefix.
+        raise
     except Exception as e:
         raise ConfigurationError(f"Registration failed: {e}")
 

--- a/sdk/python/tests/test_register_agent.py
+++ b/sdk/python/tests/test_register_agent.py
@@ -230,5 +230,57 @@ class TestRegisterAgent:
                     mock_oauth.assert_called_once()
 
 
+class TestRegisterAgentErrorPrefix:
+    """Regression: register_agent must not double the 'Registration failed:'
+    prefix. The inner helpers (_register_via_api_key / _register_via_oauth)
+    already raise ConfigurationError('Registration failed: <reason>'); the outer
+    handler must re-raise AIMError subclasses unwrapped rather than wrapping them
+    a second time. Surfaced 2026-06-01 against aim.opena2a.org."""
+
+    def test_api_key_error_prefix_not_doubled(self):
+        inner = ConfigurationError("Registration failed: backend boom")
+        with patch('aim_sdk.client.load_sdk_credentials', return_value=None):
+            with patch('aim_sdk.client._register_via_api_key', side_effect=inner):
+                with pytest.raises(ConfigurationError) as exc_info:
+                    register_agent(
+                        "test-agent",
+                        aim_url="https://aim.example.com",
+                        api_key="aim_abc123",
+                    )
+        msg = str(exc_info.value)
+        assert msg.count("Registration failed:") == 1, f"doubled prefix: {msg!r}"
+        assert "backend boom" in msg
+
+    def test_oauth_error_prefix_not_doubled(self):
+        sdk_creds = {
+            "aim_url": "https://aim.example.com",
+            "refresh_token": "mock_refresh_token",
+            "sdk_token_id": "mock_sdk_token",
+        }
+        inner = ConfigurationError("Registration failed: oauth boom")
+        with patch('aim_sdk.client.load_sdk_credentials', return_value=sdk_creds):
+            with patch('aim_sdk.client._register_via_oauth', side_effect=inner):
+                with pytest.raises(ConfigurationError) as exc_info:
+                    register_agent("test-agent")
+        msg = str(exc_info.value)
+        assert msg.count("Registration failed:") == 1, f"doubled prefix: {msg!r}"
+        assert "oauth boom" in msg
+
+    def test_generic_error_still_wrapped_once(self):
+        """A non-AIMError (e.g. a bug in a helper) is still wrapped exactly once
+        so consumers always get a typed ConfigurationError."""
+        with patch('aim_sdk.client.load_sdk_credentials', return_value=None):
+            with patch('aim_sdk.client._register_via_api_key',
+                       side_effect=ValueError("unexpected boom")):
+                with pytest.raises(ConfigurationError) as exc_info:
+                    register_agent(
+                        "test-agent",
+                        aim_url="https://aim.example.com",
+                        api_key="aim_abc123",
+                    )
+        msg = str(exc_info.value)
+        assert msg == "Registration failed: unexpected boom", repr(msg)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Fixes the doubled error prefix from `register_agent`: backend rejections surfaced as `Registration failed: Registration failed: <reason>`.

## Root cause

`register_agent`'s outer handler caught the `ConfigurationError` already raised (and prefixed with `Registration failed:`) by `_register_via_api_key` / `_register_via_oauth`, then wrapped it again. `ConfigurationError` is an `AIMError`, so the broad `except Exception` re-prefixed it.

## Fix

Re-raise `AIMError` subclasses unwrapped (they already carry a typed, well-formed message); keep wrapping genuinely-unexpected exceptions exactly once so consumers always get a typed `ConfigurationError`.

## Tests

`tests/test_register_agent.py` — added the api-key path, oauth path, and generic-exception path. Verified RED on the old code (2 failures showing the doubled prefix) and GREEN after the fix (13 passed).

## Context

Surfaced 2026-06-01 while diagnosing the `aim.opena2a.org` SDK breakage; the harness's existing `doubled_prefix` check flags this against a live backend. SDK source of truth lives here and syncs to aim-cloud.
