### PR TITLE
Capture optional signup profile questions at registration

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1486,6 +1486,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	admin.Delete("/users/:id", h.Admin.PermanentlyDeleteUser)   // Hard delete - removes from database
 
 	// Registration request management (for pending OAuth registrations)
+	admin.Get("/registration-requests", h.Admin.ListRegistrationRequests)
 	admin.Post("/registration-requests/:id/approve", h.Admin.ApproveRegistrationRequest)
 	admin.Post("/registration-requests/:id/reject", h.Admin.RejectRegistrationRequest)
 

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -56,10 +56,13 @@ func NewRegistrationService(
 	}
 }
 
-// CreateManualRegistrationRequest creates a registration request for email/password user registration
+// CreateManualRegistrationRequest creates a registration request for email/password user registration.
+// signupProfile holds optional, already-validated questionnaire answers
+// (see domain.BuildSignupProfile); pass nil when none were given.
 func (s *RegistrationService) CreateManualRegistrationRequest(
 	ctx context.Context,
 	email, firstName, lastName, password string,
+	signupProfile map[string]string,
 ) (*domain.UserRegistrationRequest, error) {
 	// Check if user already exists
 	existingUser, err := s.userRepo.GetByEmail(email)
@@ -99,6 +102,12 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 		lastName,
 		hashedPassword,
 	)
