### PR TITLE
fix(backend): force https on embedded SDK/agent URLs + emit userEmail for the Python SDK

### DIFF
--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -999,7 +999,10 @@ func getAIMBaseURL(c fiber.Ctx) string {
 	// Get host
 	host := c.Hostname()
 
-	return fmt.Sprintf("%s://%s", protocol, host)
+	// normalizeAIMURL forces https for any public host so embedded agent
+	// credentials can never point the SDK at an http:// endpoint that 301s and
+	// strips the refresh-token POST body behind a TLS-terminating ingress.
+	return normalizeAIMURL(fmt.Sprintf("%s://%s", protocol, host))
 }
 
 // ========================================

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler_test.go
@@ -1071,7 +1071,10 @@ func TestGetAIMBaseURL_DifferentHosts(t *testing.T) {
 	}{
 		{"localhost", "localhost", "", "http://localhost"},
 		{"localhost with port", "localhost:3000", "", "http://localhost"}, // port stripped by Hostname()
-		{"domain", "api.aim.example.com", "", "http://api.aim.example.com"},
+		// Public hosts are coerced to https by normalizeAIMURL even when the
+		// request arrives over http (TLS-terminating ingress doesn't forward the
+		// scheme), so the embedded URL never 301s and strips the refresh POST body.
+		{"domain", "api.aim.example.com", "", "https://api.aim.example.com"},
 		{"domain https", "api.aim.example.com", "https", "https://api.aim.example.com"},
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
@@ -173,7 +173,10 @@ func (h *PublicAgentHandler) Register(c fiber.Ctx) error {
 		DisplayName: agent.DisplayName,
 		PublicKey:   publicKey,
 		PrivateKey:  privateKey, // CRITICAL: Only returned ONCE
-		AIMURL:      c.BaseURL(),
+		// normalizeAIMURL forces https for any public host (see sdk_handler.go):
+		// behind a TLS-terminating ingress c.BaseURL() reports http, and an agent
+		// that POSTs to http first gets a 301 that drops the request body.
+		AIMURL:      normalizeAIMURL(c.BaseURL()),
 		Status:      string(agent.Status),
 		TrustScore:  trustScore,
 		Message:     h.buildRegistrationMessage(agent.Status),

--- a/apps/backend/internal/interfaces/http/handlers/sdk_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_handler.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,11 @@ type SDKCredentials struct {
 	RefreshToken  string `json:"refreshToken"`
 	SDKTokenID    string `json:"sdkTokenId"`          // For usage tracking via X-SDK-Token header
 	UserID        string `json:"userId"`
+	// The user's email is emitted under BOTH keys for cross-SDK compatibility:
+	// the Python SDK reads "userEmail" (aim_sdk/cli.py) — emitting only "email"
+	// was why `aim-sdk status` showed `User: Unknown` — while the Java SDK's
+	// CredentialManager reads "email". Populate both from the same value.
+	UserEmail     string `json:"userEmail"`
 	Email         string `json:"email"`
 }
 
@@ -156,11 +162,17 @@ func (h *SDKHandler) DownloadSDK(c fiber.Ctx) error {
 	// No logging to prevent information leakage
 	_ = h.sdkTokenRepo.Create(sdkToken)
 
-	// Get AIM URL from environment or use request base URL
+	// Get AIM URL from environment or use request base URL.
+	// normalizeAIMURL forces https for any public host so the embedded URL can
+	// never be http:// — behind a TLS-terminating ingress (Azure Container Apps,
+	// Vercel edge) c.BaseURL() reports plain http, and a downloaded SDK that
+	// POSTs its refresh token to http first gets a 301→https that drops the POST
+	// body, yielding a 401 "No authentication token provided" on registration.
 	aimURL := os.Getenv("AIM_PUBLIC_URL")
 	if aimURL == "" {
 		aimURL = c.BaseURL()
 	}
+	aimURL = normalizeAIMURL(aimURL)
 
 	// Create credentials object with schema version and type
 	// These fields help the SDK distinguish between SDK credentials and agent credentials
@@ -171,7 +183,8 @@ func (h *SDKHandler) DownloadSDK(c fiber.Ctx) error {
 		RefreshToken:  refreshToken,
 		SDKTokenID:    tokenID,    // Include SDK token ID for usage tracking
 		UserID:        userID.String(),
-		Email:         email,
+		UserEmail:     email, // read by the Python SDK
+		Email:         email, // read by the Java SDK
 	}
 
 	// Generate SDK zip with embedded credentials
@@ -189,6 +202,54 @@ func (h *SDKHandler) DownloadSDK(c fiber.Ctx) error {
 	c.Set("Content-Length", fmt.Sprintf("%d", len(zipData)))
 
 	return c.Send(zipData)
+}
+
+// normalizeAIMURL guarantees the URL embedded in a downloaded SDK uses https for
+// any public (non-loopback) host. It is applied to both AIM_PUBLIC_URL and the
+// request-derived c.BaseURL() so a missing OR misconfigured env var can never
+// embed an http:// endpoint.
+//
+// Why this matters: behind a TLS-terminating ingress (Azure Container Apps,
+// Vercel edge) the backend observes plain HTTP, so fiber's c.BaseURL() returns
+// http://api.aim.opena2a.org. The SDK's first authenticated call is a POST to
+// /api/v1/auth/refresh; the edge 301-redirects http→https and both Go's net/http
+// and Python's requests drop the POST body on a 301, so the refresh token never
+// reaches the server and registration fails with 401 "No authentication token
+// provided" (every OS, not just Windows).
+//
+// Loopback hosts keep their original scheme so local development over http://
+// localhost still works (there is no TLS terminator in front of them).
+//
+// Trade-off: a non-loopback private/LAN host (e.g. http://10.0.0.5, an internal
+// self-hosted deployment without TLS) is also coerced to https. This is a
+// deliberate security-first choice — credential-bearing SDK traffic should not
+// travel over plain http even on a LAN. Such a deployment must front AIM with a
+// TLS terminator. The coercion applies to AIM_PUBLIC_URL too, so a misconfigured
+// http value cannot reintroduce the original bug.
+func normalizeAIMURL(rawURL string) string {
+	trimmed := strings.TrimRight(rawURL, "/")
+	if trimmed == "" {
+		return trimmed
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil || u.Host == "" {
+		// Unparseable / scheme-less value: return as-is rather than guessing.
+		return trimmed
+	}
+	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
+		u.Scheme = "https"
+	}
+	return strings.TrimRight(u.String(), "/")
+}
+
+// isLoopbackHost reports whether host is a local-development address whose http
+// scheme should be preserved by normalizeAIMURL.
+func isLoopbackHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "0.0.0.0", "::1":
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(host), ".localhost")
 }
 
 // createSDKZip creates a zip file with SDK and embedded credentials

--- a/apps/backend/internal/interfaces/http/handlers/sdk_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_handler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -312,4 +313,84 @@ func TestSDKCredentials_Struct(t *testing.T) {
 	assert.Equal(t, "test-token", creds.RefreshToken)
 	assert.Equal(t, "token-123", creds.SDKTokenID)
 	assert.Equal(t, "test@example.com", creds.Email)
+}
+
+// ===========================
+// SDK download bug regressions (http-scheme + userEmail)
+// ===========================
+
+// TestNormalizeAIMURL locks in that the URL embedded in a downloaded SDK is
+// always https for a public host (so the refresh-token POST is never 301'd and
+// stripped behind a TLS-terminating ingress), while loopback hosts keep http for
+// local development.
+func TestNormalizeAIMURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"public http coerced to https", "http://api.aim.opena2a.org", "https://api.aim.opena2a.org"},
+		{"public http with path coerced", "http://api.aim.opena2a.org/", "https://api.aim.opena2a.org"},
+		{"https left untouched", "https://api.aim.opena2a.org", "https://api.aim.opena2a.org"},
+		{"misconfigured AIM_PUBLIC_URL http coerced", "http://aim.opena2a.org", "https://aim.opena2a.org"},
+		// Uppercase scheme: url.Parse lowercases the scheme, so this still coerces.
+		{"uppercase scheme coerced", "HTTP://api.aim.opena2a.org", "https://api.aim.opena2a.org"},
+		// Loopback hosts keep http for local development.
+		{"localhost http preserved", "http://localhost:8080", "http://localhost:8080"},
+		{"127.0.0.1 http preserved", "http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"0.0.0.0 http preserved", "http://0.0.0.0:8080", "http://0.0.0.0:8080"},
+		{".localhost http preserved", "http://aim.localhost", "http://aim.localhost"},
+		{"ipv6 loopback http preserved", "http://[::1]:8080", "http://[::1]:8080"},
+		// Loopback-looking-but-public hosts must NOT be treated as loopback.
+		{"localhost.evil.com is public", "http://localhost.evil.com", "https://localhost.evil.com"},
+		{"notlocalhost is public", "http://notlocalhost", "https://notlocalhost"},
+		{"127.0.0.1.evil.com is public", "http://127.0.0.1.evil.com", "https://127.0.0.1.evil.com"},
+		// Userinfo in the authority is preserved; scheme still coerced.
+		{"userinfo preserved on coercion", "http://user@evil.com", "https://user@evil.com"},
+		// DELIBERATE trade-off (security-first): a non-loopback private/LAN host
+		// served over plain http is coerced to https. A self-hosted http-only LAN
+		// deployment must front AIM with TLS. Documented in normalizeAIMURL.
+		{"rfc1918 lan http coerced", "http://10.0.0.5:8080", "https://10.0.0.5:8080"},
+		{"trailing slash trimmed", "https://api.aim.opena2a.org/", "https://api.aim.opena2a.org"},
+		{"empty stays empty", "", ""},
+		{"scheme-less value returned as-is", "api.aim.opena2a.org", "api.aim.opena2a.org"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeAIMURL(tt.in))
+		})
+	}
+}
+
+// TestSDKCredentials_JSONUsesUserEmail locks in that the credentials file
+// embedded in the download carries the email under "userEmail" (read by the
+// Python SDK, aim_sdk/cli.py — emitting only "email" produced `User: Unknown`)
+// AND under "email" (read by the Java SDK CredentialManager). Both keys must be
+// present and equal so neither SDK regresses.
+func TestSDKCredentials_JSONUsesUserEmail(t *testing.T) {
+	creds := SDKCredentials{
+		SchemaVersion: "1.0",
+		Type:          "sdk_oauth",
+		AIMUrl:        "https://api.aim.opena2a.org",
+		RefreshToken:  "test-token",
+		SDKTokenID:    "token-123",
+		UserID:        uuid.New().String(),
+		UserEmail:     "test@example.com",
+		Email:         "test@example.com",
+	}
+
+	data, err := json.Marshal(creds)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	gotUserEmail, ok := raw["userEmail"]
+	require.True(t, ok, "credentials JSON must carry userEmail (read by the Python SDK)")
+	assert.Equal(t, "test@example.com", gotUserEmail)
+
+	gotEmail, ok := raw["email"]
+	require.True(t, ok, "credentials JSON must still carry email (read by the Java SDK)")
+	assert.Equal(t, "test@example.com", gotEmail)
 }


