### PR TITLE
fix(telemetry): align auto-joiner write dir with the relay read dir

### DIFF
--- a/sdk/typescript/src/client/AIMClient.telemetry.test.ts
+++ b/sdk/typescript/src/client/AIMClient.telemetry.test.ts
@@ -329,6 +329,48 @@ describe('AIMClient causal-denial telemetry', () => {
       client.closeTelemetry();
     });
 
+    it('auto-joiner writes where the relay reads — full path uploads with no manual seed', async () => {
+      // Regression: relay.dataDir must also steer the auto-created joiner, or the
+      // relay reads an empty dir and silently uploads nothing.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cde-aimclient-align-'));
+      tmpDirs.push(dir);
+      const relayFetch = vi.fn(async () => ({
+        ok: true,
+        status: 201,
+        json: async () => ({ eventId: 'e1' }),
+        text: async () => '',
+      }));
+      const client = new AIMClient({
+        telemetry: {
+          enabled: true,
+          // No supplied joiner: AIMClient creates one and must point it at `dir`.
+          relay: {
+            enabled: true,
+            dataDir: dir,
+            intervalMs: 10,
+            fetchImpl: relayFetch as unknown as typeof fetch,
+          },
+        },
+      });
+      client.setCredentials(await realCredentials());
+      mockVerifyResponse({ actionAllowed: false, denialReason: 'blocked: injected exfil' });
+
+      await expect(
+        client.verifyAction({
+          action: 'net:connect',
+          resource: 'https://evil.example',
+          telemetry: { intent: SAMPLE_INTENT, detection: SAMPLE_DETECTION },
+        })
+      ).rejects.toThrow(ActionDeniedError);
+
+      // The denied-injection record assembled by the auto-joiner lands in `dir`,
+      // the relay reads it, and uploads — no manual seeding involved.
+      await vi.waitFor(() => expect(relayFetch).toHaveBeenCalled(), { timeout: 1500 });
+      const body = JSON.parse((relayFetch.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.eventType).toBe('denied_injection_attempt');
+      client.closeTelemetry();
+    });
+
     it('does NOT start the relay when only capture is enabled', async () => {
       const dir = relayDir();
       const relayFetch = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({}), text: async () => '' }));

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -35,6 +35,7 @@ import {
   CorrelatedRelay,
   correlationHeaders,
   mintCorrelationId,
+  openA2AHome,
   type EnforcementInput,
   type RelayConfig,
 } from '../telemetry';
