### PR TITLE
ci: retry docker registry logins to survive transient 500s

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,18 +43,41 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Registry logins are wrapped in a retry loop: transient registry 500s
+      # (e.g. registry-1.docker.io HTTP 500, observed on run 27146602888) have
+      # no built-in retry in docker/login-action and otherwise paint the repo
+      # red until a manual re-run. Backoff is linear (10s, 20s, 30s, 40s).
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin; then
+              echo "Docker Hub login succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Docker Hub login attempt $attempt failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "Docker Hub login failed after 5 attempts"
+          exit 1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if echo "$GHCR_TOKEN" | docker login "$REGISTRY" -u "$GHCR_USER" --password-stdin; then
+              echo "GHCR login succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "GHCR login attempt $attempt failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "GHCR login failed after 5 attempts"
+          exit 1
 
       - name: Extract metadata (GHCR)
         id: meta-ghcr
@@ -142,18 +165,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # See build-backend for rationale: retry transient registry 500s that
+      # docker/login-action does not retry on its own.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin; then
+              echo "Docker Hub login succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Docker Hub login attempt $attempt failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "Docker Hub login failed after 5 attempts"
+          exit 1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if echo "$GHCR_TOKEN" | docker login "$REGISTRY" -u "$GHCR_USER" --password-stdin; then
+              echo "GHCR login succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "GHCR login attempt $attempt failed; retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "GHCR login failed after 5 attempts"
+          exit 1
 
       - name: Extract metadata (GHCR)
         id: meta-ghcr


### PR DESCRIPTION
## Problem

The `Docker Publish` workflow's registry-login steps had no retry. A transient registry 500 (observed on run [27146602888](https://github.com/opena2a-org/agent-identity-management/actions/runs/27146602888) — `registry-1.docker.io` returned HTTP 500 at the *Log in to Docker Hub* step) failed the whole publish and left the public repo showing a red run until someone manually re-ran it. Secrets were valid; the prior publish on `main` succeeded with the same secrets — it was purely a Docker Hub blip.

## Change

Wrap both registry logins (Docker Hub + GHCR) in each job in a 5-attempt retry loop with linear backoff (10s/20s/30s/40s), using the `docker login` CLI already present on the runner.

- No new action dependency — in fact this **removes** the third-party `docker/login-action` in favor of the docker CLI on the runner.
- Secrets and the actor/registry values are passed via `env:` and piped through `--password-stdin`; they never appear as CLI args or in the echoed command.
- No image, build, signing, or attestation logic changed.

## Verification

- YAML parses; embedded shell passes `bash -n`.
- GitHub's default `bash -eo pipefail` makes `echo | docker login` return docker's exit code, correctly caught by the `if`.
- Pre-push review gate: PASS (CI-only diff; phases 1–3 pass, 4–7 skip by condition).