### PR TITLE
fix(ci): extract image tags from platform-v* tags in docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,10 @@ jobs:
           images: ${{ env.REGISTRY }}/opena2a-org/aim-server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/platform-v') }}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -75,6 +79,10 @@ jobs:
           images: opena2a/aim-server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/platform-v') }}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -154,6 +162,10 @@ jobs:
           images: ${{ env.REGISTRY }}/opena2a-org/aim-dashboard
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/platform-v') }}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -166,6 +178,10 @@ jobs:
           images: opena2a/aim-dashboard
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/platform-v') }}
+            type=match,pattern=platform-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+\.\d+),group=1
+            type=match,pattern=platform-v(\d+),group=1
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
## Problem

The `platform-v1.0.0` tag push triggered `docker-publish.yml`, but **both `build-backend` and `build-frontend` failed**:

```
ERROR: failed to build: tag is needed when pushing to registry
```

`metadata-action` produced **zero image tags**. Its `tags:` block used only `type=semver`, which does **not** strip the `platform-v` prefix, so it matched nothing on a `platform-v1.0.0` ref. With `is_default_branch` and `branch=main` both false on a tag push, buildx got no `-t` and refused to push. (PR #255 added the `platform-v*` *trigger* but not the tag *extraction*.)

## Fix

Add `type=match` rules that extract the semver from `platform-v<X.Y.Z>` (→ `X.Y.Z`, `X.Y`, `X`) and tag images `latest` on a `platform-v*` release — applied to all four `metadata-action` blocks (backend + frontend × ghcr.io + Docker Hub). `type=semver`/`edge`/branch rules are retained for normal branch pushes.

YAML validated; 12 match rules added (3 × 4 blocks).

## Follow-up

After merge, the `platform-v1.0.0` tag will be moved to the fixed commit and re-pushed so 1.0.0 ships with working multi-arch images (the SBOM job already succeeded; only the image publish failed).
