### PR TITLE
perf(agents): eliminate 1+2N query pattern in agent list, add server-side pagination

### DIFF
--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -509,6 +509,12 @@ func (s *AgentService) ListAgents(ctx context.Context, orgID uuid.UUID) ([]*doma
 	return s.agentRepo.GetByOrganization(orgID)
 }
 
+// ListAgentsPaged lists one page of an organization's agents plus the
+// total agent count. limit <= 0 returns all agents.
+func (s *AgentService) ListAgentsPaged(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	return s.agentRepo.GetByOrganizationPaged(orgID, limit, offset)
+}
+
 // UpdateAgent updates an agent. requestedBy is the authenticated user ID
 // driving the update; used as the RequestedBy on any capability_requests
 // rows created for new capability declarations in strict mode. A zero UUID

--- a/apps/backend/internal/application/alert_service_test.go
+++ b/apps/backend/internal/application/alert_service_test.go
@@ -1325,3 +1325,23 @@ func TestAlertService_GetAlerts_CountError(t *testing.T) {
 
 	mockAlertRepo.AssertExpectations(t)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepoForAlerts) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/apps/backend/internal/application/api_key_service_test.go
+++ b/apps/backend/internal/application/api_key_service_test.go
@@ -715,3 +715,23 @@ func TestAPIKeyService_ValidateAPIKey_Expired(t *testing.T) {
 
 	mockAPIKeyRepo.AssertExpectations(t)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepoForAPIKey) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/apps/backend/internal/application/capability_request_service_test.go
