### PR TITLE
AAP grant surface for @perform_action (Python SDK)

### DIFF
--- a/sdk/python/aim_sdk/__init__.py
+++ b/sdk/python/aim_sdk/__init__.py
@@ -77,6 +77,13 @@ secure = register_agent
 
 from .exceptions import AIMError, AuthenticationError, VerificationError, ActionDeniedError, ConfigurationError, StaleCredentialsError
 from .secrets import SecretsClient, SecretsError
+from .grant_client import (
+    BrokerClient,
+    GrantSession,
+    BrokerGrantError,
+    GrantDeniedError,
+    current_grant,
+)
 from .detection import MCPDetector, auto_detect_mcps, track_mcp_call
 from .capability_detection import CapabilityDetector, auto_detect_capabilities, auto_detect_agent_type
 from .protocol_detection import ProtocolDetector, auto_detect_protocol
@@ -164,6 +171,12 @@ __all__ = [
     "ActionDeniedError",
     "ConfigurationError",
     "StaleCredentialsError",
+    # AAP grant client
+    "BrokerClient",
+    "GrantSession",
+    "BrokerGrantError",
+    "GrantDeniedError",
+    "current_grant",
     "MCPDetector",
     "auto_detect_mcps",
     "CapabilityDetector",

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -236,6 +236,24 @@ def _warn_deprecated_capability_format(capability: str):
         )
 
 
+def _func_accepts_param(func: Callable, name: str) -> bool:
+    """True if `func` declares a parameter `name` or accepts arbitrary **kwargs."""
+    import inspect
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    for p in sig.parameters.values():
+        if p.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if p.name == name and p.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return True
+    return False
+
+
 class AIMClient:
     """
     AIM SDK Client for automatic identity verification.
@@ -2425,7 +2443,8 @@ class AIMClient:
         timeout_seconds: int = 300,
         jit_access: bool = False,
         risk_level: str = None,
-        auto_register: bool = True
+        auto_register: bool = True,
+        grant: Optional[str] = None
     ):
         """
         Decorator for automatic capability verification and action tracking.
@@ -2447,6 +2466,18 @@ class AIMClient:
             risk_level: Risk level ("low", "medium", "high", "critical"). If not provided,
                        auto-detects based on capability name.
             auto_register: If True (default), automatically registers capability on first use
+            grant: Optional AAP grant reference (e.g. "grant://orders-db"). When set, a
+                   GrantSession bound to the Secretless broker is made available to the
+                   wrapped function — injected as a ``grant`` keyword argument if the
+                   function declares one, and always via ``aim_sdk.current_grant()``. The
+                   agent references the grant; the broker resolves it and returns only the
+                   operation result. No credential or backend identifier enters the agent
+                   process (Agent Authorization Protocol §4).
+
+        Example - AAP grant (no secret ever reaches the agent):
+            @agent.perform_action(capability="orders:read", grant="grant://orders-db")
+            def recent_orders(customer_id, grant):
+                return grant.request("GET", "/orders", query={"customer": customer_id})
 
         Example - Simple usage (uses function name as capability):
             @agent.perform_action()  # auto-detects risk level
@@ -2518,9 +2549,26 @@ class AIMClient:
 
                 verification_id = verification_result["verification_id"]
 
+                # AAP: when a grant reference is set, bind a GrantSession to the broker and
+                # make it available to the function. The agent references the grant; the
+                # broker resolves it and returns only the operation result. No credential or
+                # backend identifier ever enters this process.
+                call_kwargs = kwargs
+                grant_token = None
+                if grant is not None:
+                    from .grant_client import GrantSession, BrokerClient, _current_grant
+                    broker = getattr(self, "_grant_broker", None) or BrokerClient()
+                    atx = getattr(self, "atx", None) or {}
+                    session = GrantSession(
+                        broker=broker, grant=grant, agent_id=self.agent_id, atx=atx
+                    )
+                    grant_token = _current_grant.set(session)
+                    if _func_accepts_param(func, "grant") and "grant" not in kwargs:
+                        call_kwargs = {**kwargs, "grant": session}
+
                 # Execute the function
                 try:
-                    result = func(*args, **kwargs)
+                    result = func(*args, **call_kwargs)
 
                     # Log success
                     self.log_capability_result(
@@ -2539,6 +2587,10 @@ class AIMClient:
                         error_message=str(e)
                     )
                     raise
+                finally:
+                    if grant_token is not None:
+                        from .grant_client import _current_grant
+                        _current_grant.reset(grant_token)
 
             return wrapper
         return decorator