### PR DESCRIPTION
## Problem

The hosted dashboard **"Download Python SDK (with embedded credentials)"** flow produced a broken SDK: `aim-sdk status` showed `Server: http://api.aim.opena2a.org` + `User: Unknown`, and `demo_agent.py` failed with `Token refresh failed with status 401: No authentication token provided` (reported on Windows, but **not** OS-specific).

Two root causes in `sdk_handler.go` (`DownloadSDK`):

1. **http scheme.** `aimURL := os.Getenv("AIM_PUBLIC_URL"); if aimURL=="" { aimURL = c.BaseURL() }`. Behind the Azure Container Apps TLS-terminating ingress the backend observes plain HTTP, so `c.BaseURL()` returns `http://api.aim.opena2a.org`. The download embeds only a `refreshToken`, so the SDK's first call is `POST {aimUrl}/api/v1/auth/refresh`. The edge **301-redirects http→https** and both Go's `net/http` and Python's `requests` **drop the POST body on a 301** — the refresh token is in that body — so the server replies 401. Verified live: `curl -sD- -o/dev/null -XPOST http://api.aim.opena2a.org/api/v1/auth/refresh` → `301 → https`.
2. **email vs userEmail.** The credentials struct emitted the email under json key `email`, but the Python SDK reads `userEmail` (`aim_sdk/cli.py`) → `User: Unknown`.

