### PR TITLE
fix(sdk): name real credential source path; guard login EOF

### DIFF
--- a/sdk/python/aim_sdk/cli.py
+++ b/sdk/python/aim_sdk/cli.py
@@ -312,7 +312,15 @@ def login(args):
             print(f"Already authenticated as: {user_email}")
             print(f"Server: {existing_url}")
             print()
-            response = input("Re-authenticate? [y/N]: ").strip().lower()
+            try:
+                response = input("Re-authenticate? [y/N]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                # Non-interactive stdin (CI / piped) or Ctrl-D/Ctrl-C: don't
+                # crash with a raw traceback — keep the existing credentials and
+                # tell the user how to force a re-auth non-interactively.
+                print("\nNo input received; keeping existing credentials. "
+                      "Pass --force to re-authenticate non-interactively.")
+                return 0
             if response != 'y':
                 print("Login cancelled.")
                 return 0

--- a/sdk/python/aim_sdk/credentials.py
+++ b/sdk/python/aim_sdk/credentials.py
@@ -24,7 +24,7 @@ import os
 import json
 import shutil
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 from datetime import datetime
 
 # Security logging for SOC monitoring
@@ -167,15 +167,16 @@ def load_sdk_credentials() -> Optional[Dict[str, Any]]:
             )
 
     # 3. Check SDK package for fresh download
-    sdk_package_creds = _find_sdk_package_credentials()
-    if sdk_package_creds:
+    found = _find_sdk_package_credentials()
+    if found:
+        sdk_package_creds, source_path = found
         # Install to home directory
-        _install_sdk_credentials(sdk_package_creds)
+        _install_sdk_credentials(sdk_package_creds, source_path)
         security_logger.log_credential_event(
             CredEventType.CREDENTIAL_CREATED,
             credential_type="sdk_oauth",
             success=True,
-            details={"source": "sdk_package", "installed_to": "sdk_credentials.json"}
+            details={"source": str(source_path), "installed_to": "sdk_credentials.json"}
         )
         return sdk_package_creds
 
@@ -227,7 +228,7 @@ def save_sdk_credentials(credentials: Dict[str, Any]) -> bool:
         return False
 
 
-def _find_sdk_package_credentials() -> Optional[Dict[str, Any]]:
+def _find_sdk_package_credentials() -> Optional[Tuple[Dict[str, Any], Path]]:
     """
     Find SDK credentials in the installed package (for fresh downloads).
 
@@ -267,36 +268,38 @@ def _find_sdk_package_credentials() -> Optional[Dict[str, Any]]:
                 with open(path, 'r') as f:
                     data = json.load(f)
                 if detect_credential_type(data) == CredentialType.SDK_OAUTH:
-                    return data
+                    return data, path
             except Exception:
                 continue
 
     return None
 
 
-def _install_sdk_credentials(credentials: Dict[str, Any]) -> None:
-    """Install SDK credentials from package to home directory.
+def _install_sdk_credentials(credentials: Dict[str, Any], source_path: Optional[Path] = None) -> None:
+    """Adopt SDK credentials discovered on this machine into the home directory.
 
-    Bundled SDK credentials in the package or CWD are adopted as a
-    convenience for the first run after a fresh download. The home
-    location is the long-term source of truth; on subsequent runs the
-    SDK reads from there first and ignores the bundled file (#178).
+    The credentials are read from the first existing path in the search order
+    (CWD, the installed package dir, or the nearest ancestor ``.aim/``) -- they
+    are NOT baked into the published package. The home location is the long-term
+    source of truth; on subsequent runs the SDK reads from there first and
+    ignores the discovered file (#178).
     """
     try:
         token_id = credentials.get("sdkTokenId") or credentials.get("sdk_token_id") or ""
         token_id_short = (token_id[:8] + "...") if token_id else "unknown"
-        # Visible warning so operators see when bundled (potentially stale)
-        # credentials are being adopted. Audit #37: the silent install path
-        # was how stale bundled tokens crept into the home file across
-        # demo prep runs.
+        # Name the ACTUAL source path so this line is never mistaken for a
+        # credential shipped inside the package -- it is not (see docstring).
+        # Audit #37: the silent install path was how stale tokens crept into the
+        # home file across demo-prep runs, so the adoption stays visible.
+        origin = str(source_path) if source_path else "a discovered .aim directory"
         print(
-            "INFO: Adopting SDK credentials from bundled package (token "
-            f"{token_id_short}). Long-term source: {SDK_CREDENTIALS_FILE}."
+            f"INFO: Adopting existing SDK credentials found at {origin} "
+            f"(token {token_id_short}). Long-term source: {SDK_CREDENTIALS_FILE}."
         )
         save_sdk_credentials(credentials)
-        print(f"✅ SDK credentials installed to {SDK_CREDENTIALS_FILE}")
+        print(f"SDK credentials installed to {SDK_CREDENTIALS_FILE}")
     except Exception as e:
-        print(f"⚠️  Failed to install SDK credentials: {e}")
+        print(f"Failed to install SDK credentials: {e}")
 
 
 def _migrate_sdk_credentials(credentials: Dict[str, Any]) -> None:

