### PR TITLE
fix(sdk-cli): stop doubling the Token exchange failed prefix

### DIFF
--- a/sdk/python/aim_sdk/cli.py
+++ b/sdk/python/aim_sdk/cli.py
@@ -271,8 +271,24 @@ def exchange_code_for_tokens(aim_url: str, code: str, code_verifier: str, redire
         if response.status_code == 200:
             return response.json()
         else:
-            error_data = response.json() if response.content else {}
-            return {'error': error_data.get('error', f'Token exchange failed: {response.status_code}')}
+            # Return a BARE reason — the caller prefixes "Token exchange failed: ".
+            # (Previously this returned a pre-prefixed string, so login() printed
+            # "Token exchange failed: Token exchange failed: 405".) Prefer the
+            # server's human-readable error_description, then error, then a status
+            # line that hints at the most common misconfiguration: pointing the SDK
+            # at the dashboard/frontend URL instead of the AIM API base.
+            try:
+                error_data = response.json() if response.content else {}
+            except ValueError:
+                error_data = {}
+            reason = error_data.get('error_description') or error_data.get('error')
+            if not reason:
+                reason = (
+                    f"HTTP {response.status_code} from {token_url} — verify the "
+                    f"server URL is the AIM API base (e.g. https://api.aim.opena2a.org), "
+                    f"not the dashboard URL"
+                )
+            return {'error': reason}
     except requests.RequestException as e:
         return {'error': f'Network error: {str(e)}'}
 

--- a/sdk/python/tests/test_cli_token_exchange.py
+++ b/sdk/python/tests/test_cli_token_exchange.py
@@ -1,0 +1,71 @@
+"""
+Regression tests for the SDK CLI OAuth token exchange error handling.
+
+Guards against the doubled "Token exchange failed: Token exchange failed: <status>"
+prefix: exchange_code_for_tokens() returned a pre-prefixed string and login()
+prefixed it again. The reason returned here must be BARE (the caller adds the
+single "Token exchange failed: " prefix) and should prefer the server's
+human-readable error_description.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from aim_sdk.cli import exchange_code_for_tokens
+
+ARGS = ("https://api.aim.opena2a.org", "code", "verifier", "http://localhost:1234/callback")
+
+
+def _mock_response(status_code, *, json_body=None, content=b"x", raises_json=False):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    if raises_json:
+        resp.json.side_effect = ValueError("No JSON")
+    else:
+        resp.json.return_value = json_body
+    return resp
+
+
+def test_reason_is_bare_not_preprefixed():
+    """The returned error must NOT itself contain 'Token exchange failed:' —
+    the caller adds that exactly once, so a pre-prefixed value doubles it."""
+    resp = _mock_response(400, json_body={"error": "invalid_grant",
+                                          "error_description": "Authorization code is invalid or expired"})
+    with patch("aim_sdk.cli.requests.post", return_value=resp):
+        out = exchange_code_for_tokens(*ARGS)
+    assert "Token exchange failed:" not in out["error"], out["error"]
+    # And the single-prefix composition the caller prints is not doubled:
+    rendered = f"Token exchange failed: {out['error']}"
+    assert rendered.count("Token exchange failed:") == 1, rendered
+
+
+def test_prefers_error_description():
+    resp = _mock_response(400, json_body={"error": "invalid_grant",
+                                          "error_description": "Authorization code is invalid or expired"})
+    with patch("aim_sdk.cli.requests.post", return_value=resp):
+        out = exchange_code_for_tokens(*ARGS)
+    assert out["error"] == "Authorization code is invalid or expired"
+
+
+def test_falls_back_to_error_field():
+    resp = _mock_response(400, json_body={"error": "invalid_grant"})
+    with patch("aim_sdk.cli.requests.post", return_value=resp):
+        out = exchange_code_for_tokens(*ARGS)
+    assert out["error"] == "invalid_grant"
+
+
+def test_non_json_body_gives_status_and_url_hint_without_crashing():
+    """A 405 with an HTML body (classic symptom of pointing at the dashboard/
+    frontend URL) must not raise and must hint at the URL, not double a prefix."""
+    resp = _mock_response(405, content=b"<html>405</html>", raises_json=True)
+    with patch("aim_sdk.cli.requests.post", return_value=resp):
+        out = exchange_code_for_tokens(*ARGS)
+    assert "405" in out["error"]
+    assert "api.aim.opena2a.org" in out["error"]  # actionable URL hint
+    assert "Token exchange failed:" not in out["error"]
+    assert f"Token exchange failed: {out['error']}".count("Token exchange failed:") == 1
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem
`aim-sdk login` prints `Token exchange failed: Token exchange failed: 405` — a doubled prefix. `login()` prints `Token exchange failed: {reason}`, but `exchange_code_for_tokens()` returned a **pre-prefixed** `Token exchange failed: {status}` on its fallback path. Reported by a Windows user who pointed `aim-sdk` at the dashboard URL (`https://aim.opena2a.org/`) instead of the API base, so the token POST hit a route that returned a bare non-JSON status.

This is **separate from #260** (which fixed the analogous `Registration failed:` doubling in `register_agent`).

## Fix
`exchange_code_for_tokens()` now returns a **bare** reason (the caller adds the single prefix), preferring the server's human-readable `error_description`, then `error`, then a status line that hints at the most common misconfiguration (dashboard/frontend URL vs the AIM API base). Also guards against a non-JSON error body (HTML 405) raising `JSONDecodeError` instead of reporting cleanly.

Before: `Token exchange failed: Token exchange failed: 405`
After: `Token exchange failed: Authorization code is invalid or expired` (or, on a non-JSON 405, a one-line URL hint).

## Tests
`tests/test_cli_token_exchange.py` — 4 cases: bare-not-doubled, prefers error_description, falls back to error, non-JSON body gives status+URL hint without crashing. All green.

Publishes to PyPI on the next `sdk-py-v*` tag; mirrors to aim-cloud's dashboard download via the SDK sync.
