### PR TITLE
perf: eliminate per-row query N+1 in MCP servers + pending verifications lists

### DIFF
--- a/apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh
+++ b/apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Real-backend REST smoke for the dashboard list endpoints.
+#
+# Boots a throwaway Postgres + a fresh AIM backend binary (NO OTel stack —
+# this smoke is about the HTTP/SQL contract, not telemetry), logs in as
+# admin, and drives the list endpoints that enrich each row from related
+# tables. It exists to catch the bug class that unit tests CANNOT: the
+# bulk-prefetch SQL added to kill the per-row N+1 (GetMCPServerTagsByServerIDs,
+# MCPServerCapabilityRepository.GetByServerIDs, AgentService.GetAgentsByIDs)
+# only ever runs against a real schema. A wrong column/table name compiles,
+# passes every mock-backed unit test, and — because the list handlers
+# deliberately degrade to empty on query error rather than 500 — would NOT
+# even surface as a non-200. So a 200 check is not enough: this smoke seeds a
+# tag and a capability on a server and asserts they come BACK through the bulk
+# query. A broken query shows up as a missing tag / zero toolCount, which is
+# the externally-observable signal per docs/testing/release-smoke.md.
+#
+# Hermetic: own throwaway Postgres on an alt port, own backend on an alt
+# port, torn down on exit. Does not touch a developer's running stack.
+#
+# What it does, in order:
+#   1. Pre-flight: docker, curl, jq, go, openssl on PATH.
+#   2. Throwaway Postgres (aim-listsmoke-postgres) on $SMOKE_POSTGRES_PORT.
+#   3. Build + run the backend on $SMOKE_BACKEND_PORT. Wait on /health.
+#   4. Seed admin via bootstrap; reset force_password_change; login.
+#   5. MCP list contract: create tag -> create server with that tag ->
+#      seed one 'tool' capability row -> GET /api/v1/mcp-servers and assert
+#      the server comes back WITH the tag and toolCount==1 (proves both
+#      bulk queries return correct, keyed data).
+#   6. Pending-verifications contract: GET /api/v1/admin/verifications/pending
+#      and assert 200 + the documented response shape (verifications array +
+#      pagination object) — exercises the bulk agent-name prefetch path.
+#   7. Teardown.
+#
+# Run from anywhere:   apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh
+#
+# Exit codes:
+#   0 = all list-endpoint contracts verified
+#   1 = pre-flight failure (missing tool)
+#   2 = docker run / build failed
+#   3 = a service failed health check
+#   4 = an HTTP step failed (login / create / list)
+#   5 = a list response was missing the enriched signal (bulk query regression)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+SMOKE_DIR="$(pwd)"
+BACKEND_DIR="$(cd ../.. && pwd)"
+
+SMOKE_BACKEND_PORT="${SMOKE_BACKEND_PORT:-18081}"
+SMOKE_POSTGRES_PORT="${SMOKE_POSTGRES_PORT:-55433}"
+SMOKE_PG_CONTAINER="${SMOKE_PG_CONTAINER:-aim-listsmoke-postgres}"
+SMOKE_PG_PASSWORD="${SMOKE_PG_PASSWORD:-listsmoke_postgres_password}"
+SMOKE_PG_DB="${SMOKE_PG_DB:-identity}"
+
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@opena2a.org}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-AIM2025!ListSmoke}"
+JWT_SECRET="${JWT_SECRET:-$(openssl rand -hex 32)}"
+
+API="http://localhost:${SMOKE_BACKEND_PORT}/api/v1"
+
+echo "==> AIM REST list-endpoints smoke (hermetic)"
+echo "    Backend  : localhost:${SMOKE_BACKEND_PORT}"
+echo "    Postgres : localhost:${SMOKE_POSTGRES_PORT} (container ${SMOKE_PG_CONTAINER})"
+
+echo
+echo "==> [1/6] Pre-flight"
+for tool in docker curl jq go openssl; do
+    command -v "$tool" >/dev/null || { echo "FAIL: $tool not on PATH"; exit 1; }
+done
+
+BACKEND_PID=""
+BACKEND_BIN="$SMOKE_DIR/.list-smoke-backend.bin"
+BOOTSTRAP_BIN="$SMOKE_DIR/.list-smoke-bootstrap.bin"
+BACKEND_LOG="$SMOKE_DIR/.list-smoke-backend.log"
+cleanup() {
+    if [ -n "${BACKEND_PID:-}" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
+        kill "$BACKEND_PID" 2>/dev/null || true
+        wait "$BACKEND_PID" 2>/dev/null || true
+    fi
+    rm -f "$BACKEND_BIN" "$BOOTSTRAP_BIN"
+    if [ "${KEEP_STACKS:-0}" != "1" ]; then
+        docker rm -f "$SMOKE_PG_CONTAINER" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+psql_smoke() {
+    docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
+        psql -U postgres -d "$SMOKE_PG_DB" -v ON_ERROR_STOP=1 "$@"
+}
+
+echo
+echo "==> [2/6] Throwaway Postgres"
+docker rm -f "$SMOKE_PG_CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$SMOKE_PG_CONTAINER" \
+    -e POSTGRES_PASSWORD="$SMOKE_PG_PASSWORD" \
+    -e POSTGRES_DB="$SMOKE_PG_DB" \
+    -p "127.0.0.1:${SMOKE_POSTGRES_PORT}:5432" \
+    timescale/timescaledb:latest-pg16 >/dev/null || { echo "FAIL: docker run postgres"; exit 2; }
+attempt=0
+while [ $attempt -lt 30 ]; do
+    if docker exec "$SMOKE_PG_CONTAINER" pg_isready -U postgres -d "$SMOKE_PG_DB" >/dev/null 2>&1; then
+        echo "    postgres ready"; break
+    fi
+    attempt=$((attempt+1)); sleep 2
+done
+[ $attempt -lt 30 ] || { echo "FAIL: postgres not ready"; exit 3; }
+
+echo
+echo "==> [3/6] Build + run backend (no OTel)"
+(
+    cd "$BACKEND_DIR"
+    go build -o "$BACKEND_BIN" ./cmd/server || exit 2
+    go build -o "$BOOTSTRAP_BIN" ./cmd/bootstrap || exit 2
+) || { echo "FAIL: backend build"; exit 2; }
+
+(
+    cd "$BACKEND_DIR"
+    env \
+        APP_PORT="$SMOKE_BACKEND_PORT" \
+        ENVIRONMENT="development" \
+        POSTGRES_HOST="localhost" \
+        POSTGRES_PORT="$SMOKE_POSTGRES_PORT" \
+        POSTGRES_USER="postgres" \
+        POSTGRES_PASSWORD="$SMOKE_PG_PASSWORD" \
+        POSTGRES_DB="$SMOKE_PG_DB" \
+        POSTGRES_SSL_MODE="disable" \
+        REDIS_HOST="" \
+        JWT_SECRET="$JWT_SECRET" \
+        ADMIN_EMAIL="$ADMIN_EMAIL" \
+        ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+        OTEL_EXPORTER_OTLP_ENDPOINT="" \
+        "$BACKEND_BIN" >"$BACKEND_LOG" 2>&1 &
+    echo $! > "$SMOKE_DIR/.list-smoke-backend.pid"
+)
+BACKEND_PID="$(cat "$SMOKE_DIR/.list-smoke-backend.pid")"
+rm -f "$SMOKE_DIR/.list-smoke-backend.pid"
+echo "    backend pid=$BACKEND_PID, logs at $BACKEND_LOG"
+
+attempt=0
+while [ $attempt -lt 60 ]; do
+    if curl -sf "http://localhost:${SMOKE_BACKEND_PORT}/health" 2>/dev/null \
+        | jq -e '.service == "agent-identity-management"' >/dev/null 2>&1; then
+        echo "    backend ready"; break
+    fi
+    if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+        echo "FAIL: backend exited during boot"; tail -60 "$BACKEND_LOG"; exit 3
+    fi
+    attempt=$((attempt+1)); sleep 2
+done
+[ $attempt -lt 60 ] || { echo "FAIL: backend not ready after 120s"; tail -60 "$BACKEND_LOG"; exit 3; }
+
+echo
+echo "==> [4/6] Seed admin + login"
+(
+    cd "$BACKEND_DIR"
+    env DATABASE_URL="postgres://postgres:${SMOKE_PG_PASSWORD}@localhost:${SMOKE_POSTGRES_PORT}/${SMOKE_PG_DB}?sslmode=disable" \
+        "$BOOTSTRAP_BIN" --default --admin-email="$ADMIN_EMAIL" --admin-password="$ADMIN_PASSWORD" --yes \
+        >>"$BACKEND_LOG" 2>&1
+) || { echo "FAIL: bootstrap --default"; tail -40 "$BACKEND_LOG"; exit 4; }
+psql_smoke -c "UPDATE users SET force_password_change = FALSE WHERE email = '${ADMIN_EMAIL}';" >/dev/null
+
+TOKEN=$(curl -sf -X POST "${API}/public/login" -H "Content-Type: application/json" \
+    -d "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')" \
+    | jq -r '.accessToken // empty')
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { echo "FAIL: login returned no accessToken"; exit 4; }
+echo "    login OK"
+
+auth() { curl -s -H "Authorization: Bearer ${TOKEN}" "$@"; }
+
+echo
+echo "==> [5/6] MCP list contract (bulk tags + capabilities)"
+# Create a tag, then a server carrying it, so the bulk tag join has something
+# to return. A broken GetMCPServerTagsByServerIDs would drop this tag.
+TAG_ID=$(auth -X POST "${API}/tags" -H "Content-Type: application/json" \
+    -d '{"key":"env","value":"smoke","category":"environment"}' | jq -r '.id // .tag.id // empty')
+[ -n "$TAG_ID" ] && [ "$TAG_ID" != "null" ] || { echo "FAIL: tag create returned no id"; exit 4; }
+
+SERVER_NAME="smoke-mcp-$(date +%s)"
+SERVER_ID=$(auth -X POST "${API}/mcp-servers" -H "Content-Type: application/json" \
+    -d "$(jq -n --arg n "$SERVER_NAME" --arg t "$TAG_ID" \
+        '{name:$n, url:"https://smoke.example.com/mcp", description:"list-smoke", tagIds:[$t]}')" \
+    | jq -r '.id // empty')
+[ -n "$SERVER_ID" ] && [ "$SERVER_ID" != "null" ] || { echo "FAIL: mcp create returned no id"; exit 4; }
+echo "    created tag=${TAG_ID} server=${SERVER_ID}"
+
+# Seed one active 'tool' capability directly (no public create-capability
+# route; production populates this via the attestation pipeline). A broken
+# GetByServerIDs would make toolCount come back 0.
+psql_smoke -c "INSERT INTO mcp_server_capabilities
+    (id, mcp_server_id, name, capability_type, is_active, detected_at, created_at, updated_at)
+    VALUES (gen_random_uuid(), '${SERVER_ID}', 'smoke-tool', 'tool', true, now(), now(), now());" >/dev/null
+echo "    seeded one 'tool' capability"
+
+LIST=$(auth "${API}/mcp-servers/")
+ROW=$(echo "$LIST" | jq -c --arg id "$SERVER_ID" '.mcpServers[]? | select(.id == $id)')
+[ -n "$ROW" ] || { echo "FAIL: created server not in list response"; echo "$LIST" | head -c 800; exit 5; }
+
+TAG_BACK=$(echo "$ROW" | jq -r --arg t "$TAG_ID" '[.tags[]? | select(.id == $t)] | length')
+TOOLS_BACK=$(echo "$ROW" | jq -r '.toolCount')
+if [ "$TAG_BACK" != "1" ]; then
+    echo "FAIL: bulk tag query regression — seeded tag absent from list row"
+    echo "    row: $ROW"; exit 5
+fi
+if [ "$TOOLS_BACK" != "1" ]; then
+    echo "FAIL: bulk capability query regression — toolCount=${TOOLS_BACK}, expected 1"
+    echo "    row: $ROW"; exit 5
+fi
+echo "    list row carries the bulk-prefetched tag (1) and toolCount=${TOOLS_BACK}"
+
+echo
+echo "==> [6/6] Pending-verifications contract"
+PENDING_OUT="$(mktemp -t list-smoke-pending.XXXXXX)"
+PENDING_CODE=$(auth -o "$PENDING_OUT" -w '%{http_code}' "${API}/admin/verifications/pending")
+[ "$PENDING_CODE" = "200" ] || { echo "FAIL: pending verifications returned HTTP ${PENDING_CODE}"; cat "$PENDING_OUT"; rm -f "$PENDING_OUT"; exit 4; }
+if ! jq -e '(.verifications | type == "array") and (.pagination | type == "object")' "$PENDING_OUT" >/dev/null 2>&1; then
+    echo "FAIL: pending verifications response missing verifications[]/pagination shape"
+    head -c 800 "$PENDING_OUT"; rm -f "$PENDING_OUT"; exit 5
+fi
+rm -f "$PENDING_OUT"
+echo "    pending verifications 200 + shape OK"
+
+echo
+echo "==> PASS: list-endpoint bulk-enrichment contracts verified against a real backend"
+echo "    GET /mcp-servers              -> tag + toolCount returned via bulk query"
+echo "    GET /admin/verifications/pending -> 200 + verifications[]/pagination"

--- a/apps/backend/internal/application/mcp_capability_service.go
+++ b/apps/backend/internal/application/mcp_capability_service.go
@@ -228,6 +228,12 @@ func (s *MCPCapabilityService) GetCapabilities(ctx context.Context, serverID uui
 	return s.capabilityRepo.GetByServerID(serverID)
 }
 
+// GetCapabilitiesByServerIDs retrieves active capabilities for many MCP
+// servers in a single query, keyed by MCP server ID
+func (s *MCPCapabilityService) GetCapabilitiesByServerIDs(ctx context.Context, serverIDs []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error) {
+	return s.capabilityRepo.GetByServerIDs(serverIDs)
+}
+
 // GetCapabilitiesByType retrieves capabilities by type
 func (s *MCPCapabilityService) GetCapabilitiesByType(ctx context.Context, serverID uuid.UUID, capType domain.MCPCapabilityType) ([]*domain.MCPServerCapability, error) {
 	return s.capabilityRepo.GetByServerIDAndType(serverID, capType)

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -1021,3 +1021,17 @@ func (m *SharedMockTagRepository) GetAgentTagsByAgentIDs(ctx context.Context, ag
 	}
 	return result, nil
 }
+
+func (m *SharedMockTagRepository) GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(mcpServerIDs))
+	for _, serverID := range mcpServerIDs {
+		tags, err := m.GetMCPServerTags(ctx, serverID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[serverID] = tags
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/application/tag_service.go
+++ b/apps/backend/internal/application/tag_service.go
@@ -263,6 +263,16 @@ func (s *TagService) GetMCPServerTags(ctx context.Context, mcpServerID uuid.UUID
 	return tags, nil
 }
 
+// GetMCPServerTagsByServerIDs retrieves tags for many MCP servers in a
+// single query, keyed by MCP server ID
+func (s *TagService) GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	tags, err := s.tagRepo.GetMCPServerTagsByServerIDs(ctx, mcpServerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mcp server tags: %w", err)
+	}
+	return tags, nil
+}
+
 // SuggestTagsForAgent suggests tags based on agent metadata
 // Smart suggestions based on agent type, capabilities, trust score, and MCP connections
 func (s *TagService) SuggestTagsForAgent(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error) {

--- a/apps/backend/internal/application/tag_service_test.go
+++ b/apps/backend/internal/application/tag_service_test.go
@@ -2222,3 +2222,17 @@ func (m *MockTagRepoForTags) GetAgentTagsByAgentIDs(ctx context.Context, agentID
 	}
 	return result, nil
 }
+
+func (m *MockTagRepoForTags) GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(mcpServerIDs))
+	for _, serverID := range mcpServerIDs {
+		tags, err := m.GetMCPServerTags(ctx, serverID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[serverID] = tags
+		}
+	}
+	return result, nil
+}

