### PR TITLE
feat(agents): add optional declaredPurpose to agent identity

### DIFF
--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -168,6 +168,10 @@ type CreateAgentRequest struct {
 	Capabilities     []string               `json:"capabilities,omitempty"` // Agent capabilities
 	TagIds           []string               `json:"tagIds,omitempty"`       // ✅ Tags to apply during registration
 	Metadata         map[string]interface{} `json:"metadata,omitempty"`     // Custom agent metadata (model, department, etc.)
+	// DeclaredPurpose is the optional structured "what is this agent for" declaration
+	// (atx-spec core.md §1.5). Identity/attestation + offline detection signal only;
+	// never an authorization input.
+	DeclaredPurpose *domain.DeclaredPurpose `json:"declaredPurpose,omitempty"`
 }
 
 // CreateAgent creates a new agent
@@ -260,6 +264,7 @@ func (s *AgentService) CreateAgent(ctx context.Context, req *CreateAgentRequest,
 		TalksTo:             req.TalksTo,      // MCP servers this agent communicates with
 		Capabilities:        req.Capabilities, // ✅ Store detected capabilities from SDK
 		Metadata:            req.Metadata,     // ✅ Custom metadata (model, department, owner, etc.)
+		DeclaredPurpose:     req.DeclaredPurpose,
 		Status:              domain.AgentStatusPending, // Agents start as pending, verification is earned
 		CreatedBy:           userID,
 		CreatedByName:       createdByName,   // ✅ Denormalized for audit trail
@@ -271,6 +276,19 @@ func (s *AgentService) CreateAgent(ctx context.Context, req *CreateAgentRequest,
 	// Only set encrypted private key if we generated it server-side
 	if encryptedPrivateKey != "" {
 		agent.EncryptedPrivateKey = &encryptedPrivateKey // ✅ Encrypted storage (never exposed in API)
+	}
+
+	// Validate the optional declared purpose (atx-spec core.md §1.5). Hard
+	// structural errors reject the request; coherence issues are issuance-time
+	// hygiene logged warn-only during the optional phase. declaredPurpose is never
+	// an authorization input — this is identity validation + a detection signal.
+	if agent.DeclaredPurpose != nil {
+		if err := agent.DeclaredPurpose.Validate(agent.Capabilities); err != nil {
+			return nil, fmt.Errorf("invalid declaredPurpose: %w", err)
+		}
+		for _, w := range agent.DeclaredPurpose.CoherenceWarnings(agent.Capabilities) {
+			fmt.Printf("Warning: agent %q declaredPurpose coherence: %s\n", agent.Name, w)
+		}
 	}
 
 	if err := s.agentRepo.Create(agent); err != nil {
@@ -532,6 +550,23 @@ func (s *AgentService) UpdateAgent(ctx context.Context, id uuid.UUID, req *Creat
 	// Update metadata
 	if req.Metadata != nil {
 		agent.Metadata = req.Metadata
+	}
+	// Update the optional declared purpose (atx-spec core.md §1.5). Validate
+	// against the effective granted capabilities (the incoming set if the request
+	// also changes capabilities, otherwise the stored set). Hard errors reject;
+	// coherence issues are warn-only hygiene. Never an authorization input.
+	if req.DeclaredPurpose != nil {
+		agent.DeclaredPurpose = req.DeclaredPurpose
+		grantedCaps := agent.Capabilities
+		if len(req.Capabilities) > 0 {
+			grantedCaps = req.Capabilities
+		}
+		if err := agent.DeclaredPurpose.Validate(grantedCaps); err != nil {
+			return nil, fmt.Errorf("invalid declaredPurpose: %w", err)
+		}
+		for _, w := range agent.DeclaredPurpose.CoherenceWarnings(grantedCaps) {
+			fmt.Printf("Warning: agent %q declaredPurpose coherence: %s\n", agent.Name, w)
+		}
 	}
 
 	if err := s.agentRepo.Update(agent); err != nil {

--- a/apps/backend/internal/domain/agent.go
+++ b/apps/backend/internal/domain/agent.go
@@ -109,6 +109,10 @@ type Agent struct {
 	LastHeartbeat            *time.Time             `json:"lastHeartbeat"`
 	// Custom metadata for the agent (model, department, owner, etc.)
 	Metadata                 map[string]interface{} `json:"metadata,omitempty"`
+	// DeclaredPurpose is the publisher's optional structured declaration of what
+	// the agent is for (atx-spec core.md §1.5). Identity/attestation + offline
+	// detection signal only; never an authorization input. Nil = not declared.
+	DeclaredPurpose *DeclaredPurpose `json:"declaredPurpose,omitempty"`
 }
 
 // AgentRepository defines the interface for agent persistence

--- a/apps/backend/internal/domain/declared_purpose.go
+++ b/apps/backend/internal/domain/declared_purpose.go
@@ -1,0 +1,363 @@
+package domain
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// PurposeVocabVersion is the version of the purpose vocabulary (categories and
+// reserved taskScope namespaces) that validation is performed against. Every
+// declared purpose records the vocab version it was issued under so a later
+// vocabulary revision never silently re-interprets an old declaration.
+const PurposeVocabVersion = "1"
+
+// MaxPurposeStatementLength caps the free-text statement. The statement is
+// attacker-controllable content judged only by a non-generative classifier; the
+// cap denies prose-injection room and keeps the credential small.
+const MaxPurposeStatementLength = 280
+
+// Autonomy levels for a declared purpose.
+const (
+	AutonomySupervised  = "supervised"
+	AutonomyHumanInLoop = "human_in_loop"
+	AutonomyAutonomous  = "autonomous"
+)
+
+// Purpose breadth classes. Breadth is the expected diversity of capability
+// namespaces a purpose touches; it is measured from capabilityJustification
+// (see DeclaredBreadth), never claimed by a token name.
+const (
+	PurposeBreadthNarrow   = "narrow"
+	PurposeBreadthModerate = "moderate"
+	PurposeBreadthBroad    = "broad"
+)
+
+// Purpose sensitivity classes drive verifier-policy defaults and the minimum
+// trust level a category is appropriate for.
+const (
+	PurposeSensitivityStandard  = "standard"
+	PurposeSensitivityElevated  = "elevated"
+	PurposeSensitivityRegulated = "regulated"
+)
+
+// PurposeCategoryDef describes a core purpose category: its breadth class and
+// its sensitivity class. Mirrors the capability registry's CapabilityDefinition
+// governance pattern.
+type PurposeCategoryDef struct {
+	Breadth     string
+	Sensitivity string
+}
+
+// CorePurposeCategories is the closed core category vocabulary (vocab v1). There
+// is deliberately no catch-all: an agent that spans many objectives declares
+// agent-orchestration (broad) and pays the breadth cost. Custom categories are
+// permitted under an org namespace (<org>.<name>) and always default to the
+// broadest, most sensitive class until promoted, so custom is never a cheap way
+// to claim a narrow profile.
+var CorePurposeCategories = map[string]PurposeCategoryDef{
+	"customer-support":     {PurposeBreadthNarrow, PurposeSensitivityStandard},
+	"financial-operations": {PurposeBreadthModerate, PurposeSensitivityRegulated},
+	"data-analysis":        {PurposeBreadthNarrow, PurposeSensitivityStandard},
+	"data-engineering":     {PurposeBreadthModerate, PurposeSensitivityElevated},
+	"software-development": {PurposeBreadthModerate, PurposeSensitivityStandard},
+	"devops-automation":    {PurposeBreadthBroad, PurposeSensitivityElevated},
+	"security-operations":  {PurposeBreadthBroad, PurposeSensitivityElevated},
+	"content-generation":   {PurposeBreadthNarrow, PurposeSensitivityStandard},
+	"research-assistant":   {PurposeBreadthModerate, PurposeSensitivityStandard},
+	"sales-marketing":      {PurposeBreadthModerate, PurposeSensitivityElevated},
+	"hr-people-ops":        {PurposeBreadthModerate, PurposeSensitivityRegulated},
+	"legal-compliance":     {PurposeBreadthNarrow, PurposeSensitivityRegulated},
+	"healthcare-clinical":  {PurposeBreadthModerate, PurposeSensitivityRegulated},
+	"device-control":       {PurposeBreadthModerate, PurposeSensitivityElevated},
+	"agent-orchestration":  {PurposeBreadthBroad, PurposeSensitivityElevated},
+}
+
+// ReservedTaskScopeNamespaces are the core-only taskScope namespaces (vocab v1).
+// They are an intent axis, deliberately separate from capability namespaces
+// (ReservedNamespaces, the access axis). A non-reserved namespace is a custom
+// (org) taskScope.
+var ReservedTaskScopeNamespaces = []string{
+	"support", "billing", "accounting", "analytics", "dataops", "dev", "ci",
+	"infra", "secops", "content", "research", "crm", "people", "legal",
+	"clinical", "device", "orchestrate",
+}
+
+// dualUsePurposeCategories are legitimately dual-use (their behavior resembles an
+// attacker's, or they have physical-world impact). They may not be declared with
+// a narrow breadth and their capabilityJustification must enumerate every granted
+// capability explicitly (no wildcard).
+var dualUsePurposeCategories = map[string]bool{
+	"security-operations": true,
+	"device-control":      true,
+}
+
+// IsReservedTaskScopeNamespace reports whether a namespace is a reserved core
+// taskScope namespace.
+func IsReservedTaskScopeNamespace(namespace string) bool {
+	for _, n := range ReservedTaskScopeNamespaces {
+		if n == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// DeclaredPurpose is the publisher's structured declaration of what an agent is
+// for. It mirrors the ATX declaredPurpose object (atx-spec core.md §1.5). It is
+// an identity/attestation property and an offline detection signal — NEVER an
+// authorization input. It is optional: a nil *DeclaredPurpose on an Agent means
+// no purpose was declared, which degrades the detection signal but never fails
+// verification or enforcement.
+type DeclaredPurpose struct {
+	// VocabVersion is the purpose vocabulary version this declaration targets.
+	// Defaults to PurposeVocabVersion when empty.
+	VocabVersion string `json:"vocabVersion,omitempty"`
+	// Statement is human/audit-readable intent (<= MaxPurposeStatementLength).
+	Statement string `json:"statement,omitempty"`
+	// Category is a core category key (CorePurposeCategories) or an org-custom
+	// "<org>.<name>" value.
+	Category string `json:"category"`
+	// TaskScopes are namespace:objective tokens at the objective level.
+	TaskScopes []string `json:"taskScopes"`
+	// CapabilityJustification maps each granted capability to the taskScope(s) it
+	// serves. Keys must be a subset of the agent's granted Capabilities.
+	CapabilityJustification map[string][]string `json:"capabilityJustification"`
+	// Autonomy is an optional tolerance hint.
+	Autonomy string `json:"autonomy,omitempty"`
+	// DataScopes are the declared data domains the agent operates over.
+	DataScopes []string `json:"dataScopes,omitempty"`
+	// EgressScopes are the declared external destinations (hostnames/domains; no
+	// paths, no secrets) the agent legitimately calls.
+	EgressScopes []string `json:"egressScopes,omitempty"`
+}
+
+// PurposeError is a declared-purpose validation error.
+type PurposeError struct {
+	Field   string
+	Message string
+}
+
+func (e *PurposeError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("declaredPurpose.%s: %s", e.Field, e.Message)
+	}
+	return "declaredPurpose: " + e.Message
+}
+
+// IsCustomPurposeCategory reports whether a category value is a well-formed
+// org-custom category ("<org>.<name>", each segment lowercase alphanumeric with
+// optional hyphens). Core categories are NOT custom.
+func IsCustomPurposeCategory(category string) bool {
+	if _, ok := CorePurposeCategories[category]; ok {
+		return false
+	}
+	parts := strings.Split(category, ".")
+	if len(parts) != 2 {
+		return false
+	}
+	for _, p := range parts {
+		if !isPurposeSegment(p) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPurposeSegment(s string) bool {
+	if len(s) == 0 || !isLowerLetter(rune(s[0])) {
+		return false
+	}
+	for _, c := range s {
+		if !isLowerAlphanumeric(c) && c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// CategoryBreadthClass returns the breadth class for a category: the core class
+// for a core category, or PurposeBreadthBroad for a custom category (custom
+// defaults to the broadest class until CA promotion).
+func CategoryBreadthClass(category string) string {
+	if def, ok := CorePurposeCategories[category]; ok {
+		return def.Breadth
+	}
+	return PurposeBreadthBroad
+}
+
+// maxNamespacesForBreadth returns the max distinct capability namespaces a
+// breadth class tolerates before it is over-broad. -1 means unbounded.
+func maxNamespacesForBreadth(breadth string) int {
+	switch breadth {
+	case PurposeBreadthNarrow:
+		return 1
+	case PurposeBreadthModerate:
+		return 3
+	default: // broad
+		return -1
+	}
+}
+
+// DeclaredBreadth is the measured breadth of a purpose: the count of distinct
+// capability namespaces appearing across all capabilityJustification keys. This
+// is the anti-gaming anchor (atx-spec §1.5.4) — breadth keys on the capability
+// map, not on how taskScope tokens are named.
+func (p *DeclaredPurpose) DeclaredBreadth() int {
+	seen := map[string]struct{}{}
+	for cap := range p.CapabilityJustification {
+		ns, _, err := ParseCapability(cap)
+		if err != nil {
+			continue
+		}
+		seen[ns] = struct{}{}
+	}
+	return len(seen)
+}
+
+// Validate performs hard structural validation against the agent's granted
+// capabilities. It rejects malformed declarations (bad grammar, oversized
+// statement, justification of un-granted authority, malformed egress). It does
+// NOT reject on coherence/breadth — those are issuance hygiene reported by
+// CoherenceWarnings. grantedCapabilities is the agent's Capabilities slice.
+func (p *DeclaredPurpose) Validate(grantedCapabilities []string) error {
+	if p == nil {
+		return nil
+	}
+
+	if p.VocabVersion != "" && p.VocabVersion != PurposeVocabVersion {
+		return &PurposeError{Field: "vocabVersion", Message: fmt.Sprintf("unsupported vocab version %q (expected %q)", p.VocabVersion, PurposeVocabVersion)}
+	}
+
+	if len([]rune(p.Statement)) > MaxPurposeStatementLength {
+		return &PurposeError{Field: "statement", Message: fmt.Sprintf("statement exceeds %d characters", MaxPurposeStatementLength)}
+	}
+
+	// category: core or well-formed custom.
+	if p.Category == "" {
+		return &PurposeError{Field: "category", Message: "category is required"}
+	}
+	if _, core := CorePurposeCategories[p.Category]; !core && !IsCustomPurposeCategory(p.Category) {
+		return &PurposeError{Field: "category", Message: fmt.Sprintf("unknown category %q (not a core category and not a valid <org>.<name> custom category)", p.Category)}
+	}
+
+	// autonomy: optional enum.
+	switch p.Autonomy {
+	case "", AutonomySupervised, AutonomyHumanInLoop, AutonomyAutonomous:
+	default:
+		return &PurposeError{Field: "autonomy", Message: fmt.Sprintf("invalid autonomy %q", p.Autonomy)}
+	}
+
+	// taskScopes: required, valid grammar.
+	if len(p.TaskScopes) == 0 {
+		return &PurposeError{Field: "taskScopes", Message: "at least one taskScope is required"}
+	}
+	declared := map[string]struct{}{}
+	for _, ts := range p.TaskScopes {
+		if err := ValidateCapabilityFormat(ts); err != nil {
+			return &PurposeError{Field: "taskScopes", Message: fmt.Sprintf("invalid taskScope %q: %s", ts, err.Error())}
+		}
+		declared[ts] = struct{}{}
+	}
+
+	// capabilityJustification: keys subset of granted capabilities, no wildcard,
+	// values reference declared taskScopes.
+	granted := map[string]struct{}{}
+	for _, c := range grantedCapabilities {
+		granted[c] = struct{}{}
+	}
+	for cap, scopes := range p.CapabilityJustification {
+		if strings.Contains(cap, "*") {
+			return &PurposeError{Field: "capabilityJustification", Message: fmt.Sprintf("wildcard capability %q is not allowed; enumerate each capability", cap)}
+		}
+		if _, ok := granted[cap]; !ok {
+			return &PurposeError{Field: "capabilityJustification", Message: fmt.Sprintf("capability %q is justified but not granted to the agent", cap)}
+		}
+		for _, ts := range scopes {
+			if _, ok := declared[ts]; !ok {
+				return &PurposeError{Field: "capabilityJustification", Message: fmt.Sprintf("capability %q references taskScope %q which is not in taskScopes", cap, ts)}
+			}
+		}
+	}
+
+	// egressScopes: bare hostnames/domains only (no scheme, path, credentials).
+	for _, e := range p.EgressScopes {
+		if err := validateEgressTarget(e); err != nil {
+			return &PurposeError{Field: "egressScopes", Message: err.Error()}
+		}
+	}
+
+	// dual-use categories: must enumerate every granted capability explicitly.
+	if dualUsePurposeCategories[p.Category] {
+		for _, c := range grantedCapabilities {
+			if _, ok := p.CapabilityJustification[c]; !ok {
+				return &PurposeError{Field: "capabilityJustification", Message: fmt.Sprintf("dual-use category %q requires every granted capability to be justified explicitly; %q is not justified", p.Category, c)}
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateEgressTarget enforces that an egress scope is a bare hostname/domain:
+// no scheme, no path, no credentials, no whitespace, no port.
+func validateEgressTarget(e string) error {
+	if e == "" {
+		return fmt.Errorf("egress target cannot be empty")
+	}
+	if strings.Contains(e, "://") {
+		return fmt.Errorf("egress target %q must be a bare hostname, not a URL with a scheme", e)
+	}
+	for _, bad := range []string{"/", "@", " ", ":", "?", "#"} {
+		if strings.Contains(e, bad) {
+			return fmt.Errorf("egress target %q must be a bare hostname/domain (no %q)", e, bad)
+		}
+	}
+	return nil
+}
+
+// CoherenceWarnings returns issuance-time hygiene warnings (atx-spec §1.5.4 /
+// proposal §8.1). These are NOT a security control and NOT a rejection during the
+// optional phase — they catch lazy incoherence (granted authority justified by no
+// task, dead justifications, over-broad declarations). The caller logs them and,
+// per the trust-level ramp, may later make them blocking at L>=3.
+func (p *DeclaredPurpose) CoherenceWarnings(grantedCapabilities []string) []string {
+	if p == nil {
+		return nil
+	}
+	var warnings []string
+
+	// Granted capabilities not justified by any declared task (unjustified reach).
+	var unjustified []string
+	for _, c := range grantedCapabilities {
+		if _, ok := p.CapabilityJustification[c]; !ok {
+			unjustified = append(unjustified, c)
+		}
+	}
+	sort.Strings(unjustified)
+	for _, c := range unjustified {
+		warnings = append(warnings, fmt.Sprintf("capability %q is granted but justified by no declared task", c))
+	}
+
+	// Capabilities justified by an empty taskScope list (dead authority).
+	var dead []string
+	for cap, scopes := range p.CapabilityJustification {
+		if len(scopes) == 0 {
+			dead = append(dead, cap)
+		}
+	}
+	sort.Strings(dead)
+	for _, cap := range dead {
+		warnings = append(warnings, fmt.Sprintf("capability %q is justified by no taskScope (dead authority)", cap))
+	}
+
+	// Over-broad: measured breadth exceeds the category's tolerated namespaces.
+	max := maxNamespacesForBreadth(CategoryBreadthClass(p.Category))
+	if max >= 0 {
+		if b := p.DeclaredBreadth(); b > max {
+			warnings = append(warnings, fmt.Sprintf("declared breadth %d exceeds the %q tier for category %q (max %d capability namespaces)", b, CategoryBreadthClass(p.Category), p.Category, max))
+		}
+	}
+
+	return warnings
+}

--- a/apps/backend/internal/domain/declared_purpose_test.go
+++ b/apps/backend/internal/domain/declared_purpose_test.go
@@ -1,0 +1,206 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validPurpose is a coherent baseline declaration used as the starting point for
+// mutation-based tests.
+func validPurpose() *DeclaredPurpose {
+	return &DeclaredPurpose{
+		VocabVersion: "1",
+		Statement:    "Processes customer billing inquiries and issues refunds.",
+		Category:     "financial-operations",
+		TaskScopes:   []string{"billing:inquiry", "billing:refund"},
+		CapabilityJustification: map[string][]string{
+			"db:read":  {"billing:inquiry"},
+			"api:call": {"billing:refund"},
+		},
+		Autonomy:     AutonomySupervised,
+		DataScopes:   []string{"customer.billing"},
+		EgressScopes: []string{"api.stripe.com"},
+	}
+}
+
+var validGrants = []string{"db:read", "api:call"}
+
+func TestDeclaredPurpose_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(p *DeclaredPurpose)
+		grants  []string
+		wantErr bool
+	}{
+		{"valid baseline", func(p *DeclaredPurpose) {}, validGrants, false},
+		{"nil vocab version defaults ok", func(p *DeclaredPurpose) { p.VocabVersion = "" }, validGrants, false},
+		{"unsupported vocab version", func(p *DeclaredPurpose) { p.VocabVersion = "2" }, validGrants, true},
+		{"statement too long", func(p *DeclaredPurpose) {
+			s := make([]rune, MaxPurposeStatementLength+1)
+			for i := range s {
+				s[i] = 'a'
+			}
+			p.Statement = string(s)
+		}, validGrants, true},
+		{"statement at limit ok", func(p *DeclaredPurpose) {
+			s := make([]rune, MaxPurposeStatementLength)
+			for i := range s {
+				s[i] = 'a'
+			}
+			p.Statement = string(s)
+		}, validGrants, false},
+		{"empty category", func(p *DeclaredPurpose) { p.Category = "" }, validGrants, true},
+		{"unknown bare category", func(p *DeclaredPurpose) { p.Category = "totally-made-up" }, validGrants, true},
+		{"valid custom category", func(p *DeclaredPurpose) {
+			p.Category = "acme.fx-trading"
+		}, validGrants, false},
+		{"malformed custom category (3 parts)", func(p *DeclaredPurpose) { p.Category = "a.b.c" }, validGrants, true},
+		{"invalid autonomy", func(p *DeclaredPurpose) { p.Autonomy = "yolo" }, validGrants, true},
+		{"empty autonomy ok", func(p *DeclaredPurpose) { p.Autonomy = "" }, validGrants, false},
+		{"no task scopes", func(p *DeclaredPurpose) { p.TaskScopes = nil }, validGrants, true},
+		{"bad task scope grammar", func(p *DeclaredPurpose) { p.TaskScopes = []string{"Billing:Inquiry"} }, validGrants, true},
+		{"justification key not granted", func(p *DeclaredPurpose) {
+			p.CapabilityJustification["secrets:resolve"] = []string{"billing:inquiry"}
+		}, validGrants, true},
+		{"justification wildcard key", func(p *DeclaredPurpose) {
+			p.CapabilityJustification = map[string][]string{"db:*": {"billing:inquiry"}}
+		}, validGrants, true},
+		{"justification references undeclared task scope", func(p *DeclaredPurpose) {
+			p.CapabilityJustification["db:read"] = []string{"billing:nonexistent"}
+		}, validGrants, true},
+		{"egress with scheme rejected", func(p *DeclaredPurpose) { p.EgressScopes = []string{"https://api.stripe.com"} }, validGrants, true},
+		{"egress with path rejected", func(p *DeclaredPurpose) { p.EgressScopes = []string{"api.stripe.com/v1/charges"} }, validGrants, true},
+		{"egress bare host ok", func(p *DeclaredPurpose) { p.EgressScopes = []string{"hooks.internal.acme.com"} }, validGrants, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := validPurpose()
+			tc.mutate(p)
+			err := p.Validate(tc.grants)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDeclaredPurpose_DualUseCategory: a dual-use category must justify every
+// granted capability explicitly; an unjustified grant is a hard error.
+func TestDeclaredPurpose_DualUseCategory(t *testing.T) {
+	grants := []string{"system:exec", "network:connect"}
+	p := &DeclaredPurpose{
+		Category:   "security-operations",
+		TaskScopes: []string{"secops:scan"},
+		CapabilityJustification: map[string][]string{
+			"system:exec": {"secops:scan"},
+			// network:connect deliberately left unjustified
+		},
+	}
+	require.Error(t, p.Validate(grants), "dual-use category must reject an unjustified granted capability")
+
+	p.CapabilityJustification["network:connect"] = []string{"secops:scan"}
+	require.NoError(t, p.Validate(grants), "dual-use category passes once every grant is justified")
+}
+
+func TestDeclaredPurpose_NilValidateIsNoop(t *testing.T) {
+	var p *DeclaredPurpose
+	require.NoError(t, p.Validate(validGrants))
+	assert.Nil(t, p.CoherenceWarnings(validGrants))
+}
+
+func TestDeclaredPurpose_DeclaredBreadth(t *testing.T) {
+	p := &DeclaredPurpose{
+		CapabilityJustification: map[string][]string{
+			"db:read":         {"x:y"},
+			"db:write":        {"x:y"}, // same namespace -> still 1
+			"network:connect": {"x:y"}, // second namespace -> 2
+		},
+	}
+	assert.Equal(t, 2, p.DeclaredBreadth())
+}
+
+func TestDeclaredPurpose_CoherenceWarnings(t *testing.T) {
+	t.Run("clean coherent purpose has no warnings", func(t *testing.T) {
+		assert.Empty(t, validPurpose().CoherenceWarnings(validGrants))
+	})
+
+	t.Run("granted capability justified by no task", func(t *testing.T) {
+		p := validPurpose()
+		grants := append([]string{}, validGrants...)
+		grants = append(grants, "data:export") // granted but not in justification
+		w := p.CoherenceWarnings(grants)
+		require.NotEmpty(t, w)
+		assert.Contains(t, w[0], "data:export")
+	})
+
+	t.Run("dead authority: capability justified by empty task list", func(t *testing.T) {
+		p := validPurpose()
+		p.CapabilityJustification["db:read"] = []string{}
+		w := p.CoherenceWarnings(validGrants)
+		joined := ""
+		for _, s := range w {
+			joined += s + "\n"
+		}
+		assert.Contains(t, joined, "dead authority")
+	})
+
+	t.Run("over-broad: narrow category exceeding namespace budget", func(t *testing.T) {
+		// customer-support is narrow (max 1 capability namespace); justify two.
+		p := &DeclaredPurpose{
+			Category:   "customer-support",
+			TaskScopes: []string{"support:triage"},
+			CapabilityJustification: map[string][]string{
+				"db:read":         {"support:triage"},
+				"network:connect": {"support:triage"},
+			},
+		}
+		grants := []string{"db:read", "network:connect"}
+		require.NoError(t, p.Validate(grants))
+		w := p.CoherenceWarnings(grants)
+		joined := ""
+		for _, s := range w {
+			joined += s + "\n"
+		}
+		assert.Contains(t, joined, "exceeds")
+	})
+
+	t.Run("broad category never flags over-broad", func(t *testing.T) {
+		p := &DeclaredPurpose{
+			Category:   "agent-orchestration", // broad: unbounded
+			TaskScopes: []string{"orchestrate:route"},
+			CapabilityJustification: map[string][]string{
+				"db:read":         {"orchestrate:route"},
+				"network:connect": {"orchestrate:route"},
+				"system:exec":     {"orchestrate:route"},
+				"api:call":        {"orchestrate:route"},
+			},
+		}
+		grants := []string{"db:read", "network:connect", "system:exec", "api:call"}
+		require.NoError(t, p.Validate(grants))
+		for _, s := range p.CoherenceWarnings(grants) {
+			assert.NotContains(t, s, "exceeds")
+		}
+	})
+}
+
+func TestPurposeCategoryHelpers(t *testing.T) {
+	assert.False(t, IsCustomPurposeCategory("financial-operations"), "core category is not custom")
+	assert.True(t, IsCustomPurposeCategory("acme.fx-trading"))
+	assert.False(t, IsCustomPurposeCategory("nodot"))
+	assert.False(t, IsCustomPurposeCategory("a.b.c"))
+
+	assert.Equal(t, PurposeBreadthBroad, CategoryBreadthClass("acme.fx-trading"), "custom defaults to broad")
+	assert.Equal(t, PurposeBreadthNarrow, CategoryBreadthClass("customer-support"))
+	assert.Equal(t, PurposeBreadthBroad, CategoryBreadthClass("devops-automation"))
+
+	assert.True(t, IsReservedTaskScopeNamespace("billing"))
+	assert.False(t, IsReservedTaskScopeNamespace("acme"))
+
+	assert.Len(t, CorePurposeCategories, 15, "locked core vocab has 15 categories, no catch-all")
+	assert.Len(t, ReservedTaskScopeNamespaces, 17, "locked core vocab has 17 reserved taskScope namespaces")
+}

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -62,8 +62,9 @@ func (r *AgentRepository) Create(agent *domain.Agent) error {
 		                    trust_score, talks_to, capabilities, metadata,
 		                    key_created_at, key_expires_at, key_rotation_grace_until, previous_public_key, rotation_count,
 		                    pqc_public_key, pqc_key_algorithm, hybrid_mode_enabled, pqc_key_created_at, pqc_key_expires_at, previous_pqc_public_key,
-		                    created_at, updated_at, created_by, created_by_name, created_by_email, created_by_sdk_token_id, created_by_api_key_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)
+		                    created_at, updated_at, created_by, created_by_name, created_by_email, created_by_sdk_token_id, created_by_api_key_id,
+		                    declared_purpose)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37)
 	`
 
 	now := time.Now()
@@ -99,6 +100,16 @@ func (r *AgentRepository) Create(agent *domain.Agent) error {
 	}
 	if agent.Metadata == nil {
 		metadataJSON = []byte("{}")
+	}
+
+	// Marshal declared_purpose to JSONB; SQL NULL (untyped nil) when not declared.
+	var declaredPurposeParam interface{}
+	if agent.DeclaredPurpose != nil {
+		declaredPurposeJSON, mErr := json.Marshal(agent.DeclaredPurpose)
+		if mErr != nil {
+			return fmt.Errorf("failed to marshal declared_purpose: %w", mErr)
+		}
+		declaredPurposeParam = declaredPurposeJSON
 	}
 
 	_, err = r.db.Exec(query,
@@ -138,6 +149,7 @@ func (r *AgentRepository) Create(agent *domain.Agent) error {
 		agent.CreatedByEmail,
 		agent.CreatedBySDKTokenID,
 		agent.CreatedByAPIKeyID,
+		declaredPurposeParam,
 	)
 
 	return err
@@ -153,7 +165,7 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 		       pqc_public_key, pqc_key_algorithm, COALESCE(hybrid_mode_enabled, false), pqc_key_created_at, pqc_key_expires_at, previous_pqc_public_key,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''), created_by_sdk_token_id, created_by_api_key_id,
 		       updated_by, COALESCE(updated_by_name, ''), COALESCE(updated_by_email, ''),
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE id = $1
 	`
@@ -169,6 +181,7 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	talksToJSON := make([]byte, 0)
 	capabilitiesJSON := make([]byte, 0)
 	metadataJSON := make([]byte, 0)
+	declaredPurposeJSON := make([]byte, 0)
 	var lastActive sql.NullTime
 	var keyCreatedAt sql.NullTime
 	var keyExpiresAt sql.NullTime
@@ -227,6 +240,7 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 		&agent.UpdatedByEmail,
 		&agent.CapabilityViolationCount,
 		&agent.IsCompromised,
+		&declaredPurposeJSON,
 	)
 
 	if err == sql.ErrNoRows {
@@ -323,6 +337,13 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 		}
 	}
 
+	// Unmarshal declared_purpose from JSONB
+	if len(declaredPurposeJSON) > 0 {
+		if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
+		}
+	}
+
 	return agent, nil
 }
 
@@ -333,7 +354,7 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''),
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE organization_id = $1
 		ORDER BY created_at DESC
@@ -356,6 +377,7 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 		var documentationURL sql.NullString
 		talksToJSON := make([]byte, 0)
 		metadataJSON := make([]byte, 0)
+		declaredPurposeJSON := make([]byte, 0)
 		err := rows.Scan(
 			&agent.ID,
 			&agent.OrganizationID,
@@ -380,6 +402,7 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 			&agent.CreatedByEmail,
 			&agent.CapabilityViolationCount,
 			&agent.IsCompromised,
+			&declaredPurposeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -418,6 +441,13 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 			}
 		}
 
+		// Unmarshal declared_purpose from JSONB
+		if len(declaredPurposeJSON) > 0 {
+			if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
+			}
+		}
+
 		agents = append(agents, agent)
 	}
 
@@ -435,8 +465,9 @@ func (r *AgentRepository) Update(agent *domain.Agent) error {
 		    key_created_at = $18, key_expires_at = $19, key_rotation_grace_until = $20,
 		    previous_public_key = $21, rotation_count = $22,
 		    pqc_public_key = $23, pqc_key_algorithm = $24, hybrid_mode_enabled = $25,
-		    pqc_key_created_at = $26, pqc_key_expires_at = $27, previous_pqc_public_key = $28
-		WHERE id = $29
+		    pqc_key_created_at = $26, pqc_key_expires_at = $27, previous_pqc_public_key = $28,
+		    declared_purpose = $29
+		WHERE id = $30
 	`
 
 	agent.UpdatedAt = time.Now()
@@ -460,6 +491,16 @@ func (r *AgentRepository) Update(agent *domain.Agent) error {
 	}
 	if agent.Metadata == nil {
 		metadataJSON = []byte("{}")
+	}
+
+	// Marshal declared_purpose to JSONB; SQL NULL (untyped nil) when not declared.
+	var declaredPurposeParam interface{}
+	if agent.DeclaredPurpose != nil {
+		b, mErr := json.Marshal(agent.DeclaredPurpose)
+		if mErr != nil {
+			return fmt.Errorf("failed to marshal declared_purpose: %w", mErr)
+		}
+		declaredPurposeParam = b
 	}
 
 	_, err = r.db.Exec(query,
@@ -491,6 +532,7 @@ func (r *AgentRepository) Update(agent *domain.Agent) error {
 		agent.PQCKeyCreatedAt,
 		agent.PQCKeyExpiresAt,
 		agent.PreviousPQCPublicKey,
+		declaredPurposeParam,
 		agent.ID,
 	)
 
@@ -511,7 +553,7 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''),
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -533,6 +575,7 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 		var documentationURL sql.NullString
 		talksToJSON := make([]byte, 0)
 		metadataJSON := make([]byte, 0)
+		declaredPurposeJSON := make([]byte, 0)
 		err := rows.Scan(
 			&agent.ID,
 			&agent.OrganizationID,
@@ -557,6 +600,7 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 			&agent.CreatedByEmail,
 			&agent.CapabilityViolationCount,
 			&agent.IsCompromised,
+			&declaredPurposeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -589,6 +633,13 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 		if len(metadataJSON) > 0 {
 			if err := json.Unmarshal(metadataJSON, &agent.Metadata); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+			}
+		}
+
+		// Unmarshal declared_purpose from JSONB
+		if len(declaredPurposeJSON) > 0 {
+			if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
 			}
 		}
 
@@ -631,7 +682,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE organization_id = $1
 		  AND (
@@ -662,6 +713,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 		var documentationURL sql.NullString
 		talksToJSON := make([]byte, 0)
 		metadataJSON := make([]byte, 0)
+		declaredPurposeJSON := make([]byte, 0)
 		err := rows.Scan(
 			&agent.ID,
 			&agent.OrganizationID,
@@ -684,6 +736,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 			&agent.CreatedBy,
 			&agent.CapabilityViolationCount,
 			&agent.IsCompromised,
+			&declaredPurposeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -719,6 +772,13 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 			}
 		}
 
+		// Unmarshal declared_purpose from JSONB
+		if len(declaredPurposeJSON) > 0 {
+			if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
+			}
+		}
+
 		agents = append(agents, agent)
 	}
 
@@ -737,7 +797,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE organization_id = $1
 		  AND (
@@ -768,6 +828,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 		var documentationURL sql.NullString
 		talksToJSON := make([]byte, 0)
 		metadataJSON := make([]byte, 0)
+		declaredPurposeJSON := make([]byte, 0)
 		err := rows.Scan(
 			&agent.ID,
 			&agent.OrganizationID,
@@ -790,6 +851,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 			&agent.CreatedBy,
 			&agent.CapabilityViolationCount,
 			&agent.IsCompromised,
+			&declaredPurposeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -825,6 +887,13 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 			}
 		}
 
+		// Unmarshal declared_purpose from JSONB
+		if len(declaredPurposeJSON) > 0 {
+			if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
+			}
+		}
+
 		agents = append(agents, agent)
 	}
 
@@ -840,7 +909,7 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 		       created_at, updated_at, created_by, encrypted_private_key, key_algorithm,
 		       key_created_at, key_expires_at, key_rotation_grace_until, previous_public_key, rotation_count,
 		       talks_to, capabilities, metadata,
-		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false)
+		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE organization_id = $1 AND name = $2
 		LIMIT 1
@@ -863,6 +932,7 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 	talksToJSON := make([]byte, 0)
 	capabilitiesJSON := make([]byte, 0)
 	metadataJSON := make([]byte, 0)
+	declaredPurposeJSON := make([]byte, 0)
 
 	err := r.db.QueryRow(query, orgID, name).Scan(
 		&agent.ID,
@@ -894,6 +964,7 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 		&metadataJSON,
 		&agent.CapabilityViolationCount,
 		&agent.IsCompromised,
+		&declaredPurposeJSON,
 	)
 
 	if err == sql.ErrNoRows {
@@ -959,6 +1030,13 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 	if len(metadataJSON) > 0 {
 		if err := json.Unmarshal(metadataJSON, &agent.Metadata); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+		}
+	}
+
+	// Unmarshal declared_purpose from JSONB
+	if len(declaredPurposeJSON) > 0 {
+		if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
 		}
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -145,6 +145,7 @@ func (h *AgentHandler) enrichAgentResponse(c fiber.Ctx, agent *domain.Agent) fib
 		"capabilities":             capabilityTypes,
 		"tags":                     tags,            // ✅ Include tags in response
 		"metadata":                 agent.Metadata,  // ✅ Include custom metadata (model, department, etc.)
+		"declaredPurpose":          agent.DeclaredPurpose,
 		"capabilityViolationCount": agent.CapabilityViolationCount,
 		"isCompromised":            agent.IsCompromised,
 		"certificateUrl":           agent.CertificateURL,

--- a/apps/backend/migrations/100_add_declared_purpose.sql
+++ b/apps/backend/migrations/100_add_declared_purpose.sql
@@ -1,0 +1,100 @@
+-- Migration 100: declared purpose (ATX declaredPurpose field)
+--
+-- Adds the optional, structured "what is this agent FOR" declaration to agents,
+-- plus the two governed vocabulary registry tables that back the category and
+-- taskScope vocabularies. Mirrors the capability registry governance pattern
+-- (capability_definitions): closed core (organization_id NULL) plus org-custom,
+-- versioned so a later vocabulary revision never silently re-interprets an old
+-- credential.
+--
+-- declaredPurpose is identity/attestation + an OFFLINE detection signal only. It
+-- is NEVER an authorization input: nothing in the verification or enforcement
+-- path reads this column. Optional/additive — NULL means no purpose declared,
+-- which degrades the detection signal but never fails verification.
+
+-- 1. The declared purpose on an agent (nullable; NULL = not declared).
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS declared_purpose JSONB;
+
+COMMENT ON COLUMN agents.declared_purpose IS
+    'Optional structured declaredPurpose object (atx-spec core.md §1.5): what the agent is for. Identity/attestation + offline detection signal only; never an authorization input.';
+
+-- 2. Purpose category vocabulary. Closed core (organization_id NULL) plus
+--    org-custom (<org>.<name>). breadth_class / sensitivity_class drive the
+--    breadth measure and verifier-policy defaults.
+CREATE TABLE IF NOT EXISTS purpose_categories (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key              TEXT NOT NULL,
+    display_name     TEXT NOT NULL,
+    description      TEXT NOT NULL DEFAULT '',
+    breadth_class    TEXT NOT NULL CHECK (breadth_class IN ('narrow', 'moderate', 'broad')),
+    sensitivity_class TEXT NOT NULL CHECK (sensitivity_class IN ('standard', 'elevated', 'regulated')),
+    category_type    TEXT NOT NULL CHECK (category_type IN ('core', 'custom')),
+    organization_id  UUID REFERENCES organizations(id) ON DELETE CASCADE,
+    vocab_version    TEXT NOT NULL DEFAULT '1',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Core categories are globally unique by key; custom categories are unique
+    -- per organization. NULLS NOT DISTINCT so two core rows with the same key
+    -- collide (PG15+).
+    CONSTRAINT purpose_categories_key_org_unique UNIQUE NULLS NOT DISTINCT (key, organization_id),
+    -- A core category has no organization; a custom category must have one.
+    CONSTRAINT purpose_categories_core_no_org CHECK (
+        (category_type = 'core' AND organization_id IS NULL) OR
+        (category_type = 'custom' AND organization_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_purpose_categories_org ON purpose_categories (organization_id);
+
+-- 3. TaskScope definitions (namespace:objective). Reserved core namespaces are
+--    enforced in application code (ReservedTaskScopeNamespaces); this table holds
+--    concrete objective definitions for listing and org-custom extension.
+CREATE TABLE IF NOT EXISTS task_scope_definitions (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    namespace        TEXT NOT NULL,
+    objective        TEXT NOT NULL,
+    scope_type       TEXT NOT NULL CHECK (scope_type IN ('core', 'custom')),
+    organization_id  UUID REFERENCES organizations(id) ON DELETE CASCADE,
+    description      TEXT NOT NULL DEFAULT '',
+    vocab_version    TEXT NOT NULL DEFAULT '1',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT task_scope_namespace_objective_org_unique UNIQUE NULLS NOT DISTINCT (namespace, objective, organization_id),
+    CONSTRAINT task_scope_core_no_org CHECK (
+        (scope_type = 'core' AND organization_id IS NULL) OR
+        (scope_type = 'custom' AND organization_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_scope_definitions_org ON task_scope_definitions (organization_id);
+
+-- 4. Seed the closed core category vocabulary (vocab v1). No catch-all.
+INSERT INTO purpose_categories (key, display_name, breadth_class, sensitivity_class, category_type, vocab_version) VALUES
+    ('customer-support',     'Customer support',      'narrow',   'standard',  'core', '1'),
+    ('financial-operations', 'Financial operations',  'moderate', 'regulated', 'core', '1'),
+    ('data-analysis',        'Data analysis',         'narrow',   'standard',  'core', '1'),
+    ('data-engineering',     'Data engineering',      'moderate', 'elevated',  'core', '1'),
+    ('software-development', 'Software development',   'moderate', 'standard',  'core', '1'),
+    ('devops-automation',    'DevOps automation',     'broad',    'elevated',  'core', '1'),
+    ('security-operations',  'Security operations',   'broad',    'elevated',  'core', '1'),
+    ('content-generation',   'Content generation',    'narrow',   'standard',  'core', '1'),
+    ('research-assistant',   'Research assistant',    'moderate', 'standard',  'core', '1'),
+    ('sales-marketing',      'Sales and marketing',   'moderate', 'elevated',  'core', '1'),
+    ('hr-people-ops',        'HR / people ops',       'moderate', 'regulated', 'core', '1'),
+    ('legal-compliance',     'Legal and compliance',  'narrow',   'regulated', 'core', '1'),
+    ('healthcare-clinical',  'Healthcare / clinical', 'moderate', 'regulated', 'core', '1'),
+    ('device-control',       'Device control',        'moderate', 'elevated',  'core', '1'),
+    ('agent-orchestration',  'Agent orchestration',   'broad',    'elevated',  'core', '1')
+ON CONFLICT DO NOTHING;
+
+-- 5. Seed the example core taskScope objectives named in the vocabulary (vocab v1).
+--    The reserved core NAMESPACES are governed in application code; orgs and CA
+--    add further objectives over time.
+INSERT INTO task_scope_definitions (namespace, objective, scope_type, vocab_version, description) VALUES
+    ('billing',     'inquiry',   'core', '1', 'Handle a customer billing inquiry'),
+    ('billing',     'refund',    'core', '1', 'Issue a customer refund'),
+    ('support',     'triage',    'core', '1', 'Triage an inbound support request'),
+    ('dataops',     'transform', 'core', '1', 'Transform / reshape data between systems'),
+    ('secops',      'scan',      'core', '1', 'Run a security scan'),
+    ('orchestrate', 'route',     'core', '1', 'Route or supervise other agents')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Adds the optional `declaredPurpose` attribute to the agent identity model — a machine-readable statement of what the agent is for.

## Changes
- **Domain**: `DeclaredPurpose` type with locked core vocabulary, validation, and warn-only coherence checks.
- **Migration 100**: nullable `declared_purpose` JSONB column + `purpose_categories` (15 core) and `task_scope_definitions` (6 core) seed tables. Idempotent (`IF NOT EXISTS` / `ON CONFLICT DO NOTHING`).
- **Service**: create + update validate the field against the locked vocab and emit coherence warnings — **warn-only, never blocks the request**.
- **Repository**: persists/reads the JSONB column (parameterized; absent → SQL `NULL`).
- **Handler**: surfaces `declaredPurpose` in the agent response.

## Non-enforcement
`declaredPurpose` is never an authorization input — it is identity metadata + an offline analysis signal.

## Verification
`go build ./...`, `go vet`, and domain/application/handlers unit tests green. Migration applied cleanly on a throwaway PostgreSQL 18 (column nullable JSONB, 15+6 seed rows, idempotent re-run). The 15-category vocabulary matches across the Go map and the SQL seed.

Migration uses `UNIQUE NULLS NOT DISTINCT` (PostgreSQL 15+).