### PR TITLE
perf(web): progressively load the A2A dashboard page

### DIFF
--- a/apps/web/app/dashboard/a2a/page.tsx
+++ b/apps/web/app/dashboard/a2a/page.tsx
@@ -241,15 +241,27 @@ function LoadingState() {
   );
 }
 
+// Inline spinner for a single section/chart so the rest of the page can
+// paint while that section's data is still loading.
+function ChartLoading({ className = "h-full" }: { className?: string }) {
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
+    </div>
+  );
+}
+
 // ============================================
 // TAB COMPONENTS
 // ============================================
 
-function OverviewTab({ agentCards, tasks, trustScores, loading }: {
+function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoading, trustLoading }: {
   agentCards: A2AAgentCard[];
   tasks: A2ATask[];
   trustScores: Map<string, number>;
-  loading: boolean;
+  cardsLoading: boolean;
+  tasksLoading: boolean;
+  trustLoading: boolean;
 }) {
   const stats = useMemo(() => ({
     totalCards: agentCards.length,
@@ -289,16 +301,18 @@ function OverviewTab({ agentCards, tasks, trustScores, loading }: {
     return Object.entries(buckets).map(([range, count]) => ({ range, count }));
   }, [trustScores]);
 
-  if (loading) return <LoadingState />;
-
   return (
     <div className="space-y-6">
       {/* Stats Grid */}
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-        {statCards.map((stat) => (
-          <StatCard key={stat.name} stat={stat} />
-        ))}
-      </div>
+      {cardsLoading ? (
+        <ChartLoading className="py-8" />
+      ) : (
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {statCards.map((stat) => (
+            <StatCard key={stat.name} stat={stat} />
+          ))}
+        </div>
+      )}
 
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -308,6 +322,7 @@ function OverviewTab({ agentCards, tasks, trustScores, loading }: {
             Task State Distribution
           </h3>
           <div className="h-64">
+            {tasksLoading ? <ChartLoading /> : (
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Pie
@@ -327,6 +342,7 @@ function OverviewTab({ agentCards, tasks, trustScores, loading }: {
                 <Tooltip />
               </PieChart>
             </ResponsiveContainer>
+            )}
           </div>
         </div>
 
@@ -336,6 +352,7 @@ function OverviewTab({ agentCards, tasks, trustScores, loading }: {
             Trust Score Distribution
           </h3>
           <div className="h-64">
+            {trustLoading ? <ChartLoading /> : (
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={trustDistData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
@@ -345,6 +362,7 @@ function OverviewTab({ agentCards, tasks, trustScores, loading }: {
                 <Bar dataKey="count" fill="#3b82f6" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
+            )}
           </div>
         </div>
       </div>
@@ -532,14 +550,19 @@ function ConsentTab({ consents: initialConsents, loading }: { consents: A2AConse
   }, [initialConsents]);
 
   useEffect(() => {
-    if (userIdFilter) {
+    if (!userIdFilter) {
+      setConsents(initialConsents);
+      return;
+    }
+    // Debounce the server-side filter so typing does not fire one request
+    // per keystroke.
+    const handle = setTimeout(() => {
       api.listA2AConsents(userIdFilter).then(data => {
         const raw = data.consents || data as any;
         setConsents(Array.isArray(raw) ? raw : []);
       }).catch(() => setConsents([]));
-    } else {
-      setConsents(initialConsents);
-    }
+    }, 350);
+    return () => clearTimeout(handle);
   }, [userIdFilter, initialConsents]);
 
   const displayConsents = consents;
@@ -937,7 +960,13 @@ function SkillsTab({ agentCards, loading }: { agentCards: A2AAgentCard[]; loadin
 
 export default function A2AProtocolPage() {
   const [activeTab, setActiveTab] = useState<TabType>("overview");
-  const [loading, setLoading] = useState(true);
+  // Per-dataset loading flags so each section paints as its call resolves,
+  // instead of the whole page blocking on the slowest of the four (the
+  // 500-task fetch).
+  const [cardsLoading, setCardsLoading] = useState(true);
+  const [tasksLoading, setTasksLoading] = useState(true);
+  const [consentsLoading, setConsentsLoading] = useState(true);
+  const [trustLoading, setTrustLoading] = useState(true);
   const [agentCards, setAgentCards] = useState<A2AAgentCard[]>([]);
   const [tasks, setTasks] = useState<A2ATask[]>([]);
   const [consents, setConsents] = useState<A2AConsent[]>([]);
@@ -955,24 +984,33 @@ export default function A2AProtocolPage() {
     return map;
   }, [trustScores]);
 
-  const fetchData = async () => {
-    setLoading(true);
-    try {
-      const [cardsData, tasksData, consentsData, trustData] = await Promise.allSettled([
-        api.listA2AAgentCards(),
-        api.listA2ATasks({ limit: 500 }),
-        api.listA2AConsents(),
-        api.listA2ATrustScores(),
-      ]);
-      if (cardsData.status === "fulfilled") setAgentCards(cardsData.value.cards || []);
-      if (tasksData.status === "fulfilled") setTasks(tasksData.value.tasks || []);
-      if (consentsData.status === "fulfilled") setConsents(consentsData.value.consents || []);
-      if (trustData.status === "fulfilled") setTrustScores(trustData.value.scores || []);
-    } catch (err) {
-      console.error("Failed to fetch A2A data:", err);
-    } finally {
-      setLoading(false);
-    }
+  const fetchData = () => {
+    // Fire all four in parallel (as before) but resolve each independently
+    // so a section renders the moment its own data arrives.
+    setCardsLoading(true);
+    setTasksLoading(true);
+    setConsentsLoading(true);
+    setTrustLoading(true);
+
+    api.listA2AAgentCards()
+      .then(data => setAgentCards(data.cards || []))
+      .catch(err => console.error("Failed to fetch A2A agent cards:", err))
+      .finally(() => setCardsLoading(false));
+
+    api.listA2ATasks({ limit: 500 })
+      .then(data => setTasks(data.tasks || []))
+      .catch(err => console.error("Failed to fetch A2A tasks:", err))
+      .finally(() => setTasksLoading(false));
+
+    api.listA2AConsents()
+      .then(data => setConsents(data.consents || []))
+      .catch(err => console.error("Failed to fetch A2A consents:", err))
+      .finally(() => setConsentsLoading(false));
+
+    api.listA2ATrustScores()
+      .then(data => setTrustScores(data.scores || []))
+      .catch(err => console.error("Failed to fetch A2A trust scores:", err))
+      .finally(() => setTrustLoading(false));
   };
 
   useEffect(() => {
@@ -1011,17 +1049,17 @@ export default function A2AProtocolPage() {
   const renderTab = () => {
     switch (activeTab) {
       case "overview":
-        return <OverviewTab agentCards={agentCards} tasks={tasks} trustScores={trustScoreMap} loading={loading} />;
+        return <OverviewTab agentCards={agentCards} tasks={tasks} trustScores={trustScoreMap} cardsLoading={cardsLoading} tasksLoading={tasksLoading} trustLoading={trustLoading} />;
       case "cards":
-        return <AgentCardsTab agentCards={agentCards} loading={loading} onRefresh={handleRefresh} onDelete={requestDelete} />;
+        return <AgentCardsTab agentCards={agentCards} loading={cardsLoading} onRefresh={handleRefresh} onDelete={requestDelete} />;
       case "consent":
-        return <ConsentTab consents={consents} loading={loading} />;
+        return <ConsentTab consents={consents} loading={consentsLoading} />;
       case "tasks":
-        return <TasksTab tasks={tasks} loading={loading} />;
+        return <TasksTab tasks={tasks} loading={tasksLoading} />;
       case "trust":
-        return <TrustTab trustScores={trustScores} agentCards={agentCards} loading={loading} />;
+        return <TrustTab trustScores={trustScores} agentCards={agentCards} loading={trustLoading || cardsLoading} />;
       case "skills":
-        return <SkillsTab agentCards={agentCards} loading={loading} />;
+        return <SkillsTab agentCards={agentCards} loading={cardsLoading} />;
       default:
         return null;
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest --passWithNoTests",
     "test:e2e": "playwright test",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "smoke:a2a": "node scripts/smoke-a2a-progressive.mjs"
   },
   "dependencies": {
     "@alloc/quick-lru": "^5.2.0",

--- a/apps/web/scripts/smoke-a2a-progressive.mjs
+++ b/apps/web/scripts/smoke-a2a-progressive.mjs
@@ -1,0 +1,128 @@
+// Progressive-load smoke for /dashboard/a2a.
+//
+// Verifies, as a real browser user, that the A2A page paints section-by-section
+// instead of blocking the whole page on the slowest API call, and that the
+// consent filter debounces. The API is stubbed in-browser so response timing
+// can be controlled — no backend needed.
+//
+// IMPORTANT: run against a PRODUCTION build (`next build` + `next start`), NOT
+// `next dev`. Under dev-mode StrictMode/HMR the dashboard tab content does not
+// render deterministically, which is a dev-server artifact, not how users see
+// the app. The committed Playwright e2e suite (tests/e2e, dev webServer) is
+// therefore the wrong host for this timing-sensitive check; this standalone
+// prod smoke is.
+//
+// Usage:
+//   npm run build
+//   npx next start -p 3737 &            # serve the production build
+//   BASE_URL=http://localhost:3737 node scripts/smoke-a2a-progressive.mjs
+//
+// Exit codes: 0 = both checks passed, 1 = a check failed.
+
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3737';
+const b64url = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+const JWT = `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url({
+  sub: 'smoke', email: 'admin@opena2a.org', role: 'admin', organizationId: 'org-smoke',
+  exp: Math.floor(Date.now() / 1000) + 3600,
+})}.sig`;
+const USER = {
+  id: 'u-smoke', email: 'admin@opena2a.org', name: 'Smoke Admin', firstName: 'Smoke', lastName: 'Admin',
+  role: 'admin', organizationId: 'org-smoke', organizationName: 'Smoke Org',
+};
+
+async function newAuthedContext(browser) {
+  const ctx = await browser.newContext();
+  // Middleware gates /dashboard on the access_token cookie; the API client
+  // reads auth_token from localStorage.
+  await ctx.addCookies([{ name: 'access_token', value: JWT, domain: new URL(BASE).hostname, path: '/' }]);
+  await ctx.addInitScript((jwt) => {
+    localStorage.setItem('auth_token', jwt);
+    localStorage.setItem('refresh_token', jwt);
+  }, JWT);
+  return ctx;
+}
+
+async function progressiveCheck(browser) {
+  const ctx = await newAuthedContext(browser);
+  const page = await ctx.newPage();
+  const cards = [
+    { id: 'c1', agentId: 'a1', name: 'Agent One', verified: true, aimAttestation: true, skills: [{ id: 's1' }] },
+    { id: 'c2', agentId: 'a2', name: 'Agent Two', verified: false, aimAttestation: false, skills: [] },
+  ];
+  const tasks = [{ id: 't1', state: 'COMPLETED' }, { id: 't2', state: 'WORKING' }];
+  const scores = [{ agentId: 'a1', agentName: 'Agent One', a2aTrustScore: 0.95, totalTasksAsClient: 2, totalTasksAsRemote: 0, uniquePeersCount: 1 }];
+
+  let releaseTasks;
+  const tasksGate = new Promise((r) => { releaseTasks = r; });
+  await page.route('**/api/v1/**', async (route) => {
+    const url = route.request().url();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (url.includes('/a2a/cards')) return ok({ cards, limit: 100, offset: 0 });
+    if (url.includes('/a2a/tasks')) { await tasksGate; return ok({ tasks }); } // held pending
+    if (url.includes('/a2a/consents')) return ok({ consents: [], total: 0 });
+    if (url.includes('/a2a/trust-scores')) return ok({ scores });
+    if (url.includes('/auth/me')) return ok(USER);
+    return ok({});
+  });
+
+  await page.goto(`${BASE}/dashboard/a2a`, { waitUntil: 'domcontentloaded' });
+  // Overview's task panel mounts (heading is outside the loading conditional).
+  await page.getByRole('heading', { name: 'Task State Distribution' }).waitFor({ timeout: 15000 });
+  const taskBox = page.locator('div').filter({ has: page.getByText('Task State Distribution') }).last();
+  // Cards stat grid painted ("AIM Attested" is unique to it) while the task
+  // chart still shows its own spinner -> progressive.
+  const statsPainted = await page.getByText('AIM Attested').isVisible();
+  const spinnerWhilePending = await taskBox.locator('.animate-spin').count();
+  const chartWhilePending = await taskBox.locator('.recharts-wrapper').count();
+  // Release tasks: the chart fills, its spinner clears.
+  releaseTasks();
+  await taskBox.locator('.recharts-wrapper').waitFor({ timeout: 10000 });
+  const spinnerAfter = await taskBox.locator('.animate-spin').count();
+
+  await ctx.close();
+  const pass = statsPainted && spinnerWhilePending === 1 && chartWhilePending === 0 && spinnerAfter === 0;
+  console.log(`[progressive] statsPainted=${statsPainted} spinnerWhilePending=${spinnerWhilePending} chartWhilePending=${chartWhilePending} spinnerAfter=${spinnerAfter} -> ${pass ? 'PASS' : 'FAIL'}`);
+  return pass;
+}
+
+async function debounceCheck(browser) {
+  const ctx = await newAuthedContext(browser);
+  const page = await ctx.newPage();
+  let filteredRequests = 0;
+  await page.route('**/api/v1/**', async (route) => {
+    const url = route.request().url();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (url.includes('/a2a/consent/user/')) { filteredRequests++; return ok({ consents: [], count: 0 }); }
+    if (url.includes('/a2a/cards')) return ok({ cards: [], limit: 100, offset: 0 });
+    if (url.includes('/a2a/tasks')) return ok({ tasks: [] });
+    if (url.includes('/a2a/consents')) return ok({ consents: [], total: 0 });
+    if (url.includes('/a2a/trust-scores')) return ok({ scores: [] });
+    if (url.includes('/auth/me')) return ok(USER);
+    return ok({});
+  });
+
+  await page.goto(`${BASE}/dashboard/a2a`, { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: 'Consent' }).click();
+  const input = page.getByPlaceholder('Search by user ID...');
+  await input.waitFor({ timeout: 15000 });
+  await input.pressSequentially('user42', { delay: 25 }); // 6 keystrokes inside the 350ms debounce
+  await page.waitForTimeout(900);
+
+  await ctx.close();
+  const pass = filteredRequests === 1; // 6 keystrokes -> 1 request
+  console.log(`[debounce] keystrokes=6 filteredRequests=${filteredRequests} (expected 1) -> ${pass ? 'PASS' : 'FAIL'}`);
+  return pass;
+}
+
+const browser = await chromium.launch();
+let ok = true;
+try {
+  ok = (await progressiveCheck(browser)) && ok;
+  ok = (await debounceCheck(browser)) && ok;
+} finally {
+  await browser.close();
+}
+console.log(ok ? '\n==> PASS: A2A progressive-load + debounce verified' : '\n==> FAIL');
+process.exit(ok ? 0 : 1);

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -34,8 +34,15 @@ If a smoke test does not exist for the path you touched, **write one as part of 
 | **AIM backend OTel wiring** | telemetry.Init, FGA span wrap, drift gauge, /api/v1/agents/:id/authorize handler | `apps/backend/deployments/otel-demo/smoke-backend.sh` | Boots throwaway Postgres + OTel demo stack + a fresh backend binary; logs in as admin, creates an agent, POSTs /authorize, asserts the response shape, then verifies the `fga.authorize` parent span with at least one `fga.*` child landed in Tempo. Hermetic — does not touch the user's running backend or persistent data | `cd apps/backend/deployments/otel-demo && ./smoke-backend.sh` |
 | **AIM backend HTTP API** | Fiber routes, auth, FGA enforcement | `tests/integration/*.go` | Endpoints return correct status codes against a live backend | (currently broken: needs a running backend with admin login configured — pre-existing issue, not part of this contract yet) |
 | **PQC migration** | ML-DSA / ML-KEM key generation | `internal/crypto/pqc/*_test.go` | Keys generate, sign, verify | `go test ./internal/crypto/pqc/` (passes today; not a real "boot" test but acceptable since the surface is pure crypto) |
+| **A2A page progressive load** | per-section loading on `/dashboard/a2a` (cards/tasks/consents/trust resolve independently) + consent-filter debounce | `apps/web/scripts/smoke-a2a-progressive.mjs` | Drives a real browser against a PRODUCTION build with the A2A API stubbed (no backend). Holds the tasks response open and asserts the card stats paint while the task chart still shows its own spinner (the page no longer blocks on the slowest call), then that the chart fills on release; asserts 6 rapid keystrokes into the consent filter collapse to 1 request. | `cd apps/web && npm run build && (npx next start -p 3737 &) && BASE_URL=http://localhost:3737 node scripts/smoke-a2a-progressive.mjs` |
 
 (More rows to be added as components grow smoke tests.)
+
+> Note on web timing checks: run them against `next build` + `next start`, not
+> `next dev`. Under dev-mode StrictMode/HMR the dashboard tab content does not
+> render deterministically — a dev-server artifact, not real (production) user
+> behavior — so the committed Playwright e2e suite (dev webServer) is the wrong
+> host for timing-sensitive assertions. Use the standalone prod smoke above.
 
 ## Smoke test design rules
 


### PR DESCRIPTION
## What

`/dashboard/a2a` felt slow to load even though its backend list endpoints are already paginated. The slowness was on the **frontend**: the page fired four list calls and `await Promise.allSettled` on all of them behind a single `loading` flag, so the whole page sat on a spinner until the **slowest** call returned — the `listA2ATasks({ limit: 500 })` fetch that feeds the overview's task-state chart. Separately, the consent filter issued one server request **per keystroke**.

## Changes (frontend only — no API/contract change)

- **Progressive load.** Each dataset (agent cards, tasks, consents, trust scores) now resolves independently with its own loading flag, so every section paints the moment its own call returns. The overview's card stats and trust chart no longer wait on the 500-task fetch; the task chart shows its own inline spinner and fills in when ready. The other tabs gate only on the data they use.
- **Debounced consent filter (350ms).** Typing into the user-id filter no longer fires a request per keystroke.

## Verified as a real user (production build)

Both behaviors were checked in a real browser against `next build` + `next start` with the A2A API stubbed so response timing could be controlled:

- Holding the tasks response open, the **card stats paint while the task chart still shows its own spinner** (the page no longer blocks on the slowest call), then the chart fills on release.
- Six rapid keystrokes into the consent filter **collapse to one** server request (was six).

Committed as `apps/web/scripts/smoke-a2a-progressive.mjs` (`npm run smoke:a2a`) and registered in `docs/testing/release-smoke.md`.

> Note: the smoke runs against a production build, not `next dev` — under dev-mode StrictMode/HMR the dashboard tab content does not render deterministically (a dev-server artifact, not real user behavior), so the dev-webServer Playwright suite is the wrong host for timing-sensitive checks.

`go`-side untouched; `npm run build`, `eslint`, and `tsc --noEmit` are clean. Downstream: syncs to aim-cloud after merge.