### PR TITLE
feat(ts-sdk): local ATX credential verification path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -536,6 +536,36 @@ TypeScript SDK for Node.js applications:
 
 ---
 
+### Local Credential Verification in the SDKs
+**Priority**: High
+**Status**: TypeScript shipped; Java planned
+
+The agent trust credential is a signed credential designed to be verified
+locally: a verifier checks the signature against the issuer's cached public key in
+roughly a millisecond, with the issuing node never on the verification path and
+revocation handled by an asynchronously-refreshed, short-lived cached list.
+Reference verifiers exist for Go and Python. This item brings that same local
+verification to the agent-side SDKs so that capability checks resolve from the
+signed credential's own claims without a per-action call to a central service,
+keeping verification fast and horizontally scalable. Network access is reserved
+for credential resolution and periodic revocation refresh, not per-action
+decisions.
+
+- **TypeScript SDK — shipped.** `@opena2a/aim-sdk` exposes a `LocalVerifier` and
+  `AIMClient.verifyActionLocally`, verifying ATX credentials offline against
+  cached trust anchors and authorizing from signed capabilities. It consumes the
+  shared `@opena2a/atx-verify` verifier (byte-for-byte interoperable with the Go
+  and Python reference verifiers), so there is a single conformance-locked
+  implementation rather than a per-SDK reimplementation. The existing remote
+  verification call is retained as a fallback.
+- **Java SDK — planned.** Port the same local-verify model (the Go verifier is the
+  reference) so JVM agents verify offline with the same conformance guarantees.
+
+**Use Case**: High-throughput agents that must authorize actions without a central
+verification round-trip; spec-compliant offline operation.
+
+---
+
 ### GitHub Copilot Integration
 **Priority**: Medium
 **Status**: Planned (Q2 2026)

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -51,6 +51,7 @@ console.log(`Trust score: ${result.trustScore}`);
 - **Express Middleware**: Easy integration with Express.js applications
 - **Fastify Plugin**: First-class support for Fastify applications
 - **Automatic Retries**: Built-in retry logic with exponential backoff
+- **Local Credential Verification**: Verify signed ATX credentials offline against cached trust anchors, no per-action call to a central service
 
 ## Express Integration
 