--- a/sdk/python/aim_sdk/grant_client.py
+++ b/sdk/python/aim_sdk/grant_client.py
@@ -1,0 +1,169 @@
+"""
+AAP grant client — the developer surface for the Agent Authorization Protocol.
+
+An agent references a grant (`grant://name`); the SDK talks to the Secretless broker
+daemon over its local Unix socket; the broker verifies the ATX, authorizes, resolves a
+scoped credential, performs the operation in an ephemeral worker, and returns ONLY the
+result. No credential value and no backend identifier ever enters the agent process.
+
+This module is intentionally thin: the broker (in Secretless AI) does all the work. See
+the Agent Authorization Protocol spec (opena2a-standards/agent-authorization-protocol).
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+from contextvars import ContextVar
+from typing import Any, Dict, Optional
+
+DEFAULT_SOCKET_PATH = os.path.expanduser("~/.secretless-ai/broker.sock")
+DEFAULT_TOKEN_PATH = os.path.expanduser("~/.secretless-ai/broker.token")
+
+
+class BrokerGrantError(Exception):
+    """The broker could not be reached or returned an unexpected error."""
+
+
+class GrantDeniedError(BrokerGrantError):
+    """The broker denied the grant. By design it reveals no reason (AAP §6.6)."""
+
+
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """HTTPConnection over a Unix domain socket (the broker's primary transport)."""
+
+    def __init__(self, socket_path: str, timeout: float = 5.0):
+        super().__init__("localhost", timeout=timeout)
+        self._socket_path = socket_path
+
+    def connect(self) -> None:  # noqa: D401
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(self._socket_path)
+        self.sock = sock
+
+
+class BrokerClient:
+    """Client for the Secretless broker's AAP `/grant` endpoint.
+
+    Defaults to the broker's Unix socket; pass ``http_url`` for the HTTP fallback
+    (e.g. inside Docker). The bearer token is read from the broker token file.
+    """
+
+    def __init__(
+        self,
+        socket_path: Optional[str] = None,
+        http_url: Optional[str] = None,
+        token: Optional[str] = None,
+        token_path: Optional[str] = None,
+        timeout: float = 5.0,
+    ):
+        self.socket_path = socket_path or DEFAULT_SOCKET_PATH
+        self.http_url = http_url
+        self.timeout = timeout
+        self._token = token
+        self._token_path = token_path or DEFAULT_TOKEN_PATH
+
+    def _bearer(self) -> str:
+        if self._token:
+            return self._token
+        try:
+            with open(self._token_path, "r", encoding="utf-8") as fh:
+                return fh.read().strip()
+        except OSError as exc:
+            raise BrokerGrantError(
+                f"broker token not found at {self._token_path}; is the broker running?"
+            ) from exc
+
+    def grant(
+        self,
+        agent_id: str,
+        atx: Dict[str, Any],
+        grant: str,
+        operation: Dict[str, Any],
+    ) -> Any:
+        """Resolve a grant and return ONLY the operation result.
+
+        Raises GrantDeniedError on a 403 (uniform opaque denial) and BrokerGrantError
+        on transport/other failures.
+        """
+        payload = json.dumps(
+            {"agentId": agent_id, "atx": atx, "grant": grant, "operation": operation}
+        ).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._bearer()}",
+        }
+
+        if self.http_url:
+            url = self.http_url.rstrip("/")
+            scheme, _, host = url.partition("://")
+            conn: http.client.HTTPConnection = (
+                http.client.HTTPSConnection(host, timeout=self.timeout)
+                if scheme == "https"
+                else http.client.HTTPConnection(host, timeout=self.timeout)
+            )
+        else:
+            conn = _UnixHTTPConnection(self.socket_path, timeout=self.timeout)
+
+        try:
+            conn.request("POST", "/grant", body=payload, headers=headers)
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8")
+        except OSError as exc:
+            raise BrokerGrantError(f"could not reach broker: {exc}") from exc
+        finally:
+            conn.close()
+
+        if resp.status == 200:
+            try:
+                return json.loads(body).get("result")
+            except json.JSONDecodeError as exc:
+                raise BrokerGrantError("broker returned non-JSON success body") from exc
+        if resp.status == 403:
+            raise GrantDeniedError("grant denied")
+        raise BrokerGrantError(f"broker returned status {resp.status}")
+
+
+class GrantSession:
+    """A grant bound to the broker. Performs operations and returns only results.
+
+    The agent code holds a GrantSession, never a credential. Each call sends the logical
+    operation (method + path, no host, no token) to the broker and gets the result back.
+    """
+
+    def __init__(self, broker: BrokerClient, grant: str, agent_id: str, atx: Dict[str, Any]):
+        self._broker = broker
+        self._grant = grant
+        self._agent_id = agent_id
+        self._atx = atx
+
+    @property
+    def reference(self) -> str:
+        return self._grant
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        query: Optional[Dict[str, str]] = None,
+        body: Any = None,
+    ) -> Any:
+        """Perform a logical operation against the granted resource; return only the result."""
+        operation: Dict[str, Any] = {"method": method, "path": path}
+        if query is not None:
+            operation["query"] = query
+        if body is not None:
+            operation["body"] = body
+        return self._broker.grant(self._agent_id, self._atx, self._grant, operation)
+
+
+# Active grant for the currently-executing @perform_action body (when grant= is set).
+_current_grant: ContextVar[Optional[GrantSession]] = ContextVar("aim_current_grant", default=None)
+
+
+def current_grant() -> Optional[GrantSession]:
+    """Return the GrantSession bound by the enclosing @perform_action(grant=...), if any."""
+    return _current_grant.get()