+++ b/apps/backend/internal/application/capability_request_service_test.go
@@ -713,3 +713,44 @@ func TestCapabilityRequestService_RejectRequest_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepositoryForCapReq) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockCapabilityRepoForCapReq) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		var caps []*domain.AgentCapability
+		var err error
+		if activeOnly {
+			caps, err = m.GetActiveCapabilitiesByAgentID(agentID)
+		} else {
+			caps, err = m.GetCapabilitiesByAgentID(agentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/capability_service.go
+++ b/apps/backend/internal/application/capability_service.go
@@ -468,6 +468,16 @@ func (s *CapabilityService) GetAgentCapabilities(
 	return s.capabilityRepo.GetCapabilitiesByAgentID(agentID)
 }
 
+// GetCapabilitiesByAgentIDs retrieves capabilities for many agents in a
+// single query, keyed by agent ID
+func (s *CapabilityService) GetCapabilitiesByAgentIDs(
+	ctx context.Context,
+	agentIDs []uuid.UUID,
+	activeOnly bool,
+) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	return s.capabilityRepo.GetCapabilitiesByAgentIDs(agentIDs, activeOnly)
+}
+
 // CapabilityDefinition represents a capability type available in the system
 type CapabilityDefinition struct {
 	Type           string `json:"type"`

--- a/apps/backend/internal/application/capability_service_test.go
+++ b/apps/backend/internal/application/capability_service_test.go
@@ -1289,3 +1289,44 @@ func TestCapabilityService_ValidateAndRegisterCapability_InvalidFormat(t *testin
 
 	assert.Error(t, err)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepoForCapability) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockCapabilityRepoForService) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		var caps []*domain.AgentCapability
+		var err error
+		if activeOnly {
+			caps, err = m.GetActiveCapabilitiesByAgentID(agentID)
+		} else {
+			caps, err = m.GetCapabilitiesByAgentID(agentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/drift_detection_service_test.go
+++ b/apps/backend/internal/application/drift_detection_service_test.go
@@ -711,3 +711,23 @@ func TestDetectDrift_NilTalksTo(t *testing.T) {
 
 	mockAgentRepo.AssertExpectations(t)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -965,3 +965,59 @@ func (m *SharedMockTagRepository) GetMCPServerTags(ctx context.Context, mcpServe
 	}
 	return args.Get(0).([]*domain.Tag), args.Error(1)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *SharedMockAgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *SharedMockCapabilityRepository) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		var caps []*domain.AgentCapability
+		var err error
+		if activeOnly {
+			caps, err = m.GetActiveCapabilitiesByAgentID(agentID)
+		} else {
+			caps, err = m.GetCapabilitiesByAgentID(agentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}
+
+// GetAgentTagsByAgentIDs aggregates the per-agent mocks for tests.
+func (m *SharedMockTagRepository) GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(agentIDs))
+	for _, agentID := range agentIDs {
+		tags, err := m.GetAgentTags(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[agentID] = tags
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/registry_bridge_service_test.go
+++ b/apps/backend/internal/application/registry_bridge_service_test.go
@@ -451,3 +451,23 @@ func TestInferEcosystem(t *testing.T) {
 	assert.Equal(t, "npm", inferEcosystem("https://example.com/mcp-server"))
 	assert.Equal(t, "", inferEcosystem(""))
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *mockAgentRepoForBridge) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/apps/backend/internal/application/secrets_service_test.go
+++ b/apps/backend/internal/application/secrets_service_test.go
@@ -609,3 +609,44 @@ func TestEd25519PublicToX25519(t *testing.T) {
 		t.Fatal("Should fail with short key")
 	}
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *mockAgentRepo) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *mockCapabilityRepo) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		var caps []*domain.AgentCapability
+		var err error
+		if activeOnly {
+			caps, err = m.GetActiveCapabilitiesByAgentID(agentID)
+		} else {
+			caps, err = m.GetCapabilitiesByAgentID(agentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/tag_service.go
+++ b/apps/backend/internal/application/tag_service.go
@@ -209,6 +209,16 @@ func (s *TagService) GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*do
 	return tags, nil
 }
 
+// GetAgentTagsByAgentIDs retrieves tags for many agents in a single
+// query, keyed by agent ID
+func (s *TagService) GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	tags, err := s.tagRepo.GetAgentTagsByAgentIDs(ctx, agentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agent tags: %w", err)
+	}
+	return tags, nil
+}
+
 // AddTagsToMCPServer adds tags to an MCP server with smart suggestions
 func (s *TagService) AddTagsToMCPServer(ctx context.Context, mcpServerID uuid.UUID, tagIDs []uuid.UUID, appliedBy uuid.UUID) error {
 	// Verify MCP server exists

--- a/apps/backend/internal/application/tag_service_test.go
+++ b/apps/backend/internal/application/tag_service_test.go
@@ -2187,3 +2187,38 @@ func TestTagService_CreateTag_RepoError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create tag")
 	mockTagRepo.AssertExpectations(t)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepoForTags) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetAgentTagsByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockTagRepoForTags) GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(agentIDs))
+	for _, agentID := range agentIDs {
+		tags, err := m.GetAgentTags(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[agentID] = tags
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -1168,3 +1168,44 @@ func TestTrustCalculator_ExecutionIsolation_WithAttestation(t *testing.T) {
 func timePtr(t time.Time) *time.Time {
 	return &t
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *TrustCalcMockAgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockCapabilityRepository) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		var caps []*domain.AgentCapability
+		var err error
+		if activeOnly {
+			caps, err = m.GetActiveCapabilitiesByAgentID(agentID)
+		} else {
+			caps, err = m.GetCapabilitiesByAgentID(agentID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/verification_event_service_test.go
+++ b/apps/backend/internal/application/verification_event_service_test.go
@@ -1245,3 +1245,23 @@ func TestVerificationEventService_DeleteVerificationEvent_Error(t *testing.T) {
 	assert.Error(t, err)
 	mockEventRepo.AssertExpectations(t)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepoForVerification) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/apps/backend/internal/domain/agent.go
+++ b/apps/backend/internal/domain/agent.go
@@ -121,6 +121,7 @@ type AgentRepository interface {
 	GetByID(id uuid.UUID) (*Agent, error)
 	GetByName(orgID uuid.UUID, name string) (*Agent, error)
 	GetByOrganization(orgID uuid.UUID) ([]*Agent, error)
+	GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*Agent, int, error)
 	Update(agent *Agent) error
 	Delete(id uuid.UUID) error
 	List(limit, offset int) ([]*Agent, error)

--- a/apps/backend/internal/domain/capability.go
+++ b/apps/backend/internal/domain/capability.go
@@ -49,6 +49,7 @@ type CapabilityRepository interface {
 	GetCapabilityByID(id uuid.UUID) (*AgentCapability, error)
 	GetCapabilitiesByAgentID(agentID uuid.UUID) ([]*AgentCapability, error)
 	GetActiveCapabilitiesByAgentID(agentID uuid.UUID) ([]*AgentCapability, error)
+	GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*AgentCapability, error)
 	RevokeCapability(id uuid.UUID, revokedAt time.Time) error
 	DeleteCapability(id uuid.UUID) error
 

--- a/apps/backend/internal/domain/tag.go
+++ b/apps/backend/internal/domain/tag.go
@@ -57,6 +57,7 @@ type TagRepository interface {
 	AddTagsToAgent(ctx context.Context, agentID uuid.UUID, tagIDs []uuid.UUID) error
 	RemoveTagFromAgent(ctx context.Context, agentID uuid.UUID, tagID uuid.UUID) error
 	GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*Tag, error)
+	GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*Tag, error)
 
 	// MCP Server Tag Relationships
 	AddTagsToMCPServer(ctx context.Context, mcpServerID uuid.UUID, tagIDs []uuid.UUID) error

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -349,6 +349,14 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 
 // GetByOrganization retrieves all agents in an organization
 func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, error) {
+	agents, _, err := r.GetByOrganizationPaged(orgID, 0, 0)
+	return agents, err
+}
+
+// GetByOrganizationPaged retrieves one page of an organization's agents
+// plus the total agent count for the organization. limit <= 0 returns
+// all agents.
+func (r *AgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
@@ -359,10 +367,15 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 		WHERE organization_id = $1
 		ORDER BY created_at DESC
 	`
+	args := []interface{}{orgID}
+	if limit > 0 {
+		query += " LIMIT $2 OFFSET $3"
+		args = append(args, limit, offset)
+	}
 
-	rows, err := r.db.Query(query, orgID)
+	rows, err := r.db.Query(query, args...)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
@@ -405,7 +418,7 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 			&declaredPurposeJSON,
 		)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// Convert nullable fields
@@ -431,27 +444,37 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 		// Unmarshal talks_to from JSONB (handles both string and object formats)
 		agent.TalksTo, err = unmarshalTalksTo(talksToJSON)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// Unmarshal metadata from JSONB
 		if len(metadataJSON) > 0 {
 			if err := json.Unmarshal(metadataJSON, &agent.Metadata); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+				return nil, 0, fmt.Errorf("failed to unmarshal metadata: %w", err)
 			}
 		}
 
 		// Unmarshal declared_purpose from JSONB
 		if len(declaredPurposeJSON) > 0 {
 			if err := json.Unmarshal(declaredPurposeJSON, &agent.DeclaredPurpose); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
+				return nil, 0, fmt.Errorf("failed to unmarshal declared_purpose: %w", err)
 			}
 		}
 
 		agents = append(agents, agent)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
 
-	return agents, nil
+	total := len(agents)
+	if limit > 0 {
+		if err := r.db.QueryRow(`SELECT COUNT(*) FROM agents WHERE organization_id = $1`, orgID).Scan(&total); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return agents, total, nil
 }
 
 // Update updates an agent

--- a/apps/backend/internal/infrastructure/repository/capability_repository.go
+++ b/apps/backend/internal/infrastructure/repository/capability_repository.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -203,6 +205,77 @@ func (r *CapabilityRepositoryPostgres) GetActiveCapabilitiesByAgentID(agentID uu
 	}
 
 	return capabilities, nil
+}
+
+// GetCapabilitiesByAgentIDs retrieves capabilities for many agents in a
+// single query, keyed by agent ID. When activeOnly is true, revoked
+// capabilities are excluded. Agents with no capabilities have no entry
+// in the returned map.
+func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	if len(agentIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(agentIDs))
+	args := make([]interface{}, len(agentIDs))
+	for i, id := range agentIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at
+		FROM agent_capabilities
+		WHERE agent_id IN (%s)`, strings.Join(placeholders, ","))
+	if activeOnly {
+		query += " AND revoked_at IS NULL"
+	}
+	query += " ORDER BY created_at DESC"
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var capability domain.AgentCapability
+		scopeJSON := make([]byte, 0)
+		var grantedBy uuid.NullUUID
+		var revokedAt sql.NullTime
+
+		err := rows.Scan(
+			&capability.ID,
+			&capability.AgentID,
+			&capability.CapabilityType,
+			&scopeJSON,
+			&capability.ExecutionMode,
+			&grantedBy,
+			&capability.GrantedAt,
+			&revokedAt,
+			&capability.CreatedAt,
+			&capability.UpdatedAt,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if grantedBy.Valid {
+			capability.GrantedBy = &grantedBy.UUID
+		}
+		if revokedAt.Valid {
+			capability.RevokedAt = &revokedAt.Time
+		}
+		if len(scopeJSON) > 0 {
+			json.Unmarshal(scopeJSON, &capability.CapabilityScope)
+		}
+
+		result[capability.AgentID] = append(result[capability.AgentID], &capability)
+	}
+
+	return result, rows.Err()
 }
 
 // RevokeCapability marks a capability as revoked

--- a/apps/backend/internal/infrastructure/repository/tag_repository.go
+++ b/apps/backend/internal/infrastructure/repository/tag_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
@@ -261,6 +262,60 @@ func (r *TagRepository) GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]
 	}
 
 	return tags, nil
+}
+
+// GetAgentTagsByAgentIDs retrieves tags for many agents in a single
+// query, keyed by agent ID. Agents with no tags have no entry in the
+// returned map.
+func (r *TagRepository) GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(agentIDs))
+	if len(agentIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(agentIDs))
+	args := make([]interface{}, len(agentIDs))
+	for i, id := range agentIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT at.agent_id, t.id, t.organization_id, t.key, t.value, t.category, t.description, t.color, t.created_at, t.created_by
+		FROM tags t
+		INNER JOIN agent_tags at ON t.id = at.tag_id
+		WHERE at.agent_id IN (%s)
+		ORDER BY t.category, t.key, t.value
+	`, strings.Join(placeholders, ","))
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agent tags: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var agentID uuid.UUID
+		tag := &domain.Tag{}
+		err := rows.Scan(
+			&agentID,
+			&tag.ID,
+			&tag.OrganizationID,
+			&tag.Key,
+			&tag.Value,
+			&tag.Category,
+			&tag.Description,
+			&tag.Color,
+			&tag.CreatedAt,
+			&tag.CreatedBy,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan tag: %w", err)
+		}
+		result[agentID] = append(result[agentID], tag)
+	}
+
+	return result, rows.Err()
 }
 
 // AddTagsToMCPServer adds tags to an MCP server

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -97,10 +97,12 @@ func (h *AgentHandler) enrichAgentResponse(c fiber.Ctx, agent *domain.Agent) fib
 	}
 
 	// ✅ Fetch tags from agent_tags table
-	var agentTags []*domain.Tag
+	agentTags := make([]*domain.Tag, 0)
 	if h.tagService != nil {
 		// Log error but don't fail - return empty tags
-		agentTags, _ = h.tagService.GetAgentTags(c.Context(), agent.ID)
+		if fetched, err := h.tagService.GetAgentTags(c.Context(), agent.ID); err == nil && fetched != nil {
+			agentTags = fetched
+		}
 	}
 
 	return agentResponse(agent, capabilities, agentTags)

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -96,34 +96,34 @@ func (h *AgentHandler) enrichAgentResponse(c fiber.Ctx, agent *domain.Agent) fib
 		capabilities = []*domain.AgentCapability{}
 	}
 
+	// ✅ Fetch tags from agent_tags table
+	var agentTags []*domain.Tag
+	if h.tagService != nil {
+		// Log error but don't fail - return empty tags
+		agentTags, _ = h.tagService.GetAgentTags(c.Context(), agent.ID)
+	}
+
+	return agentResponse(agent, capabilities, agentTags)
+}
+
+// agentResponse renders an agent plus its prefetched capabilities and tags
+func agentResponse(agent *domain.Agent, capabilities []*domain.AgentCapability, agentTags []*domain.Tag) fiber.Map {
 	// Extract capability types as simple string array (frontend compatible)
 	capabilityTypes := make([]string, 0, len(capabilities))
 	for _, cap := range capabilities {
 		capabilityTypes = append(capabilityTypes, cap.CapabilityType)
 	}
 
-	// ✅ Fetch tags from agent_tags table
-	tags := make([]fiber.Map, 0)
-	if h.tagService != nil {
-		agentTags, err := h.tagService.GetAgentTags(c.Context(), agent.ID)
-		if err != nil {
-			// Log error but don't fail - return empty tags
-			tags = []fiber.Map{}
-		} else {
-			tags = make([]fiber.Map, 0, len(agentTags))
-			for _, tag := range agentTags {
-				tags = append(tags, fiber.Map{
-					"id":          tag.ID,
-					"key":         tag.Key,
-					"value":       tag.Value,
-					"category":    tag.Category,
-					"description": tag.Description,
-					"color":       tag.Color,
-				})
-			}
-		}
-	} else {
-		tags = []fiber.Map{}
+	tags := make([]fiber.Map, 0, len(agentTags))
+	for _, tag := range agentTags {
+		tags = append(tags, fiber.Map{
+			"id":          tag.ID,
+			"key":         tag.Key,
+			"value":       tag.Value,
+			"category":    tag.Category,
+			"description": tag.Description,
+			"color":       tag.Color,
+		})
 	}
 
 	// Return flat response with all agent fields + capabilities + tags (camelCase for frontend)
@@ -171,27 +171,65 @@ func (h *AgentHandler) enrichAgentResponse(c fiber.Ctx, agent *domain.Agent) fib
 	}
 }
 
-// ListAgents returns all agents for the organization
+// ListAgents returns agents for the organization. Optional limit/offset
+// query parameters page server-side; without them all agents are
+// returned (existing client behavior).
 func (h *AgentHandler) ListAgents(c fiber.Ctx) error {
 	orgID, err := RequireOrganizationID(c)
 	if err != nil {
 		return err
 	}
 
-	agents, err := h.agentService.ListAgents(c.Context(), orgID)
+	limit := 0
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if parsedLimit, err := strconv.Atoi(limitStr); err == nil && parsedLimit > 0 {
+			limit = parsedLimit
+		}
+	}
+	offset := 0
+	if offsetStr := c.Query("offset"); offsetStr != "" {
+		if parsedOffset, err := strconv.Atoi(offsetStr); err == nil && parsedOffset > 0 {
+			offset = parsedOffset
+		}
+	}
+
+	agents, total, err := h.agentService.ListAgentsPaged(c.Context(), orgID, limit, offset)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to fetch agents",
 		})
 	}
+
+	// Prefetch capabilities and tags for the whole page in one query
+	// each, instead of two queries per agent
+	agentIDs := make([]uuid.UUID, len(agents))
+	for i, agent := range agents {
+		agentIDs[i] = agent.ID
+	}
+	capsByAgent, err := h.capabilityService.GetCapabilitiesByAgentIDs(c.Context(), agentIDs, true)
+	if err != nil {
+		// Log error but don't fail - return empty capabilities
+		capsByAgent = map[uuid.UUID][]*domain.AgentCapability{}
+	}
+	var tagsByAgent map[uuid.UUID][]*domain.Tag
+	if h.tagService != nil {
+		// Log error but don't fail - return empty tags
+		tagsByAgent, _ = h.tagService.GetAgentTagsByAgentIDs(c.Context(), agentIDs)
+	}
+
 	enriched := make([]fiber.Map, 0, len(agents))
 	for _, agent := range agents {
-		enriched = append(enriched, h.enrichAgentResponse(c, agent))
+		enriched = append(enriched, agentResponse(agent, capsByAgent[agent.ID], tagsByAgent[agent.ID]))
 	}
-	return c.JSON(fiber.Map{
+	response := fiber.Map{
 		"agents": enriched,
-		"total":  len(enriched),
-	})
+		"total":  total,
+	}
+	if limit > 0 {
+		response["limit"] = limit
+		response["offset"] = offset
+	}
+	return c.JSON(response)
 }
 
 // CreateAgent creates a new agent and automatically generates an API key for it

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
@@ -3469,3 +3469,62 @@ func TestAgentHandler_ListAgents_InvalidPagingParams(t *testing.T) {
 	assert.Equal(t, 0, gotLimit)
 	assert.Equal(t, 0, gotOffset)
 }
+
+// Bulk enrichment failures degrade to empty capabilities/tags (the same
+// behavior the old per-agent path had), never a 500 or a panic. Note a
+// nil map is read-safe in Go; this locks that in against "fixes" that
+// assume otherwise.
+func TestAgentHandler_ListAgents_BulkEnrichmentErrorsDegrade(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		ListAgentsPagedFunc: func(ctx context.Context, id uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+			return []*domain.Agent{{ID: uuid.New(), OrganizationID: orgID, Name: "agent1"}}, 1, nil
+		},
+	}
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetCapabilitiesByAgentIDsFunc: func(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+			return nil, errors.New("capabilities query failed")
+		},
+	}
+	mockTagService := &MockTagServiceImpl{
+		GetAgentTagsByAgentIDsFunc: func(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+			return nil, errors.New("tags query failed")
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		mockCapabilityService,
+		mockTagService,
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents", handler.ListAgents)
+
+	req := httptest.NewRequest("GET", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+
+	agents := result["agents"].([]interface{})
+	require.Len(t, agents, 1)
+	first := agents[0].(map[string]interface{})
+	assert.Equal(t, []interface{}{}, first["capabilities"])
+	assert.Equal(t, []interface{}{}, first["tags"])
+}

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler_integration_test.go
@@ -3270,3 +3270,202 @@ func TestAgentHandler_GetAgentKeyVault_IncludesPQCFields(t *testing.T) {
 	assert.NotNil(t, result["pqcKeyCreatedAt"])
 	assert.NotNil(t, result["pqcKeyExpiresAt"])
 }
+
+// ===========================
+// AgentHandler.ListAgents bulk enrichment + pagination tests
+// ===========================
+
+// TestAgentHandler_ListAgents_UsesBulkEnrichment locks in the 3-query list
+// path: capabilities and tags for the whole page come from one bulk call
+// each. Regression: the list handler used to call GetAgentCapabilities and
+// GetAgentTags per agent (1+2N queries), which made the agents page crawl
+// on large orgs.
+func TestAgentHandler_ListAgents_UsesBulkEnrichment(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agent1 := uuid.New()
+	agent2 := uuid.New()
+
+	mockAgentService := &MockAgentServiceImpl{
+		ListAgentsPagedFunc: func(ctx context.Context, id uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+			return []*domain.Agent{
+				{ID: agent1, OrganizationID: orgID, Name: "agent1"},
+				{ID: agent2, OrganizationID: orgID, Name: "agent2"},
+			}, 2, nil
+		},
+	}
+
+	bulkCapCalls := 0
+	mockCapabilityService := &MockCapabilityServiceImpl{
+		GetAgentCapabilitiesFunc: func(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error) {
+			t.Fatal("per-agent GetAgentCapabilities must not be called by ListAgents")
+			return nil, nil
+		},
+		GetCapabilitiesByAgentIDsFunc: func(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+			bulkCapCalls++
+			assert.True(t, activeOnly)
+			assert.Len(t, agentIDs, 2)
+			return map[uuid.UUID][]*domain.AgentCapability{
+				agent1: {{ID: uuid.New(), AgentID: agent1, CapabilityType: "file:read"}},
+			}, nil
+		},
+	}
+
+	bulkTagCalls := 0
+	mockTagService := &MockTagServiceImpl{
+		GetAgentTagsFunc: func(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error) {
+			t.Fatal("per-agent GetAgentTags must not be called by ListAgents")
+			return nil, nil
+		},
+		GetAgentTagsByAgentIDsFunc: func(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+			bulkTagCalls++
+			assert.Len(t, agentIDs, 2)
+			return map[uuid.UUID][]*domain.Tag{
+				agent2: {{ID: uuid.New(), Key: "env", Value: "production"}},
+			}, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		mockCapabilityService,
+		mockTagService,
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents", handler.ListAgents)
+
+	req := httptest.NewRequest("GET", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, bulkCapCalls)
+	assert.Equal(t, 1, bulkTagCalls)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+
+	agents, ok := result["agents"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, agents, 2)
+
+	first := agents[0].(map[string]interface{})
+	second := agents[1].(map[string]interface{})
+	assert.Len(t, first["capabilities"], 1)
+	assert.Len(t, first["tags"], 0)
+	assert.Len(t, second["capabilities"], 0)
+	assert.Len(t, second["tags"], 1)
+
+	// Default (no limit param) keeps the legacy response shape
+	assert.Equal(t, float64(2), result["total"])
+	_, hasLimit := result["limit"]
+	assert.False(t, hasLimit)
+}
+
+func TestAgentHandler_ListAgents_Pagination(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	var gotLimit, gotOffset int
+	mockAgentService := &MockAgentServiceImpl{
+		ListAgentsPagedFunc: func(ctx context.Context, id uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+			gotLimit, gotOffset = limit, offset
+			// One page of a 45-agent org
+			return []*domain.Agent{
+				{ID: uuid.New(), OrganizationID: orgID, Name: "agent21"},
+				{ID: uuid.New(), OrganizationID: orgID, Name: "agent22"},
+			}, 45, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents", handler.ListAgents)
+
+	req := httptest.NewRequest("GET", "/agents?limit=20&offset=20", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, 20, gotLimit)
+	assert.Equal(t, 20, gotOffset)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+
+	agents, ok := result["agents"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, agents, 2)
+	// total is the org-wide count, not the page size, so clients can
+	// keep paginating
+	assert.Equal(t, float64(45), result["total"])
+	assert.Equal(t, float64(20), result["limit"])
+	assert.Equal(t, float64(20), result["offset"])
+}
+
+// Invalid or negative paging params fall back to the unpaged path instead
+// of erroring.
+func TestAgentHandler_ListAgents_InvalidPagingParams(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	var gotLimit, gotOffset int
+	mockAgentService := &MockAgentServiceImpl{
+		ListAgentsPagedFunc: func(ctx context.Context, id uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+			gotLimit, gotOffset = limit, offset
+			return []*domain.Agent{}, 0, nil
+		},
+	}
+
+	handler := NewAgentHandlerWithInterfaces(
+		mockAgentService,
+		&MockMCPServiceImpl{},
+		&MockAuditServiceImpl{},
+		&MockAPIKeyServiceImpl{},
+		nil,
+		&MockAlertServiceImpl{},
+		&MockVerificationEventServiceImpl{},
+		&MockCapabilityServiceImpl{},
+		&MockTagServiceImpl{},
+		&MockOrganizationRepository{},
+		&MockMCPAttestationServiceImpl{},
+	)
+
+	app := createTestAppWithAuth(handler, orgID, userID)
+	app.Get("/agents", handler.ListAgents)
+
+	req := httptest.NewRequest("GET", "/agents?limit=abc&offset=-5", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, 0, gotLimit)
+	assert.Equal(t, 0, gotOffset)
+}

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -21,6 +21,7 @@ type AgentServicer interface {
 	GetAgent(ctx context.Context, id uuid.UUID) (*domain.Agent, error)
 	GetAgentByName(ctx context.Context, orgID uuid.UUID, name string) (*domain.Agent, error)
 	ListAgents(ctx context.Context, orgID uuid.UUID) ([]*domain.Agent, error)
+	ListAgentsPaged(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error)
 	UpdateAgent(ctx context.Context, id uuid.UUID, req *application.CreateAgentRequest, requestedBy uuid.UUID) (*domain.Agent, error)
 	DeleteAgent(ctx context.Context, id uuid.UUID) error
 	VerifyAgent(ctx context.Context, id uuid.UUID) error
@@ -76,6 +77,7 @@ type CapabilityServicer interface {
 	RevokeCapability(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
 	GetCapabilityByID(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilities(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
+	GetCapabilitiesByAgentIDs(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error)
 	ListCapabilities(ctx context.Context, orgID uuid.UUID) ([]application.CapabilityDefinition, error)
 	ListCapabilitiesWithMetadata(ctx context.Context, orgID uuid.UUID) (*application.ListCapabilitiesResponse, error)
 	ValidateAndRegisterCapability(ctx context.Context, capability string, orgID uuid.UUID) error
@@ -87,6 +89,7 @@ type CapabilityServicer interface {
 // TagServicer defines the methods from TagService that handlers use
 type TagServicer interface {
 	GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
+	GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
 	GetMCPServerTags(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -16,32 +16,33 @@ import (
 
 // MockAgentServiceImpl implements AgentServicer interface
 type MockAgentServiceImpl struct {
-	CreateAgentFunc                 func(ctx context.Context, req *application.CreateAgentRequest, orgID, userID uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID, userEmail string) (*domain.Agent, error)
-	GetAgentFunc                    func(ctx context.Context, id uuid.UUID) (*domain.Agent, error)
-	GetAgentByNameFunc              func(ctx context.Context, orgID uuid.UUID, name string) (*domain.Agent, error)
-	ListAgentsFunc                  func(ctx context.Context, orgID uuid.UUID) ([]*domain.Agent, error)
-	UpdateAgentFunc                 func(ctx context.Context, id uuid.UUID, req *application.CreateAgentRequest, requestedBy uuid.UUID) (*domain.Agent, error)
-	DeleteAgentFunc                 func(ctx context.Context, id uuid.UUID) error
-	VerifyAgentFunc                 func(ctx context.Context, id uuid.UUID) error
-	SuspendAgentFunc                func(ctx context.Context, id uuid.UUID) error
-	RevokeAgentFunc                 func(ctx context.Context, id uuid.UUID) error
-	ReactivateAgentFunc             func(ctx context.Context, id uuid.UUID) error
-	RecalculateTrustScoreFunc       func(ctx context.Context, id uuid.UUID) (*domain.TrustScore, error)
-	UpdateTrustScoreFunc            func(ctx context.Context, agentID uuid.UUID, newScore float64) error
-	RotateCredentialsFunc           func(ctx context.Context, id uuid.UUID) (publicKey, privateKey string, err error)
-	GetAgentCredentialsFunc         func(ctx context.Context, agentID uuid.UUID) (publicKey, privateKey string, err error)
-	UpdateAgentPublicKeyFunc        func(ctx context.Context, agentID uuid.UUID, publicKey string) error
-	AddMCPServersFunc               func(ctx context.Context, agentID uuid.UUID, mcpServerIdentifiers []string) (*domain.Agent, []string, error)
-	RemoveMCPServerFunc             func(ctx context.Context, agentID uuid.UUID, mcpServerIdentifier string) (*domain.Agent, error)
-	VerifyCapabilityFunc            func(ctx context.Context, agentID uuid.UUID, capability string, resource string, metadata map[string]interface{}, sourceIP string) (allowed bool, reason string, auditID uuid.UUID, err error)
-	LogCapabilityResultFunc         func(ctx context.Context, agentID uuid.UUID, auditID uuid.UUID, success bool, errorMsg string, result map[string]interface{}) error
-	HasCapabilityFunc               func(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
-	UpdateLastActiveFunc            func(ctx context.Context, agentID uuid.UUID) error
-	DetectMCPServersFromConfigFunc  func(ctx context.Context, agentID uuid.UUID, req *application.DetectMCPServersRequest, mcpService *application.MCPService, orgID, userID uuid.UUID) (*application.DetectMCPServersResult, error)
+	CreateAgentFunc                func(ctx context.Context, req *application.CreateAgentRequest, orgID, userID uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID, userEmail string) (*domain.Agent, error)
+	GetAgentFunc                   func(ctx context.Context, id uuid.UUID) (*domain.Agent, error)
+	GetAgentByNameFunc             func(ctx context.Context, orgID uuid.UUID, name string) (*domain.Agent, error)
+	ListAgentsFunc                 func(ctx context.Context, orgID uuid.UUID) ([]*domain.Agent, error)
+	ListAgentsPagedFunc            func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error)
+	UpdateAgentFunc                func(ctx context.Context, id uuid.UUID, req *application.CreateAgentRequest, requestedBy uuid.UUID) (*domain.Agent, error)
+	DeleteAgentFunc                func(ctx context.Context, id uuid.UUID) error
+	VerifyAgentFunc                func(ctx context.Context, id uuid.UUID) error
+	SuspendAgentFunc               func(ctx context.Context, id uuid.UUID) error
+	RevokeAgentFunc                func(ctx context.Context, id uuid.UUID) error
+	ReactivateAgentFunc            func(ctx context.Context, id uuid.UUID) error
+	RecalculateTrustScoreFunc      func(ctx context.Context, id uuid.UUID) (*domain.TrustScore, error)
+	UpdateTrustScoreFunc           func(ctx context.Context, agentID uuid.UUID, newScore float64) error
+	RotateCredentialsFunc          func(ctx context.Context, id uuid.UUID) (publicKey, privateKey string, err error)
+	GetAgentCredentialsFunc        func(ctx context.Context, agentID uuid.UUID) (publicKey, privateKey string, err error)
+	UpdateAgentPublicKeyFunc       func(ctx context.Context, agentID uuid.UUID, publicKey string) error
+	AddMCPServersFunc              func(ctx context.Context, agentID uuid.UUID, mcpServerIdentifiers []string) (*domain.Agent, []string, error)
+	RemoveMCPServerFunc            func(ctx context.Context, agentID uuid.UUID, mcpServerIdentifier string) (*domain.Agent, error)
+	VerifyCapabilityFunc           func(ctx context.Context, agentID uuid.UUID, capability string, resource string, metadata map[string]interface{}, sourceIP string) (allowed bool, reason string, auditID uuid.UUID, err error)
+	LogCapabilityResultFunc        func(ctx context.Context, agentID uuid.UUID, auditID uuid.UUID, success bool, errorMsg string, result map[string]interface{}) error
+	HasCapabilityFunc              func(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
+	UpdateLastActiveFunc           func(ctx context.Context, agentID uuid.UUID) error
+	DetectMCPServersFromConfigFunc func(ctx context.Context, agentID uuid.UUID, req *application.DetectMCPServersRequest, mcpService *application.MCPService, orgID, userID uuid.UUID) (*application.DetectMCPServersResult, error)
 	// PQC methods
-	UpdateAgentPQCKeyFunc           func(ctx context.Context, agentID uuid.UUID, pqcPublicKey string, algorithm string, hybridMode bool) error
-	RotateAgentPQCKeyFunc           func(ctx context.Context, agentID uuid.UUID, newPQCPublicKey string, algorithm string) error
-	SetAgentHybridModeFunc          func(ctx context.Context, agentID uuid.UUID, enabled bool) error
+	UpdateAgentPQCKeyFunc  func(ctx context.Context, agentID uuid.UUID, pqcPublicKey string, algorithm string, hybridMode bool) error
+	RotateAgentPQCKeyFunc  func(ctx context.Context, agentID uuid.UUID, newPQCPublicKey string, algorithm string) error
+	SetAgentHybridModeFunc func(ctx context.Context, agentID uuid.UUID, enabled bool) error
 }
 
 func (m *MockAgentServiceImpl) CreateAgent(ctx context.Context, req *application.CreateAgentRequest, orgID, userID uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID, userEmail string) (*domain.Agent, error) {
@@ -221,18 +222,18 @@ func (m *MockAgentServiceImpl) SetAgentHybridMode(ctx context.Context, agentID u
 
 // MockMCPServiceImpl implements MCPServicer interface
 type MockMCPServiceImpl struct {
-	CreateMCPServerFunc              func(ctx context.Context, req *application.CreateMCPServerRequest, orgID, userID uuid.UUID, agentID *uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID) (*domain.MCPServer, error)
-	GetMCPServerFunc                 func(ctx context.Context, id uuid.UUID) (*domain.MCPServer, error)
-	GetMCPServerByNameFunc           func(ctx context.Context, orgID uuid.UUID, name string) (*domain.MCPServer, error)
-	ListMCPServersFunc               func(ctx context.Context, orgID uuid.UUID) ([]*domain.MCPServer, error)
-	UpdateMCPServerFunc              func(ctx context.Context, id uuid.UUID, req *application.UpdateMCPServerRequest) (*domain.MCPServer, error)
-	DeleteMCPServerFunc              func(ctx context.Context, id uuid.UUID) error
-	VerifyMCPServerFunc              func(ctx context.Context, id uuid.UUID, userID uuid.UUID, userIP string) error
-	AddPublicKeyFunc                 func(ctx context.Context, serverID uuid.UUID, req *application.AddPublicKeyRequest) error
-	GetVerificationStatusFunc        func(ctx context.Context, id uuid.UUID) (*domain.MCPServerVerificationStatus, error)
-	VerifyMCPCapabilityFunc          func(ctx context.Context, mcpID uuid.UUID, capability string, resource string, targetService string, metadata map[string]interface{}) (allowed bool, reason string, auditID uuid.UUID, err error)
-	GetConnectedAgentsFunc           func(ctx context.Context, mcpServerID uuid.UUID) ([]application.ConnectedAgent, error)
-	GetConnectedAgentsCountFunc      func(ctx context.Context, mcpServerID uuid.UUID) (int, error)
+	CreateMCPServerFunc               func(ctx context.Context, req *application.CreateMCPServerRequest, orgID, userID uuid.UUID, agentID *uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID) (*domain.MCPServer, error)
+	GetMCPServerFunc                  func(ctx context.Context, id uuid.UUID) (*domain.MCPServer, error)
+	GetMCPServerByNameFunc            func(ctx context.Context, orgID uuid.UUID, name string) (*domain.MCPServer, error)
+	ListMCPServersFunc                func(ctx context.Context, orgID uuid.UUID) ([]*domain.MCPServer, error)
+	UpdateMCPServerFunc               func(ctx context.Context, id uuid.UUID, req *application.UpdateMCPServerRequest) (*domain.MCPServer, error)
+	DeleteMCPServerFunc               func(ctx context.Context, id uuid.UUID) error
+	VerifyMCPServerFunc               func(ctx context.Context, id uuid.UUID, userID uuid.UUID, userIP string) error
+	AddPublicKeyFunc                  func(ctx context.Context, serverID uuid.UUID, req *application.AddPublicKeyRequest) error
+	GetVerificationStatusFunc         func(ctx context.Context, id uuid.UUID) (*domain.MCPServerVerificationStatus, error)
+	VerifyMCPCapabilityFunc           func(ctx context.Context, mcpID uuid.UUID, capability string, resource string, targetService string, metadata map[string]interface{}) (allowed bool, reason string, auditID uuid.UUID, err error)
+	GetConnectedAgentsFunc            func(ctx context.Context, mcpServerID uuid.UUID) ([]application.ConnectedAgent, error)
+	GetConnectedAgentsCountFunc       func(ctx context.Context, mcpServerID uuid.UUID) (int, error)
 	GenerateVerificationChallengeFunc func(ctx context.Context, serverID uuid.UUID) (string, error)
 }
 
@@ -370,6 +371,7 @@ type MockCapabilityServiceImpl struct {
 	RevokeCapabilityFunc              func(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
 	GetCapabilityByIDFunc             func(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilitiesFunc          func(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
+	GetCapabilitiesByAgentIDsFunc     func(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error)
 	ListCapabilitiesFunc              func(ctx context.Context, orgID uuid.UUID) ([]application.CapabilityDefinition, error)
 	ListCapabilitiesWithMetadataFunc  func(ctx context.Context, orgID uuid.UUID) (*application.ListCapabilitiesResponse, error)
 	ValidateAndRegisterCapabilityFunc func(ctx context.Context, capability string, orgID uuid.UUID) error
@@ -457,8 +459,9 @@ func (m *MockCapabilityServiceImpl) GetRecentViolations(ctx context.Context, org
 
 // MockTagServiceImpl implements TagServicer interface
 type MockTagServiceImpl struct {
-	GetAgentTagsFunc     func(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
-	GetMCPServerTagsFunc func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
+	GetAgentTagsFunc           func(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
+	GetAgentTagsByAgentIDsFunc func(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
+	GetMCPServerTagsFunc       func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
 }
 
 func (m *MockTagServiceImpl) GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error) {
@@ -653,14 +656,14 @@ func (m *MockAuthServiceImpl) DeactivateUser(ctx context.Context, userID, orgID,
 
 // MockAdminServiceImpl implements AdminServicer interface
 type MockAdminServiceImpl struct {
-	GetPendingUsersFunc        func(ctx context.Context, adminOrgID uuid.UUID) ([]*domain.User, error)
-	ApproveUserFunc            func(ctx context.Context, userID, adminID uuid.UUID) error
-	RejectUserFunc             func(ctx context.Context, userID, adminID uuid.UUID, reason string) error
-	ActivateUserFunc           func(ctx context.Context, userID, adminID uuid.UUID) error
-	PermanentlyDeleteUserFunc  func(ctx context.Context, userID, adminID uuid.UUID) error
+	GetPendingUsersFunc         func(ctx context.Context, adminOrgID uuid.UUID) ([]*domain.User, error)
+	ApproveUserFunc             func(ctx context.Context, userID, adminID uuid.UUID) error
+	RejectUserFunc              func(ctx context.Context, userID, adminID uuid.UUID, reason string) error
+	ActivateUserFunc            func(ctx context.Context, userID, adminID uuid.UUID) error
+	PermanentlyDeleteUserFunc   func(ctx context.Context, userID, adminID uuid.UUID) error
 	GetOrganizationSettingsFunc func(ctx context.Context, orgID uuid.UUID) (*domain.Organization, error)
-	GetEnforcementSettingsFunc func(ctx context.Context, orgID uuid.UUID) (*application.EnforcementSettings, error)
-	UpdateEnforcementModeFunc  func(ctx context.Context, orgID uuid.UUID, mode domain.EnforcementMode) error
+	GetEnforcementSettingsFunc  func(ctx context.Context, orgID uuid.UUID) (*application.EnforcementSettings, error)
+	UpdateEnforcementModeFunc   func(ctx context.Context, orgID uuid.UUID, mode domain.EnforcementMode) error
 }
 
 // NOTE: Mock methods accept adminOrgID but delegate to original funcs that don't need it
@@ -803,10 +806,10 @@ func (m *MockSecurityServiceImpl) CountOpenIncidents(ctx context.Context, orgID 
 
 // MockSecurityServiceExtendedImpl implements SecurityServicerExtended interface
 type MockSecurityServiceExtendedImpl struct {
-	CountOpenIncidentsFunc   func(ctx context.Context, orgID uuid.UUID) (int, error)
-	GetThreatsFunc           func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Threat, error)
-	GetAnomaliesFunc         func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Anomaly, error)
-	GetSecurityMetricsFunc   func(ctx context.Context, orgID uuid.UUID) (*domain.SecurityMetrics, error)
+	CountOpenIncidentsFunc func(ctx context.Context, orgID uuid.UUID) (int, error)
+	GetThreatsFunc         func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Threat, error)
+	GetAnomaliesFunc       func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Anomaly, error)
+	GetSecurityMetricsFunc func(ctx context.Context, orgID uuid.UUID) (*domain.SecurityMetrics, error)
 }
 
 func (m *MockSecurityServiceExtendedImpl) CountOpenIncidents(ctx context.Context, orgID uuid.UUID) (int, error) {
@@ -1055,8 +1058,8 @@ func (m *MockMCPCapabilityServiceImpl) DetectCapabilities(ctx context.Context, m
 
 // MockAgentRepositoryerImpl implements AgentRepositoryer interface
 type MockAgentRepositoryerImpl struct {
-	GetByIDFunc          func(id uuid.UUID) (*domain.Agent, error)
-	GetByMCPServerFunc   func(mcpServerID, orgID uuid.UUID) ([]*domain.Agent, error)
+	GetByIDFunc            func(id uuid.UUID) (*domain.Agent, error)
+	GetByMCPServerFunc     func(mcpServerID, orgID uuid.UUID) ([]*domain.Agent, error)
 	GetByMCPServerNameFunc func(mcpServerName string, orgID uuid.UUID) ([]*domain.Agent, error)
 }
 
@@ -1129,17 +1132,17 @@ func (m *MockMCPAttestationServiceExtendedImpl) GetMCPAttestations(ctx context.C
 
 // MockComplianceServiceExtendedImpl implements ComplianceServicerExtended interface
 type MockComplianceServiceExtendedImpl struct {
-	GetComplianceStatusFunc       func(ctx context.Context, orgID uuid.UUID) (interface{}, error)
-	GetComplianceMetricsFunc      func(ctx context.Context, orgID uuid.UUID, startDate, endDate time.Time, interval string) (interface{}, error)
-	GetAccessReviewFunc           func(ctx context.Context, orgID uuid.UUID) (interface{}, error)
-	ListEvidenceFunc              func(ctx context.Context, orgID uuid.UUID, framework string, limit, offset int) ([]*domain.ComplianceEvidence, error)
-	RunComplianceCheckFunc        func(ctx context.Context, orgID uuid.UUID, checkType string) (interface{}, error)
+	GetComplianceStatusFunc        func(ctx context.Context, orgID uuid.UUID) (interface{}, error)
+	GetComplianceMetricsFunc       func(ctx context.Context, orgID uuid.UUID, startDate, endDate time.Time, interval string) (interface{}, error)
+	GetAccessReviewFunc            func(ctx context.Context, orgID uuid.UUID) (interface{}, error)
+	ListEvidenceFunc               func(ctx context.Context, orgID uuid.UUID, framework string, limit, offset int) ([]*domain.ComplianceEvidence, error)
+	RunComplianceCheckFunc         func(ctx context.Context, orgID uuid.UUID, checkType string) (interface{}, error)
 	ExportComplianceReportFullFunc func(ctx context.Context, orgID uuid.UUID, framework string, startDate, endDate time.Time, userID uuid.UUID) (*domain.ComplianceExportReport, error)
-	ExportToCSVFunc               func(ctx context.Context, orgID uuid.UUID, framework string) (string, error)
-	GetComplianceTrendingFunc     func(ctx context.Context, orgID uuid.UUID, framework string, startDate, endDate time.Time) (interface{}, error)
-	RecordComplianceSnapshotFunc  func(ctx context.Context, orgID uuid.UUID, framework domain.ComplianceFramework) (*domain.ComplianceSnapshot, error)
-	CollectEvidenceFunc           func(ctx context.Context, orgID uuid.UUID, framework domain.ComplianceFramework, checkName string, userID uuid.UUID) (*domain.ComplianceEvidence, error)
-	GetEvidenceForCheckFunc       func(ctx context.Context, orgID uuid.UUID, checkName string) ([]*domain.ComplianceEvidence, error)
+	ExportToCSVFunc                func(ctx context.Context, orgID uuid.UUID, framework string) (string, error)
+	GetComplianceTrendingFunc      func(ctx context.Context, orgID uuid.UUID, framework string, startDate, endDate time.Time) (interface{}, error)
+	RecordComplianceSnapshotFunc   func(ctx context.Context, orgID uuid.UUID, framework domain.ComplianceFramework) (*domain.ComplianceSnapshot, error)
+	CollectEvidenceFunc            func(ctx context.Context, orgID uuid.UUID, framework domain.ComplianceFramework, checkName string, userID uuid.UUID) (*domain.ComplianceEvidence, error)
+	GetEvidenceForCheckFunc        func(ctx context.Context, orgID uuid.UUID, checkName string) ([]*domain.ComplianceEvidence, error)
 }
 
 func (m *MockComplianceServiceExtendedImpl) GetComplianceStatus(ctx context.Context, orgID uuid.UUID) (interface{}, error) {
@@ -1235,8 +1238,8 @@ func (m *MockComplianceServiceExtendedImpl) GetEvidenceForCheck(ctx context.Cont
 
 // MockVerificationEventServiceExtendedImpl implements VerificationEventServicerExtended interface
 type MockVerificationEventServiceExtendedImpl struct {
-	LogVerificationEventFunc       func(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error)
-	GetLast24HoursStatisticsFunc   func(ctx context.Context, orgID uuid.UUID) (*domain.VerificationStatistics, error)
+	LogVerificationEventFunc     func(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error)
+	GetLast24HoursStatisticsFunc func(ctx context.Context, orgID uuid.UUID) (*domain.VerificationStatistics, error)
 }
 
 func (m *MockVerificationEventServiceExtendedImpl) LogVerificationEvent(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error) {
@@ -1298,11 +1301,11 @@ func (m *MockAgentServiceForVerificationImpl) CreateSecurityAlert(ctx context.Co
 
 // MockAuditServiceForVerificationImpl implements AuditServicerForVerification interface
 type MockAuditServiceForVerificationImpl struct {
-	LogActionFunc    func(ctx context.Context, orgID uuid.UUID, userID uuid.UUID, action domain.AuditAction, resourceType string, resourceID uuid.UUID, ipAddress string, userAgent string, metadata map[string]interface{}) error
+	LogActionFunc        func(ctx context.Context, orgID uuid.UUID, userID uuid.UUID, action domain.AuditAction, resourceType string, resourceID uuid.UUID, ipAddress string, userAgent string, metadata map[string]interface{}) error
 	GetAgentActivityFunc func(ctx context.Context, orgID, agentID uuid.UUID, limit, offset int) ([]*domain.AuditLog, error)
-	GetAuditLogsFunc func(ctx context.Context, orgID uuid.UUID, action string, entityType string, entityID *uuid.UUID, userID *uuid.UUID, startDate *time.Time, endDate *time.Time, limit int, offset int) ([]*domain.AuditLog, int, error)
-	GetByIDFunc      func(ctx context.Context, id uuid.UUID) (*domain.AuditLog, error)
-	LogFunc          func(ctx context.Context, entry *domain.AuditLog) error
+	GetAuditLogsFunc     func(ctx context.Context, orgID uuid.UUID, action string, entityType string, entityID *uuid.UUID, userID *uuid.UUID, startDate *time.Time, endDate *time.Time, limit int, offset int) ([]*domain.AuditLog, int, error)
+	GetByIDFunc          func(ctx context.Context, id uuid.UUID) (*domain.AuditLog, error)
+	LogFunc              func(ctx context.Context, entry *domain.AuditLog) error
 }
 
 func (m *MockAuditServiceForVerificationImpl) LogAction(ctx context.Context, orgID uuid.UUID, userID uuid.UUID, action domain.AuditAction, resourceType string, resourceID uuid.UUID, ipAddress string, userAgent string, metadata map[string]interface{}) error {
@@ -1394,12 +1397,12 @@ func (m *MockAlertServiceForVerificationImpl) DetectUnusualAccessPatterns(ctx co
 
 // MockVerificationEventServiceForVerificationImpl implements VerificationEventServicerForVerification interface
 type MockVerificationEventServiceForVerificationImpl struct {
-	LogVerificationEventFunc       func(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error)
-	CreateVerificationEventFunc    func(ctx context.Context, req *application.CreateVerificationEventRequest) (*domain.VerificationEvent, error)
-	GetVerificationEventFunc       func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error)
-	UpdateVerificationResultFunc   func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error
-	SearchVerificationsFunc        func(ctx context.Context, orgID uuid.UUID, params domain.VerificationQueryParams) ([]*domain.VerificationEvent, int, *domain.VerificationStatusCounts, error)
-	UpdateExecutionStatusFunc      func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error
+	LogVerificationEventFunc     func(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error)
+	CreateVerificationEventFunc  func(ctx context.Context, req *application.CreateVerificationEventRequest) (*domain.VerificationEvent, error)
+	GetVerificationEventFunc     func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error)
+	UpdateVerificationResultFunc func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error
+	SearchVerificationsFunc      func(ctx context.Context, orgID uuid.UUID, params domain.VerificationQueryParams) ([]*domain.VerificationEvent, int, *domain.VerificationStatusCounts, error)
+	UpdateExecutionStatusFunc    func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error
 }
 
 func (m *MockVerificationEventServiceForVerificationImpl) LogVerificationEvent(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID, protocol domain.VerificationProtocol, verificationType domain.VerificationType, status domain.VerificationEventStatus, durationMs int, initiatorType domain.InitiatorType, initiatorID *uuid.UUID, metadata map[string]interface{}) (*domain.VerificationEvent, error) {
@@ -1462,9 +1465,9 @@ func (m *MockOrganizationRepositoryerImpl) GetByID(id uuid.UUID) (*domain.Organi
 
 // MockTrustCalculatorServicerImpl implements TrustCalculatorServicer interface
 type MockTrustCalculatorServicerImpl struct {
-	CalculateTrustScoreFunc             func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
-	GetLatestTrustScoreFunc             func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
-	GetTrustScoreHistoryAuditTrailFunc  func(ctx context.Context, agentID uuid.UUID, limit int) ([]*domain.TrustScoreHistoryEntry, error)
+	CalculateTrustScoreFunc            func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
+	GetLatestTrustScoreFunc            func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
+	GetTrustScoreHistoryAuditTrailFunc func(ctx context.Context, agentID uuid.UUID, limit int) ([]*domain.TrustScoreHistoryEntry, error)
 }
 
 func (m *MockTrustCalculatorServicerImpl) CalculateTrustScore(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error) {
@@ -1554,4 +1557,63 @@ func (m *MockWebhookServicerImpl) TestWebhook(ctx context.Context, id uuid.UUID)
 		return m.TestWebhookFunc(ctx, id)
 	}
 	return &application.WebhookTestResult{Success: true, StatusCode: 200}, nil
+}
+
+// GetAgentTagsByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockTagServiceImpl) GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	if m.GetAgentTagsByAgentIDsFunc != nil {
+		return m.GetAgentTagsByAgentIDsFunc(ctx, agentIDs)
+	}
+	result := make(map[uuid.UUID][]*domain.Tag, len(agentIDs))
+	for _, agentID := range agentIDs {
+		tags, err := m.GetAgentTags(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[agentID] = tags
+		}
+	}
+	return result, nil
+}
+
+// GetCapabilitiesByAgentIDs aggregates the per-agent mocks for tests.
+func (m *MockCapabilityServiceImpl) GetCapabilitiesByAgentIDs(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error) {
+	if m.GetCapabilitiesByAgentIDsFunc != nil {
+		return m.GetCapabilitiesByAgentIDsFunc(ctx, agentIDs, activeOnly)
+	}
+	result := make(map[uuid.UUID][]*domain.AgentCapability, len(agentIDs))
+	for _, agentID := range agentIDs {
+		caps, err := m.GetAgentCapabilities(ctx, agentID, activeOnly)
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[agentID] = caps
+		}
+	}
+	return result, nil
+}
+
+// ListAgentsPaged pages over ListAgents for tests.
+func (m *MockAgentServiceImpl) ListAgentsPaged(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	if m.ListAgentsPagedFunc != nil {
+		return m.ListAgentsPagedFunc(ctx, orgID, limit, offset)
+	}
+	agents, err := m.ListAgents(ctx, orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
 }

--- a/apps/backend/internal/testutil/mocks/repositories.go
+++ b/apps/backend/internal/testutil/mocks/repositories.go
@@ -698,3 +698,23 @@ func (m *MockSDKTokenRepository) GetByRecoveryCodeHash(recoveryCodeHash string) 
 	}
 	return args.Get(0).(*domain.SDKToken), args.Error(1)
 }
+
+// GetByOrganizationPaged pages over GetByOrganization for tests.
+func (m *MockAgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
+	agents, err := m.GetByOrganization(orgID)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(agents)
+	if limit > 0 {
+		if offset >= len(agents) {
+			agents = nil
+		} else {
+			agents = agents[offset:]
+		}
+		if len(agents) > limit {
+			agents = agents[:limit]
+		}
+	}
+	return agents, total, nil
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -219,12 +219,13 @@ Authorization: Bearer YOUR_JWT_TOKEN
 ```
 
 **Query Parameters:**
