### PR TITLE
fix(backend): stop leaking raw DB errors and doubled prefix on agent creation

### DIFF
--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -258,11 +258,23 @@ func (s *AgentService) CreateAgent(ctx context.Context, req *CreateAgentRequest,
 	}
 
 	if err := s.agentRepo.Create(agent); err != nil {
-		// Detect PostgreSQL unique constraint violation to avoid leaking database internals
-		if strings.Contains(err.Error(), "duplicate key value") || strings.Contains(err.Error(), "unique constraint") {
+		// Map known database constraint violations to safe, user-facing messages.
+		// Raw PostgreSQL driver errors (the `pq:` prefix, table/constraint names like
+		// `agents_organization_id_fkey`) must never reach the API response — surfacing
+		// them leaks the schema and is an information-disclosure bug.
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "duplicate key value"), strings.Contains(msg, "unique constraint"):
 			return nil, fmt.Errorf("an agent with this name already exists")
+		case strings.Contains(msg, "foreign key constraint"):
+			return nil, fmt.Errorf("invalid organization or user for this registration")
+		case strings.Contains(msg, "pq:"):
+			// Any other PostgreSQL driver error: log the detail server-side, return generic.
+			fmt.Printf("agent creation failed (database error): %v\n", err)
+			return nil, fmt.Errorf("failed to create agent")
+		default:
+			return nil, fmt.Errorf("failed to create agent: %w", err)
 		}
-		return nil, fmt.Errorf("failed to create agent: %w", err)
 	}
 
 	// Calculate initial trust score

--- a/apps/backend/internal/application/agent_service_test.go
+++ b/apps/backend/internal/application/agent_service_test.go
@@ -1492,6 +1492,62 @@ func TestAgentService_CreateAgent_Success(t *testing.T) {
 	mockAgentRepo.AssertExpectations(t)
 }
 
+// TestAgentService_CreateAgent_SanitizesDBErrors locks in that raw PostgreSQL
+// driver errors (the `pq:` prefix, table/constraint names) never escape the
+// service layer — a foreign-key violation (e.g. a bad organization_id) had been
+// leaking `pq: ... violates foreign key constraint "agents_organization_id_fkey"`
+// straight to the API response (information disclosure).
+func TestAgentService_CreateAgent_SanitizesDBErrors(t *testing.T) {
+	masterKey := base64.StdEncoding.EncodeToString([]byte("test-master-key-32-bytes-long!!!"))
+	keyVault, _ := crypto.NewKeyVault(masterKey)
+
+	tests := []struct {
+		name    string
+		repoErr error
+		wantMsg string
+	}{
+		{
+			name:    "foreign key violation is sanitized",
+			repoErr: errors.New(`pq: insert or update on table "agents" violates foreign key constraint "agents_organization_id_fkey"`),
+			wantMsg: "invalid organization or user for this registration",
+		},
+		{
+			name:    "duplicate key maps to friendly message",
+			repoErr: errors.New(`pq: duplicate key value violates unique constraint "agents_name_key"`),
+			wantMsg: "an agent with this name already exists",
+		},
+		{
+			name:    "other pq error is generic",
+			repoErr: errors.New(`pq: null value in column "name" violates not-null constraint`),
+			wantMsg: "failed to create agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAgentRepo := new(MockAgentRepository)
+			service := &AgentService{agentRepo: mockAgentRepo, keyVault: keyVault}
+			mockAgentRepo.On("Create", mock.AnythingOfType("*domain.Agent")).Return(tt.repoErr)
+
+			req := &CreateAgentRequest{
+				Name:        "test-agent",
+				DisplayName: "Test Agent",
+				AgentType:   domain.AgentTypeAI,
+				Version:     "1.0.0",
+			}
+			agent, err := service.CreateAgent(context.Background(), req, uuid.New(), uuid.New(), nil, nil, "")
+
+			assert.Nil(t, agent)
+			assert.Error(t, err)
+			assert.Equal(t, tt.wantMsg, err.Error())
+			// Never leak PostgreSQL driver internals to the caller.
+			assert.NotContains(t, err.Error(), "pq:")
+			assert.NotContains(t, err.Error(), "fkey")
+			assert.NotContains(t, err.Error(), "constraint")
+		})
+	}
+}
+
 func TestAgentService_CreateAgent_WithPublicKey(t *testing.T) {
 	mockAgentRepo := new(MockAgentRepository)
 	mockTrustCalc := new(AgentServiceMockTrustScoreCalculator)

--- a/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_agent_handler.go
@@ -150,8 +150,18 @@ func (h *PublicAgentHandler) Register(c fiber.Ctx) error {
 		DocumentationURL: req.DocumentationURL,
 	}, orgID, userID, nil, nil, userEmail)
 	if err != nil {
+		// The service already maps DB constraint violations to safe messages, so
+		// surface err.Error() directly — do NOT re-prefix with "Failed to create
+		// agent:" (the service message is already "failed to create agent: ..."),
+		// which produced a doubled prefix. Mirror the authenticated handler: 409 for
+		// a duplicate name, 500 otherwise.
+		if err.Error() == "an agent with this name already exists" {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"error": err.Error(),
+			})
+		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": fmt.Sprintf("Failed to create agent: %v", err),
+			"error": err.Error(),
 		})
 	}
 


### PR DESCRIPTION
Follow-up to #263. Fixes two bugs in the agent-creation error path (deferred items #1 and #2 from the SDK-download triage).

## 1. Information disclosure — raw DB error leaked to client (P1)

A registration with a bad/unknown `organization_id` triggered a Postgres foreign-key violation that was returned **verbatim** to the client:

```
pq: insert or update on table "agents" violates foreign key constraint "agents_organization_id_fkey"
```

This leaks the schema (table + constraint names). The service (`agent_service.go`) only sanitized **duplicate-key / unique-constraint** errors; FK and any other `pq:` driver error fell through the `%w` wrap and the handler echoed them.

## 2. Doubled error prefix (P2)

The service wrapped with `failed to create agent:` and the public registration handler wrapped **again** with `Failed to create agent: %v`, producing:

```
Failed to create agent: failed to create agent: <error>
```

## Fix

Both fixed at the **service layer** (`agent_service.go` `CreateAgent`) — the single chokepoint shared by the public *and* authenticated handlers:

- FK violation → `invalid organization or user for this registration`
- Any other `pq:` driver error → logged server-side, generic `failed to create agent` to the caller
- Non-DB errors keep the existing `%w` wrap (unchanged)

The public handler now surfaces `err.Error()` directly (no second prefix) and returns **409** for a duplicate name, mirroring the authenticated handler exactly.

## Tests

`TestAgentService_CreateAgent_SanitizesDBErrors` (FK / duplicate / other-pq) asserts the message is user-friendly and never contains `pq:`, `fkey`, or `constraint`. Full `internal/application` + handlers packages green.

> Note: the triage also mentioned an "audit-log JSON blob" in the response on the bad-API-key path — I could not reproduce that in source from this handler; if it's real it's a separate middleware path. Flagging for follow-up rather than guessing.
