### PR TITLE
feat(telemetry): SDK→Registry relay for anonymized causal-denial indicators

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -104,6 +104,83 @@ fastify.post('/api/data', {
 });
 ```
 
+## Causal-Denial Telemetry (opt-in)
+
+The SDK can correlate *why* a blocked agent action happened by joining three
+signals around one verified action: the authorization outcome (an observed
+fact), the classified intent, and the injection cause (both inferences). The
+full **correlated record** is authoritative and stays on the machine; only an
+anonymized **shared indicator** is ever uploaded.
+
+Telemetry is **off by default** and gated by two independent opt-ins:
+
+1. **Capture** (`telemetry.enabled`) — mints a correlation ID per `verifyAction`,
+   assembles records, and appends them to a local log at
+   `~/.opena2a/correlated-events.jsonl`. Nothing leaves the machine.
+2. **Share** (`telemetry.relay.enabled`) — a best-effort relay reduces local
+   records to anonymized indicators and uploads only `denied_injection_attempt`
+   events to the public, count-only Registry endpoint
+   (`POST /api/v1/telemetry/runtime`).
+
+   The shared indicator carries **no** payloads, paths, credentials,
+   resource/capability names, correlation ID, agent ID, or denial reason text.
+   It carries only: a validated Threat Matrix `techniqueId` (`T-NNNN`, dropped
+   if malformed) and its source, a detection confidence, the coarse enforcement
+   outcome (`deny`/`allow`), the integrator's self-declared `packageName`/
+   `agentCategory`, `daySinceInstall`, `runtimeEnv`, `triggeredAt`, and a
+   `sensorToken` — a stable per-device pseudonym (`sha256(host+user+local salt)`)
+   that lets the Registry de-duplicate without identifying you.
+
+```typescript
+const client = new AIMClient({
+  baseUrl: 'https://aim.example.com',
+  apiKey: process.env.AIM_API_KEY,
+  telemetry: {
+    enabled: true,                 // stage 1: capture records locally
+    relay: {
+      enabled: true,               // stage 2: upload anonymized indicators
+      packageName: 'acme/support-agent', // your app's public sensor label
+      packageVersion: '2.1.0',
+      // registryUrl defaults to https://api.oa2a.org
+      // intervalMs defaults to 60000, batchSize to 50
+    },
+  },
+});
+
+// Per-action inputs (populated by the runtime-protection module, or supplied
+// directly). Ignored unless telemetry is enabled.
+await client.verifyAction({
+  action: 'file:read',
+  resource: '/data/sensitive.json',
+  telemetry: {
+    intent: { intentClass: 'exfiltration', confidence: 0.7, blocked: true, source: 'nanomind-intent' },
+    detection: {
+      injectionDetected: true,
+      techniqueId: 'T-2002',
+      techniqueSource: 'interim-mapping',
+      confidence: 0.84,
+      detector: 'nanomind-guard',
+      detectedAt: new Date().toISOString(),
+    },
+  },
+});
+
+// Stop the internally managed flush timers when shutting down.
+client.closeTelemetry();
+```
+
+**Guarantees.** Telemetry runs off the enforcement path and is best-effort: a
+capture, join, or upload failure is swallowed and never changes an action's
+verification result. When both opt-ins are off, no correlation ID is minted, no
+header is attached, and nothing is written or sent.
+
+`TelemetryConfig` fields: `enabled` (capture switch), `enforcementSource`
+(stamped on the enforcement fact, default `aim-pdp`), `joiner` (supply your own
+to control the sink/lifecycle), and `relay` (`RelayConfig`: `enabled`,
+`registryUrl`, `packageName`, `packageVersion`, `agentCategory`, `dataDir`,
+`batchSize`, `intervalMs`, `timeoutMs`). The `CorrelatedRelay` class is also
+exported for standalone use (e.g. draining the local log from a CLI).
+
 ## Configuration
 
 ### Environment Variables

--- a/sdk/typescript/src/client/AIMClient.telemetry.test.ts
+++ b/sdk/typescript/src/client/AIMClient.telemetry.test.ts
@@ -15,12 +15,17 @@ import {
   CorrelationJoiner,
   CORRELATION_HEADER,
   isCorrelationId,
+  buildCorrelatedRecord,
+  writeCorrelatedRecord,
   type CorrelatedRecord,
   type IntentInput,
   type DetectionInput,
 } from '../telemetry';
 import { generateKeyPair, toBase64 } from '../crypto/ed25519';
 import type { AgentCredentials, VerificationResult } from '../types';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -251,6 +256,110 @@ describe('AIMClient causal-denial telemetry', () => {
   describe('lifecycle', () => {
     it('closeTelemetry is safe with no internally managed joiner', () => {
       const client = new AIMClient({ telemetry: { enabled: true } });
+      expect(() => client.closeTelemetry()).not.toThrow();
+    });
+  });
+
+  describe('upload relay wiring (stage-2 opt-in)', () => {
+    const tmpDirs: string[] = [];
+    function relayDir(): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cde-aimclient-relay-'));
+      tmpDirs.push(dir);
+      // Seed one denied-injection record so the relay has something to ship.
+      writeCorrelatedRecord(
+        buildCorrelatedRecord({
+          correlationId: 'cde_000000000_aabbccddeeff',
+          agentId: 'agent-x',
+          enforcement: {
+            decision: 'deny',
+            outcome: 'DENY_INTENT',
+            capability: 'net:connect',
+            resource: 'https://evil.example',
+            occurredAt: '2026-06-06T00:00:00.000Z',
+            source: 'aim-pdp',
+          },
+          detection: {
+            injectionDetected: true,
+            techniqueId: 'T-2002',
+            techniqueSource: 'interim-mapping',
+            confidence: 0.84,
+            detector: 'nanomind-guard',
+            detectedAt: '2026-06-06T00:00:00.000Z',
+          },
+          intent: { intentClass: 'exfiltration', confidence: 0.7, blocked: true, source: 'nm-intent' },
+        }),
+        dir
+      );
+      return dir;
+    }
+    afterEach(() => {
+      for (const d of tmpDirs.splice(0)) {
+        try {
+          fs.rmSync(d, { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
+      }
+    });
+
+    it('starts the relay after a verifyAction when relay sharing is opted in', async () => {
+      const dir = relayDir();
+      const relayFetch = vi.fn(async () => ({
+        ok: true,
+        status: 201,
+        json: async () => ({ eventId: 'e1' }),
+        text: async () => '',
+      }));
+      const client = new AIMClient({
+        telemetry: {
+          enabled: true,
+          relay: {
+            enabled: true,
+            dataDir: dir,
+            intervalMs: 10,
+            fetchImpl: relayFetch as unknown as typeof fetch,
+          },
+        },
+      });
+      client.setCredentials(await realCredentials());
+      mockVerifyResponse({ actionAllowed: true });
+
+      await client.verifyAction({ action: 'db:read', resource: 'users' });
+      await vi.waitFor(() => expect(relayFetch).toHaveBeenCalled(), { timeout: 1000 });
+      client.closeTelemetry();
+    });
+
+    it('does NOT start the relay when only capture is enabled', async () => {
+      const dir = relayDir();
+      const relayFetch = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({}), text: async () => '' }));
+      const client = new AIMClient({
+        telemetry: {
+          enabled: true,
+          relay: {
+            enabled: false, // stage-2 NOT opted in
+            dataDir: dir,
+            intervalMs: 10,
+            fetchImpl: relayFetch as unknown as typeof fetch,
+          },
+        },
+      });
+      client.setCredentials(await realCredentials());
+      mockVerifyResponse({ actionAllowed: true });
+
+      await client.verifyAction({ action: 'db:read', resource: 'users' });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(relayFetch).not.toHaveBeenCalled();
+      client.closeTelemetry();
+    });
+
+    it('closeTelemetry stops the relay safely', async () => {
+      const dir = relayDir();
+      const client = new AIMClient({
+        telemetry: { enabled: true, relay: { enabled: true, dataDir: dir, intervalMs: 10 } },
+      });
+      client.setCredentials(await realCredentials());
+      mockVerifyResponse({ actionAllowed: true });
+      await client.verifyAction({ action: 'db:read', resource: 'users' });
       expect(() => client.closeTelemetry()).not.toThrow();
     });
   });

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -32,9 +32,11 @@ import {
 import type { SecretsClient } from '../secrets';
 import {
   CorrelationJoiner,
+  CorrelatedRelay,
   correlationHeaders,
   mintCorrelationId,
   type EnforcementInput,
+  type RelayConfig,
 } from '../telemetry';
 
 const DEFAULT_BASE_URL = 'http://localhost:8080';
@@ -79,6 +81,9 @@ export class AIMClient {
   private readonly enforcementSource: string;
   private readonly suppliedJoiner: CorrelationJoiner | null;
   private ownJoiner: CorrelationJoiner | undefined;
+  // Stage-2 opt-in: upload anonymized indicators to the Registry.
+  private readonly relayConfig: RelayConfig | null;
+  private ownRelay: CorrelatedRelay | undefined;
 
   constructor(config: AIMClientConfig = {}) {
     this.config = {
@@ -96,6 +101,7 @@ export class AIMClient {
     this.telemetryEnabled = telemetry.enabled === true;
     this.enforcementSource = telemetry.enforcementSource ?? DEFAULT_ENFORCEMENT_SOURCE;
     this.suppliedJoiner = telemetry.joiner ?? null;
+    this.relayConfig = telemetry.relay ?? null;
 
     // Try to load credentials from environment
     this.credentials = loadCredentialsFromEnv();
@@ -398,6 +404,8 @@ export class AIMClient {
    */
   private getJoiner(): CorrelationJoiner | null {
     if (!this.telemetryEnabled) return null;
+    // Spin up the upload relay alongside the joiner when stage-2 sharing is on.
+    this.ensureRelay();
     if (this.suppliedJoiner) return this.suppliedJoiner;
     if (!this.ownJoiner) {
       this.ownJoiner = new CorrelationJoiner();
@@ -407,13 +415,30 @@ export class AIMClient {
   }
 
   /**
-   * Stop the internally managed telemetry joiner timer, if one was created.
-   * A caller-supplied joiner is left untouched (the caller owns its lifecycle).
+   * Lazily start the managed upload relay. No-op unless telemetry capture AND
+   * relay sharing are both opted in (two-stage consent). The relay drains the
+   * local correlated-events log to the Registry on its own unref'd timer.
+   */
+  private ensureRelay(): void {
+    if (!this.telemetryEnabled || this.relayConfig?.enabled !== true) return;
+    if (this.ownRelay) return;
+    this.ownRelay = new CorrelatedRelay(this.relayConfig);
+    this.ownRelay.start();
+  }
+
+  /**
+   * Stop the internally managed telemetry joiner timer and upload relay, if
+   * created. A caller-supplied joiner is left untouched (the caller owns its
+   * lifecycle).
    */
   closeTelemetry(): void {
     if (this.ownJoiner) {
       this.ownJoiner.stop();
       this.ownJoiner = undefined;
+    }
+    if (this.ownRelay) {
+      this.ownRelay.stop();
+      this.ownRelay = undefined;
     }
   }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -240,6 +240,15 @@ export {
   readCorrelatedRecords,
   CorrelationJoiner,
   isHighConfidence,
+  CorrelatedRelay,
+  DEFAULT_REGISTRY_URL,
+  RUNTIME_TELEMETRY_PATH,
+  RELAY_EVENT_TYPE,
+  SENTINEL_PACKAGE_NAME,
+  openA2AHome,
+  deriveSensorToken,
+  detectRuntimeEnv,
+  daysSinceInstall,
   isValidTechniqueId,
   isTechniqueIdFormat,
   mapAttackClass,
@@ -258,6 +267,8 @@ export {
   type EnforcementEvent,
   type IntentEvent,
   type DetectionEvent,
+  type RelayConfig,
+  type FlushResult,
 } from './telemetry';
 
 // Version

--- a/sdk/typescript/src/telemetry/index.ts
+++ b/sdk/typescript/src/telemetry/index.ts
@@ -75,3 +75,17 @@ export {
 } from './technique-mapping';
 
 export type { InterimMappingEntry } from './technique-mapping';
+
+export {
+  CorrelatedRelay,
+  DEFAULT_REGISTRY_URL,
+  RUNTIME_TELEMETRY_PATH,
+  RELAY_EVENT_TYPE,
+  SENTINEL_PACKAGE_NAME,
+  openA2AHome,
+  deriveSensorToken,
+  detectRuntimeEnv,
+  daysSinceInstall,
+} from './relay';
+
+export type { RelayConfig, FlushResult } from './relay';

--- a/sdk/typescript/src/telemetry/relay.test.ts
+++ b/sdk/typescript/src/telemetry/relay.test.ts
@@ -9,7 +9,13 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { CorrelatedRelay, SENTINEL_PACKAGE_NAME, RELAY_EVENT_TYPE, deriveSensorToken } from './relay';
+import {
+  CorrelatedRelay,
+  SENTINEL_PACKAGE_NAME,
+  RELAY_EVENT_TYPE,
+  deriveSensorToken,
+  openA2AHome,
+} from './relay';
 import { writeCorrelatedRecord } from './local-writer';
 import { buildCorrelatedRecord, type CorrelatedRecord } from './correlated-record';
 
@@ -299,6 +305,24 @@ describe('CorrelatedRelay', () => {
       relay.start();
       relay.stop();
     }).not.toThrow();
+  });
+
+  describe('openA2AHome resolution', () => {
+    const saved = process.env.OPENA2A_HOME;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.OPENA2A_HOME;
+      else process.env.OPENA2A_HOME = saved;
+    });
+
+    it('honors and canonicalizes an absolute OPENA2A_HOME', () => {
+      process.env.OPENA2A_HOME = '/tmp/opena2a-home/../opena2a-home2';
+      expect(openA2AHome()).toBe(path.resolve('/tmp/opena2a-home2'));
+    });
+
+    it('ignores a relative OPENA2A_HOME in favor of the home default', () => {
+      process.env.OPENA2A_HOME = 'relative/evil';
+      expect(openA2AHome()).toBe(path.join(os.homedir(), '.opena2a'));
+    });
   });
 
   describe('sensor-token salt hardening', () => {

--- a/sdk/typescript/src/telemetry/relay.test.ts
+++ b/sdk/typescript/src/telemetry/relay.test.ts
@@ -8,7 +8,8 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { CorrelatedRelay, SENTINEL_PACKAGE_NAME, RELAY_EVENT_TYPE } from './relay';
+import * as crypto from 'crypto';
+import { CorrelatedRelay, SENTINEL_PACKAGE_NAME, RELAY_EVENT_TYPE, deriveSensorToken } from './relay';
 import { writeCorrelatedRecord } from './local-writer';
 import { buildCorrelatedRecord, type CorrelatedRecord } from './correlated-record';
 
@@ -298,5 +299,42 @@ describe('CorrelatedRelay', () => {
       relay.start();
       relay.stop();
     }).not.toThrow();
+  });
+
+  describe('sensor-token salt hardening', () => {
+    const posix = typeof process.getuid === 'function';
+
+    it('reuses an existing owner-only salt (stable token)', () => {
+      const dir = freshDir();
+      const t1 = deriveSensorToken(dir);
+      const t2 = deriveSensorToken(dir);
+      expect(t1).toBe(t2);
+      expect(t1).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    (posix ? it : it.skip)('regenerates a pre-created world-readable salt as 0600', () => {
+      const dir = freshDir();
+      fs.mkdirSync(dir, { recursive: true });
+      const saltPath = path.join(dir, 'gtin-sensor-salt');
+      // Attacker pre-creates a known, world-readable salt.
+      fs.writeFileSync(saltPath, 'attacker-known-salt', { mode: 0o644 });
+      fs.chmodSync(saltPath, 0o644);
+      expect(fs.statSync(saltPath).mode & 0o077).not.toBe(0);
+
+      const token = deriveSensorToken(dir);
+
+      // The untrusted salt was replaced with a fresh owner-only one.
+      expect(fs.statSync(saltPath).mode & 0o077).toBe(0);
+      const newSalt = fs.readFileSync(saltPath, 'utf-8').trim();
+      expect(newSalt).not.toBe('attacker-known-salt');
+
+      // The token derives from the regenerated salt, NOT the attacker-known one,
+      // so a pre-created salt cannot be used to de-anonymize the sensor token.
+      const attackerToken = crypto
+        .createHash('sha256')
+        .update(`${os.hostname()}|${os.userInfo().username}|attacker-known-salt`)
+        .digest('hex');
+      expect(token).not.toBe(attackerToken);
+    });
   });
 });

--- a/sdk/typescript/src/telemetry/relay.test.ts
+++ b/sdk/typescript/src/telemetry/relay.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for the SDK -> Registry relay. Key guarantees: inert when disabled;
+ * uploads only denied_injection_attempt indicators; ships NO identifiers; the
+ * cursor advances so records are not re-sent; failures block the cursor (retry)
+ * while 4xx rejections advance it; nothing here ever throws.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CorrelatedRelay, SENTINEL_PACKAGE_NAME, RELAY_EVENT_TYPE } from './relay';
+import { writeCorrelatedRecord } from './local-writer';
+import { buildCorrelatedRecord, type CorrelatedRecord } from './correlated-record';
+
+const tmpDirs: string[] = [];
+
+function freshDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cde-relay-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+/** Build a record, then pin createdAt for deterministic cursor tests. */
+function makeRecord(opts: {
+  createdAt: string;
+  injection: boolean;
+  decision?: 'allow' | 'deny';
+}): CorrelatedRecord {
+  const decision = opts.decision ?? (opts.injection ? 'deny' : 'allow');
+  const rec = buildCorrelatedRecord({
+    correlationId: `cde_000000000_${Math.random().toString(16).slice(2, 14)}`,
+    agentId: 'agent-secret-id',
+    enforcement: {
+      decision,
+      outcome: decision === 'deny' ? 'DENY_INTENT' : 'ALLOW',
+      capability: 'net:connect',
+      resource: 'https://evil.example/secret-path',
+      deniedReason: 'blocked because injected exfil instruction',
+      credentialRef: 'ref:db-prod',
+      occurredAt: opts.createdAt,
+      source: 'aim-pdp',
+    },
+    detection: opts.injection
+      ? {
+          injectionDetected: true,
+          attackClass: 'injection',
+          techniqueId: 'T-2002',
+          techniqueSource: 'interim-mapping',
+          confidence: 0.84,
+          detector: 'nanomind-guard',
+          inputRef: 'sha256:abcd',
+          detectedAt: opts.createdAt,
+        }
+      : undefined,
+    intent: opts.injection
+      ? { intentClass: 'exfiltration', confidence: 0.7, blocked: true, source: 'nanomind-intent' }
+      : undefined,
+  });
+  return { ...rec, createdAt: opts.createdAt };
+}
+
+function okResponse(): Response {
+  return { ok: true, status: 201, json: async () => ({ eventId: 'e1' }), text: async () => '' } as unknown as Response;
+}
+function statusResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}), text: async () => 'err' } as unknown as Response;
+}
+
+describe('CorrelatedRelay', () => {
+  it('is fully inert when disabled', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:00.000Z', injection: true }), dir);
+    const fetchImpl = vi.fn();
+    const relay = new CorrelatedRelay({ enabled: false, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await relay.flushOnce();
+    expect(res).toEqual({ considered: 0, uploaded: 0, stoppedOnError: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('uploads only denied_injection_attempt indicators and skips the rest', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:02.000Z', injection: false }), dir); // allow
+    writeCorrelatedRecord(
+      makeRecord({ createdAt: '2026-06-06T00:00:03.000Z', injection: false, decision: 'deny' }), // deny w/o injection
+      dir
+    );
+
+    const fetchImpl = vi.fn(async () => okResponse());
+    const relay = new CorrelatedRelay({
+      enabled: true,
+      dataDir: dir,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const res = await relay.flushOnce();
+    expect(res.considered).toBe(3);
+    expect(res.uploaded).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('ships no identifiers — only the anonymized indicator shape', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    let sentBody: Record<string, unknown> = {};
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(init.body as string);
+      return okResponse();
+    });
+    const relay = new CorrelatedRelay({
+      enabled: true,
+      dataDir: dir,
+      packageName: 'acme/support-agent',
+      packageVersion: '2.1.0',
+      sensorToken: 'sensor-abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await relay.flushOnce();
+
+    expect(sentBody.eventType).toBe(RELAY_EVENT_TYPE);
+    expect(sentBody.packageName).toBe('acme/support-agent');
+    expect(sentBody.packageVersion).toBe('2.1.0');
+    expect(sentBody.sensorToken).toBe('sensor-abc');
+    expect(sentBody.techniqueId).toBe('T-2002');
+    expect(sentBody.enforcementOutcome).toBe('deny');
+    expect(sentBody.detectionConfidence).toBe(0.84);
+
+    // Identifiers must NEVER appear in the wire payload.
+    const wire = JSON.stringify(sentBody);
+    expect(wire).not.toContain('agent-secret-id');
+    expect(wire).not.toContain('evil.example');
+    expect(wire).not.toContain('secret-path');
+    expect(wire).not.toContain('db-prod');
+    expect(wire).not.toContain('sha256:abcd');
+    expect(wire).not.toContain('correlationId');
+    expect(sentBody.deniedReason).toBeUndefined();
+    expect(sentBody.resource).toBeUndefined();
+    expect(sentBody.capability).toBeUndefined();
+  });
+
+  it('omits a malformed/tampered techniqueId rather than transmitting it', async () => {
+    const dir = freshDir();
+    // A locally-tampered record whose techniqueId smuggles free text.
+    const rec = makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true });
+    const tampered: CorrelatedRecord = {
+      ...rec,
+      detection: {
+        ...rec.detection!,
+        techniqueId: 'T-2002; /Users/v/secret.key; AKIAEXFIL',
+        techniqueSource: 'totally-made-up' as never,
+      },
+    };
+    writeCorrelatedRecord(tampered, dir);
+
+    let sentBody: Record<string, unknown> = {};
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(init.body as string);
+      return okResponse();
+    });
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+    await relay.flushOnce();
+
+    // The indicator is still sent (it is a valid denial), but the malformed
+    // record-derived fields are dropped — no free text leaves the machine.
+    expect(sentBody.eventType).toBe(RELAY_EVENT_TYPE);
+    expect(sentBody.techniqueId).toBeUndefined();
+    expect(sentBody.techniqueSource).toBeUndefined();
+    expect(JSON.stringify(sentBody)).not.toContain('AKIAEXFIL');
+    expect(JSON.stringify(sentBody)).not.toContain('secret.key');
+  });
+
+  it('defaults packageName to the sentinel when none is configured', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    let sentBody: Record<string, unknown> = {};
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(init.body as string);
+      return okResponse();
+    });
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+    await relay.flushOnce();
+    expect(sentBody.packageName).toBe(SENTINEL_PACKAGE_NAME);
+  });
+
+  it('advances the cursor so a second flush re-sends nothing', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    const fetchImpl = vi.fn(async () => okResponse());
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const first = await relay.flushOnce();
+    expect(first.uploaded).toBe(1);
+    const second = await relay.flushOnce();
+    expect(second.considered).toBe(0);
+    expect(second.uploaded).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up only records appended after the cursor', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    const fetchImpl = vi.fn(async () => okResponse());
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+    await relay.flushOnce();
+
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:05.000Z', injection: true }), dir);
+    const res = await relay.flushOnce();
+    expect(res.considered).toBe(1);
+    expect(res.uploaded).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks the cursor on a 5xx so the record is retried next flush', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(statusResponse(503))
+      .mockResolvedValueOnce(okResponse());
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const first = await relay.flushOnce();
+    expect(first.uploaded).toBe(0);
+    expect(first.stoppedOnError).toBe(true);
+
+    const second = await relay.flushOnce();
+    expect(second.considered).toBe(1); // same record, retried
+    expect(second.uploaded).toBe(1);
+  });
+
+  it('advances the cursor on a 4xx (non-retryable rejection)', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    const errors: unknown[] = [];
+    const fetchImpl = vi.fn(async () => statusResponse(400));
+    const relay = new CorrelatedRelay({
+      enabled: true,
+      dataDir: dir,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onError: (e) => errors.push(e),
+    });
+    const first = await relay.flushOnce();
+    expect(first.uploaded).toBe(0);
+    expect(first.stoppedOnError).toBe(false); // 4xx treated as handled
+    expect(errors.length).toBe(1);
+
+    const second = await relay.flushOnce();
+    expect(second.considered).toBe(0); // cursor advanced past the rejected record
+  });
+
+  it('caps uploads to batchSize per flush', async () => {
+    const dir = freshDir();
+    for (let i = 0; i < 5; i++) {
+      writeCorrelatedRecord(
+        makeRecord({ createdAt: `2026-06-06T00:00:0${i}.000Z`, injection: true }),
+        dir
+      );
+    }
+    const fetchImpl = vi.fn(async () => okResponse());
+    const relay = new CorrelatedRelay({
+      enabled: true,
+      dataDir: dir,
+      batchSize: 2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const first = await relay.flushOnce();
+    expect(first.uploaded).toBe(2);
+    const second = await relay.flushOnce();
+    expect(second.uploaded).toBe(2);
+    const third = await relay.flushOnce();
+    expect(third.uploaded).toBe(1);
+  });
+
+  it('never throws when fetch rejects, and blocks the cursor', async () => {
+    const dir = freshDir();
+    writeCorrelatedRecord(makeRecord({ createdAt: '2026-06-06T00:00:01.000Z', injection: true }), dir);
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const relay = new CorrelatedRelay({ enabled: true, dataDir: dir, fetchImpl: fetchImpl as unknown as typeof fetch });
+    // flushOnce swallows all errors internally; it resolves, never rejects.
+    const res = await relay.flushOnce();
+    expect(res).toEqual({ considered: 1, uploaded: 0, stoppedOnError: true });
+  });
+
+  it('start() is a no-op when disabled and does not keep the event loop alive', () => {
+    const relay = new CorrelatedRelay({ enabled: false });
+    expect(() => {
+      relay.start();
+      relay.stop();
+    }).not.toThrow();
+  });
+});

--- a/sdk/typescript/src/telemetry/relay.ts
+++ b/sdk/typescript/src/telemetry/relay.ts
@@ -1,0 +1,433 @@
+/**
+ * Causal-denial telemetry — SDK -> Registry relay (the leg that ships indicators up).
+ *
+ * Reads full {@link CorrelatedRecord}s from the local authoritative log
+ * (~/.opena2a/correlated-events.jsonl), reduces each to an anonymized
+ * {@link SharedIndicator} via {@link toSharedIndicator} (which strips every
+ * identifier — payloads, paths, credentials, resource/capability names,
+ * correlationId, agentId, inputRef), and POSTs the denied-injection indicators
+ * to the Registry's PUBLIC, count-only telemetry endpoint.
+ *
+ * CA decision (ARC-AIM-RUNTIME-PLAN.md §5.3/§5.4):
+ *   - D-R1: targets the PUBLIC `POST /api/v1/telemetry/runtime` (count-only, no
+ *     side-effects). The authenticated `/internal/telemetry/denial-correlated`
+ *     path is reserved for a trusted internal aggregator — an end-user SDK does
+ *     not hold an `internal:telemetry:write` service-account token.
+ *   - D-R2: the indicator carries no package identity; `packageName` is attached
+ *     at POST time from static relay config (the integrator's self-declared
+ *     sensor package, like sensorToken), defaulting to a sentinel.
+ *   - D-R3: the relay has its OWN master switch, default OFF, separate from
+ *     telemetry capture. Sharing is a second, explicit opt-in.
+ *   - D-R5: only `denied_injection_attempt` indicators are uploaded.
+ *
+ * Everything here is opt-in, consent-gated, off the enforcement critical path,
+ * and best-effort: a failure is swallowed and never affects verifyAction.
+ */
+import { createHash, randomBytes } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { hostname, userInfo, homedir } from 'os';
+import { join } from 'path';
+import {
+  toSharedIndicator,
+  TELEMETRY_SCHEMA_VERSION,
+  type CorrelatedRecord,
+  type SharedIndicator,
+  type SharedIndicatorContext,
+} from './correlated-record';
+import { readCorrelatedRecords } from './local-writer';
+
+/** Default Registry base URL (shared with hackmyagent's GTIN forwarder). */
+export const DEFAULT_REGISTRY_URL = 'https://api.oa2a.org';
+/** Public, count-only runtime telemetry path. */
+export const RUNTIME_TELEMETRY_PATH = '/api/v1/telemetry/runtime';
+/** The only event type this relay uploads (CA D-R5). */
+export const RELAY_EVENT_TYPE = 'denied_injection_attempt';
+/** Sentinel package label used when the integrator declares none (CA D-R2). */
+export const SENTINEL_PACKAGE_NAME = '_unattributed';
+
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const CURSOR_FILE = 'correlated-relay-cursor.json';
+
+// Egress validation: the relay GUARANTEES the shape of what leaves the machine
+// rather than trusting the server to reject malformed values after transmission.
+// Record-derived optional fields (techniqueId, techniqueSource, confidence) are
+// validated here and OMITTED if they do not match — a record tampered with
+// locally cannot smuggle free text out via these fields.
+const TECHNIQUE_ID_RE = /^T-\d{1,6}$/;
+const VALID_TECHNIQUE_SOURCES = new Set(['apia', 'interim-mapping']);
+const MAX_AGENT_CATEGORY = 128;
+// Bound on same-millisecond boundary recordIds carried in the cursor. Sub-ms
+// bursts beyond this (astronomically unlikely with ISO ms timestamps) may
+// re-send a few count-only indicators on the next flush — acceptable for
+// best-effort anonymized telemetry, and never a privacy or correctness hazard.
+const MAX_BOUNDARY_IDS = 1000;
+
+/** Cursor persisted between flushes so records are not re-uploaded. */
+interface RelayCursor {
+  /** ISO createdAt of the last fully-handled record. */
+  lastCreatedAt: string;
+  /** recordIds whose createdAt === lastCreatedAt (boundary dedup, capped at MAX_BOUNDARY_IDS). */
+  lastRecordIds: string[];
+}
+
+export interface RelayConfig {
+  /** Master switch for UPLOAD. Default false. Separate from telemetry capture. */
+  enabled?: boolean;
+  /** Registry base URL. Default https://api.oa2a.org. */
+  registryUrl?: string;
+  /** Integrator's self-declared sensor package (public). Default sentinel. */
+  packageName?: string;
+  /** Optional public package version label. */
+  packageVersion?: string;
+  /** Broad agent category (NOT identity). Optional. */
+  agentCategory?: string;
+  /** Data dir holding the local log + cursor. Default ~/.opena2a (OPENA2A_HOME aware). */
+  dataDir?: string;
+  /** Max indicators uploaded per flush. Default 50. */
+  batchSize?: number;
+  /** Managed flush interval (ms). Default 60000. */
+  intervalMs?: number;
+  /** Per-request timeout (ms). Default 10000. */
+  timeoutMs?: number;
+  /** Pre-derived sensor token. Default: sha256(host+user+salt). */
+  sensorToken?: string;
+  /** Injectable fetch (tests). Default global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Optional sink for swallowed errors (best-effort observability). */
+  onError?: (err: unknown) => void;
+}
+
+/** Outcome of a single flush, for tests/observability. Never thrown. */
+export interface FlushResult {
+  /** Records read fresh since the cursor (capped consideration). */
+  considered: number;
+  /** Indicators successfully POSTed this flush. */
+  uploaded: number;
+  /** True if a POST failed and the flush stopped early (cursor not advanced past it). */
+  stoppedOnError: boolean;
+}
+
+/** Resolve the OpenA2A home dir (OPENA2A_HOME override, else ~/.opena2a). */
+export function openA2AHome(): string {
+  return process.env.OPENA2A_HOME || join(homedir(), '.opena2a');
+}
+
+/**
+ * Stable per-device sensor token: sha256(hostname + username + persisted salt).
+ * Uses the SAME salt file as hackmyagent's GTIN module so one device maps to one
+ * anonymous sensor identity across tools. Best-effort; falls back to an ephemeral
+ * token if the salt cannot be persisted.
+ */
+export function deriveSensorToken(dataDir: string = openA2AHome()): string {
+  let salt: string;
+  try {
+    const saltPath = join(dataDir, 'gtin-sensor-salt');
+    if (existsSync(saltPath)) {
+      salt = readFileSync(saltPath, 'utf-8').trim();
+    } else {
+      salt = randomBytes(32).toString('hex');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(saltPath, salt, { mode: 0o600 });
+    }
+  } catch {
+    // Cannot persist a salt — use an ephemeral one. Still anonymous; just not
+    // stable across process restarts.
+    salt = randomBytes(32).toString('hex');
+  }
+
+  let host = 'unknown';
+  let user = 'unknown';
+  try {
+    host = hostname();
+  } catch {
+    /* keep default */
+  }
+  try {
+    user = userInfo().username;
+  } catch {
+    /* keep default */
+  }
+  return createHash('sha256').update(`${host}|${user}|${salt}`).digest('hex');
+}
+
+/** Detect the runtime environment for the shared indicator. */
+export function detectRuntimeEnv(): 'node' | 'python' | 'deno' {
+  if (typeof (globalThis as Record<string, unknown>).Deno !== 'undefined') return 'deno';
+  return 'node';
+}
+
+/**
+ * Whole days since the relay was first used on this device. Marker file shared
+ * with the GTIN module. Best-effort; returns 0 if it cannot be read/written.
+ */
+export function daysSinceInstall(dataDir: string = openA2AHome()): number {
+  try {
+    const markerPath = join(dataDir, 'gtin-install-date');
+    let installDate: Date;
+    if (existsSync(markerPath)) {
+      installDate = new Date(readFileSync(markerPath, 'utf-8').trim());
+      if (isNaN(installDate.getTime())) {
+        installDate = new Date();
+        writeFileSync(markerPath, installDate.toISOString(), { mode: 0o600 });
+      }
+    } else {
+      installDate = new Date();
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(markerPath, installDate.toISOString(), { mode: 0o600 });
+    }
+    const diffMs = Date.now() - installDate.getTime();
+    return Math.max(0, Math.floor(diffMs / (24 * 60 * 60 * 1000)));
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Ships locally-captured causal-denial indicators to the Registry.
+ *
+ * Call {@link start} for a managed unref'd flush timer, or {@link flushOnce}
+ * to drive it manually (tests, one-shot CLI). Inert unless `enabled` is true.
+ */
+export class CorrelatedRelay {
+  private readonly enabled: boolean;
+  private readonly url: string;
+  private readonly packageName: string;
+  private readonly packageVersion?: string;
+  private readonly agentCategory: string;
+  private readonly dataDir: string;
+  private readonly batchSize: number;
+  private readonly intervalMs: number;
+  private readonly timeoutMs: number;
+  private readonly sensorToken: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly onError: (err: unknown) => void;
+
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private flushing = false;
+
+  constructor(config: RelayConfig = {}) {
+    this.enabled = config.enabled === true;
+    this.url = (config.registryUrl ?? DEFAULT_REGISTRY_URL).replace(/\/+$/, '') + RUNTIME_TELEMETRY_PATH;
+    this.packageName = config.packageName?.trim() || SENTINEL_PACKAGE_NAME;
+    this.packageVersion = config.packageVersion?.trim() || undefined;
+    this.agentCategory = (config.agentCategory?.trim() || 'unspecified').slice(0, MAX_AGENT_CATEGORY);
+    this.dataDir = config.dataDir ?? openA2AHome();
+    this.batchSize = config.batchSize && config.batchSize > 0 ? config.batchSize : DEFAULT_BATCH_SIZE;
+    this.intervalMs = config.intervalMs && config.intervalMs > 0 ? config.intervalMs : DEFAULT_INTERVAL_MS;
+    this.timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS;
+    this.sensorToken = config.sensorToken || deriveSensorToken(this.dataDir);
+    this.fetchImpl = config.fetchImpl ?? globalThis.fetch;
+    this.onError = config.onError ?? (() => {});
+  }
+
+  /** Start a managed flush interval. No-op when disabled or already running. */
+  start(): void {
+    if (!this.enabled || this.timer) return;
+    this.timer = setInterval(() => {
+      void this.flushOnce();
+    }, this.intervalMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  /** Stop the managed interval. Does not flush. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  /**
+   * Read fresh records, upload eligible indicators, advance the cursor. Never
+   * throws. Returns a summary. Re-entrancy-guarded so overlapping timer ticks
+   * cannot double-send.
+   */
+  async flushOnce(): Promise<FlushResult> {
+    const result: FlushResult = { considered: 0, uploaded: 0, stoppedOnError: false };
+    if (!this.enabled || this.flushing) return result;
+    this.flushing = true;
+    try {
+      const cursor = this.readCursor();
+      const fresh = this.readFresh(cursor);
+      result.considered = fresh.length;
+      if (fresh.length === 0) return result;
+
+      // Build the sensor-level context once; it is identical for every record.
+      const ctx: SharedIndicatorContext = {
+        sensorToken: this.sensorToken,
+        agentCategory: this.agentCategory,
+        daySinceInstall: daysSinceInstall(this.dataDir),
+        runtimeEnv: detectRuntimeEnv(),
+      };
+
+      let lastCreatedAt = cursor?.lastCreatedAt;
+      let boundaryIds: string[] = cursor ? [...cursor.lastRecordIds] : [];
+
+      for (const rec of fresh) {
+        if (result.uploaded >= this.batchSize) break;
+
+        const indicator = toSharedIndicator(rec, ctx);
+        if (indicator.eventType === RELAY_EVENT_TYPE) {
+          const outcome = await this.post(indicator);
+          if (outcome === 'failed') {
+            // Transient failure: leave this record (and the rest) for the next
+            // flush; do NOT advance the cursor past it.
+            result.stoppedOnError = true;
+            break;
+          }
+          if (outcome === 'uploaded') result.uploaded++;
+          // 'rejected' (4xx): non-retryable, advance the cursor without counting.
+        }
+
+        // Record handled (uploaded, or skipped because ineligible). Advance.
+        if (rec.createdAt === lastCreatedAt) {
+          boundaryIds.push(rec.recordId);
+          // Bound the boundary set (see MAX_BOUNDARY_IDS). Keep the most recent.
+          if (boundaryIds.length > MAX_BOUNDARY_IDS) {
+            boundaryIds = boundaryIds.slice(-MAX_BOUNDARY_IDS);
+          }
+        } else {
+          lastCreatedAt = rec.createdAt;
+          boundaryIds = [rec.recordId];
+        }
+      }
+
+      if (lastCreatedAt && lastCreatedAt !== cursor?.lastCreatedAt) {
+        this.writeCursor({ lastCreatedAt, lastRecordIds: boundaryIds });
+      } else if (lastCreatedAt && boundaryIds.length !== (cursor?.lastRecordIds.length ?? 0)) {
+        this.writeCursor({ lastCreatedAt, lastRecordIds: boundaryIds });
+      }
+    } catch (err) {
+      this.onError(err);
+    } finally {
+      this.flushing = false;
+    }
+    return result;
+  }
+
+  /**
+   * Records not yet handled, in stable (createdAt, recordId) order. Assumes the
+   * local log's `createdAt` is roughly monotonic (it is — records are appended
+   * in assembly order by a single writer). A record appended out of order with
+   * a `createdAt` earlier than the cursor is skipped; this is acceptable
+   * best-effort data loss for anonymized count telemetry, never a correctness
+   * hazard for the records that are sent.
+   */
+  private readFresh(cursor: RelayCursor | undefined): CorrelatedRecord[] {
+    // `since` filters createdAt > since; subtract 1ms so the boundary timestamp
+    // is included, then dedup precisely against the boundary recordIds.
+    const sinceParam = cursor
+      ? new Date(new Date(cursor.lastCreatedAt).getTime() - 1).toISOString()
+      : undefined;
+    const records = readCorrelatedRecords(this.dataDir, sinceParam ? { since: sinceParam } : undefined);
+
+    const cutoff = cursor ? new Date(cursor.lastCreatedAt).getTime() : -Infinity;
+    const fresh = records.filter((r) => {
+      const t = new Date(r.createdAt).getTime();
+      if (t > cutoff) return true;
+      if (t === cutoff && cursor) return !cursor.lastRecordIds.includes(r.recordId);
+      return false;
+    });
+
+    fresh.sort((a, b) => {
+      const ta = new Date(a.createdAt).getTime();
+      const tb = new Date(b.createdAt).getTime();
+      if (ta !== tb) return ta - tb;
+      return a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0;
+    });
+    return fresh;
+  }
+
+  /**
+   * POST one indicator. Never throws.
+   *   - 'uploaded': 2xx — counted and cursor advances.
+   *   - 'rejected': 4xx — non-retryable (bad/duplicate indicator); cursor
+   *      advances but it is NOT counted as an upload.
+   *   - 'failed':   5xx / network / timeout — transient; cursor stays put.
+   */
+  private async post(indicator: SharedIndicator): Promise<'uploaded' | 'rejected' | 'failed'> {
+    const body: Record<string, unknown> = {
+      schemaVersion: TELEMETRY_SCHEMA_VERSION,
+      sensorToken: indicator.sensorToken,
+      eventType: indicator.eventType,
+      packageName: this.packageName,
+      runtimeEnv: indicator.runtimeEnv,
+      triggeredAt: indicator.triggeredAt,
+      daySinceInstall: indicator.daySinceInstall,
+      enforcementOutcome: indicator.enforcementOutcome,
+      agentCategory: indicator.agentCategory,
+    };
+    if (this.packageVersion) body.packageVersion = this.packageVersion;
+    // Validate record-derived optional fields before egress; omit on mismatch
+    // so malformed/tampered values never leave the machine.
+    if (indicator.techniqueId && TECHNIQUE_ID_RE.test(indicator.techniqueId)) {
+      body.techniqueId = indicator.techniqueId;
+    }
+    if (indicator.techniqueSource && VALID_TECHNIQUE_SOURCES.has(indicator.techniqueSource)) {
+      body.techniqueSource = indicator.techniqueSource;
+    }
+    if (
+      typeof indicator.detectionConfidence === 'number' &&
+      indicator.detectionConfidence >= 0 &&
+      indicator.detectionConfidence <= 1
+    ) {
+      body.detectionConfidence = indicator.detectionConfidence;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(this.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'OpenA2A-AIM-SDK-Relay',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      // 4xx (bad/duplicate indicator) is non-retryable from our side: treat as
+      // handled so the cursor advances. Only 5xx / network errors block.
+      if (res.ok) return 'uploaded';
+      if (res.status >= 400 && res.status < 500) {
+        this.onError(new Error(`relay rejected indicator: HTTP ${res.status}`));
+        return 'rejected';
+      }
+      this.onError(new Error(`relay upload failed: HTTP ${res.status}`));
+      return 'failed';
+    } catch (err) {
+      this.onError(err);
+      return 'failed';
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private cursorPath(): string {
+    return join(this.dataDir, CURSOR_FILE);
+  }
+
+  private readCursor(): RelayCursor | undefined {
+    try {
+      const raw = readFileSync(this.cursorPath(), 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<RelayCursor>;
+      if (typeof parsed.lastCreatedAt === 'string' && Array.isArray(parsed.lastRecordIds)) {
+        return { lastCreatedAt: parsed.lastCreatedAt, lastRecordIds: parsed.lastRecordIds };
+      }
+    } catch {
+      // No cursor yet, or corrupt — start from the beginning.
+    }
+    return undefined;
+  }
+
+  private writeCursor(cursor: RelayCursor): void {
+    try {
+      mkdirSync(this.dataDir, { recursive: true });
+      writeFileSync(this.cursorPath(), JSON.stringify(cursor), { mode: 0o600 });
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+}

--- a/sdk/typescript/src/telemetry/relay.ts
+++ b/sdk/typescript/src/telemetry/relay.ts
@@ -26,7 +26,7 @@
 import { createHash, randomBytes } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync, chmodSync } from 'fs';
 import { hostname, userInfo, homedir } from 'os';
-import { join } from 'path';
+import { join, isAbsolute, resolve } from 'path';
 import {
   toSharedIndicator,
   TELEMETRY_SCHEMA_VERSION,
@@ -109,9 +109,19 @@ export interface FlushResult {
   stoppedOnError: boolean;
 }
 
-/** Resolve the OpenA2A home dir (OPENA2A_HOME override, else ~/.opena2a). */
+/**
+ * Resolve the OpenA2A home dir. An operator may override it with OPENA2A_HOME,
+ * but only an ABSOLUTE path is honored, and it is canonicalized with resolve()
+ * so a value like `/a/../b` collapses to its real location (no unresolved `..`
+ * segments). A relative or empty value is ignored in favor of ~/.opena2a rather
+ * than creating files relative to the current working directory.
+ */
 export function openA2AHome(): string {
-  return process.env.OPENA2A_HOME || join(homedir(), '.opena2a');
+  const configured = process.env.OPENA2A_HOME;
+  if (configured && isAbsolute(configured)) {
+    return resolve(configured);
+  }
+  return join(homedir(), '.opena2a');
 }
 
 /**

--- a/sdk/typescript/src/telemetry/relay.ts
+++ b/sdk/typescript/src/telemetry/relay.ts
@@ -24,7 +24,7 @@
  * and best-effort: a failure is swallowed and never affects verifyAction.
  */
 import { createHash, randomBytes } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync, chmodSync } from 'fs';
 import { hostname, userInfo, homedir } from 'os';
 import { join } from 'path';
 import {
@@ -115,6 +115,46 @@ export function openA2AHome(): string {
 }
 
 /**
+ * Read the persisted salt, or create a fresh owner-only one. The salt's
+ * confidentiality is what anonymizes the sensor token (host+user are
+ * low-entropy), so an EXISTING salt is reused only when it is a regular file,
+ * owned by us, with no group/other permission bits. A pre-created
+ * world-readable or wrong-owner salt is NOT trusted: it is overwritten with a
+ * fresh 0600 salt, closing the "attacker pre-creates a readable salt to
+ * de-anonymize the sensor token" vector. Permission checks apply on POSIX only
+ * (mode bits are not meaningful on Windows, where ACLs govern access).
+ */
+function loadOrCreateSalt(dataDir: string): string {
+  const saltPath = join(dataDir, 'gtin-sensor-salt');
+  const isPosix = typeof process.getuid === 'function';
+  if (existsSync(saltPath)) {
+    try {
+      const st = statSync(saltPath);
+      const ownerOnly = !isPosix || (st.mode & 0o077) === 0;
+      const sameOwner = !isPosix || st.uid === process.getuid!();
+      if (st.isFile() && ownerOnly && sameOwner) {
+        const existing = readFileSync(saltPath, 'utf-8').trim();
+        if (existing) return existing;
+      }
+      // Untrusted (loose perms, wrong owner, not a file, or empty) — replace it.
+    } catch {
+      // fall through to (re)create
+    }
+  }
+  const salt = randomBytes(32).toString('hex');
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(saltPath, salt, { mode: 0o600 });
+  // Tighten perms even if the file pre-existed with looser bits (writeFileSync
+  // does not chmod an existing file). Best-effort on platforms without chmod.
+  try {
+    chmodSync(saltPath, 0o600);
+  } catch {
+    /* best-effort */
+  }
+  return salt;
+}
+
+/**
  * Stable per-device sensor token: sha256(hostname + username + persisted salt).
  * Uses the SAME salt file as hackmyagent's GTIN module so one device maps to one
  * anonymous sensor identity across tools. Best-effort; falls back to an ephemeral
@@ -123,14 +163,7 @@ export function openA2AHome(): string {
 export function deriveSensorToken(dataDir: string = openA2AHome()): string {
   let salt: string;
   try {
-    const saltPath = join(dataDir, 'gtin-sensor-salt');
-    if (existsSync(saltPath)) {
-      salt = readFileSync(saltPath, 'utf-8').trim();
-    } else {
-      salt = randomBytes(32).toString('hex');
-      mkdirSync(dataDir, { recursive: true });
-      writeFileSync(saltPath, salt, { mode: 0o600 });
-    }
+    salt = loadOrCreateSalt(dataDir);
   } catch {
     // Cannot persist a salt — use an ephemeral one. Still anonymous; just not
     // stable across process restarts.
@@ -154,7 +187,12 @@ export function deriveSensorToken(dataDir: string = openA2AHome()): string {
 
 /** Detect the runtime environment for the shared indicator. */
 export function detectRuntimeEnv(): 'node' | 'python' | 'deno' {
-  if (typeof (globalThis as Record<string, unknown>).Deno !== 'undefined') return 'deno';
+  try {
+    if (typeof (globalThis as Record<string, unknown>).Deno !== 'undefined') return 'deno';
+  } catch {
+    // A hostile globalThis accessor (e.g. a throwing Proxy trap) must not abort
+    // the flush — default to node.
+  }
   return 'node';
 }
 
@@ -405,6 +443,13 @@ export class CorrelatedRelay {
     }
   }
 
+  // Cursor persistence assumes a SINGLE relay process per dataDir (the common
+  // case: one SDK instance per agent process). It is not file-locked: two
+  // processes sharing a dataDir can race and re-send overlapping batches. That
+  // only produces duplicate count-only indicators on the public endpoint —
+  // acceptable for best-effort anonymized telemetry — and never corrupts a
+  // record or leaks data. Locking is intentionally omitted to avoid a native
+  // dependency for a count-only relay.
   private cursorPath(): string {
     return join(this.dataDir, CURSOR_FILE);
   }

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -2,7 +2,7 @@
  * AIM SDK Type Definitions
  */
 
-import type { CorrelationJoiner, IntentInput, DetectionInput } from '../telemetry';
+import type { CorrelationJoiner, IntentInput, DetectionInput, RelayConfig } from '../telemetry';
 
 /**
  * Agent types supported by AIM
@@ -99,6 +99,13 @@ export interface TelemetryConfig {
   joiner?: CorrelationJoiner;
   /** Stamped onto the enforcement fact's `source`. Default 'aim-pdp'. */
   enforcementSource?: string;
+  /**
+   * Stage-2 opt-in: ship anonymized indicators from the local log to the
+   * Registry. Inert unless BOTH `enabled` (above, capture) and `relay.enabled`
+   * (share) are true. Only anonymized `SharedIndicator`s leave the machine —
+   * never full correlated records. When omitted, nothing is uploaded.
+   */
+  relay?: RelayConfig;
 }
 
 /**


### PR DESCRIPTION
## What

Ships the missing **relay leg** of the causal-denial telemetry pipeline: the SDK now reduces locally-captured correlated records to anonymized **shared indicators** and uploads them to the Registry. This closes the SDK→Registry gap (the local JSONL had no path to the deployed ingest endpoint).

The full correlated record stays on the machine and is authoritative; **only the anonymized indicator leaves**.

## How

- **`src/telemetry/relay.ts` (new) — `CorrelatedRelay`:** reads `~/.opena2a/correlated-events.jsonl` on a disk cursor (boundary-dedup, capped), reduces each record via `toSharedIndicator`, filters to `denied_injection_attempt`, and POSTs on a batched, `unref`'d timer. Three-way upload outcome: `2xx` advances the cursor and counts; `4xx` advances (non-retryable rejection); `5xx`/network blocks the cursor and retries next flush. Best-effort — never throws into the enforcement path.
- **Egress validation:** record-derived optional fields (`techniqueId`, `techniqueSource`, `detectionConfidence`) are validated **before** transmission and omitted on mismatch, so a locally-tampered record can't smuggle free text out (the SDK guarantees the indicator shape rather than trusting the server to reject it).
- **`AIMClient` wiring:** stage-2 opt-in `telemetry.relay.enabled`, gated independently of capture (`telemetry.enabled`); lazily started alongside the joiner, stopped by `closeTelemetry`.
- Exported at the package top level; README documents the two-stage consent and exactly which fields the indicator carries.

## CA decision

- **D-R1** target the **public, count-only** `POST /api/v1/telemetry/runtime` — end-user SDK installs hold no `internal:telemetry:write` service-account token; the authenticated `/internal/telemetry/denial-correlated` path is reserved for a trusted internal aggregator. Anonymous field telemetry stays count-only and never mutates curated data (CA D-B1).
- **D-R2** `gtin_events.package_name` is NOT NULL, but the indicator omits identifiers → `packageName` is attached at POST time from static relay config (the integrator's self-declared sensor package), default sentinel `_unattributed`. **No Registry change** (SDK-only).
- **D-R3** relay has its own master switch, default **off**, separate from capture (two-stage consent).
- **D-R4** reduce via `toSharedIndicator` only; never the full record.
- **D-R5** upload only `denied_injection_attempt`.

## Privacy

The shared indicator carries **no** payloads, paths, credentials, resource/capability names, correlation ID, agent ID, or denial reason. It carries a validated `T-NNNN` technique id + source, a confidence, the coarse `deny`/`allow` outcome, the self-declared `packageName`/`agentCategory`, `daySinceInstall`, `runtimeEnv`, `triggeredAt`, and a stable per-device pseudonym `sensorToken` (`sha256(host+user+local salt)`).

## Testing

- 455 SDK tests pass (12 relay + 13 AIMClient telemetry, incl. a malicious-`techniqueId`-is-dropped test and cursor stop-on-failure). tsc + build clean.
- 8-phase pre-push review run; adversarial self-review surfaced and fixed a HIGH (unvalidated egress) and a broken top-level export before push.

## Not in this PR (follow-ups)

- Two hardening MEDIUMs (joiner `maxBuffers` cap; defer default-sink `fs.appendFileSync` off the verify path) — only needed before telemetry goes on-by-default.
- Arch-site (`opena2a-architecture`) AIM/ARC runtime page update — after the flow is verified end-to-end in prod.