--- a/apps/backend/internal/domain/tag.go
+++ b/apps/backend/internal/domain/tag.go
@@ -63,4 +63,5 @@ type TagRepository interface {
 	AddTagsToMCPServer(ctx context.Context, mcpServerID uuid.UUID, tagIDs []uuid.UUID) error
 	RemoveTagFromMCPServer(ctx context.Context, mcpServerID uuid.UUID, tagID uuid.UUID) error
 	GetMCPServerTags(ctx context.Context, mcpServerID uuid.UUID) ([]*Tag, error)
+	GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*Tag, error)
 }

--- a/apps/backend/internal/infrastructure/repository/mcp_capability_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_capability_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -161,6 +162,78 @@ func (r *MCPServerCapabilityRepository) GetByServerID(serverID uuid.UUID) ([]*do
 	}
 
 	return capabilities, nil
+}
+
+// GetByServerIDs retrieves active capabilities for many MCP servers in a
+// single query, keyed by MCP server ID. Servers with no capabilities have
+// no entry in the returned map.
+func (r *MCPServerCapabilityRepository) GetByServerIDs(serverIDs []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error) {
+	result := make(map[uuid.UUID][]*domain.MCPServerCapability, len(serverIDs))
+	if len(serverIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(serverIDs))
+	args := make([]interface{}, len(serverIDs))
+	for i, id := range serverIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			id, mcp_server_id, name, capability_type, description,
+			capability_schema, detected_at, last_verified_at, is_active,
+			created_at, updated_at
+		FROM mcp_server_capabilities
+		WHERE mcp_server_id IN (%s) AND is_active = true
+		ORDER BY capability_type, name
+	`, strings.Join(placeholders, ","))
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list mcp server capabilities: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		capability := &domain.MCPServerCapability{}
+		var description sql.NullString
+		capabilitySchema := make([]byte, 0)
+		var lastVerifiedAt sql.NullTime
+
+		err := rows.Scan(
+			&capability.ID,
+			&capability.MCPServerID,
+			&capability.Name,
+			&capability.CapabilityType,
+			&description,
+			&capabilitySchema,
+			&capability.DetectedAt,
+			&lastVerifiedAt,
+			&capability.IsActive,
+			&capability.CreatedAt,
+			&capability.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan mcp server capability: %w", err)
+		}
+
+		// Convert nullable fields
+		if description.Valid {
+			capability.Description = description.String
+		}
+		if capabilitySchema != nil {
+			capability.CapabilitySchema = capabilitySchema
+		}
+		if lastVerifiedAt.Valid {
+			capability.LastVerifiedAt = &lastVerifiedAt.Time
+		}
+
+		result[capability.MCPServerID] = append(result[capability.MCPServerID], capability)
+	}
+
+	return result, rows.Err()
 }
 
 func (r *MCPServerCapabilityRepository) GetByServerIDAndType(serverID uuid.UUID, capType domain.MCPCapabilityType) ([]*domain.MCPServerCapability, error) {

--- a/apps/backend/internal/infrastructure/repository/tag_repository.go
+++ b/apps/backend/internal/infrastructure/repository/tag_repository.go
@@ -405,6 +405,60 @@ func (r *TagRepository) GetMCPServerTags(ctx context.Context, mcpServerID uuid.U
 	return tags, nil
 }
 
+// GetMCPServerTagsByServerIDs retrieves tags for many MCP servers in a
+// single query, keyed by MCP server ID. Servers with no tags have no
+// entry in the returned map.
+func (r *TagRepository) GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	result := make(map[uuid.UUID][]*domain.Tag, len(mcpServerIDs))
+	if len(mcpServerIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(mcpServerIDs))
+	args := make([]interface{}, len(mcpServerIDs))
+	for i, id := range mcpServerIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT mst.mcp_server_id, t.id, t.organization_id, t.key, t.value, t.category, t.description, t.color, t.created_at, t.created_by
+		FROM tags t
+		INNER JOIN mcp_server_tags mst ON t.id = mst.tag_id
+		WHERE mst.mcp_server_id IN (%s)
+		ORDER BY t.category, t.key, t.value
+	`, strings.Join(placeholders, ","))
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mcp server tags: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var serverID uuid.UUID
+		tag := &domain.Tag{}
+		err := rows.Scan(
+			&serverID,
+			&tag.ID,
+			&tag.OrganizationID,
+			&tag.Key,
+			&tag.Value,
+			&tag.Category,
+			&tag.Description,
+			&tag.Color,
+			&tag.CreatedAt,
+			&tag.CreatedBy,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan tag: %w", err)
+		}
+		result[serverID] = append(result[serverID], tag)
+	}
+
+	return result, rows.Err()
+}
+
 // GetPopularTags retrieves the most popular tags by usage count
 func (r *TagRepository) GetPopularTags(ctx context.Context, organizationID uuid.UUID, limit int) ([]*domain.Tag, error) {
 	query := `

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -91,6 +91,7 @@ type TagServicer interface {
 	GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
 	GetAgentTagsByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
 	GetMCPServerTags(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
+	GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
 }
 
 // APIKeyServicer defines the methods from APIKeyService that handlers use
@@ -217,6 +218,7 @@ type ComplianceServicerExtended interface {
 // MCPCapabilityServicer defines the methods from MCPCapabilityService that handlers use
 type MCPCapabilityServicer interface {
 	GetCapabilities(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.MCPServerCapability, error)
+	GetCapabilitiesByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error)
 	DetectCapabilities(ctx context.Context, mcpServerID uuid.UUID) error
 }
 
@@ -268,6 +270,7 @@ type SecurityServicerForAnalytics interface {
 type AgentServicerForVerification interface {
 	AgentServicer
 	CreateSecurityAlert(ctx context.Context, alert *domain.Alert) error
+	GetAgentsByIDs(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error)
 }
 
 // AuditServicerForVerification extends AuditServicer with Log method for VerificationHandler

--- a/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_handler.go
@@ -124,30 +124,34 @@ func (h *MCPHandler) getAttestationService() MCPAttestationServicerExtended {
 	return h.attestationService
 }
 
-// enrichMCPServerResponse adds tags to MCP server response
+// enrichMCPServerResponse adds tags to a single MCP server response. List
+// endpoints should use mcpServerResponse with prefetched tags instead, to
+// avoid a per-server tag query.
 func (h *MCPHandler) enrichMCPServerResponse(c fiber.Ctx, server *domain.MCPServer) fiber.Map {
 	// ✅ Fetch tags from mcp_server_tags table
-	tags := make([]fiber.Map, 0)
-	tagSvc := h.getTagService()
-	if tagSvc != nil {
-		serverTags, err := tagSvc.GetMCPServerTags(c.Context(), server.ID)
-		if err != nil {
-			tags = []fiber.Map{}
-		} else {
-			tags = make([]fiber.Map, 0, len(serverTags))
-			for _, tag := range serverTags {
-				tags = append(tags, fiber.Map{
-					"id":          tag.ID,
-					"key":         tag.Key,
-					"value":       tag.Value,
-					"category":    tag.Category,
-					"description": tag.Description,
-					"color":       tag.Color,
-				})
-			}
+	serverTags := make([]*domain.Tag, 0)
+	if tagSvc := h.getTagService(); tagSvc != nil {
+		// Log error but don't fail - return empty tags
+		if fetched, err := tagSvc.GetMCPServerTags(c.Context(), server.ID); err == nil && fetched != nil {
+			serverTags = fetched
 		}
-	} else {
-		tags = []fiber.Map{}
+	}
+	return mcpServerResponse(server, serverTags)
+}
+
+// mcpServerResponse renders an MCP server plus its prefetched tags. The
+// same response shape is used by single-server and bulk-list paths.
+func mcpServerResponse(server *domain.MCPServer, serverTags []*domain.Tag) fiber.Map {
+	tags := make([]fiber.Map, 0, len(serverTags))
+	for _, tag := range serverTags {
+		tags = append(tags, fiber.Map{
+			"id":          tag.ID,
+			"key":         tag.Key,
+			"value":       tag.Value,
+			"category":    tag.Category,
+			"description": tag.Description,
+			"color":       tag.Color,
+		})
 	}
 
 	return fiber.Map{
@@ -326,30 +330,40 @@ func (h *MCPHandler) ListMCPServers(c fiber.Ctx) error {
 		})
 	}
 
-	// ✅ Enrich each server with tags and tool count
+	// Prefetch tags and capabilities for the whole page in one query
+	// each, instead of two queries per server (the old 1+2N pattern).
+	serverIDs := make([]uuid.UUID, len(servers))
+	for i, server := range servers {
+		serverIDs[i] = server.ID
+	}
+
+	var tagsByServer map[uuid.UUID][]*domain.Tag
+	if tagSvc := h.getTagService(); tagSvc != nil {
+		// Log error but don't fail - servers degrade to empty tags
+		tagsByServer, _ = tagSvc.GetMCPServerTagsByServerIDs(c.Context(), serverIDs)
+	}
+
+	capsByServer := map[uuid.UUID][]*domain.MCPServerCapability{}
+	if capSvc := h.getMCPCapabilityService(); capSvc != nil {
+		// Log error but don't fail - servers degrade to a zero tool count
+		if fetched, err := capSvc.GetCapabilitiesByServerIDs(c.Context(), serverIDs); err == nil && fetched != nil {
+			capsByServer = fetched
+		}
+	}
+
 	enriched := make([]fiber.Map, 0, len(servers))
-	capSvc := h.getMCPCapabilityService()
 	for _, server := range servers {
-		serverMap := h.enrichMCPServerResponse(c, server)
+		serverMap := mcpServerResponse(server, tagsByServer[server.ID])
 
 		// ✅ Add actual tool count from mcp_server_capabilities table
-		if capSvc != nil {
-			capabilities, err := capSvc.GetCapabilities(c.Context(), server.ID)
-			if err == nil {
-				// Count only tools (not prompts/resources)
-				toolCount := 0
-				for _, cap := range capabilities {
-					if cap.CapabilityType == "tool" {
-						toolCount++
-					}
-				}
-				serverMap["toolCount"] = toolCount
-			} else {
-				serverMap["toolCount"] = 0
+		// (count only tools, not prompts/resources)
+		toolCount := 0
+		for _, cap := range capsByServer[server.ID] {
+			if cap.CapabilityType == "tool" {
+				toolCount++
 			}
-		} else {
-			serverMap["toolCount"] = 0
 		}
+		serverMap["toolCount"] = toolCount
 
 		enriched = append(enriched, serverMap)
 	}

--- a/apps/backend/internal/interfaces/http/handlers/mcp_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/mcp_handler_integration_test.go
@@ -137,6 +137,142 @@ func TestMCPHandler_ListMCPServers_ServiceError(t *testing.T) {
 	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
 }
 
+// TestMCPHandler_ListMCPServers_BulkPrefetch locks the N+1 fix: the list
+// path must use the bulk tag/capability queries (keyed by server) and must
+// NOT fall back to a per-server query inside the loop.
+func TestMCPHandler_ListMCPServers_BulkPrefetch(t *testing.T) {
+	orgID := uuid.New()
+	serverID1 := uuid.New()
+	serverID2 := uuid.New()
+	tagID := uuid.New()
+
+	mockMCPService := &MockMCPServiceExtendedImpl{
+		ListMCPServersFunc: func(ctx context.Context, oID uuid.UUID) ([]*domain.MCPServer, error) {
+			return []*domain.MCPServer{
+				{ID: serverID1, OrganizationID: oID, Name: "Server1", Status: domain.MCPServerStatusVerified},
+				{ID: serverID2, OrganizationID: oID, Name: "Server2", Status: domain.MCPServerStatusPending},
+			}, nil
+		},
+	}
+
+	mockCapabilityService := &MockMCPCapabilityServiceImpl{
+		// Per-server query must never be called from the list path.
+		GetCapabilitiesFunc: func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.MCPServerCapability, error) {
+			t.Errorf("per-server GetCapabilities called for %s; list path must use the bulk query", mcpServerID)
+			return nil, nil
+		},
+		GetCapabilitiesByServerIDsFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error) {
+			assert.ElementsMatch(t, []uuid.UUID{serverID1, serverID2}, ids)
+			return map[uuid.UUID][]*domain.MCPServerCapability{
+				serverID1: {
+					{ID: uuid.New(), CapabilityType: "tool", Name: "tool-a"},
+					{ID: uuid.New(), CapabilityType: "tool", Name: "tool-b"},
+					{ID: uuid.New(), CapabilityType: "prompt", Name: "prompt-a"},
+				},
+			}, nil
+		},
+	}
+
+	mockTagService := &MockTagServiceImpl{
+		GetMCPServerTagsFunc: func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error) {
+			t.Errorf("per-server GetMCPServerTags called for %s; list path must use the bulk query", mcpServerID)
+			return nil, nil
+		},
+		GetMCPServerTagsByServerIDsFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+			assert.ElementsMatch(t, []uuid.UUID{serverID1, serverID2}, ids)
+			return map[uuid.UUID][]*domain.Tag{
+				serverID1: {{ID: tagID, Key: "env", Value: "prod"}},
+			}, nil
+		},
+	}
+
+	handler := createMCPHandlerWithMocks(mockMCPService, mockCapabilityService, nil, nil, nil, mockTagService, nil)
+
+	app := fiber.New()
+	app.Get("/mcp-servers", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.ListMCPServers(c)
+	})
+
+	req := httptest.NewRequest("GET", "/mcp-servers", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var result map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+
+	servers := result["mcpServers"].([]interface{})
+	require.Len(t, servers, 2)
+
+	byID := map[string]map[string]interface{}{}
+	for _, s := range servers {
+		m := s.(map[string]interface{})
+		byID[m["id"].(string)] = m
+	}
+
+	// Server1: 2 tools (prompt excluded) and 1 tag from the bulk maps.
+	s1 := byID[serverID1.String()]
+	assert.Equal(t, float64(2), s1["toolCount"])
+	assert.Len(t, s1["tags"].([]interface{}), 1)
+
+	// Server2: absent from both bulk maps -> zero tools, empty tags.
+	s2 := byID[serverID2.String()]
+	assert.Equal(t, float64(0), s2["toolCount"])
+	assert.Empty(t, s2["tags"].([]interface{}))
+}
+
+// TestMCPHandler_ListMCPServers_BulkDegradesOnError locks that a failure of
+// either bulk query degrades to empty tags / zero tool count with a 200,
+// matching the old per-server behavior.
+func TestMCPHandler_ListMCPServers_BulkDegradesOnError(t *testing.T) {
+	orgID := uuid.New()
+	serverID := uuid.New()
+
+	mockMCPService := &MockMCPServiceExtendedImpl{
+		ListMCPServersFunc: func(ctx context.Context, oID uuid.UUID) ([]*domain.MCPServer, error) {
+			return []*domain.MCPServer{
+				{ID: serverID, OrganizationID: oID, Name: "Server1", Status: domain.MCPServerStatusVerified},
+			}, nil
+		},
+	}
+	mockCapabilityService := &MockMCPCapabilityServiceImpl{
+		GetCapabilitiesByServerIDsFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error) {
+			return nil, assert.AnError
+		},
+	}
+	mockTagService := &MockTagServiceImpl{
+		GetMCPServerTagsByServerIDsFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	handler := createMCPHandlerWithMocks(mockMCPService, mockCapabilityService, nil, nil, nil, mockTagService, nil)
+
+	app := fiber.New()
+	app.Get("/mcp-servers", func(c fiber.Ctx) error {
+		c.Locals("organization_id", orgID)
+		return handler.ListMCPServers(c)
+	})
+
+	req := httptest.NewRequest("GET", "/mcp-servers", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var result map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	servers := result["mcpServers"].([]interface{})
+	require.Len(t, servers, 1)
+	s := servers[0].(map[string]interface{})
+	assert.Equal(t, float64(0), s["toolCount"])
+	assert.Empty(t, s["tags"].([]interface{}))
+}
+
 // ===========================
 // GetMCPServer Tests
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -18,6 +18,7 @@ import (
 type MockAgentServiceImpl struct {
 	CreateAgentFunc                func(ctx context.Context, req *application.CreateAgentRequest, orgID, userID uuid.UUID, sdkTokenID *uuid.UUID, apiKeyID *uuid.UUID, userEmail string) (*domain.Agent, error)
 	GetAgentFunc                   func(ctx context.Context, id uuid.UUID) (*domain.Agent, error)
+	GetAgentsByIDsFunc             func(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error)
 	GetAgentByNameFunc             func(ctx context.Context, orgID uuid.UUID, name string) (*domain.Agent, error)
 	ListAgentsFunc                 func(ctx context.Context, orgID uuid.UUID) ([]*domain.Agent, error)
 	ListAgentsPagedFunc            func(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error)
@@ -57,6 +58,23 @@ func (m *MockAgentServiceImpl) GetAgent(ctx context.Context, id uuid.UUID) (*dom
 		return m.GetAgentFunc(ctx, id)
 	}
 	return nil, nil
+}
+
+func (m *MockAgentServiceImpl) GetAgentsByIDs(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error) {
+	if m.GetAgentsByIDsFunc != nil {
+		return m.GetAgentsByIDsFunc(ctx, ids)
+	}
+	agents := make([]*domain.Agent, 0, len(ids))
+	for _, id := range ids {
+		agent, err := m.GetAgent(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if agent != nil {
+			agents = append(agents, agent)
+		}
+	}
+	return agents, nil
 }
 
 func (m *MockAgentServiceImpl) GetAgentByName(ctx context.Context, orgID uuid.UUID, name string) (*domain.Agent, error) {
@@ -459,9 +477,10 @@ func (m *MockCapabilityServiceImpl) GetRecentViolations(ctx context.Context, org
 
 // MockTagServiceImpl implements TagServicer interface
 type MockTagServiceImpl struct {
-	GetAgentTagsFunc           func(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
-	GetAgentTagsByAgentIDsFunc func(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
-	GetMCPServerTagsFunc       func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
+	GetAgentTagsFunc                func(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error)
+	GetAgentTagsByAgentIDsFunc      func(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
+	GetMCPServerTagsFunc            func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.Tag, error)
+	GetMCPServerTagsByServerIDsFunc func(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error)
 }
 
 func (m *MockTagServiceImpl) GetAgentTags(ctx context.Context, agentID uuid.UUID) ([]*domain.Tag, error) {
@@ -476,6 +495,23 @@ func (m *MockTagServiceImpl) GetMCPServerTags(ctx context.Context, mcpServerID u
 		return m.GetMCPServerTagsFunc(ctx, mcpServerID)
 	}
 	return []*domain.Tag{}, nil
+}
+
+func (m *MockTagServiceImpl) GetMCPServerTagsByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.Tag, error) {
+	if m.GetMCPServerTagsByServerIDsFunc != nil {
+		return m.GetMCPServerTagsByServerIDsFunc(ctx, mcpServerIDs)
+	}
+	result := make(map[uuid.UUID][]*domain.Tag, len(mcpServerIDs))
+	for _, serverID := range mcpServerIDs {
+		tags, err := m.GetMCPServerTags(ctx, serverID)
+		if err != nil {
+			return nil, err
+		}
+		if len(tags) > 0 {
+			result[serverID] = tags
+		}
+	}
+	return result, nil
 }
 
 // MockAPIKeyServiceImpl implements APIKeyServicer interface
@@ -1038,8 +1074,9 @@ func (m *MockMCPServiceExtendedImpl) GenerateVerificationChallenge(ctx context.C
 
 // MockMCPCapabilityServiceImpl implements MCPCapabilityServicer interface
 type MockMCPCapabilityServiceImpl struct {
-	GetCapabilitiesFunc    func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.MCPServerCapability, error)
-	DetectCapabilitiesFunc func(ctx context.Context, mcpServerID uuid.UUID) error
+	GetCapabilitiesFunc            func(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.MCPServerCapability, error)
+	GetCapabilitiesByServerIDsFunc func(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error)
+	DetectCapabilitiesFunc         func(ctx context.Context, mcpServerID uuid.UUID) error
 }
 
 func (m *MockMCPCapabilityServiceImpl) GetCapabilities(ctx context.Context, mcpServerID uuid.UUID) ([]*domain.MCPServerCapability, error) {
@@ -1047,6 +1084,24 @@ func (m *MockMCPCapabilityServiceImpl) GetCapabilities(ctx context.Context, mcpS
 		return m.GetCapabilitiesFunc(ctx, mcpServerID)
 	}
 	return []*domain.MCPServerCapability{}, nil
+}
+
+// GetCapabilitiesByServerIDs aggregates the per-server mocks for tests.
+func (m *MockMCPCapabilityServiceImpl) GetCapabilitiesByServerIDs(ctx context.Context, mcpServerIDs []uuid.UUID) (map[uuid.UUID][]*domain.MCPServerCapability, error) {
+	if m.GetCapabilitiesByServerIDsFunc != nil {
+		return m.GetCapabilitiesByServerIDsFunc(ctx, mcpServerIDs)
+	}
+	result := make(map[uuid.UUID][]*domain.MCPServerCapability, len(mcpServerIDs))
+	for _, serverID := range mcpServerIDs {
+		caps, err := m.GetCapabilities(ctx, serverID)
+		if err != nil {
+			return nil, err
+		}
+		if len(caps) > 0 {
+			result[serverID] = caps
+		}
+	}
+	return result, nil
 }
 
 func (m *MockMCPCapabilityServiceImpl) DetectCapabilities(ctx context.Context, mcpServerID uuid.UUID) error {

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler.go
@@ -1441,6 +1441,33 @@ func (h *VerificationHandler) ListPendingVerifications(c fiber.Ctx) error {
 		}
 	}
 
+	// Prefetch names for events that lack an inline initiator/agent name in
+	// one bulk query, instead of one GetAgent call per event.
+	agentNameByID := make(map[uuid.UUID]string)
+	missingNameIDs := make([]uuid.UUID, 0)
+	seenAgentID := make(map[uuid.UUID]bool)
+	for _, event := range events {
+		hasInlineName := (event.InitiatorName != nil && *event.InitiatorName != "") ||
+			(event.AgentName != nil && *event.AgentName != "")
+		if !hasInlineName && event.AgentID != nil && !seenAgentID[*event.AgentID] {
+			seenAgentID[*event.AgentID] = true
+			missingNameIDs = append(missingNameIDs, *event.AgentID)
+		}
+	}
+	if len(missingNameIDs) > 0 {
+		// Log error but don't fail - names degrade to empty, same as the
+		// old per-event lookup which left the name blank on error.
+		if agents, err := h.getAgentService().GetAgentsByIDs(c.Context(), missingNameIDs); err == nil {
+			for _, agent := range agents {
+				name := agent.DisplayName
+				if name == "" {
+					name = agent.Name
+				}
+				agentNameByID[agent.ID] = name
+			}
+		}
+	}
+
 	responseItems := make([]PendingVerificationResponse, 0)
 	for _, event := range events {
 		// Get agent name with fallbacks
@@ -1451,15 +1478,9 @@ func (h *VerificationHandler) ListPendingVerifications(c fiber.Ctx) error {
 			agentName = *event.AgentName
 		}
 
-		// If still no name, try to get from agent repo
+		// If still no name, use the bulk-prefetched name
 		if agentName == "" && event.AgentID != nil {
-			if agent, err := h.getAgentService().GetAgent(c.Context(), *event.AgentID); err == nil {
-				if agent.DisplayName != "" {
-					agentName = agent.DisplayName
-				} else {
-					agentName = agent.Name
-				}
-			}
+			agentName = agentNameByID[*event.AgentID]
 		}
 
 		actionType := ""

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler_integration_test.go
@@ -1477,3 +1477,82 @@ func TestNormalizeVerificationStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestVerificationHandler_ListPendingVerifications_BulkAgentNames locks the
+// N+1 fix: events lacking an inline name resolve through a single bulk
+// GetAgentsByIDs call, and the per-event GetAgent must never be called.
+func TestVerificationHandler_ListPendingVerifications_BulkAgentNames(t *testing.T) {
+	agentA := uuid.New()
+	agentB := uuid.New()
+	inlineName := "inline-initiator"
+	now := time.Now()
+
+	mockEventService := &MockVerificationEventServiceForVerificationImpl{
+		SearchVerificationsFunc: func(ctx context.Context, orgID uuid.UUID, params domain.VerificationQueryParams) ([]*domain.VerificationEvent, int, *domain.VerificationStatusCounts, error) {
+			events := []*domain.VerificationEvent{
+				// Two events for agentA and one for agentB, all missing an
+				// inline name -> must be resolved via the bulk query.
+				{ID: uuid.New(), OrganizationID: orgID, AgentID: &agentA, CreatedAt: now},
+				{ID: uuid.New(), OrganizationID: orgID, AgentID: &agentA, CreatedAt: now},
+				{ID: uuid.New(), OrganizationID: orgID, AgentID: &agentB, CreatedAt: now},
+				// One event already carries an inline name -> agentID not in bulk set.
+				{ID: uuid.New(), OrganizationID: orgID, AgentID: &agentA, InitiatorName: &inlineName, CreatedAt: now},
+			}
+			return events, len(events), &domain.VerificationStatusCounts{}, nil
+		},
+	}
+
+	var bulkCalls int
+	var bulkRequested []uuid.UUID
+	mockAgentService := &MockAgentServiceForVerificationImpl{}
+	mockAgentService.GetAgentFunc = func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+		t.Errorf("per-event GetAgent called for %s; list path must use the bulk query", id)
+		return nil, nil
+	}
+	mockAgentService.GetAgentsByIDsFunc = func(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error) {
+		bulkCalls++
+		bulkRequested = ids
+		return []*domain.Agent{
+			{ID: agentA, DisplayName: "Agent A"},
+			{ID: agentB, Name: "agent-b-fallback"}, // no DisplayName -> Name fallback
+		}, nil
+	}
+
+	handler := NewVerificationHandlerWithInterfaces(
+		mockAgentService,
+		&MockAuditServiceForVerificationImpl{},
+		&MockAlertServiceForVerificationImpl{},
+		mockEventService,
+		&MockOrganizationRepositoryerImpl{},
+	)
+
+	app := setupVerificationTestApp(handler)
+
+	req := httptest.NewRequest("GET", "/api/v1/admin/verifications/pending", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// Exactly one bulk call, for the two distinct name-missing agents only.
+	assert.Equal(t, 1, bulkCalls)
+	assert.ElementsMatch(t, []uuid.UUID{agentA, agentB}, bulkRequested)
+
+	var listResp PendingVerificationListResponse
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &listResp))
+	require.Len(t, listResp.Verifications, 4)
+
+	for _, v := range listResp.Verifications {
+		switch {
+		case v.AgentID == agentA.String() && v.AgentName == inlineName:
+			// inline-named event keeps its inline name
+		case v.AgentID == agentA.String():
+			assert.Equal(t, "Agent A", v.AgentName)
+		case v.AgentID == agentB.String():
+			assert.Equal(t, "agent-b-fallback", v.AgentName)
+		default:
+			t.Fatalf("unexpected agent id %s", v.AgentID)
+		}
+	}
+}

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -34,6 +34,7 @@ If a smoke test does not exist for the path you touched, **write one as part of 
 | **AIM backend OTel wiring** | telemetry.Init, FGA span wrap, drift gauge, /api/v1/agents/:id/authorize handler | `apps/backend/deployments/otel-demo/smoke-backend.sh` | Boots throwaway Postgres + OTel demo stack + a fresh backend binary; logs in as admin, creates an agent, POSTs /authorize, asserts the response shape, then verifies the `fga.authorize` parent span with at least one `fga.*` child landed in Tempo. Hermetic — does not touch the user's running backend or persistent data | `cd apps/backend/deployments/otel-demo && ./smoke-backend.sh` |
 | **AIM backend HTTP API** | Fiber routes, auth, FGA enforcement | `tests/integration/*.go` | Endpoints return correct status codes against a live backend | (currently broken: needs a running backend with admin login configured — pre-existing issue, not part of this contract yet) |
 | **PQC migration** | ML-DSA / ML-KEM key generation | `internal/crypto/pqc/*_test.go` | Keys generate, sign, verify | `go test ./internal/crypto/pqc/` (passes today; not a real "boot" test but acceptable since the surface is pure crypto) |
+| **AIM backend list endpoints** | bulk-prefetch row enrichment on `GET /api/v1/mcp-servers` + `GET /api/v1/admin/verifications/pending` | `apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh` | Boots throwaway Postgres + a fresh backend (no OTel stack); creates a tag, a server carrying it, and one `tool` capability, then asserts the list row comes back WITH the bulk-prefetched tag and `toolCount==1`; asserts pending-verifications returns 200 + the `verifications[]`/`pagination` shape. Catches bulk-query column/table typos that mock-backed unit tests cannot — see design rule 9 | `cd apps/backend/deployments/smoke && ./rest-list-endpoints-smoke.sh` |
 
 (More rows to be added as components grow smoke tests.)
 
@@ -100,6 +101,17 @@ A smoke test that fails halfway and leaves orphan containers/files/ports must be
 4 = a signal failed to land in its backend
 ```
 
+### 9. For degrade-on-error read paths, a 200 is NOT the signal — seed and assert the enriched value
+
+List/detail endpoints that enrich each row from a related table (tags, capabilities, names, counts) almost always degrade to an empty value on a query error rather than returning 500 — that is correct production behavior (one bad join should not blank the whole page). The trap is that it makes the failure **invisible at the HTTP status level**: a bulk-prefetch query with a wrong column or table name compiles, passes every mock-backed unit test, and still returns `200` with the enriched field silently empty.
+
+So the smoke for any such endpoint must **seed a real related row and assert it comes back through the query**, not just assert `200`:
+
+- For `GET /mcp-servers`: create a tag + attach it + seed a `tool` capability, then assert the list row has that tag and `toolCount == 1`. A broken bulk query shows up as a missing tag / `toolCount == 0`.
+- General rule: if the handler does `result, err := bulkFetch(...); if err != nil { result = empty }`, the only way a smoke catches a broken `bulkFetch` is to assert a non-empty, *specific* enriched value that only appears when the query is correct.
+
+This rule is repo-agnostic. Any service in the org with a row-enriching read path (the Registry trust-graph queries, ai-trust/HMA result joins, dashboard list endpoints) should follow it: seed the related entity, assert it surfaces, never settle for status-code-only coverage on a degrade-on-error path.
+
 ## Running smoke tests
 
 ### Locally
@@ -124,6 +136,9 @@ The `pre-push-review` skill should be extended (TODO) to run the smoke test for 
 | `apps/backend/internal/application/fga_engine.go` | `apps/backend/deployments/otel-demo/smoke-backend.sh` |
 | `apps/backend/internal/interfaces/http/handlers/authorize_handler.go` | `apps/backend/deployments/otel-demo/smoke-backend.sh` |
 | `apps/backend/cmd/server/main.go` (FGA wiring, Authorize handler init, route reg) | `apps/backend/deployments/otel-demo/smoke-backend.sh` |
+| `apps/backend/internal/interfaces/http/handlers/mcp_handler.go` (ListMCPServers) | `apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh` |
+| `apps/backend/internal/interfaces/http/handlers/verification_handler.go` (ListPendingVerifications) | `apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh` |
+| any new/changed repository bulk query feeding a list handler (`*ByIDs`, `*ByServerIDs`, `*ByAgentIDs`) | `apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh` (extend it with the new seed+assert) |
 
 Until that wiring lands, the rule is: **before you push, manually run the smoke for any component touched in your diff**, and paste the `==> PASS` line into your PR description.
 


### PR DESCRIPTION
## What

Applies the agents-list fix ([#295](https://github.com/opena2a-org/agent-identity-management/pull/295)) to the next two slowest dashboard list endpoints, both of which ran one query per row to enrich each item.

### `GET /api/v1/mcp-servers` (the MCP servers page)
Previously ran **1 + 2N** queries: one for the server list, then one for tags **and** one for capabilities *per server*. Now prefetches both for the whole page with one bulk query each, keyed by server id — **1+2N collapses to 3 queries**, flat regardless of server count.

- New `TagRepository.GetMCPServerTagsByServerIDs` and `MCPServerCapabilityRepository.GetByServerIDs` (single query, map keyed by server id), mirroring the agents-fix bulk methods exactly, plus the `TagService`/`MCPCapabilityService` passthroughs.
- `enrichMCPServerResponse` split into a shared `mcpServerResponse(server, tags)` builder so the single-server and bulk-list paths share one shape.
- **Response shape is byte-for-byte unchanged** (same fields, `tags`, `toolCount`) — the frontend needs no change.

### `GET /api/v1/admin/verifications/pending`
Ran one `GetAgent` per event whose name wasn't inlined. Now collects the distinct name-missing agent ids and resolves them in a single `GetAgentsByIDs` call.

## Why
The agents page was sped up in #295 by killing this exact 1+2N pattern. The MCP page is its structural twin and was the next slow page reported. The remaining backend list endpoints were audited and are already bulk/paginated.

## Tests
- Regression tests lock that both list paths use the **bulk** queries (the per-row query is asserted **never** to fire) and degrade to empty tags / zero tool count / blank name on bulk-query error, matching the old behavior.
- **Real-backend smoke** (`apps/backend/deployments/smoke/rest-list-endpoints-smoke.sh`): boots a throwaway Postgres + a fresh backend, seeds a tag + server + capability, and asserts the list row comes back carrying the bulk-prefetched tag and `toolCount==1`. This catches the bug class unit tests cannot — the new bulk SQL only runs against a real schema, and the handlers degrade to empty on query error (no 500), so a wrong column/table name is invisible at the HTTP-status level. Registered in `docs/testing/release-smoke.md` with a new design rule: degrade-on-error read paths need seed-and-assert coverage, a 200 is not the signal.
- `go build`, `go test -race`, `go vet`, jsonarray-lint, tenant-scoping lint all green. gosec G201 is repo-excluded for this parameterized-query pattern; `sql.Rows` are closed (`defer rows.Close()` + `rows.Err()`).

## Notes
- `IN (...)` clauses build `$1,$2,...` placeholders (not values) and bind ids as args — no string interpolation of values.
- Bulk methods short-circuit on an empty id slice (no `IN ()`).