## Fix

- **`normalizeAIMURL()`** forces `https` for any public (non-loopback) host, applied to **both** `AIM_PUBLIC_URL` and the request-derived base URL, so a missing **or** misconfigured env var can never embed `http` again. Loopback hosts (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `*.localhost`, `[::1]`) keep `http` for local dev.
  - Applied to **all three** URL-embed sites to close the class: SDK download (`sdk_handler.go`), agent SDK download (`agent_handler.go` `getAIMBaseURL`), and public agent registration (`public_agent_handler.go`).
  - **Deliberate trade-off (documented):** a non-loopback private/LAN host on plain http (e.g. `http://10.0.0.5`) is also coerced to https — security-first, no plaintext credential transport. A self-hosted http-only deployment must front AIM with TLS.
- **Email keyed under both `userEmail` and `email`.** The Python SDK reads `userEmail`; the **Java SDK** `CredentialManager` reads `email`. Emitting both from the source fixes the Python `User: Unknown` without regressing the Java SDK (no SDK redistribution needed).

## Tests

- `TestNormalizeAIMURL` — table incl. uppercase scheme, IPv6 `[::1]`, loopback-looking-but-public hosts (`localhost.evil.com`, `127.0.0.1.evil.com`, `notlocalhost`), userinfo authority, and the RFC1918 coercion trade-off.
- `TestSDKCredentials_JSONUsesUserEmail` — asserts both `userEmail` and `email` are present and equal.
- Updated `TestGetAIMBaseURL_DifferentHosts` to reflect public-host https coercion.

`go build ./...`, `go vet`, and `go test -race ./internal/interfaces/http/handlers/` all green.

## Repo choice & deploy path

`sdk_handler.go` is **not** in `aim-cloud/.sync-protect`, so per the one-directional sync model this lands in the public source-of-truth repo (`agent-identity-management`) and the sync carries it to `aim-cloud` (deploys to Azure Container Apps via `deploy.yml`). Files are byte-identical between repos except the module-import path.

**Immediate prod relief is independent of this PR:** set `AIM_PUBLIC_URL=https://api.aim.opena2a.org` on `ca-aim-backend-prod` (and pin it in `aim-cloud/deploy.yml` so a rollback can't regress it). This code change is the durable defense-in-depth.

## Out of scope (noted, not addressed here)

- **Host-header substitution** (pre-existing): when no env override is set, `c.BaseURL()`/`c.Hostname()` derive from the `Host` header, so a spoofed host could embed `https://attacker-host`. This fix corrects the *scheme*, not the *host*; the durable mitigation is `AIM_PUBLIC_URL` always set in prod.

🤖 Reviewed via the 8-phase pre-push gate (incl. adversarial self-review, which caught the Java `email`-key regression).
