### PR TITLE
Wire MCP manifest drift detection into capability and attestation flows

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -465,6 +465,7 @@ type Repositories struct {
 	Alert              *repository.AlertRepository
 	MCPServer          *repository.MCPServerRepository
 	MCPCapability      *repository.MCPServerCapabilityRepository // ✅ For MCP server capabilities
+	MCPManifest        *repository.MCPManifestRepository         // ✅ For MCP manifest baseline + drift detection
 	MCPAttestation     *repository.MCPAttestationRepository      // ✅ For agent attestation of MCPs
 	AgentMCPConnection *repository.AgentMCPConnectionRepository  // ✅ For agent-MCP connections
 	Security           *repository.SecurityRepository
@@ -518,6 +519,7 @@ func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPos
 		Alert:              repository.NewAlertRepository(db),
 		MCPServer:          repository.NewMCPServerRepository(db),
 		MCPCapability:      repository.NewMCPServerCapabilityRepository(db), // ✅ For MCP server capabilities
+		MCPManifest:        repository.NewMCPManifestRepository(db),         // ✅ For MCP manifest baseline + drift detection
 		MCPAttestation:     repository.NewMCPAttestationRepository(db),      // ✅ For agent attestation of MCPs
 		AgentMCPConnection: repository.NewAgentMCPConnectionRepository(dbx), // ✅ For agent-MCP connections
 		Security:           repository.NewSecurityRepository(db),
@@ -732,6 +734,18 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.MCPCapability, // ✅ For syncing capabilities from attestations
 		repos.Alert,         // ✅ For low-trust attestation alerts
 	)
+
+	// ✅ Initialize MCP manifest/drift service and wire it into both the capability and attestation
+	// services. It maintains a per-server tool-manifest baseline and records drift when a trusted
+	// server's surface changes: every /.well-known capability fetch updates the baseline, and
+	// agent-attested tool sets move it only once multi-agent consensus is reached (baseline-poisoning
+	// guard). Injected via setters so the existing service constructors stay unchanged.
+	mcpManifestService := application.NewMCPManifestService(
+		repos.MCPCapability,
+		repos.MCPManifest,
+	)
+	mcpCapabilityService.SetManifestService(mcpManifestService)
+	mcpAttestationService.SetManifestService(mcpManifestService)
 
 	securityService := application.NewSecurityService(
 		repos.Security,

--- a/apps/backend/internal/application/mcp_attestation_service.go
+++ b/apps/backend/internal/application/mcp_attestation_service.go
@@ -121,6 +121,15 @@ type MCPAttestationService struct {
 	capabilityRepo   *repository.MCPServerCapabilityRepository
 	alertRepo        *repository.AlertRepository
 	cryptoService    *infracrypto.ED25519Service
+	manifestService  *MCPManifestService
+}
+
+// SetManifestService wires the manifest/drift service in after construction. It is optional: when
+// unset, attestations are recorded exactly as before with no manifest side effects. Kept as a setter
+// (rather than a constructor parameter) so the two existing constructors and their callers/tests are
+// unaffected and the consensus-gated drift hook stays a best-effort side effect.
+func (s *MCPAttestationService) SetManifestService(m *MCPManifestService) {
+	s.manifestService = m
 }
 
 func NewMCPAttestationService(
@@ -530,6 +539,26 @@ func (s *MCPAttestationService) VerifyAndRecordAttestation(
 	// 8. Update or create agent-MCP connection
 	if err := s.updateAgentMCPConnection(ctx, agentID, mcpServerID, now); err != nil {
 		return nil, fmt.Errorf("failed to update agent-MCP connection: %w", err)
+	}
+
+	// 9. Recompute the manifest baseline from the tool names this attestation observed and record drift
+	// if it diverges from the trusted baseline. Divergence is only treated as server drift once the
+	// server has reached multi-agent consensus, so a single rogue or misconfigured agent cannot poison
+	// the baseline. consensusMet is read after the confidence-score update above so it reflects this
+	// attestation. Best-effort: a drift-tracking failure must not fail the attestation.
+	if s.manifestService != nil && len(req.Attestation.CapabilitiesFound) > 0 {
+		consensusMet := false
+		if status, err := s.GetConsensusStatus(ctx, mcpServerID); err != nil {
+			fmt.Printf("⚠️  Failed to read consensus status for manifest drift on %s: %v\n", mcpServerID, err)
+		} else {
+			consensusMet = status.ConsensusReached
+		}
+		if drift, err := s.manifestService.RecomputeFromAttestation(ctx, mcpServerID, req.Attestation.CapabilitiesFound, consensusMet); err != nil {
+			fmt.Printf("⚠️  Failed to recompute MCP manifest from attestation for %s: %v\n", mcpServerID, err)
+		} else if drift != nil {
+			fmt.Printf("⚠️  MCP manifest drift detected from attestation for %s (severity=%s, +%d/-%d tools)\n",
+				mcpServerID, drift.Severity, len(drift.AddedTools), len(drift.RemovedTools))
+		}
 	}
 
 	return &AttestMCPResponse{

--- a/apps/backend/internal/application/mcp_capability_service.go
+++ b/apps/backend/internal/application/mcp_capability_service.go
@@ -16,9 +16,10 @@ import (
 )
 
 type MCPCapabilityService struct {
-	capabilityRepo *repository.MCPServerCapabilityRepository
-	mcpRepo        *repository.MCPServerRepository
-	httpClient     *http.Client
+	capabilityRepo  *repository.MCPServerCapabilityRepository
+	mcpRepo         *repository.MCPServerRepository
+	httpClient      *http.Client
+	manifestService *MCPManifestService
 }
 
 // MCPCapabilitiesResponse represents the standard MCP protocol capabilities response
@@ -64,6 +65,14 @@ func NewMCPCapabilityService(
 			Timeout: 30 * time.Second, // 30 second timeout for capability discovery
 		},
 	}
+}
+
+// SetManifestService wires the manifest/drift service in after construction. It is optional: when
+// unset, capability detection still works and simply records no manifest baseline or drift. Kept as a
+// setter (rather than a constructor parameter) so existing callers and tests are unaffected and the
+// drift hook stays a best-effort side effect that can never fail a capability fetch.
+func (s *MCPCapabilityService) SetManifestService(m *MCPManifestService) {
+	s.manifestService = m
 }
 
 // DetectCapabilities detects and stores capabilities for an MCP server
@@ -189,18 +198,28 @@ func (s *MCPCapabilityService) DetectCapabilities(ctx context.Context, serverID 
 		})
 	}
 
-	// Step 5: Store detected capabilities in database
-	for _, cap := range capabilities {
-		if err := s.capabilityRepo.Create(cap); err != nil {
-			// Log error but continue with other capabilities
-			fmt.Printf("⚠️  Failed to store capability %s: %v\n", cap.Name, err)
-			continue
-		}
-
-		fmt.Printf("✅ Detected %s capability: %s\n", cap.CapabilityType, cap.Name)
+	// Step 5: Reconcile stored capabilities to exactly this fetched set. This is a full replace (stale
+	// rows deactivated, present rows upserted with current schema), not a per-row insert — so a tool
+	// the server has since removed or reshaped is reflected, which is what lets manifest drift detect
+	// removals and schema changes rather than only additions.
+	if err := s.capabilityRepo.ReplaceActiveCapabilities(serverID, capabilities); err != nil {
+		return fmt.Errorf("failed to store detected capabilities: %w", err)
 	}
 
 	fmt.Printf("✅ Successfully detected %d real capabilities from MCP server %s\n", len(capabilities), server.Name)
+
+	// Recompute the manifest baseline from the server's freshly-stored /.well-known capabilities and
+	// record drift if the trusted tool surface changed. Best-effort: a drift-tracking failure must not
+	// fail capability detection, so the error is logged, not returned.
+	if s.manifestService != nil {
+		if drift, err := s.manifestService.RecomputeFromWellKnown(ctx, serverID); err != nil {
+			fmt.Printf("⚠️  Failed to recompute MCP manifest for %s: %v\n", server.Name, err)
+		} else if drift != nil {
+			fmt.Printf("⚠️  MCP manifest drift detected for %s (severity=%s, +%d/-%d/~%d tools)\n",
+				server.Name, drift.Severity, len(drift.AddedTools), len(drift.RemovedTools), len(drift.ChangedTools))
+		}
+	}
+
 	return nil
 }
 