--- a/sdk/python/tests/test_grant_decorator.py
+++ b/sdk/python/tests/test_grant_decorator.py
@@ -1,0 +1,157 @@
+"""Tests for the AAP grant surface: GrantSession + @perform_action(grant=...)."""
+
+import json
+
+import pytest
+
+from aim_sdk.client import AIMClient
+from aim_sdk.grant_client import (
+    BrokerClient,
+    GrantSession,
+    GrantDeniedError,
+    BrokerGrantError,
+    current_grant,
+)
+
+
+class FakeBroker(BrokerClient):
+    """In-memory broker double — records the last grant call, returns only a result."""
+
+    def __init__(self, result=None, raises=None):
+        # Skip BrokerClient.__init__ (no socket/token needed for the double).
+        self.calls = []
+        self._result = result if result is not None else {"rows": [{"id": 1}]}
+        self._raises = raises
+
+    def grant(self, agent_id, atx, grant, operation):
+        self.calls.append(
+            {"agent_id": agent_id, "atx": atx, "grant": grant, "operation": operation}
+        )
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _bare_agent(broker, atx=None):
+    """An AIMClient with just the attributes the grant path needs (no network/__init__)."""
+    agent = AIMClient.__new__(AIMClient)
+    agent.agent_id = "aim_orders_reader"
+    agent._grant_broker = broker
+    agent.atx = atx if atx is not None else {"atcVersion": "1.0", "agentId": "aim_orders_reader"}
+    # Stub the verification + logging touchpoints used by perform_action.
+    agent.register_capability = lambda **kw: None
+    agent.verify_capability = lambda **kw: {"verification_id": "ver-123"}
+    agent.log_capability_result = lambda **kw: None
+    return agent
+
+
+class TestGrantSession:
+    def test_request_sends_logical_operation_and_returns_only_result(self):
+        broker = FakeBroker(result={"rows": [{"id": 1, "total": 42}]})
+        session = GrantSession(broker, "grant://orders-db", "aim_orders_reader", {"atcVersion": "1.0"})
+
+        result = session.request("GET", "/orders", query={"customer": "c-123"})
+
+        assert result == {"rows": [{"id": 1, "total": 42}]}
+        call = broker.calls[0]
+        assert call["grant"] == "grant://orders-db"
+        assert call["operation"] == {"method": "GET", "path": "/orders", "query": {"customer": "c-123"}}
+        # The result handed back carries no credential/backend field.
+        assert "token" not in json.dumps(result).lower()
+
+    def test_denial_raises(self):
+        broker = FakeBroker(raises=GrantDeniedError("grant denied"))
+        session = GrantSession(broker, "grant://orders-db", "a", {})
+        with pytest.raises(GrantDeniedError):
+            session.request("GET", "/orders")
+
+
+class TestPerformActionGrant:
+    def test_injects_grant_session_as_kwarg(self):
+        broker = FakeBroker(result={"rows": ["ok"]})
+        agent = _bare_agent(broker)
+
+        @agent.perform_action(capability="orders:read", grant="grant://orders-db")
+        def recent_orders(customer_id, grant):
+            assert isinstance(grant, GrantSession)
+            assert grant.reference == "grant://orders-db"
+            return grant.request("GET", "/orders", query={"customer": customer_id})
+
+        out = recent_orders("c-123")
+        assert out == {"rows": ["ok"]}
+        assert broker.calls[0]["operation"]["query"] == {"customer": "c-123"}
+
+    def test_grant_available_via_contextvar_when_not_a_param(self):
+        broker = FakeBroker(result={"ok": True})
+        agent = _bare_agent(broker)
+
+        @agent.perform_action(capability="orders:read", grant="grant://orders-db")
+        def do_it():
+            session = current_grant()
+            assert session is not None
+            return session.request("POST", "/orders", body={"x": 1})
+
+        assert do_it() == {"ok": True}
+        # Context is cleared after the call returns.
+        assert current_grant() is None
+
+    def test_no_grant_means_no_session_and_no_broker_calls(self):
+        broker = FakeBroker()
+        agent = _bare_agent(broker)
+
+        @agent.perform_action(capability="weather:read")
+        def get_weather():
+            assert current_grant() is None
+            return "sunny"
+
+        assert get_weather() == "sunny"
+        assert broker.calls == []
+
+
+class TestBrokerClientWire:
+    def test_grant_denied_maps_403(self, monkeypatch):
+        client = BrokerClient(socket_path="/nonexistent.sock", token="t")
+
+        class _Resp:
+            status = 403
+            def read(self):
+                return b'{"error":"denied"}'
+
+        class _Conn:
+            def request(self, *a, **k):
+                pass
+            def getresponse(self):
+                return _Resp()
+            def close(self):
+                pass
+
+        monkeypatch.setattr(client, "_bearer", lambda: "t")
+        monkeypatch.setattr(
+            "aim_sdk.grant_client._UnixHTTPConnection", lambda *a, **k: _Conn()
+        )
+        with pytest.raises(GrantDeniedError):
+            client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
+
+    def test_grant_success_returns_result_only(self, monkeypatch):
+        client = BrokerClient(socket_path="/nonexistent.sock", token="t")
+
+        class _Resp:
+            status = 200
+            def read(self):
+                return b'{"result":{"rows":[1,2,3]}}'
+
+        class _Conn:
+            captured = {}
+            def request(self, method, path, body=None, headers=None):
+                _Conn.captured = {"method": method, "path": path, "body": body, "headers": headers}
+            def getresponse(self):
+                return _Resp()
+            def close(self):
+                pass
+
+        monkeypatch.setattr("aim_sdk.grant_client._UnixHTTPConnection", lambda *a, **k: _Conn())
+        result = client.grant("a", {"atcVersion": "1.0"}, "grant://x", {"method": "GET", "path": "/orders"})
+
+        assert result == {"rows": [1, 2, 3]}
+        assert _Conn.captured["path"] == "/grant"
+        assert _Conn.captured["headers"]["Authorization"] == "Bearer t"