--- a/sdk/python/tests/test_cli_login_noninteractive.py
+++ b/sdk/python/tests/test_cli_login_noninteractive.py
@@ -1,0 +1,50 @@
+"""
+Regression test: `aim-sdk login` must not crash with a raw EOFError traceback
+when stdin is non-interactive (CI / piped) and credentials already exist.
+Previously the unguarded input("Re-authenticate? [y/N]: ") raised EOFError and
+dumped a stack trace; now it keeps the existing credentials and exits cleanly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+import io
+from contextlib import redirect_stdout
+
+from aim_sdk import cli
+
+EXISTING = {
+    "aimUrl": "https://api.aim.opena2a.org",
+    "userEmail": "u@example.com",
+    "refreshToken": "rt",
+}
+
+
+def _run_login():
+    args = SimpleNamespace(url="https://api.aim.opena2a.org", force=False)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.login(args)
+    return rc, buf.getvalue()
+
+
+def test_login_eof_keeps_credentials_no_traceback():
+    with patch("aim_sdk.credentials.load_sdk_credentials", return_value=EXISTING):
+        with patch("builtins.input", side_effect=EOFError):
+            rc, out = _run_login()
+    assert rc == 0, out
+    assert "keeping existing credentials" in out.lower()
+    assert "--force" in out  # actionable next step
+    assert "Traceback" not in out
+
+
+def test_login_ctrl_c_at_prompt_is_clean():
+    with patch("aim_sdk.credentials.load_sdk_credentials", return_value=EXISTING):
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            rc, out = _run_login()
+    assert rc == 0, out
+    assert "Traceback" not in out
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/sdk/python/tests/test_stale_creds_and_rotation.py
+++ b/sdk/python/tests/test_stale_creds_and_rotation.py
@@ -90,18 +90,38 @@ class TestInstallSdkCredentialsWarning:
             "email": "u@example.com",
             "schemaVersion": "1.0",
         }
+        src = tmp_path / "src" / ".aim" / "sdk_credentials.json"
         with patch("aim_sdk.credentials.SDK_CREDENTIALS_FILE", tmp_path / "sdk_credentials.json"):
             with patch("aim_sdk.credentials.save_sdk_credentials", return_value=True) as mock_save:
                 buf = io.StringIO()
                 with redirect_stdout(buf):
-                    _install_sdk_credentials(creds)
+                    _install_sdk_credentials(creds, source_path=src)
 
                 out = buf.getvalue()
-                assert "Adopting SDK credentials from bundled package" in out
+                assert "Adopting existing SDK credentials found at" in out
+                # The misleading "bundled package" wording must NOT return — it
+                # made a discovered ~/.aim credential look like a shipped secret.
+                assert "bundled package" not in out
+                # The ACTUAL source path is named so it can't be mistaken for a
+                # credential baked into the published package.
+                assert str(src) in out
                 # Truncated token id (first 8 chars + ellipsis), full token not echoed.
                 assert "abcdefgh..." in out
                 assert "abcdefghij1234567890" not in out
                 mock_save.assert_called_once()
+
+    def test_install_without_source_path_is_generic_not_bundled(self, tmp_path):
+        """No source path -> a generic origin, still never claims 'bundled package'."""
+        creds = {"aimUrl": "https://aim.example.com", "sdkTokenId": "zzzzzzzz1111",
+                 "refreshToken": "rt", "schemaVersion": "1.0"}
+        with patch("aim_sdk.credentials.SDK_CREDENTIALS_FILE", tmp_path / "sdk_credentials.json"):
+            with patch("aim_sdk.credentials.save_sdk_credentials", return_value=True):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    _install_sdk_credentials(creds)
+                out = buf.getvalue()
+                assert "bundled package" not in out
+                assert "Adopting existing SDK credentials" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two fixes surfaced by the **aim-sdk 1.24.1 release test** (both pre-existing in 1.24.0, neither introduced by 1.24.1):

### 1. Misleading "bundled package" credential message
`_install_sdk_credentials` printed `Adopting SDK credentials from bundled package (token …)`. The credential is actually **discovered at runtime** in the search order (CWD `.aim/`, the installed package dir, or the nearest ancestor `~/.aim/`) — it is **not** shipped in the package. I verified the published 1.24.0 sdist + wheel contain **no** credential. The wording made a developer's own `~/.aim` token look like a baked-in secret (it made our own release test cry wolf — exactly the kind of thing that triggers a false security report).

Fix: thread the real source path through `_find_sdk_package_credentials → _install_sdk_credentials` and print `Adopting existing SDK credentials found at <path>`. Dropped the decorative emoji.

### 2. `login` EOFError traceback on non-interactive stdin
With existing credentials + piped/CI stdin, the `input("Re-authenticate? [y/N]: ")` raised a raw `EOFError` traceback (exit 1). Now guarded: keep existing credentials, exit 0, and print an actionable `--force` hint.

### Tests
- `test_stale_creds_and_rotation.py` updated: asserts the new "found at `<path>`" message, asserts `bundled package` is gone, asserts the path is shown.
- `test_cli_login_noninteractive.py` (new): EOF + Ctrl-C at the re-auth prompt exit cleanly with no traceback.
- Full `sdk/python` suite: 444 passed.

Folds into the pending **1.24.1** PyPI release (the tag points at main after this merges).