@@ -103,6 +104,67 @@ fastify.post('/api/data', {
   return { success: true };
 });
 ```
+
+## Local Credential Verification (offline)
+
+An ATX (Agent Trust eXtension) credential is a signed, portable credential
+designed to be verified *locally*: the signature is checked against the issuer's
+cached public key in roughly a millisecond, the issuing node is never on the
+verification path, and revocation rides on an asynchronously-refreshed,
+short-lived cached list. When you configure `localVerification` with cached trust
+anchors, the client verifies a resolved credential offline and decides
+authorization from the credential's own signed claims — no per-action call to a
+central service. The remote `verifyAction` POST is retained as the fallback for
+when no local credential is available.
+
+The verifier is the shared, conformance-locked `@opena2a/atx-verify` — byte-for-byte
+interoperable with the Go (`opena2a-registry/pkg/atcverify`) and Python reference
+verifiers.
+
+```typescript
+import { AIMClient } from '@opena2a/aim-sdk';
+
+const client = new AIMClient({
+  // Cached once from AIM/the Registry; refresh the CRL off the hot path.
+  localVerification: {
+    trustedIssuers: ['did:opena2a:issuer-1'],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: '<issuer raw ed25519 pubkey hex>' }],
+    // crl: { entries: [{ agentId, reason }] }, // optional cached revocation list
+  },
+});
+
+// Resolve the agent's ATX once (the AAP broker / network step), then cache it.
+client.setLocalCredential(resolvedAtx);
+
+// Per action: verified offline, sub-millisecond, no network.
+const result = await client.verifyActionLocally({ action: 'file:read' });
+// or just call verifyAction(): it takes the local path automatically when a
+// credential is cached, and falls back to the remote POST otherwise.
+```
+
+Authorization is gated on *signed* capabilities. ATX v1.1 credentials carry
+capabilities under the signature, so they are trusted; v1.0 capabilities are
+forgeable by the holder and are refused by default. Passing
+`requireSignedCapabilities: false` to `LocalVerifier.authorize` overrides this,
+but then authorization runs on holder-forgeable capabilities — only do this for a
+closed, trusted v1.0 deployment, never across a trust boundary.
+
+> **Single-issuer anchor sets.** The verifier does not yet bind a public key to
+> the issuer that owns it, so a `localVerification` anchor set must hold keys for
+> exactly one trusted issuer. For federated multi-issuer setups, use a separate
+> `AIMClient` / `LocalVerifier` per issuer until key-to-issuer binding lands in
+> `@opena2a/atx-verify`.
+
+For credential verification without the action-authorization adaptation, use the
+verifier directly:
+
+```typescript
+const verifier = client.getLocalVerifier();
+const { valid, context, rejectCategory } = await verifier!.verifyCredential(atx);
+```
+
+> Network is reserved for credential *resolution* (the AAP broker hands the agent
+> its ATX) and the periodic CRL refresh — never for a per-action decision.
 
 ## Causal-Denial Telemetry (opt-in)
 
@@ -276,7 +338,10 @@ client.setCredentials(saved);
 ### AIMClient
 
 - `registerAgent(options)` - Register a new agent
-- `verifyAction(options)` - Verify an action
+- `verifyAction(options, atx?)` - Verify an action (local path when a credential is cached, remote POST fallback otherwise)
+- `verifyActionLocally(options, atx?)` - Verify an action against a locally-held ATX credential, fully offline
+- `setLocalCredential(atx)` - Cache the resolved ATX credential for offline verification (pass `null` to clear)
+- `getLocalVerifier()` - The configured `LocalVerifier`, or `null` when local verification is not enabled
 - `getAgent()` - Get current agent info
 - `updateAgent(updates)` - Update agent metadata
 - `reportCapabilities(capabilities)` - Report agent capabilities

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -149,11 +149,12 @@ forgeable by the holder and are refused by default. Passing
 but then authorization runs on holder-forgeable capabilities — only do this for a
 closed, trusted v1.0 deployment, never across a trust boundary.
 
-> **Single-issuer anchor sets.** The verifier does not yet bind a public key to
-> the issuer that owns it, so a `localVerification` anchor set must hold keys for
-> exactly one trusted issuer. For federated multi-issuer setups, use a separate
-> `AIMClient` / `LocalVerifier` per issuer until key-to-issuer binding lands in
-> `@opena2a/atx-verify`.
+> **Multi-issuer anchor sets.** Give each key a DID-URL `keyId` (e.g.
+> `did:opena2a:authority:opena2a.org#key-1`). `@opena2a/atx-verify` binds a key
+> to its controller DID, so a key may only verify credentials issued by that DID
+> (or, for v1.1, a signed `issuerChain` authority) — one trusted issuer cannot
+> impersonate another. A key with no `keyId` fragment is unbound and eligible for
+> any issuer: fine for a single-issuer anchor set, unsafe for a multi-issuer one.
 
 For credential verification without the action-authorization adaptation, use the
 verifier directly:

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/ed25519": "^2.1.0"
+        "@noble/ed25519": "^2.1.0",
+        "@opena2a/atx-verify": "0.1.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -896,6 +897,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opena2a/atx-verify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.1.1.tgz",
+      "integrity": "sha512-zS0Pg0cWiRQ6St08VdGpJHCtXeiNNivAqqsAitpjhiuNGRy7Ozf8DzNoydDdB/AtO02frR4c/03eDufuaZ04Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "canonicalize": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -1908,6 +1921,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
       }
     },
     "node_modules/chai": {

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
-        "@opena2a/atx-verify": "0.1.1"
+        "@opena2a/atx-verify": "0.2.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@opena2a/atx-verify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.1.1.tgz",
-      "integrity": "sha512-zS0Pg0cWiRQ6St08VdGpJHCtXeiNNivAqqsAitpjhiuNGRy7Ozf8DzNoydDdB/AtO02frR4c/03eDufuaZ04Jg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.2.0.tgz",
+      "integrity": "sha512-tq1mZTgDLhEm0Gyhh0jqtcon1iBQbwYNxGPly3uT/SQoRVHXMRNCx8b9zmBFKgSwe8Q7NBrLjOHySGuKCX/ucg==",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -34,6 +34,7 @@
     "test:coverage": "vitest --coverage",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
+    "smoke:local": "npm run build && node tests/local-verify-consumer.cjs && node tests/local-verify-consumer.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -62,7 +63,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@noble/ed25519": "^2.1.0"
+    "@noble/ed25519": "^2.1.0",
+    "@opena2a/atx-verify": "0.1.1"
   },
   "optionalDependencies": {
     "@noble/post-quantum": "^0.2.1"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^2.1.0",
-    "@opena2a/atx-verify": "0.1.1"
+    "@opena2a/atx-verify": "0.2.0"
   },
   "optionalDependencies": {
     "@noble/post-quantum": "^0.2.1"

--- a/sdk/typescript/src/client/AIMClient.local.test.ts
+++ b/sdk/typescript/src/client/AIMClient.local.test.ts
@@ -1,0 +1,151 @@
+/**
+ * AIMClient local-verification path: offline ATX verification + local broker
+ * policy, with the remote POST retained as fallback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as crypto from 'node:crypto';
+import { canonicalPayloadV11 } from '@opena2a/atx-verify';
+import type { Atx } from '@opena2a/atx-verify';
+import { AIMClient } from './AIMClient';
+import { ActionDeniedError, AuthenticationError, ConfigurationError } from '../exceptions';
+import type { LocalVerificationConfig } from '../local';
+
+const ISSUER_DID = 'did:opena2a:issuer-1';
+const FIXED_NOW = () => new Date('2026-06-15T00:00:00Z');
+
+function genKey(): { privateKey: crypto.KeyObject; rawHex: string } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+  return { privateKey, rawHex: spki.subarray(spki.length - 32).toString('hex') };
+}
+
+function signedAtx(privateKey: crypto.KeyObject, capabilities: string[]): Atx {
+  const atx: Atx = {
+    atcVersion: '1.1',
+    agentId: 'agent-123',
+    agentDid: 'did:opena2a:agent-123',
+    version: '1.0.0',
+    contentHash: 'sha256:abc123',
+    issuerDid: ISSUER_DID,
+    trustLevel: 3,
+    trustScore: 87.5,
+    issuedAt: '2026-06-01T00:00:00Z',
+    expiresAt: '2026-06-30T00:00:00Z',
+    capabilities,
+    signatures: [],
+  };
+  const value = crypto.sign(null, canonicalPayloadV11(atx), privateKey).toString('base64');
+  return { ...atx, signatures: [{ algorithm: 'Ed25519', keyId: 'k1', value }] };
+}
+
+function localConfig(rawHex: string): LocalVerificationConfig {
+  return {
+    trustedIssuers: [ISSUER_DID],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: rawHex }],
+    now: FIXED_NOW,
+  };
+}
+
+const mockFetch = vi.fn();
+
+describe('AIMClient local verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    delete process.env.AIM_BASE_URL;
+    delete process.env.AIM_API_KEY;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('verifyActionLocally allows a signed capability without any network call', async () => {
+    const { privateKey, rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    client.setLocalCredential(signedAtx(privateKey, ['file:read']));
+
+    const result = await client.verifyActionLocally({ action: 'file:read' });
+
+    expect(result.actionAllowed).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(result.agentId).toBe('agent-123');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('verifyAction takes the local path when a credential is cached (no network)', async () => {
+    const { privateKey, rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    client.setLocalCredential(signedAtx(privateKey, ['file:read']));
+
+    const result = await client.verifyAction({ action: 'file:read' });
+
+    expect(result.actionAllowed).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('verifyActionLocally throws ActionDeniedError on a denied action', async () => {
+    const { privateKey, rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    client.setLocalCredential(signedAtx(privateKey, ['file:read']));
+
+    await expect(client.verifyActionLocally({ action: 'file:delete' })).rejects.toBeInstanceOf(
+      ActionDeniedError,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('verifyActionLocally throws ConfigurationError when local verification is not configured', async () => {
+    const { privateKey } = genKey();
+    const client = new AIMClient();
+    await expect(
+      client.verifyActionLocally({ action: 'file:read' }, signedAtx(privateKey, ['file:read'])),
+    ).rejects.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('verifyActionLocally requires a credential', async () => {
+    const { rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    await expect(client.verifyActionLocally({ action: 'file:read' })).rejects.toThrow(
+      /no local atx credential/i,
+    );
+  });
+
+  it('accepts a per-call ATX argument that overrides the cached credential', async () => {
+    const { privateKey, rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    // no cached credential set; pass per-call
+    const result = await client.verifyAction(
+      { action: 'net:fetch' },
+      signedAtx(privateKey, ['net:fetch']),
+    );
+    expect(result.actionAllowed).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the remote path when no local credential is available', async () => {
+    const { rawHex } = genKey();
+    // local verification configured, but no cached credential and no agent
+    // credentials -> verifyAction must fall through to the remote path, which
+    // requires registered credentials (proving it did NOT take the local path).
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    await expect(client.verifyAction({ action: 'file:read' })).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+  });
+
+  it('clearing the cached credential reverts verifyAction to the remote path', async () => {
+    const { privateKey, rawHex } = genKey();
+    const client = new AIMClient({ localVerification: localConfig(rawHex) });
+    client.setLocalCredential(signedAtx(privateKey, ['file:read']));
+    client.setLocalCredential(null);
+    await expect(client.verifyAction({ action: 'file:read' })).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+  });
+
+  it('getLocalVerifier exposes the verifier when configured, null otherwise', () => {
+    const { rawHex } = genKey();
+    expect(new AIMClient({ localVerification: localConfig(rawHex) }).getLocalVerifier()).not.toBeNull();
+    expect(new AIMClient().getLocalVerifier()).toBeNull();
+  });
+});

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -10,6 +10,7 @@ import type {
   VerificationResult,
   VerifyActionOptions,
 } from '../types';
+import { RiskLevel } from '../types';
 import { OAuthTokenManager, loadCredentialsFromEnv } from '../auth/oauth';
 import { generateKeyPair, toBase64, createRequestSignature, fromBase64 } from '../crypto/ed25519';
 import {
@@ -17,9 +18,12 @@ import {
   AuthenticationError,
   ActionDeniedError,
   VerificationError,
+  ConfigurationError,
   NetworkError,
   parseAPIError,
 } from '../exceptions';
+import { LocalVerifier } from '../local';
+import type { Atx } from '../local';
 import {
   SandboxType,
   NetworkIsolation,
@@ -71,11 +75,17 @@ const DEFAULT_ENFORCEMENT_SOURCE = 'aim-pdp';
  * ```
  */
 export class AIMClient {
-  private readonly config: Required<AIMClientConfig>;
+  private readonly config: Required<Omit<AIMClientConfig, 'localVerification'>>;
   private tokenManager: OAuthTokenManager | null = null;
   private credentials: AgentCredentials | null = null;
   private agent: Agent | null = null;
   private _secrets: SecretsClient | null = null;
+
+  // Spec-compliant local ATX verification (opt-in). When a verifier and a
+  // resolved credential are present, verifyAction verifies the signed credential
+  // offline instead of calling the central PDP. The remote POST stays as fallback.
+  private readonly localVerifier: LocalVerifier | null;
+  private localCredential: Atx | null = null;
 
   // Causal-denial telemetry — opt-in, best-effort, off the enforcement path.
   private readonly telemetryEnabled: boolean;
@@ -109,6 +119,12 @@ export class AIMClient {
     // Resolve once: a relay.dataDir override (else ~/.opena2a) is the single
     // location both the auto-joiner sink and the relay use.
     this.telemetryDir = this.relayConfig?.dataDir ?? openA2AHome();
+
+    // Opt-in local verification: build a verifier from cached trust anchors.
+    // Absent this, verifyAction behaves exactly as before (remote POST).
+    this.localVerifier = config.localVerification
+      ? new LocalVerifier(config.localVerification)
+      : null;
 
     // Try to load credentials from environment
     this.credentials = loadCredentialsFromEnv();
@@ -322,9 +338,24 @@ export class AIMClient {
   }
 
   /**
-   * Verify an action
+   * Verify an action.
+   *
+   * When local verification is configured (a {@link LocalVerificationConfig} was
+   * passed to the constructor) AND a resolved ATX credential is available (via
+   * {@link setLocalCredential} or the `atx` argument), the signed credential is
+   * verified offline and authorization is decided from its signed claims — no
+   * call to the central PDP. Otherwise this falls back to the remote
+   * `POST /api/v1/verify` decision (the original behavior).
+   *
+   * @param atx Optional ATX credential to verify locally for this call. Overrides
+   *   any credential set via {@link setLocalCredential}.
    */
-  async verifyAction(options: VerifyActionOptions): Promise<VerificationResult> {
+  async verifyAction(options: VerifyActionOptions, atx?: Atx): Promise<VerificationResult> {
+    const credential = atx ?? this.localCredential;
+    if (this.localVerifier && credential) {
+      return this.verifyActionLocally(options, credential);
+    }
+
     if (!this.credentials) {
       throw new AuthenticationError('No credentials available. Register an agent first.');
     }
@@ -363,6 +394,90 @@ export class AIMClient {
         options.action,
         result.denialReason ?? 'Action not allowed',
         result.trustScore
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Cache a resolved ATX credential for the agent. This is the output of AAP
+   * credential resolution (the only step that touches the network); once cached,
+   * {@link verifyAction} / {@link verifyActionLocally} verify it offline per
+   * action. Pass `null` to clear it (falling back to the remote PDP path).
+   */
+  setLocalCredential(atx: Atx | null): void {
+    this.localCredential = atx;
+  }
+
+  /**
+   * The configured local verifier, or null when local verification is not enabled.
+   * Use it directly for credential verification without the action-authorization
+   * adaptation that {@link verifyActionLocally} performs.
+   */
+  getLocalVerifier(): LocalVerifier | null {
+    return this.localVerifier;
+  }
+
+  /**
+   * Verify an action against a locally-held ATX credential — fully offline,
+   * sub-millisecond after the first call. The credential's signature, expiry,
+   * revocation, and issuer trust are checked against the cached anchors, then a
+   * local broker policy authorizes the action from the credential's *signed*
+   * capabilities (v1.0 capabilities are forgeable and are refused by default).
+   *
+   * Mirrors {@link verifyAction}'s contract: returns a {@link VerificationResult}
+   * on allow and throws {@link ActionDeniedError} on deny.
+   *
+   * @param atx The ATX to verify. Falls back to the credential set via
+   *   {@link setLocalCredential}.
+   */
+  async verifyActionLocally(options: VerifyActionOptions, atx?: Atx): Promise<VerificationResult> {
+    if (!this.localVerifier) {
+      throw new ConfigurationError(
+        'Local verification is not configured. Pass `localVerification` (trust anchors) to the AIMClient constructor.',
+      );
+    }
+    const credential = atx ?? this.localCredential;
+    if (!credential) {
+      throw new VerificationError(
+        'No local ATX credential available. Resolve one and call setLocalCredential(), or pass it to verifyActionLocally().',
+      );
+    }
+
+    this.log('Verifying action locally:', options.action);
+
+    // Mint the correlation ID at the earliest ingestion point (telemetry off
+    // unless enabled), exactly as the remote path does.
+    const correlationId = this.telemetryEnabled ? mintCorrelationId() : undefined;
+
+    const auth = await this.localVerifier.authorize(credential, { action: options.action });
+
+    const result: VerificationResult = {
+      verified: auth.verified,
+      agentId: auth.agentId,
+      // An ATX carries no display name, so report the agent's DID rather than
+      // aliasing the opaque agentId as a "name" (which would misrepresent the
+      // field and diverge from the remote path's real agentName).
+      agentName: auth.agentDid,
+      trustScore: auth.trustScore,
+      riskLevel: options.riskLevel ?? RiskLevel.LOW,
+      actionAllowed: auth.actionAllowed,
+      denialReason: auth.denialReason,
+      timestamp: new Date().toISOString(),
+    };
+
+    // Record the enforcement outcome (allow OR deny) BEFORE the deny throw, so the
+    // causal-denial case is captured. Best-effort; never affects the result.
+    if (correlationId) {
+      this.recordVerificationTelemetry(correlationId, options, result);
+    }
+
+    if (!result.actionAllowed) {
+      throw new ActionDeniedError(
+        options.action,
+        result.denialReason ?? 'Action not allowed',
+        result.trustScore,
       );
     }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -222,6 +222,21 @@ export {
   type AuditLogOptions,
 } from './secrets';
 
+// Local, offline ATX credential verification (spec-compliant local-verify path,
+// powered by the shared conformance-locked @opena2a/atx-verify verifier).
+export {
+  LocalVerifier,
+  type LocalVerificationConfig,
+  type LocalAuthorizationOptions,
+  type LocalAuthorizationResult,
+  type Atx,
+  type AtxPublicKey,
+  type AtxTrustAnchors,
+  type AtxVerificationResult,
+  type RejectCategory,
+  type ResolutionContext,
+} from './local';
+
 // Causal-denial telemetry (correlate why a blocked action happened; off the
 // enforcement critical path, best-effort)
 export {

--- a/sdk/typescript/src/local/LocalVerifier.test.ts
+++ b/sdk/typescript/src/local/LocalVerifier.test.ts
@@ -141,25 +141,29 @@ describe('LocalVerifier.verifyCredential', () => {
     expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
   });
 
-  // KNOWN LIMITATION (characterization / tripwire). @opena2a/atx-verify does not
-  // bind a public key to the issuer DID that owns it, so with a multi-issuer
-  // anchor set a credential claiming issuer A but signed by trusted issuer B's
-  // key currently verifies and is attributed to A. This is why
-  // LocalVerificationConfig documents single-issuer anchor sets only. When
-  // upstream key-to-issuer binding ships, this test will start FAILING — flip it
-  // to assert rejection at that point.
-  it('[limitation] currently accepts a cross-issuer signature in a multi-issuer anchor set', async () => {
+  // Key-to-issuer binding (@opena2a/atx-verify >= 0.2.0). With a multi-issuer
+  // anchor set, a credential claiming issuer A but signed by trusted issuer B's
+  // key is REJECTED, because B's key (keyId controller = issuer-B) is not
+  // controlled by the credential's issuer (A). One trusted issuer cannot
+  // impersonate another. (Engaging binding requires the key to carry a DID-URL
+  // keyId; a key with no keyId stays unbound for back-compat.)
+  it('rejects a cross-issuer signature in a multi-issuer anchor set', async () => {
+    const ISSUER_B = 'did:opena2a:issuer-B';
     const issuerB = genKey();
     const atxClaimingA = sign(baseAtx({ issuerDid: ISSUER_DID }), issuerB.privateKey);
     const verifier = new LocalVerifier(
-      anchors(issuerB.rawHex, { trustedIssuers: [ISSUER_DID, 'did:opena2a:issuer-B'] }),
+      anchors(issuerB.rawHex, {
+        trustedIssuers: [ISSUER_DID, ISSUER_B],
+        publicKeys: [
+          { algorithm: 'Ed25519', publicKeyHex: issuerB.rawHex, keyId: `${ISSUER_B}#key-1` },
+        ],
+      }),
     );
 
     const result = await verifier.verifyCredential(atxClaimingA);
 
-    // documents today's behavior; not the desired end state.
-    expect(result.valid).toBe(true);
-    expect(result.context?.issuerDid).toBe(ISSUER_DID);
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
   });
 });
 

--- a/sdk/typescript/src/local/LocalVerifier.test.ts
+++ b/sdk/typescript/src/local/LocalVerifier.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import { canonicalPayload, canonicalPayloadV11 } from '@opena2a/atx-verify';
+import type { Atx } from '@opena2a/atx-verify';
+import { LocalVerifier, type LocalVerificationConfig } from './LocalVerifier';
+
+// --- test helpers: mint real Ed25519 keys and sign real ATX credentials so the
+// tests exercise the actual shared verifier, not a mock. ---
+
+const ISSUER_DID = 'did:opena2a:issuer-1';
+const FIXED_NOW = () => new Date('2026-06-15T00:00:00Z');
+
+function genKey(): { privateKey: crypto.KeyObject; rawHex: string } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+  // raw Ed25519 public key = last 32 bytes of the SPKI DER.
+  const rawHex = spki.subarray(spki.length - 32).toString('hex');
+  return { privateKey, rawHex };
+}
+
+function baseAtx(overrides: Partial<Atx> = {}): Atx {
+  return {
+    atcVersion: '1.1',
+    agentId: 'agent-123',
+    agentDid: 'did:opena2a:agent-123',
+    version: '1.0.0',
+    contentHash: 'sha256:abc123',
+    issuerDid: ISSUER_DID,
+    trustLevel: 3,
+    trustScore: 87.5,
+    issuedAt: '2026-06-01T00:00:00Z',
+    expiresAt: '2026-06-30T00:00:00Z',
+    capabilities: ['file:read', 'net:fetch'],
+    signatures: [],
+    ...overrides,
+  };
+}
+
+function sign(atx: Atx, privateKey: crypto.KeyObject): Atx {
+  const payload = atx.atcVersion === '1.1' ? canonicalPayloadV11(atx) : canonicalPayload(atx);
+  const value = crypto.sign(null, payload, privateKey).toString('base64');
+  return { ...atx, signatures: [{ algorithm: 'Ed25519', keyId: 'k1', value }] };
+}
+
+function anchors(rawHex: string, extra: Partial<LocalVerificationConfig> = {}): LocalVerificationConfig {
+  return {
+    trustedIssuers: [ISSUER_DID],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: rawHex }],
+    now: FIXED_NOW,
+    ...extra,
+  };
+}
+
+describe('LocalVerifier.verifyCredential', () => {
+  it('verifies a valid v1.1 credential offline', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const result = await verifier.verifyCredential(atx);
+
+    expect(result.valid).toBe(true);
+    expect(result.context?.agentId).toBe('agent-123');
+    expect(result.context?.signedCapabilities).toBe(true);
+    expect(result.context?.trustScore).toBeCloseTo(87.5);
+  });
+
+  it('ready() pre-loads so a subsequent verify still succeeds', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+    await verifier.ready();
+    const result = await verifier.verifyCredential(atx);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a tampered signature (fail closed)', async () => {
+    const { privateKey, rawHex } = genKey();
+    const signed = sign(baseAtx(), privateKey);
+    // flip the last base64 char of the signature
+    const v = signed.signatures[0].value;
+    const tampered: Atx = {
+      ...signed,
+      signatures: [{ ...signed.signatures[0], value: v.slice(0, -2) + (v.endsWith('A') ? 'B' : 'A') + '=' }],
+    };
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const result = await verifier.verifyCredential(tampered);
+
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('rejects an expired credential', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx({ expiresAt: '2026-06-10T00:00:00Z' }), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const result = await verifier.verifyCredential(atx);
+
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('EXPIRED');
+  });
+
+  it('rejects a credential on the CRL', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(
+      anchors(rawHex, { crl: { entries: [{ agentId: 'agent-123', reason: 'key compromise' }] } }),
+    );
+
+    const result = await verifier.verifyCredential(atx);
+
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('REVOKED');
+  });
+
+  it('rejects an untrusted issuer', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex, { trustedIssuers: [] }));
+
+    const result = await verifier.verifyCredential(atx);
+
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('UNTRUSTED_ISSUER');
+  });
+
+  it('rejects when the signing key is not among the configured anchors', async () => {
+    // Trusted issuer, valid signature — but signed by a key the verifier does not
+    // hold. Proves the signature is actually checked against the configured keys,
+    // not blindly accepted because the issuer DID is trusted.
+    const signer = genKey();
+    const other = genKey();
+    const atx = sign(baseAtx(), signer.privateKey);
+    const verifier = new LocalVerifier(anchors(other.rawHex)); // only the wrong key
+
+    const result = await verifier.verifyCredential(atx);
+
+    expect(result.valid).toBe(false);
+    expect(result.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  // KNOWN LIMITATION (characterization / tripwire). @opena2a/atx-verify does not
+  // bind a public key to the issuer DID that owns it, so with a multi-issuer
+  // anchor set a credential claiming issuer A but signed by trusted issuer B's
+  // key currently verifies and is attributed to A. This is why
+  // LocalVerificationConfig documents single-issuer anchor sets only. When
+  // upstream key-to-issuer binding ships, this test will start FAILING — flip it
+  // to assert rejection at that point.
+  it('[limitation] currently accepts a cross-issuer signature in a multi-issuer anchor set', async () => {
+    const issuerB = genKey();
+    const atxClaimingA = sign(baseAtx({ issuerDid: ISSUER_DID }), issuerB.privateKey);
+    const verifier = new LocalVerifier(
+      anchors(issuerB.rawHex, { trustedIssuers: [ISSUER_DID, 'did:opena2a:issuer-B'] }),
+    );
+
+    const result = await verifier.verifyCredential(atxClaimingA);
+
+    // documents today's behavior; not the desired end state.
+    expect(result.valid).toBe(true);
+    expect(result.context?.issuerDid).toBe(ISSUER_DID);
+  });
+});
+
+describe('LocalVerifier.authorize (local broker policy)', () => {
+  it('allows an action covered by a signed capability', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, { action: 'file:read' });
+
+    expect(res.verified).toBe(true);
+    expect(res.actionAllowed).toBe(true);
+    expect(res.source).toBe('local');
+    expect(res.denialReason).toBeUndefined();
+  });
+
+  it('denies an action not in the granted capabilities', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx(), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, { action: 'file:delete' });
+
+    expect(res.verified).toBe(true);
+    expect(res.actionAllowed).toBe(false);
+    expect(res.denialReason).toContain('file:delete');
+  });
+
+  it('allows a wildcard capability', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx({ capabilities: ['*'] }), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, { action: 'anything:goes' });
+
+    expect(res.actionAllowed).toBe(true);
+  });
+
+  it('refuses to authorize on forgeable v1.0 capabilities by default', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx({ atcVersion: '1.0' }), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, { action: 'file:read' });
+
+    // credential is cryptographically valid, but its capabilities are not
+    // signature-covered (v1.0), so capability-based authorization is refused.
+    expect(res.verified).toBe(true);
+    expect(res.signedCapabilities).toBe(false);
+    expect(res.actionAllowed).toBe(false);
+    expect(res.denialReason).toContain('v1.0');
+  });
+
+  it('allows v1.0 capability authorization only when explicitly opted in', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx({ atcVersion: '1.0' }), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, {
+      action: 'file:read',
+      requireSignedCapabilities: false,
+    });
+
+    expect(res.actionAllowed).toBe(true);
+  });
+
+  it('denies (fail closed) when the credential does not verify', async () => {
+    const { privateKey, rawHex } = genKey();
+    const atx = sign(baseAtx({ expiresAt: '2026-06-10T00:00:00Z' }), privateKey);
+    const verifier = new LocalVerifier(anchors(rawHex));
+
+    const res = await verifier.authorize(atx, { action: 'file:read' });
+
+    expect(res.verified).toBe(false);
+    expect(res.actionAllowed).toBe(false);
+    expect(res.rejectCategory).toBe('EXPIRED');
+  });
+});

