### PR TITLE
chore(platform): version platform manifests at 1.0.0 + add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to the AIM platform are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and from this release
+forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Scope: this changelog tracks the **platform** (backend + dashboard), tagged
+> `platform-v<version>`. The SDKs are versioned and released independently
+> (`aim-sdk` on PyPI, `@opena2a/aim-sdk` on npm, `org.opena2a:aim-sdk` on Maven
+> Central) under their own `sdk-*-v<version>` tags.
+
+## [1.0.0] - 2026-06-01
+
+First stable release of the AIM platform. The stage in
+[STATUS.md](STATUS.md) is `stable`, and every gate criterion in
+[HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" was met (PRs #247, #248, #250).
+Semver is honored from this release forward: breaking changes go through a
+deprecation cycle and ship in a major bump; security patches are triaged within
+24 hours per [SECURITY.md](SECURITY.md).
+
+See [README.md](README.md) for the full feature set (agent identity and
+attestation, Ed25519 key management, per-capability trust and execution modes,
+MCP and A2A support, PKCE / OAuth Device Grant auth, and the Python/TypeScript/Java
+SDKs).
+
+### Fixed
+- SDK download embedded an `http://` server URL behind the TLS-terminating
+  ingress; the SDK's refresh-token POST was then 301'd and its body dropped,
+  failing registration with 401. Embedded URLs are now coerced to `https` for any
+  public host, and the credentials email is keyed as both `userEmail` (Python SDK)
+  and `email` (Java SDK) (#263).
+- Agent-creation no longer leaks raw PostgreSQL driver errors (e.g. foreign-key
+  constraint violations) to the API response, and the duplicated
+  "failed to create agent:" error prefix is removed (#264).
+- Release CI `verify-publish` poll window widened to ~2 minutes so registry
+  propagation no longer marks successful publishes as failed (#265).
+
+### Notes
+- This is the first release under the `platform-v*` tag convention. Earlier bare
+  `v*` tags in this repository tracked the Python SDK's version line and a legacy
+  ad-hoc tag, not the platform; they do not represent platform releases.
+
+[1.0.0]: https://github.com/opena2a-org/agent-identity-management/releases/tag/platform-v1.0.0

--- a/apps/backend/internal/telemetry/init.go
+++ b/apps/backend/internal/telemetry/init.go
@@ -72,7 +72,7 @@ func Init(ctx context.Context, cfg Config) (shutdown func(context.Context) error
 		}
 	}
 	if cfg.ServiceVersion == "" {
-		cfg.ServiceVersion = "0.x"
+		cfg.ServiceVersion = "1.0.0"
 	}
 
 	res, err := resource.New(ctx,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aim/web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-identity-management",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "production-ready identity verification and security platform for AI agents and MCP servers",
   "workspaces": [


### PR DESCRIPTION
Prerequisite for cutting `platform-v1.0.0`. Reconciles the version story before the tag.

## Why

The platform manifests were stuck at `0.1.0` while `STATUS.md` declares the stage **`stable`** and *"AIM 1.0 … semver honored from this release forward."* Tagging `platform-v1.0.0` against a `0.1.0` manifest would be internally inconsistent.

Investigation of the existing tags confirmed they are **not** platform releases:
- `v1.5.0` (GitHub "Latest", 2026-03-18) points at commit #84 where the code was actually `package.json` 0.1.0 / SDK 0.5.2 — an arbitrary tag.
- `v1.21.0`/`v1.22.0`/`v1.23.0` (Feb 2026) tracked the **Python SDK** version line (`v1.23.0` is literally *"bump SDK version to 1.23.0"*).

## Changes

- Root `package.json` `0.1.0 → 1.0.0`
- `apps/web/package.json` `0.1.0 → 1.0.0`
- OpenTelemetry service-version default `"0.x" → "1.0.0"` (the backend `/` status endpoint already self-reports `1.0.0`)
- New root `CHANGELOG.md` with the `1.0.0` entry under the `platform-v*` convention

No behavior change. `go build`/`vet` clean, package.json valid.

## Follow-up (not in this PR)

After merge: cut `platform-v1.0.0`, then set it as the GitHub **Latest** release and demote the legacy `v1.5.0` so the release list doesn't read as a downgrade.
