### PR TITLE
feat(telemetry): harden joiner — bounded buffers + deferred default-sink write

### DIFF
--- a/sdk/typescript/src/telemetry/joiner.defer.test.ts
+++ b/sdk/typescript/src/telemetry/joiner.defer.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The joiner's DEFAULT sink must defer the synchronous disk write off the
+ * caller's stack, so the full-record case never adds fs.appendFileSync latency
+ * to the verifyAction path. local-writer is mocked so this test touches no disk.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./local-writer', () => ({
+  writeCorrelatedRecord: vi.fn(() => true),
+  readCorrelatedRecords: vi.fn(() => []),
+  defaultDataDir: vi.fn(() => '/tmp/never-written'),
+}));
+
+import { CorrelationJoiner } from './joiner';
+import { writeCorrelatedRecord } from './local-writer';
+
+const CID = 'cde_000000000_aabbccddeeff';
+
+function feedFullRecord(joiner: CorrelationJoiner): void {
+  joiner.ingestEnforcement({
+    correlationId: CID,
+    agentId: 'agent-1',
+    enforcement: {
+      decision: 'deny',
+      outcome: 'DENY_INTENT',
+      capability: 'fs:write',
+      resource: '/etc/x',
+      occurredAt: '2026-06-06T00:00:00.000Z',
+      source: 'aim-pdp',
+    },
+  });
+  joiner.ingestIntent({
+    correlationId: CID,
+    intent: { intentClass: 'exfil', confidence: 0.7, blocked: true, source: 'nm-intent' },
+  });
+  joiner.ingestDetection({
+    correlationId: CID,
+    detection: {
+      injectionDetected: true,
+      techniqueId: 'T-2002',
+      techniqueSource: 'interim-mapping',
+      confidence: 0.84,
+      detector: 'nanomind-guard',
+      detectedAt: '2026-06-06T00:00:00.000Z',
+    },
+  });
+}
+
+describe('default sink defers the disk write', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not write synchronously on emit, but writes on the next tick', () => {
+    const joiner = new CorrelationJoiner({ windowMs: 60_000 }); // default (deferred) sink
+    feedFullRecord(joiner);
+
+    // The record assembled synchronously, but the disk write is deferred.
+    expect(writeCorrelatedRecord).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    expect(writeCorrelatedRecord).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/typescript/src/telemetry/joiner.test.ts
+++ b/sdk/typescript/src/telemetry/joiner.test.ts
@@ -136,4 +136,25 @@ describe('CorrelationJoiner', () => {
     expect(h.records).toHaveLength(1); // first id completed
     expect(h.joiner.pending).toBe(1); // second id still waiting
   });
+
+  it('caps buffered correlation IDs with oldest-eviction', () => {
+    const records: CorrelatedRecord[] = [];
+    const joiner = new CorrelationJoiner({
+      windowMs: 60_000,
+      maxBuffers: 3,
+      onRecord: (r) => records.push(r),
+    });
+    const mk = (s: string) => `cde_000000000_${s}`;
+    // Four distinct IDs into a cap of 3 — the oldest ('a') is evicted.
+    ['aaaaaaaaaaaa', 'bbbbbbbbbbbb', 'cccccccccccc', 'dddddddddddd'].forEach((s) =>
+      joiner.ingestEnforcement(enforcement(mk(s)))
+    );
+    expect(joiner.pending).toBe(3);
+    expect(joiner.droppedOverflow).toBe(1);
+
+    // The newest survivor ('d') still completes normally — eviction took the oldest.
+    joiner.ingestIntent(intent(mk('dddddddddddd')));
+    joiner.ingestDetection(detection(mk('dddddddddddd')));
+    expect(records).toHaveLength(1);
+  });
 });