--- a/sdk/typescript/src/local/LocalVerifier.ts
+++ b/sdk/typescript/src/local/LocalVerifier.ts
@@ -56,23 +56,24 @@ function loadAtxVerify(): Promise<AtxVerifyModule> {
  * once from AIM/the Registry and cached; revocation rides on the short-lived,
  * asynchronously-refreshed CRL (soft-fail) per AAP §6.
  *
- * SECURITY — single-issuer anchor sets only (current limitation). The underlying
- * `@opena2a/atx-verify` verifier tries a credential's signature against EVERY
- * Ed25519 key in `publicKeys` and does not bind a key to the issuer DID that owns
- * it (`AtxPublicKey` carries no issuerDid/keyId). So if `publicKeys` holds keys
- * for more than one issuer, a credential claiming issuer A but signed by issuer
- * B's trusted key would verify and be attributed to A. Until key-to-issuer
- * binding lands upstream, configure anchors for exactly ONE trusted issuer per
- * `LocalVerifier` instance (one entry in `trustedIssuers`, only that issuer's
- * keys in `publicKeys`). Use separate instances for federated multi-issuer setups.
+ * SECURITY — multi-issuer anchor sets are safe when each key carries a DID-URL
+ * `keyId`. `@opena2a/atx-verify` (>= 0.2.0) binds a key to its controller DID:
+ * a key whose `keyId` is a DID-URL (e.g. `did:…:opena2a.org#key-1`) may only
+ * verify credentials issued by that DID (or, for v1.1, a signed issuerChain
+ * authority), so one trusted issuer's key cannot satisfy a credential issued
+ * under a different issuer's DID. Always set a DID-URL `keyId` on each key when
+ * `publicKeys` holds keys for more than one issuer. A key without a `keyId`
+ * fragment is unbound and eligible for any issuer — fine for a single-issuer
+ * anchor set, unsafe for a multi-issuer one.
  */
 export interface LocalVerificationConfig {
-  /**
-   * Issuer DIDs the verifier trusts. See the single-issuer security note above:
-   * prefer exactly one entry until upstream key-to-issuer binding ships.
-   */
+  /** Issuer DIDs the verifier trusts. */
   trustedIssuers: string[];
-  /** Issuer public keys keyed by algorithm. Ed25519 is verified; ML-DSA-65 presence is recorded. */
+  /**
+   * Issuer public keys keyed by algorithm. Ed25519 is verified; ML-DSA-65
+   * presence is recorded. Set each key's `keyId` to a DID-URL to bind it to its
+   * controller (required to be safe with a multi-issuer anchor set).
+   */
   publicKeys: AtxPublicKey[];
   /** Cached federated revocation list. Refresh off the hot path; absence soft-fails open on revocation only. */
   crl?: { entries: Array<{ agentId: string; reason?: string }> };

--- a/sdk/typescript/src/local/LocalVerifier.ts
+++ b/sdk/typescript/src/local/LocalVerifier.ts
@@ -1,0 +1,233 @@
+/**
+ * Local, offline ATX credential verification for the AIM agent SDK.
+ *
+ * The ATX spec (core §9, AAP-SPEC §3.3) mandates that credential verification is
+ * local: the issuing node is never on the hot path. This module brings that model
+ * to the agent-side SDK by wrapping the shared, conformance-locked verifier
+ * `@opena2a/atx-verify` (the SAME `LocalAtxVerifier` the secretless broker and the
+ * Go/Python reference verifiers agree with byte-for-byte). It then evaluates a
+ * minimal local broker policy over the credential's *signed* claims.
+ *
+ * No verifier is reimplemented here — duplicating it would reintroduce exactly the
+ * drift the cross-language conformance gate exists to prevent. The package is
+ * loaded via a cached dynamic `import()` so this works identically from both the
+ * CJS and ESM builds of the SDK on every supported Node (the package is ESM-only).
+ *
+ * Network is reserved for credential *resolution* (the AAP broker hands the agent
+ * its ATX) and the periodic CRL refresh — never for a per-action decision.
+ */
+
+// Type-only imports are erased at build time, so they never force a runtime
+// `require()` of the ESM-only package. Values are loaded via dynamic import below.
+import type {
+  Atx,
+  AtxPublicKey,
+  AtxTrustAnchors,
+  AtxVerificationResult,
+  AtxVerifier,
+  RejectCategory,
+  ResolutionContext,
+} from '@opena2a/atx-verify';
+
+// Re-export the credential types so SDK consumers get them without a second
+// dependency on @opena2a/atx-verify.
+export type {
+  Atx,
+  AtxPublicKey,
+  AtxTrustAnchors,
+  AtxVerificationResult,
+  RejectCategory,
+  ResolutionContext,
+} from '@opena2a/atx-verify';
+
+type AtxVerifyModule = typeof import('@opena2a/atx-verify');
+
+// One module load per process, shared across every LocalVerifier instance.
+let modulePromise: Promise<AtxVerifyModule> | null = null;
+function loadAtxVerify(): Promise<AtxVerifyModule> {
+  if (!modulePromise) {
+    modulePromise = import('@opena2a/atx-verify');
+  }
+  return modulePromise;
+}
+
+/**
+ * Trust anchors and clock for local verification. In production these are fetched
+ * once from AIM/the Registry and cached; revocation rides on the short-lived,
+ * asynchronously-refreshed CRL (soft-fail) per AAP §6.
+ *
+ * SECURITY — single-issuer anchor sets only (current limitation). The underlying
+ * `@opena2a/atx-verify` verifier tries a credential's signature against EVERY
+ * Ed25519 key in `publicKeys` and does not bind a key to the issuer DID that owns
+ * it (`AtxPublicKey` carries no issuerDid/keyId). So if `publicKeys` holds keys
+ * for more than one issuer, a credential claiming issuer A but signed by issuer
+ * B's trusted key would verify and be attributed to A. Until key-to-issuer
+ * binding lands upstream, configure anchors for exactly ONE trusted issuer per
+ * `LocalVerifier` instance (one entry in `trustedIssuers`, only that issuer's
+ * keys in `publicKeys`). Use separate instances for federated multi-issuer setups.
+ */
+export interface LocalVerificationConfig {
+  /**
+   * Issuer DIDs the verifier trusts. See the single-issuer security note above:
+   * prefer exactly one entry until upstream key-to-issuer binding ships.
+   */
+  trustedIssuers: string[];
+  /** Issuer public keys keyed by algorithm. Ed25519 is verified; ML-DSA-65 presence is recorded. */
+  publicKeys: AtxPublicKey[];
+  /** Cached federated revocation list. Refresh off the hot path; absence soft-fails open on revocation only. */
+  crl?: { entries: Array<{ agentId: string; reason?: string }> };
+  /** Injectable clock (tests). Defaults to the wall clock. */
+  now?: () => Date;
+}
+
+/** Inputs to the local broker policy for a single action. */
+export interface LocalAuthorizationOptions {
+  /** The capability/action the agent is attempting; matched against the credential's capabilities. */
+  action: string;
+  /**
+   * Require the credential to be v1.1+ (capabilities covered by the signature)
+   * before authorizing on capabilities. Default `true`: a v1.0 ATX's capabilities
+   * are forgeable by the holder and MUST NOT be trusted for authorization.
+   *
+   * WARNING: setting this to `false` authorizes on holder-forgeable capabilities.
+   * Any holder of a validly-signed v1.0 credential can edit its (unsigned)
+   * `capabilities` to grant themselves anything — including `"*"`. Only enable
+   * this for a closed, trusted v1.0 deployment where the holder is not the
+   * adversary; never for credentials that cross a trust boundary.
+   */
+  requireSignedCapabilities?: boolean;
+}
+
+/** The outcome of a local verify-then-authorize. Never throws; inspect the fields. */
+export interface LocalAuthorizationResult {
+  /** Credential is cryptographically valid (signature, expiry, revocation, issuer trust). */
+  verified: boolean;
+  /** Local broker-policy verdict for the requested action. */
+  actionAllowed: boolean;
+  agentId: string;
+  agentDid: string;
+  issuerDid: string;
+  trustLevel: number;
+  trustScore: number;
+  capabilities: string[];
+  /** True iff capabilities are covered by the signature (v1.1). */
+  signedCapabilities: boolean;
+  /** Present when verification failed. */
+  rejectCategory?: RejectCategory;
+  /** Present when `verified` is false or `actionAllowed` is false. */
+  denialReason?: string;
+  /** Whether an ML-DSA-65 signature was present (delegated, not silently skipped). */
+  mldsaPresent?: boolean;
+  /** Always `'local'` — distinguishes this from the remote PDP path. */
+  source: 'local';
+}
+
+/**
+ * Verify ATX credentials offline against cached trust anchors and evaluate a
+ * local broker policy. Reusable on its own or via {@link AIMClient.verifyActionLocally}.
+ */
+export class LocalVerifier {
+  private readonly anchors: AtxTrustAnchors;
+  private verifier: AtxVerifier | null = null;
+
+  constructor(config: LocalVerificationConfig) {
+    this.anchors = {
+      trustedIssuers: config.trustedIssuers,
+      publicKeys: config.publicKeys,
+      crl: config.crl,
+      now: config.now,
+    };
+  }
+
+  /**
+   * Pre-load the verifier module so the first {@link verifyCredential} is also
+   * sub-millisecond. Optional — `verifyCredential`/`authorize` load it lazily.
+   */
+  async ready(): Promise<void> {
+    await this.getVerifier();
+  }
+
+  private async getVerifier(): Promise<AtxVerifier> {
+    if (!this.verifier) {
+      const { LocalAtxVerifier } = await loadAtxVerify();
+      this.verifier = new LocalAtxVerifier(this.anchors);
+    }
+    return this.verifier;
+  }
+
+  /** Cryptographically verify an ATX credential offline. No network access. */
+  async verifyCredential(atx: Atx): Promise<AtxVerificationResult> {
+    const verifier = await this.getVerifier();
+    return verifier.verify(atx);
+  }
+
+  /**
+   * Verify the credential, then evaluate the local broker policy for `action`.
+   * Fails closed: a credential that does not verify denies the action.
+   */
+  async authorize(atx: Atx, options: LocalAuthorizationOptions): Promise<LocalAuthorizationResult> {
+    const result = await this.verifyCredential(atx);
+
+    if (!result.valid || !result.context) {
+      return {
+        verified: false,
+        actionAllowed: false,
+        agentId: atx.agentId ?? '',
+        agentDid: atx.agentDid ?? '',
+        issuerDid: atx.issuerDid ?? '',
+        trustLevel: 0,
+        trustScore: 0,
+        capabilities: [],
+        signedCapabilities: false,
+        rejectCategory: result.rejectCategory,
+        denialReason: result.reason ?? 'credential verification failed',
+        mldsaPresent: result.mldsaPresent,
+        source: 'local',
+      };
+    }
+
+    const ctx = result.context;
+    const requireSigned = options.requireSignedCapabilities !== false;
+    const decision = evaluateBrokerPolicy(ctx, options.action, requireSigned);
+
+    return {
+      verified: true,
+      actionAllowed: decision.allowed,
+      agentId: ctx.agentId,
+      agentDid: ctx.agentDid,
+      issuerDid: ctx.issuerDid,
+      trustLevel: ctx.trustLevel,
+      trustScore: ctx.trustScore,
+      capabilities: ctx.capabilities,
+      signedCapabilities: ctx.signedCapabilities,
+      denialReason: decision.allowed ? undefined : decision.reason,
+      mldsaPresent: result.mldsaPresent,
+      source: 'local',
+    };
+  }
+}
+
+/**
+ * Minimal local broker policy: an action is allowed iff a *signed* capability
+ * grants it. A richer policy (resource scoping, role mapping) plugs in here.
+ */
+function evaluateBrokerPolicy(
+  ctx: ResolutionContext,
+  action: string,
+  requireSigned: boolean,
+): { allowed: boolean; reason?: string } {
+  // v1.0 capabilities are not under the signature (forgeable by the holder), so by
+  // default refuse to authorize on them. The security note in @opena2a/atx-verify
+  // is the source of this rule.
+  if (requireSigned && !ctx.signedCapabilities) {
+    return {
+      allowed: false,
+      reason:
+        'capabilities are not covered by the signature (credential is v1.0); refusing capability-based authorization',
+    };
+  }
+  if (ctx.capabilities.includes('*') || ctx.capabilities.includes(action)) {
+    return { allowed: true };
+  }
+  return { allowed: false, reason: `action "${action}" is not in the credential's granted capabilities` };
+}

--- a/sdk/typescript/src/local/index.ts
+++ b/sdk/typescript/src/local/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Local, offline ATX credential verification (spec-compliant local-verify path).
+ */
+export {
+  LocalVerifier,
+  type LocalVerificationConfig,
+  type LocalAuthorizationOptions,
+  type LocalAuthorizationResult,
+  type Atx,
+  type AtxPublicKey,
+  type AtxTrustAnchors,
+  type AtxVerificationResult,
+  type RejectCategory,
+  type ResolutionContext,
+} from './LocalVerifier';

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CorrelationJoiner, IntentInput, DetectionInput, RelayConfig } from '../telemetry';
+import type { LocalVerificationConfig } from '../local';
 
 /**
  * Agent types supported by AIM
@@ -79,6 +80,12 @@ export interface AIMClientConfig {
   headers?: Record<string, string>;
   /** Causal-denial telemetry (opt-in, best-effort, off the enforcement path). */
   telemetry?: TelemetryConfig;
+  /**
+   * Spec-compliant local ATX verification (opt-in). When set, the client can
+   * verify a resolved credential offline against these cached trust anchors
+   * instead of calling the central PDP per action. See {@link LocalVerificationConfig}.
+   */
+  localVerification?: LocalVerificationConfig;
 }
 
 /**

--- a/sdk/typescript/tests/local-verify-consumer.cjs
+++ b/sdk/typescript/tests/local-verify-consumer.cjs
@@ -1,0 +1,65 @@
+// CJS consumer smoke: require() the built CJS entry and exercise the local
+// verification path end-to-end. Proves an ESM-only @opena2a/atx-verify dep loads
+// from the CJS build (the dynamic import() must resolve natively on this Node).
+const crypto = require('node:crypto');
+const assert = require('node:assert');
+const { AIMClient, ActionDeniedError } = require('../dist/index.js');
+
+const ISSUER_DID = 'did:opena2a:issuer-1';
+
+(async () => {
+  // canonicalPayloadV11 lives in the ESM-only package; pull it via dynamic import.
+  const { canonicalPayloadV11 } = await import('@opena2a/atx-verify');
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' });
+  const rawHex = spki.subarray(spki.length - 32).toString('hex');
+
+  const atx = {
+    atcVersion: '1.1',
+    agentId: 'agent-cjs',
+    agentDid: 'did:opena2a:agent-cjs',
+    version: '1.0.0',
+    contentHash: 'sha256:cjs',
+    issuerDid: ISSUER_DID,
+    trustLevel: 3,
+    trustScore: 90,
+    issuedAt: '2026-06-01T00:00:00Z',
+    expiresAt: '2026-06-30T00:00:00Z',
+    capabilities: ['file:read'],
+    signatures: [],
+  };
+  atx.signatures = [
+    {
+      algorithm: 'Ed25519',
+      keyId: 'k1',
+      value: crypto.sign(null, canonicalPayloadV11(atx), privateKey).toString('base64'),
+    },
+  ];
+
+  const client = new AIMClient({
+    localVerification: {
+      trustedIssuers: [ISSUER_DID],
+      publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: rawHex }],
+      now: () => new Date('2026-06-15T00:00:00Z'),
+    },
+  });
+  client.setLocalCredential(atx);
+
+  const allowed = await client.verifyActionLocally({ action: 'file:read' });
+  assert.strictEqual(allowed.actionAllowed, true, 'expected file:read allowed');
+  assert.strictEqual(allowed.verified, true, 'expected verified');
+
+  let denied = false;
+  try {
+    await client.verifyActionLocally({ action: 'file:delete' });
+  } catch (e) {
+    denied = e instanceof ActionDeniedError;
+  }
+  assert.ok(denied, 'expected ActionDeniedError for file:delete');
+
+  console.log('CJS consumer smoke OK');
+})().catch((e) => {
+  console.error('CJS consumer smoke FAILED:', e);
+  process.exit(1);
+});

--- a/sdk/typescript/tests/local-verify-consumer.mjs
+++ b/sdk/typescript/tests/local-verify-consumer.mjs
@@ -1,0 +1,49 @@
+// ESM consumer smoke: import the built ESM entry and exercise the local
+// verification path end-to-end against the ESM-only @opena2a/atx-verify dep.
+import crypto from 'node:crypto';
+import assert from 'node:assert';
+import { AIMClient } from '../dist/index.mjs';
+import { canonicalPayloadV11 } from '@opena2a/atx-verify';
+
+const ISSUER_DID = 'did:opena2a:issuer-1';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+const spki = publicKey.export({ type: 'spki', format: 'der' });
+const rawHex = spki.subarray(spki.length - 32).toString('hex');
+
+const atx = {
+  atcVersion: '1.1',
+  agentId: 'agent-mjs',
+  agentDid: 'did:opena2a:agent-mjs',
+  version: '1.0.0',
+  contentHash: 'sha256:mjs',
+  issuerDid: ISSUER_DID,
+  trustLevel: 3,
+  trustScore: 90,
+  issuedAt: '2026-06-01T00:00:00Z',
+  expiresAt: '2026-06-30T00:00:00Z',
+  capabilities: ['file:read'],
+  signatures: [],
+};
+atx.signatures = [
+  {
+    algorithm: 'Ed25519',
+    keyId: 'k1',
+    value: crypto.sign(null, canonicalPayloadV11(atx), privateKey).toString('base64'),
+  },
+];
+
+const client = new AIMClient({
+  localVerification: {
+    trustedIssuers: [ISSUER_DID],
+    publicKeys: [{ algorithm: 'Ed25519', publicKeyHex: rawHex }],
+    now: () => new Date('2026-06-15T00:00:00Z'),
+  },
+});
+client.setLocalCredential(atx);
+
+const allowed = await client.verifyActionLocally({ action: 'file:read' });
+assert.strictEqual(allowed.actionAllowed, true, 'expected file:read allowed');
+assert.strictEqual(allowed.verified, true, 'expected verified');
+
+console.log('ESM consumer smoke OK');

--- a/sdk/typescript/tsup.config.ts
+++ b/sdk/typescript/tsup.config.ts
@@ -13,5 +13,8 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   minify: false,
-  external: ['express', 'fastify'],
+  // @opena2a/atx-verify is ESM-only; keep it external and load it via a dynamic
+  // import() at runtime so both the CJS and ESM builds resolve it natively on
+  // every supported Node (a static require of an ESM package would throw).
+  external: ['express', 'fastify', '@opena2a/atx-verify'],
 });


### PR DESCRIPTION
## Summary

Adds a spec-compliant **local, offline ATX credential verification path** to the AIM TypeScript SDK (`@opena2a/aim-sdk`), consuming the published, conformance-locked `@opena2a/atx-verify@0.1.1`. Closes step 4 of the atx-verify extraction (`todo/2026-06-10-aim-local-verification-gap.md`).

The ATX spec mandates that credential verification is local (the issuing node is never on the hot path). Until now the agent SDK an adopter installs did a blocking per-action POST to a central PDP. This brings the spec's local-verify model to the installed SDK.

## What it does

- **`LocalVerifier`** wraps the shared `LocalAtxVerifier` from `@opena2a/atx-verify` — the SAME verifier secretless and the Go/Python reference verifiers agree with byte-for-byte. No reimplementation (no drift).
- **`AIMClient.verifyActionLocally(options, atx?)`** — verifies a credential offline and authorizes from its signed claims; mirrors `verifyAction`'s contract (returns `VerificationResult`, throws `ActionDeniedError` on deny).
- **`AIMClient.verifyAction`** now takes the local path automatically when a credential is cached (`setLocalCredential`), and **falls back to the remote POST** otherwise. Default behavior (no `localVerification` config) is unchanged.
- Authorization is gated on **signed** capabilities: v1.1 capabilities are signature-covered (trusted); v1.0 capabilities are forgeable and refused by default. Fail-closed throughout.

## Design notes

- `@opena2a/atx-verify` is ESM-only; the SDK builds dual CJS+ESM via tsup. It's kept **external** and loaded via a **dynamic `import()`**, so it resolves natively from both builds on every supported Node. Proven by real CJS and ESM consumer smokes against the built `dist` (`tests/local-verify-consumer.{cjs,mjs}`, `npm run smoke:local`).
- Exact-pinned `0.1.1` per org supply-chain policy.

## Tests

- `src/local/LocalVerifier.test.ts` — verify (valid / tampered / expired / revoked / untrusted-issuer / wrong-key) + authorize (allow / deny / wildcard / v1.0-refusal / opt-in / fail-closed), signing real ATX credentials with `node:crypto`.
- `src/client/AIMClient.local.test.ts` — local-first dispatch, remote fallback, **asserts no network call on the hot path**.
- Full suite: 486 passing. Build + dual-format smokes green.

## Known limitation (documented + follow-up filed)

`@opena2a/atx-verify` does not yet bind a public key to the issuer DID that owns it, so a `localVerification` anchor set must hold keys for **a single issuer**. Documented in `LocalVerificationConfig` + README; characterization/tripwire test in place; upstream fix tracked in `todo/2026-06-15-atx-verify-key-issuer-binding.md`.

## Honesty constraint

With this merged, the TS SDK actually performs offline local verification — the "AIM does sub-ms offline verification" claim now holds for `@opena2a/aim-sdk` (Java SDK still pending; ROADMAP updated accordingly).

🤖 Reviewed via /pre-push-review (Phase 4.5 adversarial, verifier path): no CRITICAL/HIGH; MEDIUM/LOW addressed or documented.