-- `page` (optional): Page number (default: 1)
-- `limit` (optional): Items per page (default: 20, max: 100)
-- `status` (optional): Filter by status (`active`, `pending_verification`, `revoked`)
-- `type` (optional): Filter by type (`ai_agent`, `mcp_server`)
+- `limit` (optional): Page size. When omitted, all agents are returned.
+- `offset` (optional): Number of agents to skip (default: 0). Only applied when `limit` is set.
 
 **Response:**
+
+`total` is always the organization-wide agent count, so clients can keep paginating. The `limit` and `offset` fields are echoed back only when `limit` was provided.
+
 ```json
 {
   "agents": [
@@ -232,19 +233,17 @@ Authorization: Bearer YOUR_JWT_TOKEN
       "id": "550e8400-e29b-41d4-a716-446655440000",
       "name": "my-agent",
       "displayName": "My Awesome Agent",
-      "type": "ai_agent",
-      "status": "active",
+      "agentType": "ai_agent",
+      "status": "verified",
       "trustScore": 75.5,
-      "lastVerifiedAt": "2025-10-08T00:00:00Z",
+      "capabilities": ["file:read"],
+      "tags": [],
       "createdAt": "2025-10-07T00:00:00Z"
     }
   ],
-  "pagination": {
-    "page": 1,
-    "limit": 20,
-    "total": 45,
-    "totalPages": 3
-  }
+  "total": 45,
+  "limit": 20,
+  "offset": 0
 }
 ```
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/agents` ran 1 query for the agent list plus 2 queries per agent (capabilities and tags via `enrichAgentResponse`), which made the agents page slow for large organizations. The list handler now prefetches both with one bulk query each (`WHERE agent_id IN (...)`), so a page costs a constant number of queries regardless of agent count.
- Adds optional `limit`/`offset` query parameters (server-side pagination). `total` is the org-wide count so clients can keep paginating; `limit`/`offset` are echoed back only when `limit` is provided. Without params the response is byte-compatible with the old shape, so the dashboard's existing client-side paging keeps working unchanged.
- New methods: `CapabilityRepository.GetCapabilitiesByAgentIDs`, `TagRepository.GetAgentTagsByAgentIDs`, `AgentRepository.GetByOrganizationPaged`, `AgentService.ListAgentsPaged`. `GetByOrganization` now delegates to the paged variant (no behavior change).
- `docs/API.md` for this endpoint documented `page`/`status`/`type` parameters and a `pagination` object the handler never implemented; replaced with the real contract.

## Tests
- `TestAgentHandler_ListAgents_UsesBulkEnrichment` — fails the test if the per-agent capability/tag methods are called from the list path (locks out the N+1 regression)
- `TestAgentHandler_ListAgents_Pagination`, `TestAgentHandler_ListAgents_InvalidPagingParams`
- `TestAgentHandler_ListAgents_BulkEnrichmentErrorsDegrade` — bulk query failures degrade to empty arrays with a 200, matching the old per-agent behavior
- `go build`, `go vet`, `go test -race ./internal/...` all green; pre-existing `tests/integration` flakiness under full-suite runs reproduces identically on `origin/main`