--- a/apps/backend/internal/application/mcp_manifest_drift_integration_test.go
+++ b/apps/backend/internal/application/mcp_manifest_drift_integration_test.go
@@ -1,0 +1,222 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
+)
+
+// TestMCPManifestDrift_Wiring exercises the manifest/drift service end-to-end against a real
+// database (migrations 098/099 + mcp_server_capabilities). It validates the three behaviors the
+// capability and attestation services depend on once the manifest service is wired in:
+//
+//   - a server's first /.well-known capture seeds the baseline and records no drift;
+//   - a later capture that adds a high-risk tool records HIGH-severity drift and advances the baseline;
+//   - an attestation whose observed tool set diverges from the baseline only records drift once
+//     multi-agent consensus is reached (below consensus it is ignored to avoid single-agent poisoning).
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestMCPManifestDrift_Wiring ./internal/application/...
+func TestMCPManifestDrift_Wiring(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping manifest drift integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	capabilityRepo := repository.NewMCPServerCapabilityRepository(db)
+	manifestRepo := repository.NewMCPManifestRepository(db)
+	svc := NewMCPManifestService(capabilityRepo, manifestRepo)
+
+	// seedServer creates an organization + MCP server and registers cleanup. The manifest tables
+	// cascade-delete with the server, so removing the server clears any baselines/drift it produced.
+	seedServer := func(t *testing.T) uuid.UUID {
+		orgID := uuid.New()
+		userID := uuid.New()
+		serverID := uuid.New()
+		suffix := serverID.String()[:8]
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(ctx, `DELETE FROM mcp_server_capabilities WHERE mcp_server_id = $1`, serverID)
+			_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+			_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+			_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+		})
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO organizations (id, name, domain, created_at, updated_at) VALUES ($1, $2, $3, NOW(), NOW())`,
+			orgID, "mcp-manifest-test-org-"+suffix, "mcp-manifest-test-"+suffix+".example.com")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, 'test', $5, NOW(), NOW())`,
+			userID, orgID, "owner-"+suffix+"@example.com", "manifest-test-owner-"+suffix, userID.String())
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx,
+			`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, '1.0.0', '[]'::jsonb, $5, NOW(), NOW())`,
+			serverID, orgID,
+			"mcp-manifest-test-server-"+suffix,
+			"https://mcp-manifest-test-"+suffix+".example.com",
+			userID)
+		require.NoError(t, err)
+		return serverID
+	}
+
+	addTool := func(t *testing.T, serverID uuid.UUID, name string) {
+		schema, _ := json.Marshal(map[string]any{"type": "object", "title": name})
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO mcp_server_capabilities
+			   (id, mcp_server_id, name, capability_type, description, capability_schema,
+			    is_active, detected_at, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'tool', '', $4::jsonb, TRUE, NOW(), NOW(), NOW())`,
+			uuid.New(), serverID, name, schema)
+		require.NoError(t, err)
+	}
+
+	driftCount := func(t *testing.T, serverID uuid.UUID) int {
+		var n int
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM mcp_manifest_drift WHERE mcp_server_id = $1`, serverID).Scan(&n))
+		return n
+	}
+
+	t.Run("well-known first capture seeds baseline with no drift", func(t *testing.T) {
+		serverID := seedServer(t)
+		addTool(t, serverID, "list_files")
+		addTool(t, serverID, "get_status")
+
+		drift, err := svc.RecomputeFromWellKnown(ctx, serverID)
+		require.NoError(t, err)
+		require.Nil(t, drift, "first capture must not record drift")
+
+		baseline, entries, err := manifestRepo.GetCurrentBaseline(serverID)
+		require.NoError(t, err)
+		require.NotNil(t, baseline, "first capture must seed a baseline")
+		require.Equal(t, 2, baseline.ToolCount)
+		require.Len(t, entries, 2)
+		require.Equal(t, 0, driftCount(t, serverID))
+	})
+
+	t.Run("well-known adding a high-risk tool records HIGH drift", func(t *testing.T) {
+		serverID := seedServer(t)
+		addTool(t, serverID, "list_files")
+		_, err := svc.RecomputeFromWellKnown(ctx, serverID) // seed baseline
+		require.NoError(t, err)
+
+		// Silently add a tool that touches a high-risk surface (exec/command) after the server was trusted.
+		addTool(t, serverID, "exec_command")
+
+		drift, err := svc.RecomputeFromWellKnown(ctx, serverID)
+		require.NoError(t, err)
+		require.NotNil(t, drift, "adding a tool must record drift")
+		require.Equal(t, domain.DriftSeverityHigh, drift.Severity)
+		require.Equal(t, []string{"tool:exec_command"}, drift.AddedTools)
+		require.Empty(t, drift.RemovedTools)
+		require.Equal(t, 1, driftCount(t, serverID))
+
+		// Baseline advanced to the new surface, so a re-capture is now stable (no repeated drift).
+		baseline, _, err := manifestRepo.GetCurrentBaseline(serverID)
+		require.NoError(t, err)
+		require.Equal(t, 2, baseline.ToolCount)
+		again, err := svc.RecomputeFromWellKnown(ctx, serverID)
+		require.NoError(t, err)
+		require.Nil(t, again)
+		require.Equal(t, 1, driftCount(t, serverID))
+	})
+
+	t.Run("attestation divergence ignored below consensus, recorded at consensus", func(t *testing.T) {
+		serverID := seedServer(t)
+		addTool(t, serverID, "list_files")
+		_, err := svc.RecomputeFromWellKnown(ctx, serverID) // baseline = {list_files}
+		require.NoError(t, err)
+		require.Equal(t, 0, driftCount(t, serverID))
+
+		// An agent reports a tool the server never declared. Generic category tokens are ignored.
+		observed := []string{"tools", "list_files", "delete_everything"}
+
+		// Below consensus: a single (or sub-threshold) agent's divergence must not move the baseline
+		// or record drift.
+		drift, err := svc.RecomputeFromAttestation(ctx, serverID, observed, false)
+		require.NoError(t, err)
+		require.Nil(t, drift, "sub-consensus divergence must not record drift")
+		require.Equal(t, 0, driftCount(t, serverID))
+		baseline, _, err := manifestRepo.GetCurrentBaseline(serverID)
+		require.NoError(t, err)
+		require.Equal(t, 1, baseline.ToolCount, "baseline unchanged below consensus")
+
+		// At consensus: the divergence is confirmed and recorded as drift; the high-risk
+		// "delete_everything" addition escalates severity to high.
+		drift, err = svc.RecomputeFromAttestation(ctx, serverID, observed, true)
+		require.NoError(t, err)
+		require.NotNil(t, drift, "consensus-confirmed divergence must record drift")
+		require.Equal(t, domain.ManifestSourceAttestation, drift.Source)
+		require.Equal(t, domain.DriftSeverityHigh, drift.Severity)
+		require.Equal(t, []string{"tool:delete_everything"}, drift.AddedTools)
+		require.Empty(t, drift.RemovedTools, "list_files is in both sets, so nothing removed")
+		require.Equal(t, 1, driftCount(t, serverID))
+
+		// Baseline-poisoning guard: attestation NEVER moves the baseline. Only the server's own
+		// /.well-known capture is authoritative, so the baseline stays exactly what well-known seeded.
+		baseline, _, err = manifestRepo.GetCurrentBaseline(serverID)
+		require.NoError(t, err)
+		require.Equal(t, domain.ManifestSourceWellKnown, baseline.CapturedFrom, "attestation must not author the baseline")
+		require.Equal(t, 1, baseline.ToolCount, "baseline unchanged by attestation")
+
+		// Dedup: the same divergence reported again (still consensus-met) must NOT record a second
+		// drift row, since the baseline correctly never absorbed it.
+		drift, err = svc.RecomputeFromAttestation(ctx, serverID, observed, true)
+		require.NoError(t, err)
+		require.Nil(t, drift, "identical unacknowledged divergence must not be re-recorded")
+		require.Equal(t, 1, driftCount(t, serverID))
+	})
+
+	t.Run("well-known reconcile detects removal and schema change", func(t *testing.T) {
+		serverID := seedServer(t)
+
+		// Drive capabilities through the same reconcile path DetectCapabilities uses, so this exercises
+		// removal/schema-change detection rather than the addition-only behavior of a plain insert.
+		tool := func(name, title string) *domain.MCPServerCapability {
+			schema, _ := json.Marshal(map[string]any{"type": "object", "title": title})
+			return &domain.MCPServerCapability{
+				MCPServerID: serverID, Name: name, CapabilityType: domain.MCPCapabilityTypeTool,
+				CapabilitySchema: schema,
+			}
+		}
+
+		// Initial trusted surface: two tools. Seed baseline, no drift.
+		require.NoError(t, capabilityRepo.ReplaceActiveCapabilities(serverID,
+			[]*domain.MCPServerCapability{tool("list_files", "v1"), tool("read_data", "v1")}))
+		_, err := svc.RecomputeFromWellKnown(ctx, serverID)
+		require.NoError(t, err)
+		require.Equal(t, 0, driftCount(t, serverID))
+
+		// Server silently: removes read_data, reshapes list_files' schema, adds exec_command.
+		require.NoError(t, capabilityRepo.ReplaceActiveCapabilities(serverID,
+			[]*domain.MCPServerCapability{tool("list_files", "v2-reshaped"), tool("exec_command", "v1")}))
+
+		drift, err := svc.RecomputeFromWellKnown(ctx, serverID)
+		require.NoError(t, err)
+		require.NotNil(t, drift, "removal + schema change + add must record drift")
+		require.Equal(t, []string{"tool:exec_command"}, drift.AddedTools)
+		require.Equal(t, []string{"tool:read_data"}, drift.RemovedTools, "removed tool must be detected (not left active)")
+		require.Equal(t, []string{"tool:list_files"}, drift.ChangedTools, "reshaped schema must be detected")
+		require.Equal(t, domain.DriftSeverityHigh, drift.Severity, "exec_command addition escalates to high")
+		require.Equal(t, 1, driftCount(t, serverID))
+	})
+}

