### PR TITLE
ci(release): widen SDK verify-publish poll to ~2 minutes for registry propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,14 +128,15 @@ jobs:
         if: steps.idempotence.outputs.skip != 'true'
         run: |
           VERSION="$(cat VERSION)"
-          # Brief retry — registry indexing can lag a few seconds after upload.
-          for i in 1 2 3 4 5; do
+          # Retry — PyPI CDN propagation routinely lags 30–120s after upload, so a
+          # 25s window produced false-red runs on successful publishes. ~2 minutes.
+          for i in $(seq 1 12); do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/aim-sdk/${VERSION}/json")
             if [ "$STATUS" = "200" ]; then
               echo "✓ aim-sdk ${VERSION} is live on PyPI"
               exit 0
             fi
-            sleep 5
+            sleep 10
           done
           echo "✗ aim-sdk ${VERSION} not visible on PyPI after publish — investigate"
           exit 1
@@ -227,8 +228,9 @@ jobs:
         if: steps.idempotence.outputs.skip != 'true'
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          # Brief retry — registry indexing can lag a few seconds.
-          for i in 1 2 3 4 5; do
+          # Retry — npm registry propagation can lag 30–120s after upload, so a 25s
+          # window produced false-red runs on successful publishes. ~2 minutes.
+          for i in $(seq 1 12); do
             if npm view "@opena2a/aim-sdk@${VERSION}" version > /dev/null 2>&1; then
               echo "✓ @opena2a/aim-sdk@${VERSION} is live on npm"
               # Provenance check: dist.attestations must be non-empty
@@ -242,7 +244,7 @@ jobs:
               echo "✓ SLSA provenance attached"
               exit 0
             fi
-            sleep 5
+            sleep 10
           done
           echo "✗ @opena2a/aim-sdk@${VERSION} not visible on npm after publish — investigate"
           exit 1


### PR DESCRIPTION
Deferred item #5 from the SDK-download triage.

## Problem

The PyPI and npm **"Verify publish"** steps in `release.yml` polled only `5 × 5s = 25s`. PyPI CDN and npm registry propagation routinely lag **30–120s** after upload, so a successful publish frequently showed the release run **red** (`not visible after publish`) even though the package was live.

## Fix

Widen both windows to `12 × 10s = ~2 minutes` (`seq 1 12`, `sleep 10`), matching the Java step's already-longer window (`seq 1 30`, `sleep 20`). No change to provenance, idempotence, or publish logic. YAML validated.