--- a/sdk/typescript/src/telemetry/joiner.ts
+++ b/sdk/typescript/src/telemetry/joiner.ts
@@ -26,6 +26,25 @@ import {
 import { writeCorrelatedRecord } from './local-writer';
 
 const DEFAULT_WINDOW_MS = 5000;
+// Hard cap on buffered correlation IDs. Without it, a flood of IDs arriving
+// faster than the flush interval clears them grows the Map unboundedly (memory
+// exhaustion). At the cap, the oldest buffer is evicted to admit the new one.
+const DEFAULT_MAX_BUFFERS = 10_000;
+
+/**
+ * Defer a synchronous disk write off the caller's stack. The default sink runs
+ * on the verifyAction path when a full record assembles inline; deferring keeps
+ * fs.appendFileSync latency off that path. Falls back to setTimeout where
+ * setImmediate is unavailable (non-Node runtimes).
+ */
+const deferWrite: (record: CorrelatedRecord) => void =
+  typeof setImmediate === 'function'
+    ? (record) => {
+        setImmediate(() => void writeCorrelatedRecord(record));
+      }
+    : (record) => {
+        setTimeout(() => void writeCorrelatedRecord(record), 0);
+      };
 
 export interface EnforcementEvent {
   correlationId: string;
@@ -46,10 +65,12 @@ export interface JoinerOptions {
   windowMs?: number;
   /** Clock source (ms). Default Date.now. Injected for deterministic tests. */
   now?: () => number;
-  /** Sink for assembled records. Default: append to the local log. */
+  /** Sink for assembled records. Default: append to the local log (deferred). */
   onRecord?: (record: CorrelatedRecord) => void;
   /** Stamped into assembly.joinerVersion. */
   joinerVersion?: string;
+  /** Max buffered correlation IDs before oldest-eviction. Default 10000. */
+  maxBuffers?: number;
 }
 
 interface Buffer {
@@ -69,17 +90,21 @@ export class CorrelationJoiner {
   private readonly now: () => number;
   private readonly onRecord: (record: CorrelatedRecord) => void;
   private readonly joinerVersion: string;
+  private readonly maxBuffers: number;
   private readonly buffers = new Map<string, Buffer>();
   private timer: ReturnType<typeof setInterval> | undefined;
 
   /** Count of part-sets dropped for never receiving an enforcement fact. */
   public droppedOrphans = 0;
+  /** Count of buffers evicted because the maxBuffers cap was reached. */
+  public droppedOverflow = 0;
 
   constructor(options: JoinerOptions = {}) {
     this.windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
     this.now = options.now ?? Date.now;
-    this.onRecord = options.onRecord ?? ((r) => void writeCorrelatedRecord(r));
+    this.onRecord = options.onRecord ?? deferWrite;
     this.joinerVersion = options.joinerVersion ?? TELEMETRY_SCHEMA_VERSION;
+    this.maxBuffers = options.maxBuffers && options.maxBuffers > 0 ? options.maxBuffers : DEFAULT_MAX_BUFFERS;
   }
 
   /** Number of correlation IDs currently buffered. */
@@ -140,6 +165,16 @@ export class CorrelationJoiner {
   private bufferFor(correlationId: string): Buffer {
     let buf = this.buffers.get(correlationId);
     if (!buf) {
+      // Enforce the hard cap before admitting a new ID. Map preserves insertion
+      // order and firstSeenMs is stamped at insertion, so the first entry is the
+      // oldest — evict it (oldest-eviction).
+      if (this.buffers.size >= this.maxBuffers) {
+        const oldest = this.buffers.keys().next().value;
+        if (oldest !== undefined) {
+          this.buffers.delete(oldest);
+          this.droppedOverflow++;
+        }
+      }
       buf = { firstSeenMs: this.now() };
       this.buffers.set(correlationId, buf);
     }


### PR DESCRIPTION
## What

The two non-blocking hardening MEDIUMs flagged in PR #277's adversarial review, needed before causal-denial telemetry goes on-by-default. Independent of (and non-overlapping with) the relay PR #278.

- **Bounded joiner buffers.** `CorrelationJoiner`'s buffer Map was bounded only by `window × throughput` — a flood of correlation IDs arriving faster than the flush interval clears them could exhaust memory. Adds a `maxBuffers` hard cap (default 10000) with **oldest-eviction** (Map insertion order = age order, so the first entry is the oldest). A `droppedOverflow` counter tracks evictions.
- **Deferred default-sink write.** The default sink did a synchronous `fs.appendFileSync`. When a full record assembles inline during `verifyAction`, that disk write added latency to the enforcement path. It is now deferred to a microtask (`setImmediate`, `setTimeout(0)` fallback for non-Node runtimes). Supplied custom sinks are unaffected.

Both remain off the enforcement path and best-effort.

## Testing

- 442 SDK tests pass (2 new: `maxBuffers` oldest-eviction in `joiner.test.ts`; a disk-free deferral test in `joiner.defer.test.ts` that mocks `local-writer` and asserts the write is scheduled, not synchronous). tsc + build clean.
- Pre-push review run (Phases 1–4, 7; 4.5/5/6 N/A — no detection/scoring, no server, no CLI/API surface). HMA 95/100, only the pre-existing package.json identity MEDIUM.

## Relationship to #278

Touches only `joiner.ts` / its tests — no overlap with #278's files (`relay.ts`, `AIMClient.ts`, `types`, `index`, `README`). Either can merge first.