+
+	if len(signupProfile) > 0 {
+		req.Metadata = map[string]interface{}{
+			domain.SignupProfileMetadataKey: signupProfile,
+		}
+	}
 
 	if shouldAutoApprove {
 		req.Status = domain.RegistrationStatusApproved
@@ -239,11 +248,11 @@ func (s *RegistrationService) CreateAccessRequest(
 		Status:             domain.RegistrationStatusPending,
 		RequestedAt:        now,
 		OAuthEmailVerified: false,
-		Metadata:           map[string]interface{}{
+		Metadata: map[string]interface{}{
 			"reason": reason,
 		},
-		CreatedAt:          now,
-		UpdatedAt:          now,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	// Add organization name to metadata if provided
@@ -319,7 +328,7 @@ func (s *RegistrationService) ApproveRegistrationRequest(
 	}
 
 	// Determine provider based on registration request type
-	provider := "local" // Default to local for email/password
+	provider := "local"     // Default to local for email/password
 	providerID := req.Email // Use email as provider ID for local auth
 
 	// If OAuth registration, use OAuth provider info
@@ -335,7 +344,7 @@ func (s *RegistrationService) ApproveRegistrationRequest(
 	if err != nil {
 		return nil, fmt.Errorf("failed to check existing users: %w", err)
 	}
-	
+
 	userRole := domain.RoleViewer // Default to viewer
 	if len(existingUsers) == 0 {
 		userRole = domain.RoleAdmin // First user becomes admin
@@ -350,7 +359,7 @@ func (s *RegistrationService) ApproveRegistrationRequest(
 		Role:           userRole, // Admin if first user, otherwise viewer
 		Provider:       provider,
 		ProviderID:     providerID,
-		PasswordHash:   req.PasswordHash,  // Will be set for email/password registrations
+		PasswordHash:   req.PasswordHash, // Will be set for email/password registrations
 		ApprovedBy:     &reviewerID,
 		ApprovedAt:     &time.Time{},
 		Status:         domain.UserStatusActive, // Set user as active upon approval
@@ -625,7 +634,7 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 
 	// Organization doesn't exist, create new one
 	fmt.Printf("📝 Creating new organization for domain: %s\n", domainName)
-	
+
 	newOrg := &domain.Organization{
 		ID:        uuid.New(),
 		Name:      domainName, // Use domain as organization name

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -860,7 +860,7 @@ func TestRegistrationService_CreateManualRegistrationRequest_UserExists(t *testi
 
 	service := NewRegistrationService(nil, mockUserRepo, nil, nil, nil)
 
-	req, err := service.CreateManualRegistrationRequest(ctx, "existing@example.com", "John", "Doe", "Password123!")
+	req, err := service.CreateManualRegistrationRequest(ctx, "existing@example.com", "John", "Doe", "Password123!", nil)
 
 	assert.Nil(t, req)
 	assert.Equal(t, ErrUserAlreadyExists, err)
@@ -885,7 +885,7 @@ func TestRegistrationService_CreateManualRegistrationRequest_PendingRequestExist
 
 	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
 
-	req, err := service.CreateManualRegistrationRequest(ctx, "pending@example.com", "John", "Doe", "Password123!")
+	req, err := service.CreateManualRegistrationRequest(ctx, "pending@example.com", "John", "Doe", "Password123!", nil)
 
 	assert.Nil(t, req)
 	assert.Equal(t, ErrRegistrationRequestExists, err)
@@ -905,11 +905,56 @@ func TestRegistrationService_CreateManualRegistrationRequest_WeakPassword(t *tes
 	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
 
 	// Weak password
-	req, err := service.CreateManualRegistrationRequest(ctx, "new@example.com", "John", "Doe", "weak")
+	req, err := service.CreateManualRegistrationRequest(ctx, "new@example.com", "John", "Doe", "weak", nil)
 
 	assert.Nil(t, req)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "password validation failed")
+}
+
+func TestRegistrationService_CreateManualRegistrationRequest_StoresSignupProfile(t *testing.T) {
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "survey@example.com").Return(nil, errors.New("not found"))
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "survey@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("CreateRegistrationRequest", ctx, mock.AnythingOfType("*domain.UserRegistrationRequest")).Return(nil)
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	profile := map[string]string{
+		"role":           "developer",
+		"primaryUseCase": "securing-production-agents",
+		"referralSource": "github",
+	}
+	req, err := service.CreateManualRegistrationRequest(ctx, "survey@example.com", "John", "Doe", "Password123!", profile)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+	assert.Equal(t, map[string]interface{}{domain.SignupProfileMetadataKey: profile}, req.Metadata)
+	mockRegRepo.AssertExpectations(t)
+}
+
+func TestRegistrationService_CreateManualRegistrationRequest_NoProfileLeavesMetadataNil(t *testing.T) {
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "plain@example.com").Return(nil, errors.New("not found"))
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "plain@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("CreateRegistrationRequest", ctx, mock.AnythingOfType("*domain.UserRegistrationRequest")).Return(nil)
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateManualRegistrationRequest(ctx, "plain@example.com", "John", "Doe", "Password123!", nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+	assert.Nil(t, req.Metadata)
+	mockRegRepo.AssertExpectations(t)
 }
 
 func TestRegistrationService_CreateAccessRequest_Success(t *testing.T) {

--- a/apps/backend/internal/domain/signup_profile.go
+++ b/apps/backend/internal/domain/signup_profile.go
@@ -1,0 +1,79 @@
+package domain
+
+import "fmt"
+
+// SignupProfileMetadataKey is the key under user_registration_requests.metadata
+// that holds the optional signup questionnaire answers.
+const SignupProfileMetadataKey = "signupProfile"
+
+// Signup profile answers use a closed vocabulary: the registration endpoint is
+// public, so free text would let arbitrary content into the database and make
+// the captured stats unaggregatable.
+var (
+	SignupProfileRoles = []string{
+		"developer",
+		"security-engineer",
+		"founder-or-exec",
+		"student-or-researcher",
+		"other",
+	}
+	SignupProfileUseCases = []string{
+		"securing-production-agents",
+		"evaluating-for-team",
+		"research-or-learning",
+		"personal-project",
+		"other",
+	}
+	SignupProfileReferralSources = []string{
+		"github",
+		"search",
+		"social-media",
+		"colleague-or-friend",
+		"blog-or-article",
+		"other",
+	}
+)
+
+// BuildSignupProfile validates the optional questionnaire answers and returns
+// the map to store under SignupProfileMetadataKey. Empty answers are skipped
+// (the questions are optional at the API level); a non-empty answer outside
+// its vocabulary is an error. Returns nil when no answers were provided.
+func BuildSignupProfile(role, primaryUseCase, referralSource string) (map[string]string, error) {
+	profile := make(map[string]string)
+
+	// Error messages deliberately omit the submitted value: they are returned
+	// verbatim by a public endpoint, so echoing input would reflect
+	// arbitrarily long attacker-controlled strings.
+	if role != "" {
+		if !containsString(SignupProfileRoles, role) {
+			return nil, fmt.Errorf("invalid signup profile role")
+		}
+		profile["role"] = role
+	}
+	if primaryUseCase != "" {
+		if !containsString(SignupProfileUseCases, primaryUseCase) {
+			return nil, fmt.Errorf("invalid signup profile primaryUseCase")
+		}
+		profile["primaryUseCase"] = primaryUseCase
+	}
+	if referralSource != "" {
+		if !containsString(SignupProfileReferralSources, referralSource) {
+			return nil, fmt.Errorf("invalid signup profile referralSource")
+		}
+		profile["referralSource"] = referralSource
+	}
+
+	if len(profile) == 0 {
+		return nil, nil
+	}
+	return profile, nil
+}
+
+func containsString(values []string, v string) bool {
+	for _, candidate := range values {
+		if candidate == v {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/backend/internal/domain/signup_profile_test.go
+++ b/apps/backend/internal/domain/signup_profile_test.go
@@ -1,0 +1,55 @@
+package domain
+
+import (
+	"testing"
+)
+
+func TestBuildSignupProfile_AllAnswersValid(t *testing.T) {
+	profile, err := BuildSignupProfile("developer", "securing-production-agents", "github")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile["role"] != "developer" ||
+		profile["primaryUseCase"] != "securing-production-agents" ||
+		profile["referralSource"] != "github" {
+		t.Fatalf("unexpected profile: %v", profile)
+	}
+}
+
+func TestBuildSignupProfile_PartialAnswers(t *testing.T) {
+	profile, err := BuildSignupProfile("", "research-or-learning", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(profile) != 1 || profile["primaryUseCase"] != "research-or-learning" {
+		t.Fatalf("unexpected profile: %v", profile)
+	}
+}
+
+func TestBuildSignupProfile_NoAnswersReturnsNil(t *testing.T) {
+	profile, err := BuildSignupProfile("", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile != nil {
+		t.Fatalf("expected nil profile, got: %v", profile)
+	}
+}
+
+func TestBuildSignupProfile_RejectsUnknownValues(t *testing.T) {
+	cases := []struct {
+		name                          string
+		role, useCase, referralSource string
+	}{
+		{"unknown role", "ceo<script>", "", ""},
+		{"unknown use case", "", "world-domination", ""},
+		{"unknown referral source", "", "", "carrier-pigeon"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildSignupProfile(tc.role, tc.useCase, tc.referralSource); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/infrastructure/repository/oauth_repository.go
+++ b/apps/backend/internal/infrastructure/repository/oauth_repository.go
@@ -3,12 +3,48 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
+
+// maxRegistrationMetadataBytes bounds the metadata column: every current
+// producer (signup profile, access-request reason) stays well under this, and
+// registration requests originate from unauthenticated endpoints, so an
+// unbounded write here would be a storage-abuse vector.
+const maxRegistrationMetadataBytes = 16 * 1024
+
+// marshalRegistrationMetadata converts the metadata map to a JSONB parameter
+// (NULL when empty).
+func marshalRegistrationMetadata(m map[string]interface{}) (interface{}, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal registration metadata: %w", err)
+	}
+	if len(raw) > maxRegistrationMetadataBytes {
+		return nil, fmt.Errorf("registration metadata exceeds %d bytes", maxRegistrationMetadataBytes)
+	}
+	return raw, nil
+}
+
+// unmarshalRegistrationMetadata converts a scanned JSONB value back to a map
+// (nil when the column is NULL).
+func unmarshalRegistrationMetadata(raw []byte) (map[string]interface{}, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal registration metadata: %w", err)
+	}
+	return m, nil
+}
 
 type OAuthRepositoryPostgres struct {
 	db *sqlx.DB
@@ -27,13 +63,18 @@ func (r *OAuthRepositoryPostgres) CreateRegistrationRequest(ctx context.Context,
 		INSERT INTO user_registration_requests (
 			id, email, first_name, last_name,
 			organization_id, status, requested_at,
-			password_hash, created_at, updated_at
+			password_hash, metadata, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 		)
 	`
 
-	_, err := r.db.ExecContext(ctx, query,
+	metadata, err := marshalRegistrationMetadata(req.Metadata)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.db.ExecContext(ctx, query,
 		req.ID,
 		req.Email,
 		req.FirstName,
@@ -42,6 +83,7 @@ func (r *OAuthRepositoryPostgres) CreateRegistrationRequest(ctx context.Context,
 		req.Status,
 		req.RequestedAt,
 		req.PasswordHash,
+		metadata,
 		req.CreatedAt,
 		req.UpdatedAt,
 	)
@@ -57,12 +99,13 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequest(ctx context.Context, id
 	query := `
 		SELECT id, email, first_name, last_name,
 			   organization_id, status, requested_at, reviewed_at, reviewed_by,
-			   rejection_reason, password_hash, created_at, updated_at
+			   rejection_reason, password_hash, metadata, created_at, updated_at
 		FROM user_registration_requests
 		WHERE id = $1
 	`
 
 	var req domain.UserRegistrationRequest
+	var metadataRaw []byte
 
 	err := r.db.QueryRowContext(ctx, query, id).Scan(
 		&req.ID,
@@ -76,6 +119,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequest(ctx context.Context, id
 		&req.ReviewedBy,
 		&req.RejectionReason,
 		&req.PasswordHash,
+		&metadataRaw,
 		&req.CreatedAt,
 		&req.UpdatedAt,
 	)
@@ -85,6 +129,10 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequest(ctx context.Context, id
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get registration request: %w", err)
+	}
+
+	if req.Metadata, err = unmarshalRegistrationMetadata(metadataRaw); err != nil {
+		return nil, err
 	}
 
 	return &req, nil
@@ -108,7 +156,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmail(
 	query := `
 		SELECT id, email, first_name, last_name,
 			   organization_id, status, requested_at, reviewed_at, reviewed_by,
-			   rejection_reason, password_hash, created_at, updated_at
+			   rejection_reason, password_hash, metadata, created_at, updated_at
 		FROM user_registration_requests
 		WHERE email = $1 AND status = $2
 		ORDER BY created_at DESC
@@ -116,6 +164,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmail(
 	`
 
 	var req domain.UserRegistrationRequest
+	var metadataRaw []byte
 
 	err := r.db.QueryRowContext(ctx, query, email, domain.RegistrationStatusPending).Scan(
 		&req.ID,
@@ -129,6 +178,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmail(
 		&req.ReviewedBy,
 		&req.RejectionReason,
 		&req.PasswordHash,
+		&metadataRaw,
 		&req.CreatedAt,
 		&req.UpdatedAt,
 	)
@@ -138,6 +188,10 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmail(
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get registration request: %w", err)
+	}
+
+	if req.Metadata, err = unmarshalRegistrationMetadata(metadataRaw); err != nil {
+		return nil, err
 	}
 
 	return &req, nil
@@ -151,7 +205,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmailAnyStatus(
 	query := `
 		SELECT id, email, first_name, last_name,
 			   organization_id, status, requested_at, reviewed_at, reviewed_by,
-			   rejection_reason, password_hash, created_at, updated_at
+			   rejection_reason, password_hash, metadata, created_at, updated_at
 		FROM user_registration_requests
 		WHERE email = $1
 		ORDER BY created_at DESC
@@ -159,6 +213,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmailAnyStatus(
 	`
 
 	var req domain.UserRegistrationRequest
+	var metadataRaw []byte
 
 	err := r.db.QueryRowContext(ctx, query, email).Scan(
 		&req.ID,
@@ -172,6 +227,7 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmailAnyStatus(
 		&req.ReviewedBy,
 		&req.RejectionReason,
 		&req.PasswordHash,
+		&metadataRaw,
 		&req.CreatedAt,
 		&req.UpdatedAt,
 	)
@@ -180,6 +236,10 @@ func (r *OAuthRepositoryPostgres) GetRegistrationRequestByEmailAnyStatus(
 		return nil, fmt.Errorf("registration request not found")
 	}
 	if err != nil {
+		return nil, err
+	}
+
+	if req.Metadata, err = unmarshalRegistrationMetadata(metadataRaw); err != nil {
 		return nil, err
 	}
 
@@ -206,7 +266,7 @@ func (r *OAuthRepositoryPostgres) ListPendingRegistrationRequests(
 	query := `
 		SELECT id, email, first_name, last_name,
 			   organization_id, status, requested_at, reviewed_at, reviewed_by,
-			   rejection_reason, password_hash, created_at, updated_at
+			   rejection_reason, password_hash, metadata, created_at, updated_at
 		FROM user_registration_requests
 		WHERE status = $1 AND (organization_id = $2 OR organization_id IS NULL)
 		ORDER BY requested_at DESC
@@ -222,6 +282,7 @@ func (r *OAuthRepositoryPostgres) ListPendingRegistrationRequests(
 	requests := make([]*domain.UserRegistrationRequest, 0)
 	for rows.Next() {
 		var req domain.UserRegistrationRequest
+		var metadataRaw []byte
 
 		err := rows.Scan(
 			&req.ID,
@@ -235,11 +296,16 @@ func (r *OAuthRepositoryPostgres) ListPendingRegistrationRequests(
 			&req.ReviewedBy,
 			&req.RejectionReason,
 			&req.PasswordHash,
+			&metadataRaw,
 			&req.CreatedAt,
 			&req.UpdatedAt,
 		)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to scan registration request: %w", err)
+		}
+
+		if req.Metadata, err = unmarshalRegistrationMetadata(metadataRaw); err != nil {
+			return nil, 0, err
 		}
 
 		requests = append(requests, &req)

--- a/apps/backend/internal/infrastructure/repository/oauth_repository_metadata_test.go
+++ b/apps/backend/internal/infrastructure/repository/oauth_repository_metadata_test.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarshalRegistrationMetadata_EmptyIsNull(t *testing.T) {
+	for _, m := range []map[string]interface{}{nil, {}} {
+		v, err := marshalRegistrationMetadata(m)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != nil {
+			t.Fatalf("expected nil (SQL NULL), got %v", v)
+		}
+	}
+}
+
+func TestMarshalRegistrationMetadata_RoundTrip(t *testing.T) {
+	in := map[string]interface{}{
+		"signupProfile": map[string]interface{}{
+			"role":           "developer",
+			"primaryUseCase": "securing-production-agents",
+			"referralSource": "github",
+		},
+	}
+
+	v, err := marshalRegistrationMetadata(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	raw, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("expected []byte, got %T", v)
+	}
+
+	out, err := unmarshalRegistrationMetadata(raw)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	profile, ok := out["signupProfile"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("signupProfile missing or wrong type: %v", out)
+	}
+	if profile["role"] != "developer" ||
+		profile["primaryUseCase"] != "securing-production-agents" ||
+		profile["referralSource"] != "github" {
+		t.Fatalf("round-trip mismatch: %v", profile)
+	}
+}
+
+func TestMarshalRegistrationMetadata_RejectsOversize(t *testing.T) {
+	m := map[string]interface{}{
+		"reason": strings.Repeat("a", maxRegistrationMetadataBytes+1),
+	}
+	if _, err := marshalRegistrationMetadata(m); err == nil {
+		t.Fatal("expected oversize metadata to be rejected")
+	}
+}
+
+func TestUnmarshalRegistrationMetadata_NullColumn(t *testing.T) {
+	out, err := unmarshalRegistrationMetadata(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil map for NULL column, got %v", out)
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/admin_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/admin_handler.go
@@ -1435,6 +1435,35 @@ func (h *AdminHandler) RejectUser(c fiber.Ctx) error {
 	})
 }
 
+// ListRegistrationRequests returns pending registration requests for the
+// admin registrations page (includes signup profile answers via metadata)
+func (h *AdminHandler) ListRegistrationRequests(c fiber.Ctx) error {
+	orgID := c.Locals("organization_id").(uuid.UUID)
+
+	limit := 50
+	if parsed, err := strconv.Atoi(c.Query("limit", "50")); err == nil && parsed > 0 && parsed <= 100 {
+		limit = parsed
+	}
+	offset := 0
+	if parsed, err := strconv.Atoi(c.Query("offset", "0")); err == nil && parsed >= 0 {
+		offset = parsed
+	}
+
+	requests, total, err := h.getRegistrationService().ListPendingRegistrationRequests(c.Context(), orgID, limit, offset)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to fetch registration requests",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"requests": requests,
+		"total":    total,
+		"limit":    limit,
+		"offset":   offset,
+	})
+}
+
 // ApproveRegistrationRequest approves a pending registration request from the users page
 func (h *AdminHandler) ApproveRegistrationRequest(c fiber.Ctx) error {
 	orgID := c.Locals("organization_id").(uuid.UUID)

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
@@ -33,10 +33,20 @@ func NewPublicRegistrationHandler(
 
 // RegisterUserRequest represents the public registration request
 type RegisterUserRequest struct {
-	Email     string `json:"email" validate:"required,email"`
-	FirstName string `json:"firstName" validate:"required,min=1,max=100"`
-	LastName  string `json:"lastName" validate:"required,min=1,max=100"`
-	Password  string `json:"password" validate:"required,min=8"`
+	Email         string                `json:"email" validate:"required,email"`
+	FirstName     string                `json:"firstName" validate:"required,min=1,max=100"`
+	LastName      string                `json:"lastName" validate:"required,min=1,max=100"`
+	Password      string                `json:"password" validate:"required,min=8"`
+	SignupProfile *SignupProfileRequest `json:"signupProfile,omitempty"`
+}
+
+// SignupProfileRequest carries the optional signup questionnaire answers.
+// Values must come from the closed vocabularies in domain (SignupProfileRoles,
+// SignupProfileUseCases, SignupProfileReferralSources).
+type SignupProfileRequest struct {
+	Role           string `json:"role,omitempty"`
+	PrimaryUseCase string `json:"primaryUseCase,omitempty"`
+	ReferralSource string `json:"referralSource,omitempty"`
 }
 
 // RegisterUserResponse represents the registration response
@@ -69,8 +79,8 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 	}
 
 	// Basic validation (struct tags handle detailed validation)
-	if strings.TrimSpace(req.Email) == "" || strings.TrimSpace(req.FirstName) == "" || 
-	   strings.TrimSpace(req.LastName) == "" || strings.TrimSpace(req.Password) == "" {
+	if strings.TrimSpace(req.Email) == "" || strings.TrimSpace(req.FirstName) == "" ||
+		strings.TrimSpace(req.LastName) == "" || strings.TrimSpace(req.Password) == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"success": false,
 			"error":   "All fields are required",
@@ -82,6 +92,23 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 	firstName := strings.TrimSpace(req.FirstName)
 	lastName := strings.TrimSpace(req.LastName)
 
+	// Validate the optional signup questionnaire answers (closed vocabulary)
+	var signupProfile map[string]string
+	if req.SignupProfile != nil {
+		var profileErr error
+		signupProfile, profileErr = domain.BuildSignupProfile(
+			strings.TrimSpace(req.SignupProfile.Role),
+			strings.TrimSpace(req.SignupProfile.PrimaryUseCase),
+			strings.TrimSpace(req.SignupProfile.ReferralSource),
+		)
+		if profileErr != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"error":   profileErr.Error(),
+			})
+		}
+	}
+
 	// Create manual registration request with password
 	registrationRequest, err := h.registrationService.CreateManualRegistrationRequest(
 		c.Context(),
@@ -89,6 +116,7 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 		firstName,
 		lastName,
 		req.Password,
+		signupProfile,
 	)
 	if err != nil {
 		// Handle specific error cases
@@ -121,10 +149,10 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(&RegisterUserResponse{
-		Success: true,
-		Message: "Registration request submitted successfully. Please wait for admin approval.",
+		Success:             true,
+		Message:             "Registration request submitted successfully. Please wait for admin approval.",
 		RegistrationRequest: registrationRequest,
-		RequestID: registrationRequest.ID,
+		RequestID:           registrationRequest.ID,
 	})
 }
 
@@ -180,15 +208,15 @@ func (h *PublicRegistrationHandler) CheckRegistrationStatus(c fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{
-		"success":    true,
-		"status":     registrationRequest.Status,
-		"message":    statusMessage,
-		"requestId":  registrationRequest.ID,
-		"email":      registrationRequest.Email,
-		"firstName":  registrationRequest.FirstName,
-		"lastName":   registrationRequest.LastName,
+		"success":     true,
+		"status":      registrationRequest.Status,
+		"message":     statusMessage,
+		"requestId":   registrationRequest.ID,
+		"email":       registrationRequest.Email,
+		"firstName":   registrationRequest.FirstName,
+		"lastName":    registrationRequest.LastName,
 		"requestedAt": registrationRequest.RequestedAt,
-		"reviewedAt": registrationRequest.ReviewedAt,
+		"reviewedAt":  registrationRequest.ReviewedAt,
 	})
 }
 
@@ -200,13 +228,13 @@ type LoginRequest struct {
 
 // LoginResponse represents the login response
 type LoginResponse struct {
-	Success                bool          `json:"success"`
-	Message                string        `json:"message"`
-	User                   *domain.User  `json:"user"`
-	AccessToken            *string       `json:"accessToken,omitempty"`
-	RefreshToken           *string       `json:"refreshToken,omitempty"`
-	IsApproved             bool          `json:"isApproved"`
-	RequiresPasswordChange bool          `json:"requiresPasswordChange,omitempty"`
+	Success                bool         `json:"success"`
+	Message                string       `json:"message"`
+	User                   *domain.User `json:"user"`
+	AccessToken            *string      `json:"accessToken,omitempty"`
+	RefreshToken           *string      `json:"refreshToken,omitempty"`
+	IsApproved             bool         `json:"isApproved"`
+	RequiresPasswordChange bool         `json:"requiresPasswordChange,omitempty"`
 }
 
 // Login handles public user login with email and password
@@ -297,7 +325,7 @@ func (h *PublicRegistrationHandler) Login(c fiber.Ctx) error {
 						// Default organization for registration requests without org
 						orgID = uuid.MustParse("e7743fb0-d42d-4c3d-8684-38dc189f9ad4")
 					}
-					
+
 					tempUser := &domain.User{
 						ID:             regRequest.ID,
 						OrganizationID: orgID,
@@ -394,13 +422,13 @@ func (h *PublicRegistrationHandler) generatePasswordChangeRequiredResponse(c fib
 	}
 
 	response := &LoginResponse{
-		Success:              true,
-		User:                 user,
-		IsApproved:           true,
-		AccessToken:          &accessToken,
-		RefreshToken:         &refreshToken,
+		Success:                true,
+		User:                   user,
+		IsApproved:             true,
+		AccessToken:            &accessToken,
+		RefreshToken:           &refreshToken,
 		RequiresPasswordChange: true,
-		Message:              "You must change your password before continuing",
+		Message:                "You must change your password before continuing",
 	}
 
 	// Set cookies for web clients
@@ -478,6 +506,28 @@ func (h *PublicRegistrationHandler) RequestAccess(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"success": false,
 			"error":   "Reason must be at least 10 characters",
+		})
+	}
+
+	// Enforce length caps explicitly: this endpoint is unauthenticated and the
+	// reason/organizationName values are persisted to registration metadata,
+	// and the struct validate tags are not wired to a fiber StructValidator.
+	if len(req.Reason) > 1000 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "Reason must be at most 1000 characters",
+		})
+	}
+	if len(req.FullName) > 200 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "Full name must be at most 200 characters",
+		})
+	}
+	if req.OrganizationName != nil && len(*req.OrganizationName) > 200 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "Organization name must be at most 200 characters",
 		})
 	}
 

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler_test.go
@@ -86,6 +86,56 @@ func TestPublicRegistrationHandler_RegisterUser_MissingPassword(t *testing.T) {
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
+func TestPublicRegistrationHandler_RegisterUser_InvalidSignupProfileValue(t *testing.T) {
+	// Profile validation runs before the registration service is called,
+	// so an out-of-vocabulary answer must 400 even with valid credentials.
+	handler := &PublicRegistrationHandler{}
+	app := fiber.New()
+	app.Post("/public/register", handler.RegisterUser)
+
+	body := `{"email":"test@example.com","firstName":"John","lastName":"Doe","password":"Password123!","signupProfile":{"role":"supreme-leader"}}`
+	req := httptest.NewRequest("POST", "/public/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPublicRegistrationHandler_RequestAccess_OversizeFieldsRejected(t *testing.T) {
+	// Length caps run before any service lookup, so a zero-value handler
+	// (nil services) returning 400 instead of panicking proves ordering.
+	handler := &PublicRegistrationHandler{}
+	app := fiber.New()
+	app.Post("/public/request-access", handler.RequestAccess)
+
+	longReason := strings.Repeat("a", 1001)
+	longName := strings.Repeat("b", 201)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"oversize reason", `{"email":"t@example.com","fullName":"John Doe","reason":"` + longReason + `"}`},
+		{"oversize full name", `{"email":"t@example.com","fullName":"` + longName + `","reason":"a valid reason here"}`},
+		{"oversize organization name", `{"email":"t@example.com","fullName":"John Doe","organizationName":"` + longName + `","reason":"a valid reason here"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/public/request-access", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
 // ===========================
 // PublicRegistrationHandler.CheckRegistrationStatus Tests
 // ===========================

--- a/apps/web/app/admin/registrations/page.tsx
+++ b/apps/web/app/admin/registrations/page.tsx
@@ -10,8 +10,8 @@ interface RegistrationRequest {
   email: string;
   firstName: string;
   lastName: string;
-  oauthProvider: "google" | "microsoft" | "okta";
-  oauthUserId: string;
+  oauthProvider?: "google" | "microsoft" | "okta" | "local";
+  oauthUserId?: string;
   status: "pending" | "approved" | "rejected";
   requestedAt: string;
   reviewedAt?: string;
@@ -19,6 +19,13 @@ interface RegistrationRequest {
   rejectionReason?: string;
   profilePictureUrl?: string;
   oauthEmailVerified: boolean;
+  metadata?: {
+    signupProfile?: {
+      role?: string;
+      primaryUseCase?: string;
+      referralSource?: string;
+    };
+  };
 }
 
 export default function RegistrationsPage() {

--- a/apps/web/app/auth/register/page.tsx
+++ b/apps/web/app/auth/register/page.tsx
@@ -15,6 +15,32 @@ import Link from "next/link";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 
+// Values must match the backend vocabulary in domain/signup_profile.go
+const ROLE_OPTIONS = [
+  { value: "developer", label: "Developer" },
+  { value: "security-engineer", label: "Security engineer" },
+  { value: "founder-or-exec", label: "Founder or executive" },
+  { value: "student-or-researcher", label: "Student or researcher" },
+  { value: "other", label: "Other" },
+];
+
+const USE_CASE_OPTIONS = [
+  { value: "securing-production-agents", label: "Securing AI agents in production" },
+  { value: "evaluating-for-team", label: "Evaluating AIM for my team" },
+  { value: "research-or-learning", label: "Research or learning" },
+  { value: "personal-project", label: "Personal project" },
+  { value: "other", label: "Other" },
+];
+
+const REFERRAL_OPTIONS = [
+  { value: "github", label: "GitHub" },
+  { value: "search", label: "Search engine" },
+  { value: "social-media", label: "Social media" },
+  { value: "colleague-or-friend", label: "Colleague or friend" },
+  { value: "blog-or-article", label: "Blog or article" },
+  { value: "other", label: "Other" },
+];
+
 export default function RegisterPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -24,6 +50,9 @@ export default function RegisterPage() {
     lastName: "",
     password: "",
     confirmPassword: "",
+    role: "",
+    primaryUseCase: "",
+    referralSource: "",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [showPassword, setShowPassword] = useState(false);
@@ -58,6 +87,12 @@ export default function RegisterPage() {
       newErrors.confirmPassword = "Passwords do not match";
     }
 
+    if (!formData.role) newErrors.role = "Please select an option";
+    if (!formData.primaryUseCase)
+      newErrors.primaryUseCase = "Please select an option";
+    if (!formData.referralSource)
+      newErrors.referralSource = "Please select an option";
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -76,6 +111,11 @@ export default function RegisterPage() {
         lastName: formData.lastName,
         password: formData.password,
         provider: "local",
+        signupProfile: {
+          role: formData.role,
+          primaryUseCase: formData.primaryUseCase,
+          referralSource: formData.referralSource,
+        },
       });
 
       if (response.success) {
@@ -306,6 +346,114 @@ export default function RegisterPage() {
                   {errors.confirmPassword}
                 </p>
               )}
+            </div>
+
+            <div className="pt-2 border-t border-gray-200 space-y-4">
+              <p className="text-sm text-gray-600">
+                A few quick questions so we can improve AIM:
+              </p>
+
+              <div>
+                <label
+                  htmlFor="role"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  What best describes you?
+                </label>
+                <select
+                  id="role"
+                  value={formData.role}
+                  onChange={(e) =>
+                    setFormData({ ...formData, role: e.target.value })
+                  }
+                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    errors.role ? "border-red-500" : "border-gray-300"
+                  } ${formData.role ? "text-gray-900" : "text-gray-400"}`}
+                >
+                  <option value="" disabled>
+                    Select an option
+                  </option>
+                  {ROLE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.role && (
+                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                    <AlertCircle className="h-4 w-4" />
+                    {errors.role}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="primaryUseCase"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  What will you use AIM for?
+                </label>
+                <select
+                  id="primaryUseCase"
+                  value={formData.primaryUseCase}
+                  onChange={(e) =>
+                    setFormData({ ...formData, primaryUseCase: e.target.value })
+                  }
+                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    errors.primaryUseCase ? "border-red-500" : "border-gray-300"
+                  } ${formData.primaryUseCase ? "text-gray-900" : "text-gray-400"}`}
+                >
+                  <option value="" disabled>
+                    Select an option
+                  </option>
+                  {USE_CASE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.primaryUseCase && (
+                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                    <AlertCircle className="h-4 w-4" />
+                    {errors.primaryUseCase}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="referralSource"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  How did you hear about AIM?
+                </label>
+                <select
+                  id="referralSource"
+                  value={formData.referralSource}
+                  onChange={(e) =>
+                    setFormData({ ...formData, referralSource: e.target.value })
+                  }
+                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                    errors.referralSource ? "border-red-500" : "border-gray-300"
+                  } ${formData.referralSource ? "text-gray-900" : "text-gray-400"}`}
+                >
+                  <option value="" disabled>
+                    Select an option
+                  </option>
+                  {REFERRAL_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.referralSource && (
+                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                    <AlertCircle className="h-4 w-4" />
+                    {errors.referralSource}
+                  </p>
+                )}
+              </div>
             </div>
 
             <button

--- a/apps/web/components/admin/registration-request-card.tsx
+++ b/apps/web/components/admin/registration-request-card.tsx
@@ -9,8 +9,10 @@ interface RegistrationRequest {
   email: string
   firstName: string
   lastName: string
-  oauthProvider: 'google' | 'microsoft' | 'okta'
-  oauthUserId: string
+  // Absent for email/password registrations (the backend list query does not
+  // populate OAuth columns), so always guard when rendering
+  oauthProvider?: 'google' | 'microsoft' | 'okta' | 'local'
+  oauthUserId?: string
   status: 'pending' | 'approved' | 'rejected'
   requestedAt: string
   reviewedAt?: string
@@ -18,6 +20,13 @@ interface RegistrationRequest {
   rejectionReason?: string
   profilePictureUrl?: string
   oauthEmailVerified: boolean
+  metadata?: {
+    signupProfile?: {
+      role?: string
+      primaryUseCase?: string
+      referralSource?: string
+    }
+  }
 }
 
 interface RegistrationRequestCardProps {
@@ -30,7 +39,30 @@ const providerColors = {
   google: 'bg-blue-100 text-blue-700',
   microsoft: 'bg-gray-800 text-white',
   okta: 'bg-blue-600 text-white',
+  local: 'bg-gray-100 text-gray-700',
 }
+
+// Human-readable labels for the signup questionnaire slugs
+// (vocabulary defined in backend domain/signup_profile.go)
+const signupProfileLabels: Record<string, string> = {
+  developer: 'Developer',
+  'security-engineer': 'Security engineer',
+  'founder-or-exec': 'Founder or executive',
+  'student-or-researcher': 'Student or researcher',
+  'securing-production-agents': 'Securing production agents',
+  'evaluating-for-team': 'Evaluating for team',
+  'research-or-learning': 'Research or learning',
+  'personal-project': 'Personal project',
+  github: 'GitHub',
+  search: 'Search engine',
+  'social-media': 'Social media',
+  'colleague-or-friend': 'Colleague or friend',
+  'blog-or-article': 'Blog or article',
+  other: 'Other',
+}
+
+const formatProfileValue = (value?: string) =>
+  value ? (signupProfileLabels[value] ?? value) : null
 
 export function RegistrationRequestCard({ request, onApproved, onRejected }: RegistrationRequestCardProps) {
   const [isApproving, setIsApproving] = useState(false)
@@ -40,6 +72,13 @@ export function RegistrationRequestCard({ request, onApproved, onRejected }: Reg
   const [error, setError] = useState<string | null>(null)
 
   const fullName = [request.firstName, request.lastName].filter(Boolean).join(' ') || 'Unknown'
+
+  const signupProfile = request.metadata?.signupProfile
+  const profileEntries = [
+    { label: 'Role', value: formatProfileValue(signupProfile?.role) },
+    { label: 'Use case', value: formatProfileValue(signupProfile?.primaryUseCase) },
+    { label: 'Heard via', value: formatProfileValue(signupProfile?.referralSource) },
+  ].filter((entry) => entry.value)
 
   const handleApprove = async () => {
     setIsApproving(true)
@@ -116,8 +155,8 @@ export function RegistrationRequestCard({ request, onApproved, onRejected }: Reg
                 </div>
               </div>
 
-              <span className={`px-3 py-1 rounded-full text-xs font-medium ${providerColors[request.oauthProvider]}`}>
-                {request.oauthProvider.toUpperCase()}
+              <span className={`px-3 py-1 rounded-full text-xs font-medium ${providerColors[request.oauthProvider ?? 'local']}`}>
+                {(request.oauthProvider ?? 'local').toUpperCase()}
               </span>
             </div>
 
@@ -142,6 +181,21 @@ export function RegistrationRequestCard({ request, onApproved, onRejected }: Reg
                 )}
               </div>
             </div>
+
+            {/* Signup Profile Answers */}
+            {profileEntries.length > 0 && (
+              <div className="flex flex-wrap gap-2 mb-4">
+                {profileEntries.map((entry) => (
+                  <span
+                    key={entry.label}
+                    className="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-50 border border-gray-200 rounded-full text-xs"
+                  >
+                    <span className="text-gray-500">{entry.label}:</span>
+                    <span className="font-medium text-gray-800">{entry.value}</span>
+                  </span>
+                ))}
+              </div>
+            )}
 
             {/* Error Message */}
             {error && (

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -741,6 +741,11 @@ class APIClient {
     lastName: string;
     password: string;
     provider: string;
+    signupProfile?: {
+      role?: string;
+      primaryUseCase?: string;
+      referralSource?: string;
+    };
   }): Promise<{
     success: boolean;
     message: string;


### PR DESCRIPTION
## Summary
- Adds three closed-vocabulary questions to the registration form (role, primary use case, referral source) so signups carry basic stats without requiring email verification
- Persists answers under `user_registration_requests.metadata -> signupProfile` (JSONB column from migration 012, previously never written — no new migration)
- Adds the missing `GET /api/v1/admin/registration-requests` endpoint the admin registrations page has always called, and renders the answers as chips on each request card
- Hardens the now-active metadata path: 16KB cap at the repository, length caps on the public request-access free-text fields, validation errors never echo input

## Security notes
- Answers validated against a closed vocabulary in `domain/signup_profile.go` (public endpoint — no free text reaches the DB through `signupProfile`)
- `signupProfile` is optional at the API level: existing SDK/CLI/aim-cloud clients are byte-identical in behavior
- Adversarial review of the diff: 2 HIGH findings (missing list endpoint; unvalidated request-access text now persisting) — both fixed in this PR

## Testing
- `go build ./...`, `go vet`, `go test -race` green (new domain/service/handler/repository tests)
- Web `tsc --noEmit` + `next build` green
- Playwright walkthrough on the register page: 14/14 (desktop 1280 + mobile 375), payload verified to carry `signupProfile`, zero console errors

## aim-cloud rollout
Sync-protected mirror PR in aim-cloud covers `lib/api.ts`, the `main.go` route, and the handler method: see opena2a-org/aim-cloud (feat/signup-profile-api-mirror). Merge order: this PR first, then the sync PR + mirror PR.