--- a/apps/backend/internal/application/mcp_manifest_service.go
+++ b/apps/backend/internal/application/mcp_manifest_service.go
@@ -15,6 +15,26 @@ func sortedStrings(s []string) []string {
 	return s
 }
 
+// genericCapabilityCategories are the MCP capability-category tokens an attestation may report instead
+// of (or alongside) concrete tool names. They are not tool names and must not enter the tool manifest.
+// Kept in sync with MCPServerCapabilityRepository.UpsertFromAttestation, which skips the same tokens.
+var genericCapabilityCategories = map[string]struct{}{
+	"tools": {}, "resources": {}, "prompts": {},
+}
+
+// filterAttestedToolNames drops generic capability-category tokens from an attestation's reported names,
+// leaving only concrete tool names for manifest diffing.
+func filterAttestedToolNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if _, generic := genericCapabilityCategories[n]; generic {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
 // MCPManifestService maintains a per-server manifest baseline and records drift when a server's
 // tool surface changes after it was trusted. Two sources feed it:
 //
@@ -89,19 +109,39 @@ func (s *MCPManifestService) RecomputeFromWellKnown(ctx context.Context, serverI
 }
 
 // RecomputeFromAttestation compares the tool names an agent reported against the current baseline's
-// tool set. Divergence (a tool agents see that the server never declared, or vice versa) is only
-// treated as server drift when consensusMet is true; below consensus it is ignored to avoid
-// single-agent false positives. Resources and prompts are not attested, so non-tool baseline entries
-// are carried forward unchanged. Returns the drift record when one was created, otherwise nil.
+// tool set and records drift when they diverge. It deliberately NEVER mutates the baseline: the
+// /.well-known feed is the sole baseline author. This is the baseline-poisoning guard — the consensus
+// signal available here ("has this server ever reached multi-agent verification?") is a server-lifetime
+// latch, not per-manifest corroboration, so allowing it to advance the baseline would let a single
+// trusted in-org agent silently rebaseline a verified server to an arbitrary tool set. Instead,
+// consensus-confirmed divergence is recorded as a drift observation against the unchanged baseline;
+// the server's own next /.well-known capture is what legitimately moves the baseline.
+//
+// consensusMet still gates RECORDING (below consensus, a lone agent's divergence is ignored to avoid
+// false positives). Divergence is deduplicated against recent unacknowledged attestation drift so the
+// same discrepancy is not re-recorded on every subsequent attestation. Only tool-type entries are
+// attested (resources/prompts are not), so the diff is over tool names. Returns the drift record when
+// one was created, otherwise nil.
 func (s *MCPManifestService) RecomputeFromAttestation(ctx context.Context, serverID uuid.UUID, observedNames []string, consensusMet bool) (*domain.MCPManifestDrift, error) {
+	// Attestation payloads mix real tool names with the generic MCP capability-category tokens
+	// ("tools"/"resources"/"prompts"). The capability sync (UpsertFromAttestation) skips those tokens
+	// because they are not tool names; the manifest diff must skip them too, or every consensus-met
+	// attestation that lists a category would record spurious "added tool: tools" drift.
+	observedNames = filterAttestedToolNames(observedNames)
 	if len(observedNames) == 0 {
-		// Empty report is treated as missing data, never as "all tools removed".
+		// Empty report (or one carrying only category tokens) is treated as missing data, never as
+		// "all tools removed".
 		return nil, nil
 	}
 
 	baseline, prevEntries, err := s.manifestRepo.GetCurrentBaseline(serverID)
 	if err != nil {
 		return nil, err
+	}
+	if baseline == nil {
+		// No /.well-known baseline yet: there is nothing authoritative to diverge from, and attestation
+		// must not seed a baseline (well-known is the sole author). Nothing to record.
+		return nil, nil
 	}
 
 	observedEntries, _ := domain.BuildManifestFromNames(observedNames)
@@ -110,30 +150,16 @@ func (s *MCPManifestService) RecomputeFromAttestation(ctx context.Context, serve
 		observedSet[e.Name] = struct{}{}
 	}
 
-	if baseline == nil {
-		// Only a consensus-backed attestation may establish a baseline from observation alone.
-		if !consensusMet {
-			return nil, nil
-		}
-		hash, tools, res, prm := domain.HashManifestEntries(observedEntries)
-		return nil, s.manifestRepo.ReplaceBaseline(&domain.MCPManifestBaseline{
-			MCPServerID: serverID, ManifestHash: hash, ToolCount: tools,
-			ResourceCount: res, PromptCount: prm, CapturedFrom: domain.ManifestSourceAttestation,
-		}, observedEntries)
-	}
-
 	// Diff observed tool names against the baseline's tool names (only tool-type entries are attested).
-	baselineTools := make(map[string]domain.ManifestEntry)
-	var carried []domain.ManifestEntry // non-tool entries preserved across an attestation baseline move
+	baselineTools := make(map[string]struct{})
 	for _, e := range prevEntries {
 		if e.Type == domain.MCPCapabilityTypeTool {
-			baselineTools[e.Name] = e
-		} else {
-			carried = append(carried, e)
+			baselineTools[e.Name] = struct{}{}
 		}
 	}
 
-	var added, removed []string
+	added := make([]string, 0)
+	removed := make([]string, 0)
 	for name := range observedSet {
 		if _, ok := baselineTools[name]; !ok {
 			added = append(added, "tool:"+name)
@@ -148,26 +174,30 @@ func (s *MCPManifestService) RecomputeFromAttestation(ctx context.Context, serve
 		return nil, nil
 	}
 	if !consensusMet {
-		// Unconfirmed divergence from a single agent is not recorded as server drift.
+		// Unconfirmed divergence from a sub-threshold agent set is not recorded as server drift.
 		return nil, nil
 	}
 
-	// Consensus-confirmed: record drift and advance the baseline. Carry forward known tools' schema
-	// hashes so a later well-known capture can still detect a schema change on a surviving tool.
-	newEntries := append([]domain.ManifestEntry{}, carried...)
-	for name := range observedSet {
-		if prev, ok := baselineTools[name]; ok {
-			newEntries = append(newEntries, prev)
-		} else {
-			newEntries = append(newEntries, domain.ManifestEntry{Type: domain.MCPCapabilityTypeTool, Name: name})
-		}
+	// Hash of what the agents observed, used both as the drift's NewHash (the baseline's hash is the
+	// unchanged PrevHash) and as the dedup key.
+	observedHash, _, _, _ := domain.HashManifestEntries(observedEntries)
+
+	// Dedup: if this exact observed divergence is already recorded and unacknowledged, do not record it
+	// again. Without this, every attestation carrying the same divergence would add a duplicate row,
+	// because the baseline (correctly) never moves to absorb it. Exact existence check, so a repeat is
+	// suppressed regardless of how many other drift rows accumulated in between.
+	dup, err := s.manifestRepo.HasUnacknowledgedDriftWithHash(serverID, domain.ManifestSourceAttestation, observedHash)
+	if err != nil {
+		return nil, err
 	}
-	newHash, tools, res, prm := domain.HashManifestEntries(newEntries)
+	if dup {
+		return nil, nil
+	}
 
 	drift := &domain.MCPManifestDrift{
 		MCPServerID:  serverID,
 		PrevHash:     baseline.ManifestHash,
-		NewHash:      newHash,
+		NewHash:      observedHash,
 		AddedTools:   sortedStrings(added),
 		RemovedTools: sortedStrings(removed),
 		ChangedTools: []string{},
@@ -175,12 +205,6 @@ func (s *MCPManifestService) RecomputeFromAttestation(ctx context.Context, serve
 		Source:       domain.ManifestSourceAttestation,
 	}
 	if err := s.manifestRepo.InsertDrift(drift); err != nil {
-		return nil, err
-	}
-	if err := s.manifestRepo.ReplaceBaseline(&domain.MCPManifestBaseline{
-		MCPServerID: serverID, ManifestHash: newHash, ToolCount: tools,
-		ResourceCount: res, PromptCount: prm, CapturedFrom: domain.ManifestSourceAttestation,
-	}, newEntries); err != nil {
 		return nil, err
 	}
 	return drift, nil

--- a/apps/backend/internal/application/mcp_manifest_service.go
+++ b/apps/backend/internal/application/mcp_manifest_service.go
@@ -1,0 +1,187 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
+)
+
+func sortedStrings(s []string) []string {
+	sort.Strings(s)
+	return s
+}
+
+// MCPManifestService maintains a per-server manifest baseline and records drift when a server's
+// tool surface changes after it was trusted. Two sources feed it:
+//
+//   - well_known: the server's own /.well-known/mcp/capabilities declaration. Authoritative; every
+//     change updates the baseline and records drift.
+//   - attestation: tool names observed by attesting agents. Used to catch a server that declares one
+//     thing but behaves differently to agents. Baseline movement and drift recording from this source
+//     require multi-agent consensus, so a single rogue or misconfigured agent cannot poison the baseline.
+type MCPManifestService struct {
+	capabilityRepo *repository.MCPServerCapabilityRepository
+	manifestRepo   *repository.MCPManifestRepository
+}
+
+func NewMCPManifestService(
+	capabilityRepo *repository.MCPServerCapabilityRepository,
+	manifestRepo *repository.MCPManifestRepository,
+) *MCPManifestService {
+	return &MCPManifestService{capabilityRepo: capabilityRepo, manifestRepo: manifestRepo}
+}
+
+// RecomputeFromWellKnown rebuilds the manifest from the server's stored capabilities (populated by a
+// /.well-known capability fetch) and compares it to the current baseline. On first capture it seeds
+// the baseline and records no drift. On a hash change it records drift and advances the baseline.
+// Returns the drift record when one was created, otherwise nil.
+func (s *MCPManifestService) RecomputeFromWellKnown(ctx context.Context, serverID uuid.UUID) (*domain.MCPManifestDrift, error) {
+	caps, err := s.capabilityRepo.GetByServerID(serverID)
+	if err != nil {
+		return nil, fmt.Errorf("load capabilities: %w", err)
+	}
+	entries, hash, tools, resources, prompts := domain.BuildManifest(caps)
+
+	baseline, prevEntries, err := s.manifestRepo.GetCurrentBaseline(serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	newBaseline := &domain.MCPManifestBaseline{
+		MCPServerID:   serverID,
+		ManifestHash:  hash,
+		ToolCount:     tools,
+		ResourceCount: resources,
+		PromptCount:   prompts,
+		CapturedFrom:  domain.ManifestSourceWellKnown,
+	}
+
+	if baseline == nil {
+		// First capture: establish baseline, no drift.
+		return nil, s.manifestRepo.ReplaceBaseline(newBaseline, entries)
+	}
+	if baseline.ManifestHash == hash {
+		return nil, nil
+	}
+
+	added, removed, changed := domain.DiffManifests(prevEntries, entries)
+	drift := &domain.MCPManifestDrift{
+		MCPServerID:  serverID,
+		PrevHash:     baseline.ManifestHash,
+		NewHash:      hash,
+		AddedTools:   added,
+		RemovedTools: removed,
+		ChangedTools: changed,
+		Severity:     domain.ClassifyDriftSeverity(added, removed, changed),
+		Source:       domain.ManifestSourceWellKnown,
+	}
+	if err := s.manifestRepo.InsertDrift(drift); err != nil {
+		return nil, err
+	}
+	if err := s.manifestRepo.ReplaceBaseline(newBaseline, entries); err != nil {
+		return nil, err
+	}
+	return drift, nil
+}
+
+// RecomputeFromAttestation compares the tool names an agent reported against the current baseline's
+// tool set. Divergence (a tool agents see that the server never declared, or vice versa) is only
+// treated as server drift when consensusMet is true; below consensus it is ignored to avoid
+// single-agent false positives. Resources and prompts are not attested, so non-tool baseline entries
+// are carried forward unchanged. Returns the drift record when one was created, otherwise nil.
+func (s *MCPManifestService) RecomputeFromAttestation(ctx context.Context, serverID uuid.UUID, observedNames []string, consensusMet bool) (*domain.MCPManifestDrift, error) {
+	if len(observedNames) == 0 {
+		// Empty report is treated as missing data, never as "all tools removed".
+		return nil, nil
+	}
+
+	baseline, prevEntries, err := s.manifestRepo.GetCurrentBaseline(serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	observedEntries, _ := domain.BuildManifestFromNames(observedNames)
+	observedSet := make(map[string]struct{}, len(observedEntries))
+	for _, e := range observedEntries {
+		observedSet[e.Name] = struct{}{}
+	}
+
+	if baseline == nil {
+		// Only a consensus-backed attestation may establish a baseline from observation alone.
+		if !consensusMet {
+			return nil, nil
+		}
+		hash, tools, res, prm := domain.HashManifestEntries(observedEntries)
+		return nil, s.manifestRepo.ReplaceBaseline(&domain.MCPManifestBaseline{
+			MCPServerID: serverID, ManifestHash: hash, ToolCount: tools,
+			ResourceCount: res, PromptCount: prm, CapturedFrom: domain.ManifestSourceAttestation,
+		}, observedEntries)
+	}
+
+	// Diff observed tool names against the baseline's tool names (only tool-type entries are attested).
+	baselineTools := make(map[string]domain.ManifestEntry)
+	var carried []domain.ManifestEntry // non-tool entries preserved across an attestation baseline move
+	for _, e := range prevEntries {
+		if e.Type == domain.MCPCapabilityTypeTool {
+			baselineTools[e.Name] = e
+		} else {
+			carried = append(carried, e)
+		}
+	}
+
+	var added, removed []string
+	for name := range observedSet {
+		if _, ok := baselineTools[name]; !ok {
+			added = append(added, "tool:"+name)
+		}
+	}
+	for name := range baselineTools {
+		if _, ok := observedSet[name]; !ok {
+			removed = append(removed, "tool:"+name)
+		}
+	}
+	if len(added) == 0 && len(removed) == 0 {
+		return nil, nil
+	}
+	if !consensusMet {
+		// Unconfirmed divergence from a single agent is not recorded as server drift.
+		return nil, nil
+	}
+
+	// Consensus-confirmed: record drift and advance the baseline. Carry forward known tools' schema
+	// hashes so a later well-known capture can still detect a schema change on a surviving tool.
+	newEntries := append([]domain.ManifestEntry{}, carried...)
+	for name := range observedSet {
+		if prev, ok := baselineTools[name]; ok {
+			newEntries = append(newEntries, prev)
+		} else {
+			newEntries = append(newEntries, domain.ManifestEntry{Type: domain.MCPCapabilityTypeTool, Name: name})
+		}
+	}
+	newHash, tools, res, prm := domain.HashManifestEntries(newEntries)
+
+	drift := &domain.MCPManifestDrift{
+		MCPServerID:  serverID,
+		PrevHash:     baseline.ManifestHash,
+		NewHash:      newHash,
+		AddedTools:   sortedStrings(added),
+		RemovedTools: sortedStrings(removed),
+		ChangedTools: []string{},
+		Severity:     domain.ClassifyDriftSeverity(added, removed, nil),
+		Source:       domain.ManifestSourceAttestation,
+	}
+	if err := s.manifestRepo.InsertDrift(drift); err != nil {
+		return nil, err
+	}
+	if err := s.manifestRepo.ReplaceBaseline(&domain.MCPManifestBaseline{
+		MCPServerID: serverID, ManifestHash: newHash, ToolCount: tools,
+		ResourceCount: res, PromptCount: prm, CapturedFrom: domain.ManifestSourceAttestation,
+	}, newEntries); err != nil {
+		return nil, err
+	}
+	return drift, nil
+}

--- a/apps/backend/internal/domain/mcp_manifest.go
+++ b/apps/backend/internal/domain/mcp_manifest.go
@@ -1,0 +1,223 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ManifestSource identifies how a manifest snapshot was captured.
+type ManifestSource string
+
+const (
+	// ManifestSourceWellKnown is the server's own /.well-known/mcp/capabilities declaration.
+	// This is authoritative for "what the server claims to expose".
+	ManifestSourceWellKnown ManifestSource = "well_known"
+	// ManifestSourceAttestation is the tool set observed by attesting agents.
+	ManifestSourceAttestation ManifestSource = "attestation"
+)
+
+// DriftSeverity grades a manifest change. Removing or changing a tool ranks above adding one,
+// and any high-risk capability surface (exec/filesystem/network) escalates to high.
+type DriftSeverity string
+
+const (
+	DriftSeverityLow    DriftSeverity = "low"
+	DriftSeverityMedium DriftSeverity = "medium"
+	DriftSeverityHigh   DriftSeverity = "high"
+)
+
+// MCPManifestBaseline is an append-only snapshot of an MCP server's tool manifest.
+// The newest row for a server has IsCurrent=true and is the baseline future captures diff against.
+type MCPManifestBaseline struct {
+	ID            uuid.UUID      `json:"id"`
+	MCPServerID   uuid.UUID      `json:"mcpServerId"`
+	ManifestHash  string         `json:"manifestHash"`
+	ToolCount     int            `json:"toolCount"`
+	ResourceCount int            `json:"resourceCount"`
+	PromptCount   int            `json:"promptCount"`
+	CapturedFrom  ManifestSource `json:"capturedFrom"`
+	CapturedAt    time.Time      `json:"capturedAt"`
+	IsCurrent     bool           `json:"isCurrent"`
+}
+
+// MCPManifestDrift records a detected change between the previous baseline and a new capture.
+type MCPManifestDrift struct {
+	ID           uuid.UUID      `json:"id"`
+	MCPServerID  uuid.UUID      `json:"mcpServerId"`
+	PrevHash     string         `json:"prevHash"`
+	NewHash      string         `json:"newHash"`
+	AddedTools   []string       `json:"addedTools"`
+	RemovedTools []string       `json:"removedTools"`
+	ChangedTools []string       `json:"changedTools"`
+	Severity     DriftSeverity  `json:"severity"`
+	Source       ManifestSource `json:"source"`
+	DetectedAt   time.Time      `json:"detectedAt"`
+	Acknowledged bool           `json:"acknowledged"`
+}
+
+// ManifestEntry is the canonical per-capability unit used for hashing and diffing.
+// SchemaHash makes a schema change detectable without storing the full schema in the manifest.
+// It is persisted inside a baseline row so drift diffing does not depend on the mutable
+// mcp_server_capabilities rows (which only ever reflect the current state).
+type ManifestEntry struct {
+	Type       MCPCapabilityType `json:"type"`
+	Name       string            `json:"name"`
+	SchemaHash string            `json:"schemaHash"`
+}
+
+// key uniquely identifies an entry across captures (type + name).
+func (e ManifestEntry) key() string {
+	return string(e.Type) + ":" + e.Name
+}
+
+// CanonicalSchemaHash returns a stable SHA-256 of a capability schema. JSON object key order is
+// normalized (Go marshals map keys sorted) so cosmetic reordering or whitespace is not seen as drift;
+// array order is preserved because it is semantically meaningful. Invalid/empty schemas hash their raw bytes.
+func CanonicalSchemaHash(raw json.RawMessage) string {
+	canonical := raw
+	if len(raw) > 0 {
+		var v interface{}
+		if err := json.Unmarshal(raw, &v); err == nil {
+			if b, err := json.Marshal(v); err == nil {
+				canonical = b
+			}
+		}
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:])
+}
+
+// BuildManifest converts the stored capabilities into a sorted canonical manifest, returning the
+// entries (sorted by type then name), the manifest hash, and per-type counts. Only active
+// capabilities are included.
+func BuildManifest(caps []*MCPServerCapability) (entries []ManifestEntry, manifestHash string, tools, resources, prompts int) {
+	for _, c := range caps {
+		if c == nil || !c.IsActive {
+			continue
+		}
+		entries = append(entries, ManifestEntry{
+			Type:       c.CapabilityType,
+			Name:       c.Name,
+			SchemaHash: CanonicalSchemaHash(c.CapabilitySchema),
+		})
+	}
+
+	manifestHash, tools, resources, prompts = HashManifestEntries(entries)
+	return entries, manifestHash, tools, resources, prompts
+}
+
+// HashManifestEntries sorts a manifest entry set (by type then name), returns its canonical hash and
+// per-type counts. Sorting makes the hash order-invariant; unit separators keep field boundaries
+// unambiguous so distinct manifests cannot collide.
+func HashManifestEntries(entries []ManifestEntry) (manifestHash string, tools, resources, prompts int) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Type != entries[j].Type {
+			return entries[i].Type < entries[j].Type
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	var sb strings.Builder
+	for _, e := range entries {
+		sb.WriteString(string(e.Type))
+		sb.WriteByte(0x1f)
+		sb.WriteString(e.Name)
+		sb.WriteByte(0x1f)
+		sb.WriteString(e.SchemaHash)
+		sb.WriteByte(0x1e)
+		switch e.Type {
+		case MCPCapabilityTypeTool:
+			tools++
+		case MCPCapabilityTypeResource:
+			resources++
+		case MCPCapabilityTypePrompt:
+			prompts++
+		}
+	}
+	sum := sha256.Sum256([]byte(sb.String()))
+	return hex.EncodeToString(sum[:]), tools, resources, prompts
+}
+
+// BuildManifestFromNames builds a names-only manifest from agent-attested tool names. Attestations
+// report tool names without schemas, so SchemaHash is left empty; diffing against this manifest is
+// add/remove by name, not schema change. Names are deduplicated.
+func BuildManifestFromNames(names []string) (entries []ManifestEntry, manifestHash string) {
+	seen := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		entries = append(entries, ManifestEntry{Type: MCPCapabilityTypeTool, Name: n})
+	}
+	manifestHash, _, _, _ = HashManifestEntries(entries)
+	return entries, manifestHash
+}
+
+// DiffManifests compares a previous and new manifest, returning capability keys that were added,
+// removed, or changed (same key, different schema hash).
+func DiffManifests(prev, next []ManifestEntry) (added, removed, changed []string) {
+	prevByKey := make(map[string]ManifestEntry, len(prev))
+	for _, e := range prev {
+		prevByKey[e.key()] = e
+	}
+	nextByKey := make(map[string]ManifestEntry, len(next))
+	for _, e := range next {
+		nextByKey[e.key()] = e
+	}
+
+	for k, ne := range nextByKey {
+		pe, ok := prevByKey[k]
+		if !ok {
+			added = append(added, k)
+			continue
+		}
+		if pe.SchemaHash != ne.SchemaHash {
+			changed = append(changed, k)
+		}
+	}
+	for k := range prevByKey {
+		if _, ok := nextByKey[k]; !ok {
+			removed = append(removed, k)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(changed)
+	return added, removed, changed
+}
+
+// highRiskHints are capability-name substrings whose addition or change to a server's manifest
+// warrants elevated scrutiny. Heuristic, intentionally conservative toward over-flagging.
+var highRiskHints = []string{
+	"exec", "shell", "command", "spawn", "eval",
+	"file", "fs", "read_file", "write_file", "delete",
+	"http", "fetch", "request", "network", "socket",
+	"secret", "credential", "token", "env",
+}
+
+// ClassifyDriftSeverity grades a diff. Any added or changed capability matching a high-risk hint is
+// high; removals or changes without high-risk hints are medium; additions alone are low.
+func ClassifyDriftSeverity(added, removed, changed []string) DriftSeverity {
+	for _, k := range append(append([]string{}, added...), changed...) {
+		lower := strings.ToLower(k)
+		for _, hint := range highRiskHints {
+			if strings.Contains(lower, hint) {
+				return DriftSeverityHigh
+			}
+		}
+	}
+	if len(removed) > 0 || len(changed) > 0 {
+		return DriftSeverityMedium
+	}
+	return DriftSeverityLow
+}

--- a/apps/backend/internal/domain/mcp_manifest_test.go
+++ b/apps/backend/internal/domain/mcp_manifest_test.go
@@ -1,0 +1,103 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func cap(name string, t MCPCapabilityType, schema string) *MCPServerCapability {
+	return &MCPServerCapability{
+		ID:               uuid.New(),
+		MCPServerID:      uuid.Nil,
+		Name:             name,
+		CapabilityType:   t,
+		CapabilitySchema: json.RawMessage(schema),
+		IsActive:         true,
+	}
+}
+
+// Manifest hash must be stable regardless of capability ordering — otherwise a server reordering its
+// tools/list would falsely register as drift.
+func TestBuildManifest_OrderInvariant(t *testing.T) {
+	a := []*MCPServerCapability{
+		cap("get_weather", MCPCapabilityTypeTool, `{"type":"object"}`),
+		cap("search_code", MCPCapabilityTypeTool, `{"type":"string"}`),
+	}
+	b := []*MCPServerCapability{
+		cap("search_code", MCPCapabilityTypeTool, `{"type":"string"}`),
+		cap("get_weather", MCPCapabilityTypeTool, `{"type":"object"}`),
+	}
+	_, hashA, _, _, _ := BuildManifest(a)
+	_, hashB, _, _, _ := BuildManifest(b)
+	if hashA != hashB {
+		t.Fatalf("manifest hash must be order-invariant: %s != %s", hashA, hashB)
+	}
+}
+
+// JSON key reordering and whitespace inside a schema must NOT count as drift.
+func TestCanonicalSchemaHash_KeyOrderInvariant(t *testing.T) {
+	h1 := CanonicalSchemaHash(json.RawMessage(`{"a":1,"b":2}`))
+	h2 := CanonicalSchemaHash(json.RawMessage(`{ "b": 2, "a": 1 }`))
+	if h1 != h2 {
+		t.Fatalf("schema hash must ignore key order/whitespace: %s != %s", h1, h2)
+	}
+}
+
+// A real schema change (different input shape for the same tool) MUST change the hash.
+func TestBuildManifest_SchemaChangeDetected(t *testing.T) {
+	before := []*MCPServerCapability{cap("run", MCPCapabilityTypeTool, `{"type":"object","properties":{"cmd":{"type":"string"}}}`)}
+	after := []*MCPServerCapability{cap("run", MCPCapabilityTypeTool, `{"type":"object","properties":{"cmd":{"type":"string"},"cwd":{"type":"string"}}}`)}
+	_, hb, _, _, _ := BuildManifest(before)
+	_, ha, _, _, _ := BuildManifest(after)
+	if hb == ha {
+		t.Fatal("schema change must produce a different manifest hash")
+	}
+}
+
+func TestDiffManifests_AddRemoveChange(t *testing.T) {
+	prev, _, _, _, _ := BuildManifest([]*MCPServerCapability{
+		cap("keep", MCPCapabilityTypeTool, `{"v":1}`),
+		cap("gone", MCPCapabilityTypeTool, `{"v":1}`),
+		cap("mutate", MCPCapabilityTypeTool, `{"v":1}`),
+	})
+	next, _, _, _, _ := BuildManifest([]*MCPServerCapability{
+		cap("keep", MCPCapabilityTypeTool, `{"v":1}`),
+		cap("mutate", MCPCapabilityTypeTool, `{"v":2}`),
+		cap("brand_new", MCPCapabilityTypeTool, `{"v":1}`),
+	})
+	added, removed, changed := DiffManifests(prev, next)
+	if len(added) != 1 || added[0] != "tool:brand_new" {
+		t.Fatalf("added wrong: %v", added)
+	}
+	if len(removed) != 1 || removed[0] != "tool:gone" {
+		t.Fatalf("removed wrong: %v", removed)
+	}
+	if len(changed) != 1 || changed[0] != "tool:mutate" {
+		t.Fatalf("changed wrong: %v", changed)
+	}
+}
+
+// Silent injection of a high-risk tool (the core threat) must escalate to high severity.
+func TestClassifyDriftSeverity_HighRiskInjection(t *testing.T) {
+	if got := ClassifyDriftSeverity([]string{"tool:exec_shell"}, nil, nil); got != DriftSeverityHigh {
+		t.Fatalf("high-risk add must be high, got %s", got)
+	}
+	if got := ClassifyDriftSeverity([]string{"tool:list_items"}, nil, nil); got != DriftSeverityLow {
+		t.Fatalf("benign add must be low, got %s", got)
+	}
+	if got := ClassifyDriftSeverity(nil, []string{"tool:list_items"}, nil); got != DriftSeverityMedium {
+		t.Fatalf("removal must be medium, got %s", got)
+	}
+}
+
+// Inactive capabilities are excluded from the manifest.
+func TestBuildManifest_SkipsInactive(t *testing.T) {
+	c := cap("dormant", MCPCapabilityTypeTool, `{}`)
+	c.IsActive = false
+	entries, _, tools, _, _ := BuildManifest([]*MCPServerCapability{c})
+	if len(entries) != 0 || tools != 0 {
+		t.Fatalf("inactive capability must be excluded: entries=%d tools=%d", len(entries), tools)
+	}
+}

--- a/apps/backend/internal/infrastructure/repository/mcp_capability_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_capability_repository.go
@@ -614,3 +614,58 @@ func (r *MCPServerCapabilityRepository) UpsertFromAttestation(serverID uuid.UUID
 
 	return nil
 }
+
+// ReplaceActiveCapabilities reconciles a server's stored capabilities to exactly the freshly-fetched
+// set (e.g. from /.well-known) in a single transaction: every currently-active capability is first
+// deactivated, then each fetched capability is upserted as active with its current schema. The net
+// effect is that capabilities absent from the new set become is_active=false (a removal), capabilities
+// with a changed schema have capability_schema updated (a change), and new ones are inserted (an
+// addition). This is what lets manifest drift detect removals and schema reshapes — a plain per-row
+// INSERT (Create) leaves stale rows active forever, so removed/changed tools would be invisible.
+//
+// Soft-deactivation (not delete) preserves history and matches the mcp_servers.capabilities cache
+// trigger, which recomputes from is_active=true rows.
+func (r *MCPServerCapabilityRepository) ReplaceActiveCapabilities(serverID uuid.UUID, capabilities []*domain.MCPServerCapability) error {
+	now := time.Now().UTC()
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin capability reconcile tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// 1. Mark all current capabilities stale. Any still present in the fetched set is reactivated below;
+	//    whatever remains deactivated is a genuine removal.
+	if _, err := tx.Exec(
+		`UPDATE mcp_server_capabilities SET is_active = false, updated_at = $2
+		 WHERE mcp_server_id = $1 AND is_active = true`, serverID, now,
+	); err != nil {
+		return fmt.Errorf("failed to deactivate stale capabilities: %w", err)
+	}
+
+	// 2. Upsert each fetched capability as active, refreshing schema/description on conflict so a
+	//    reshaped tool's capability_schema (and thus its manifest schema hash) actually changes.
+	for _, c := range capabilities {
+		if c == nil {
+			continue
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO mcp_server_capabilities (
+				id, mcp_server_id, name, capability_type, description,
+				capability_schema, detected_at, last_verified_at, is_active, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9, $10)
+			ON CONFLICT (mcp_server_id, name, capability_type) DO UPDATE SET
+				description = EXCLUDED.description,
+				capability_schema = EXCLUDED.capability_schema,
+				last_verified_at = EXCLUDED.last_verified_at,
+				is_active = true,
+				updated_at = EXCLUDED.updated_at`,
+			uuid.New(), serverID, c.Name, c.CapabilityType, c.Description,
+			c.CapabilitySchema, now, now, now, now,
+		); err != nil {
+			return fmt.Errorf("failed to upsert capability %s: %w", c.Name, err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/apps/backend/internal/infrastructure/repository/mcp_manifest_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_manifest_repository.go
@@ -39,7 +39,7 @@ func (r *MCPManifestRepository) GetCurrentBaseline(serverID uuid.UUID) (*domain.
 		return nil, nil, fmt.Errorf("failed to load current manifest baseline: %w", err)
 	}
 
-	var entries []domain.ManifestEntry
+	entries := make([]domain.ManifestEntry, 0)
 	if len(entriesJSON) > 0 {
 		if err := json.Unmarshal(entriesJSON, &entries); err != nil {
 			return nil, nil, fmt.Errorf("failed to decode baseline entries: %w", err)
@@ -102,6 +102,24 @@ func (r *MCPManifestRepository) InsertDrift(d *domain.MCPManifestDrift) error {
 	).Scan(&d.ID, &d.DetectedAt)
 }
 
+// HasUnacknowledgedDriftWithHash reports whether an unacknowledged drift row from the given source
+// already records new_hash for a server. Used to deduplicate attestation-observed divergence exactly:
+// the baseline never absorbs attestation drift, so without this check the same divergence would
+// re-insert on every subsequent attestation. An exact SQL existence test (not a bounded scan of recent
+// rows) so a repeat is suppressed no matter how many other drift rows have accumulated since.
+func (r *MCPManifestRepository) HasUnacknowledgedDriftWithHash(serverID uuid.UUID, source domain.ManifestSource, newHash string) (bool, error) {
+	var exists bool
+	err := r.db.QueryRow(
+		`SELECT EXISTS (
+			SELECT 1 FROM mcp_manifest_drift
+			WHERE mcp_server_id = $1 AND source = $2 AND new_hash = $3 AND acknowledged = FALSE
+		)`, serverID, string(source), newHash).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check existing drift: %w", err)
+	}
+	return exists, nil
+}
+
 // GetRecentDrift returns the most recent drift records for a server, newest first.
 func (r *MCPManifestRepository) GetRecentDrift(serverID uuid.UUID, limit int) ([]*domain.MCPManifestDrift, error) {
 	rows, err := r.db.Query(
@@ -116,7 +134,7 @@ func (r *MCPManifestRepository) GetRecentDrift(serverID uuid.UUID, limit int) ([
 	}
 	defer rows.Close()
 
-	var out []*domain.MCPManifestDrift
+	out := make([]*domain.MCPManifestDrift, 0)
 	for rows.Next() {
 		var d domain.MCPManifestDrift
 		var added, removed, changed []byte

--- a/apps/backend/internal/infrastructure/repository/mcp_manifest_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_manifest_repository.go
@@ -1,0 +1,142 @@
+package repository
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+type MCPManifestRepository struct {
+	db *sql.DB
+}
+
+func NewMCPManifestRepository(db *sql.DB) *MCPManifestRepository {
+	return &MCPManifestRepository{db: db}
+}
+
+// GetCurrentBaseline returns the current baseline for a server and its stored manifest entries.
+// Returns (nil, nil, nil) when no baseline exists yet.
+func (r *MCPManifestRepository) GetCurrentBaseline(serverID uuid.UUID) (*domain.MCPManifestBaseline, []domain.ManifestEntry, error) {
+	query := `
+		SELECT id, mcp_server_id, manifest_hash, entries, tool_count, resource_count,
+		       prompt_count, captured_from, captured_at, is_current
+		FROM mcp_manifest_baselines
+		WHERE mcp_server_id = $1 AND is_current = TRUE`
+
+	var b domain.MCPManifestBaseline
+	var entriesJSON []byte
+	err := r.db.QueryRow(query, serverID).Scan(
+		&b.ID, &b.MCPServerID, &b.ManifestHash, &entriesJSON, &b.ToolCount,
+		&b.ResourceCount, &b.PromptCount, &b.CapturedFrom, &b.CapturedAt, &b.IsCurrent,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load current manifest baseline: %w", err)
+	}
+
+	var entries []domain.ManifestEntry
+	if len(entriesJSON) > 0 {
+		if err := json.Unmarshal(entriesJSON, &entries); err != nil {
+			return nil, nil, fmt.Errorf("failed to decode baseline entries: %w", err)
+		}
+	}
+	return &b, entries, nil
+}
+
+// ReplaceBaseline atomically demotes the current baseline (if any) and inserts the new one as
+// current. The append-only history is preserved; only the is_current flag moves.
+func (r *MCPManifestRepository) ReplaceBaseline(b *domain.MCPManifestBaseline, entries []domain.ManifestEntry) error {
+	entriesJSON, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("failed to encode baseline entries: %w", err)
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin baseline tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(
+		`UPDATE mcp_manifest_baselines SET is_current = FALSE
+		 WHERE mcp_server_id = $1 AND is_current = TRUE`, b.MCPServerID,
+	); err != nil {
+		return fmt.Errorf("failed to demote previous baseline: %w", err)
+	}
+
+	if err := tx.QueryRow(
+		`INSERT INTO mcp_manifest_baselines
+		   (mcp_server_id, manifest_hash, entries, tool_count, resource_count,
+		    prompt_count, captured_from, is_current)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE)
+		 RETURNING id, captured_at`,
+		b.MCPServerID, b.ManifestHash, entriesJSON, b.ToolCount, b.ResourceCount,
+		b.PromptCount, string(b.CapturedFrom),
+	).Scan(&b.ID, &b.CapturedAt); err != nil {
+		return fmt.Errorf("failed to insert baseline: %w", err)
+	}
+	b.IsCurrent = true
+
+	return tx.Commit()
+}
+
+// InsertDrift records a detected manifest change.
+func (r *MCPManifestRepository) InsertDrift(d *domain.MCPManifestDrift) error {
+	added, _ := json.Marshal(nonNil(d.AddedTools))
+	removed, _ := json.Marshal(nonNil(d.RemovedTools))
+	changed, _ := json.Marshal(nonNil(d.ChangedTools))
+
+	return r.db.QueryRow(
+		`INSERT INTO mcp_manifest_drift
+		   (mcp_server_id, prev_hash, new_hash, added_tools, removed_tools,
+		    changed_tools, severity, source)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 RETURNING id, detected_at`,
+		d.MCPServerID, d.PrevHash, d.NewHash, added, removed, changed,
+		string(d.Severity), string(d.Source),
+	).Scan(&d.ID, &d.DetectedAt)
+}
+
+// GetRecentDrift returns the most recent drift records for a server, newest first.
+func (r *MCPManifestRepository) GetRecentDrift(serverID uuid.UUID, limit int) ([]*domain.MCPManifestDrift, error) {
+	rows, err := r.db.Query(
+		`SELECT id, mcp_server_id, prev_hash, new_hash, added_tools, removed_tools,
+		        changed_tools, severity, source, detected_at, acknowledged
+		 FROM mcp_manifest_drift
+		 WHERE mcp_server_id = $1
+		 ORDER BY detected_at DESC
+		 LIMIT $2`, serverID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query drift: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*domain.MCPManifestDrift
+	for rows.Next() {
+		var d domain.MCPManifestDrift
+		var added, removed, changed []byte
+		if err := rows.Scan(
+			&d.ID, &d.MCPServerID, &d.PrevHash, &d.NewHash, &added, &removed,
+			&changed, &d.Severity, &d.Source, &d.DetectedAt, &d.Acknowledged,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan drift row: %w", err)
+		}
+		_ = json.Unmarshal(added, &d.AddedTools)
+		_ = json.Unmarshal(removed, &d.RemovedTools)
+		_ = json.Unmarshal(changed, &d.ChangedTools)
+		out = append(out, &d)
+	}
+	return out, rows.Err()
+}
+
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/apps/backend/migrations/098_mcp_manifest_baselines.sql
+++ b/apps/backend/migrations/098_mcp_manifest_baselines.sql
@@ -1,0 +1,30 @@
+-- Migration 098: MCP manifest baselines
+--
+-- Append-only snapshots of an MCP server's tool manifest, identified by a
+-- canonical hash over (capability type, name, schema hash). The newest row
+-- per server has is_current = TRUE and is the baseline that later captures
+-- diff against. Capability detail already lives in mcp_server_capabilities;
+-- this table records the aggregate manifest hash so a server quietly adding,
+-- removing, or reshaping a tool after it was trusted becomes detectable.
+
+CREATE TABLE IF NOT EXISTS mcp_manifest_baselines (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    mcp_server_id  UUID NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+    manifest_hash  TEXT NOT NULL,
+    entries        JSONB NOT NULL DEFAULT '[]',
+    tool_count     INTEGER NOT NULL DEFAULT 0,
+    resource_count INTEGER NOT NULL DEFAULT 0,
+    prompt_count   INTEGER NOT NULL DEFAULT 0,
+    captured_from  TEXT NOT NULL CHECK (captured_from IN ('well_known', 'attestation')),
+    captured_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    is_current     BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- One current baseline per server. Partial unique index allows the full
+-- append-only history while guaranteeing a single is_current row.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_manifest_baselines_current
+    ON mcp_manifest_baselines (mcp_server_id)
+    WHERE is_current = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_mcp_manifest_baselines_server_time
+    ON mcp_manifest_baselines (mcp_server_id, captured_at DESC);

--- a/apps/backend/migrations/099_mcp_manifest_drift.sql
+++ b/apps/backend/migrations/099_mcp_manifest_drift.sql
@@ -1,0 +1,29 @@
+-- Migration 099: MCP manifest drift records
+--
+-- One row per detected change between a server's previous current baseline and
+-- a new manifest capture. added/removed/changed hold capability keys
+-- ("type:name"). severity follows the domain heuristic: any high-risk surface
+-- (exec/filesystem/network/credential) added or changed => high; other
+-- removals/changes => medium; benign additions => low.
+
+CREATE TABLE IF NOT EXISTS mcp_manifest_drift (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    mcp_server_id UUID NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+    prev_hash     TEXT NOT NULL,
+    new_hash      TEXT NOT NULL,
+    added_tools   JSONB NOT NULL DEFAULT '[]',
+    removed_tools JSONB NOT NULL DEFAULT '[]',
+    changed_tools JSONB NOT NULL DEFAULT '[]',
+    severity      TEXT NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+    source        TEXT NOT NULL CHECK (source IN ('well_known', 'attestation')),
+    detected_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    acknowledged  BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_manifest_drift_server_time
+    ON mcp_manifest_drift (mcp_server_id, detected_at DESC);
+
+-- Surface unacknowledged high-severity drift cheaply for alerting.
+CREATE INDEX IF NOT EXISTS idx_mcp_manifest_drift_open_high
+    ON mcp_manifest_drift (mcp_server_id)
+    WHERE acknowledged = FALSE AND severity = 'high';


### PR DESCRIPTION
## What

Connects the MCP manifest baseline/drift service to the two paths that observe a server's tool surface, so a server quietly adding, removing, or reshaping a tool after it was trusted becomes detectable.

- **Capability detection** now reconciles stored capabilities to exactly the freshly fetched `/.well-known` set (deactivate-stale + upsert in one transaction) instead of insert-only. This lets drift detection see **removals and schema changes**, not just additions. The well-known feed is the authoritative baseline author.
- **Attestation** records consensus-gated divergence between agent-observed tools and the baseline, but **never mutates the baseline itself**. The available consensus signal is a server-lifetime verification latch, not per-manifest corroboration, so allowing it to move the baseline would let a single trusted in-org agent rebaseline a verified server; recording-only closes that. Divergence is deduplicated against unacknowledged drift via an exact hash check.
- Both hooks are best-effort and never fail the parent operation; the manifest service is injected via a setter so existing constructors are unchanged.

## Tests

Integration test (`//go:build integration`) covers first-capture baseline seeding, addition/removal/schema-change detection through the reconcile path, the consensus gate, and dedup. `go build`, `go test -race ./...` (22 packages), and `go vet` all pass.

## Known v1 follow-ups (non-blocking)

- Drift is recorded (and logged) but does not yet raise an operator alert — surfacing was the deferred optional v1 item.
- The well-known `InsertDrift` + baseline replace pair is not yet a single transaction (best-effort concurrent-recompute race).