@@ -84,6 +85,9 @@ export class AIMClient {
   // Stage-2 opt-in: upload anonymized indicators to the Registry.
   private readonly relayConfig: RelayConfig | null;
   private ownRelay: CorrelatedRelay | undefined;
+  // Single resolved telemetry dir shared by the auto-joiner sink and the relay,
+  // so the relay always reads exactly where the joiner writes.
+  private readonly telemetryDir: string;
 
   constructor(config: AIMClientConfig = {}) {
     this.config = {
@@ -102,6 +106,9 @@ export class AIMClient {
     this.enforcementSource = telemetry.enforcementSource ?? DEFAULT_ENFORCEMENT_SOURCE;
     this.suppliedJoiner = telemetry.joiner ?? null;
     this.relayConfig = telemetry.relay ?? null;
+    // Resolve once: a relay.dataDir override (else ~/.opena2a) is the single
+    // location both the auto-joiner sink and the relay use.
+    this.telemetryDir = this.relayConfig?.dataDir ?? openA2AHome();
 
     // Try to load credentials from environment
     this.credentials = loadCredentialsFromEnv();
@@ -408,7 +415,9 @@ export class AIMClient {
     this.ensureRelay();
     if (this.suppliedJoiner) return this.suppliedJoiner;
     if (!this.ownJoiner) {
-      this.ownJoiner = new CorrelationJoiner();
+      // Write to the same dir the relay reads, so an enabled relay actually
+      // finds the records this joiner produces.
+      this.ownJoiner = new CorrelationJoiner({ dataDir: this.telemetryDir });
       this.ownJoiner.start();
     }
     return this.ownJoiner;
@@ -422,7 +431,8 @@ export class AIMClient {
   private ensureRelay(): void {
     if (!this.telemetryEnabled || this.relayConfig?.enabled !== true) return;
     if (this.ownRelay) return;
-    this.ownRelay = new CorrelatedRelay(this.relayConfig);
+    // Pin the relay to the same resolved dir as the auto-joiner sink.
+    this.ownRelay = new CorrelatedRelay({ ...this.relayConfig, dataDir: this.telemetryDir });
     this.ownRelay.start();
   }
 

--- a/sdk/typescript/src/telemetry/joiner.defer.test.ts
+++ b/sdk/typescript/src/telemetry/joiner.defer.test.ts
@@ -65,4 +65,14 @@ describe('default sink defers the disk write', () => {
     vi.runAllTimers();
     expect(writeCorrelatedRecord).toHaveBeenCalledTimes(1);
   });
+
+  it('forwards the configured dataDir to the writer (so it matches the relay)', () => {
+    const joiner = new CorrelationJoiner({ windowMs: 60_000, dataDir: '/custom/telemetry/dir' });
+    feedFullRecord(joiner);
+    vi.runAllTimers();
+    expect(writeCorrelatedRecord).toHaveBeenCalledTimes(1);
+    expect((writeCorrelatedRecord as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][1]).toBe(
+      '/custom/telemetry/dir'
+    );
+  });
 });

--- a/sdk/typescript/src/telemetry/joiner.ts
+++ b/sdk/typescript/src/telemetry/joiner.ts
@@ -35,16 +35,16 @@ const DEFAULT_MAX_BUFFERS = 10_000;
  * Defer a synchronous disk write off the caller's stack. The default sink runs
  * on the verifyAction path when a full record assembles inline; deferring keeps
  * fs.appendFileSync latency off that path. Falls back to setTimeout where
- * setImmediate is unavailable (non-Node runtimes).
+ * setImmediate is unavailable (non-Node runtimes). When `dataDir` is given the
+ * record is written there (so it matches where the relay reads); otherwise the
+ * writer's default (~/.opena2a) is used.
  */
-const deferWrite: (record: CorrelatedRecord) => void =
-  typeof setImmediate === 'function'
-    ? (record) => {
-        setImmediate(() => void writeCorrelatedRecord(record));
-      }
-    : (record) => {
-        setTimeout(() => void writeCorrelatedRecord(record), 0);
-      };
+const schedule: (fn: () => void) => void =
+  typeof setImmediate === 'function' ? (fn) => void setImmediate(fn) : (fn) => void setTimeout(fn, 0);
+
+function deferWrite(record: CorrelatedRecord, dataDir?: string): void {
+  schedule(() => void writeCorrelatedRecord(record, dataDir));
+}
 
 export interface EnforcementEvent {
   correlationId: string;
@@ -71,6 +71,12 @@ export interface JoinerOptions {
   joinerVersion?: string;
   /** Max buffered correlation IDs before oldest-eviction. Default 10000. */
   maxBuffers?: number;
+  /**
+   * Directory the DEFAULT sink writes to (must match where the relay reads).
+   * Ignored when a custom `onRecord` is supplied. Defaults to the writer's
+   * ~/.opena2a.
+   */
+  dataDir?: string;
 }
 
 interface Buffer {
@@ -102,7 +108,8 @@ export class CorrelationJoiner {
   constructor(options: JoinerOptions = {}) {
     this.windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
     this.now = options.now ?? Date.now;
-    this.onRecord = options.onRecord ?? deferWrite;
+    const dataDir = options.dataDir;
+    this.onRecord = options.onRecord ?? ((r) => deferWrite(r, dataDir));
     this.joinerVersion = options.joinerVersion ?? TELEMETRY_SCHEMA_VERSION;
     this.maxBuffers = options.maxBuffers && options.maxBuffers > 0 ? options.maxBuffers : DEFAULT_MAX_BUFFERS;
   }


### PR DESCRIPTION
## What

Closes the integration sharp-edge found during the end-to-end smoke after #278/#279 merged: the relay reads `relay.dataDir` (or `~/.opena2a`), but the AIMClient-created joiner's default sink wrote to `~/.opena2a` unconditionally. Setting `relay.dataDir` to any other path made the relay read an **empty dir and silently upload nothing**. Default usage (no override) worked because both resolved to `~/.opena2a`.

## How

- `CorrelationJoiner` gains a `dataDir` option; its default (deferred) sink writes there, preserving the off-path `setImmediate` behavior from #279.
- `AIMClient` resolves a single telemetry dir (`relay.dataDir ?? openA2AHome()`) and passes it to **both** the auto-joiner and the relay, so they can never diverge.
- A supplied custom joiner is untouched (the caller owns its sink/dir).

## Testing

- 463 tests pass (3 new): joiner forwards `dataDir` to the writer; AIMClient drives the **full path** with `relay.dataDir` set and **no manual seed**, asserting the relay uploads a `denied_injection_attempt` indicator (the regression guard).
- Re-ran the local end-to-end smoke: with this fix, `relay.dataDir` alone is sufficient (the earlier run needed a custom-joiner workaround).
- Pre-push review: Phases 1–4 (4.5/5/6 N/A). HMA 95/100 (only the pre-existing package.json identity MEDIUM).

## Context

Follow-up to the causal-denial telemetry relay (#278) and joiner hardening (#279), both merged. The end-to-end flow is verified via a local capture server applying the registry's real validation rules; no staging registry exists and no prod write was made.