### PR TITLE
Bump bouncycastle to 1.84 (CVE-2026-5598)

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -44,7 +44,7 @@
         <jackson.version>2.16.1</jackson.version>
         <okhttp.version>4.12.0</okhttp.version>
         <slf4j.version>2.0.11</slf4j.version>
-        <bouncycastle.version>1.79</bouncycastle.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <junit.version>5.10.1</junit.version>
         <aspectj.version>1.9.21</aspectj.version>
     </properties>


### PR DESCRIPTION
Trivy flags bcprov-jdk18on 1.79 (HIGH, private key leakage via non-constant time comparisons, fixed in 1.84) and blocks aim-cloud PR CI. Drop-in security patch. `mvn compile` verified against 1.84. Same bump applied directly to aim-cloud in opena2a-org/aim-cloud#45 since the sync token is expired.