### PR DESCRIPTION
## AAP grant surface for `@perform_action`

Adds the developer-facing half of the [Agent Authorization Protocol](https://github.com/opena2a-standards/agent-authorization-protocol) to the Python SDK: an agent references a grant (`grant://name`) and the SDK talks to the Secretless broker daemon over its local Unix socket. The broker verifies the ATX, authorizes via default-deny local policy, resolves a scoped credential, runs the operation in an ephemeral worker, and returns **only** the result. No credential value or backend identifier ever enters the agent process (AAP §4).

- `aim_sdk/grant_client.py` — `BrokerClient` (Unix-socket + HTTP fallback), `GrantSession`, `current_grant()`, and typed errors (`BrokerGrantError`, `GrantDeniedError`). Intentionally thin: the broker does all the work and enforces all security properties.
- `aim_sdk/client.py` — `@perform_action` gains an optional `grant=` kwarg. When set, after capability verification it binds a `GrantSession`, injects it as a `grant` argument when the wrapped function declares one, and exposes it via `current_grant()`. The ContextVar is reset in a `finally` so nothing leaks across calls.
- `aim_sdk/__init__.py` — exports the new public surface.

```python
@agent.perform_action(capability="orders:read", grant="grant://orders-db")
def recent_orders(customer_id, grant):
    return grant.request("GET", "/orders", query={"customer": customer_id})
```

Pairs with the broker reference implementation in `secretless-ai` (opena2a-org/secretless-ai#76).

## Verification

- `pytest tests/test_grant_decorator.py tests/test_client.py` → 28 passed.
- Full Python SDK suite → 388 passed, 34 skipped (excluding `test_sdk_verification.py`, a pre-existing integration test that needs a live server at `localhost:8080`).
- SDK import smoke: all new exports load; `current_grant()` is `None` outside a grant scope.
- Rebased onto current `main` (includes #263); no file overlap, clean.

## Pre-existing findings (NOT introduced here — flagged for follow-up)

`hackmyagent secure` on `sdk/python` reports 2 CRITICAL + 1 HIGH, all in files this PR does not touch and all present on `main` today:
- 2 CRITICAL on `docs/MCP_INTEGRATION.md` — NanoMind classifies the documentation guide's embedded example code as an executable skill with exfiltration/credential patterns. FP-shaped (it's a Markdown doc, not a live skill); worth a NanoMind classification review.
- 1 HIGH "Incomplete .gitignore" on `sdk/python/.gitignore` — genuinely missing `.env`/`*.pem`/`*.key`/`secrets.json`. Real, minor; recommend a separate hygiene PR.

The AAP files added here carry zero findings.
