### PR TITLE
ci(sync): bump actions/checkout v4 -> v5

### DIFF
--- a/.github/workflows/sync-to-cloud.yml
+++ b/.github/workflows/sync-to-cloud.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout source (agent-identity-management)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
           fetch-depth: 2  # Need previous commit for change detection
@@ -52,7 +52,7 @@ jobs:
 
       - name: Checkout target (aim-cloud)
         if: steps.preflight.outputs.ok == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opena2a-org/aim-cloud
           token: ${{ secrets.AIM_CLOUD_SYNC_TOKEN }}


### PR DESCRIPTION
checkout@v4 runs on Node 20, which GitHub Actions flags as deprecated on every "Sync to AIM Cloud" run. v5 runs on Node 24. CI-only change.

Note: the sync workflow itself is still silently skipping on an expired `AIM_CLOUD_SYNC_TOKEN` (preflight warns, run reports success) — the token needs to be re-minted as a fine-grained PAT with contents:write + pull-requests:write on opena2a-org/aim-cloud. The backlog through today was caught up manually in aim-cloud#48.