### PR TITLE
feat(java-sdk): local ATX credential verification (atx-verify extraction step 5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -558,8 +558,12 @@ decisions.
   and Python reference verifiers), so there is a single conformance-locked
   implementation rather than a per-SDK reimplementation. The existing remote
   verification call is retained as a fallback.
-- **Java SDK — planned.** Port the same local-verify model (the Go verifier is the
-  reference) so JVM agents verify offline with the same conformance guarantees.
+- **Java SDK — shipped.** `org.opena2a.aim.atx` provides `LocalAtxVerifier` and
+  `AtxCanonicalizer`, a native port of the Go reference verifier (Ed25519 over the
+  v1.0 pipe / v1.1 JCS canonical payload, expiry, revocation, issuer-trust, and
+  key-to-issuer binding). Byte-for-byte interoperable with the TS/Go/Python
+  verifiers — gated by the pinned jcs-vectors canonical hash and the shared
+  conformance fixtures.
 
 **Use Case**: High-throughput agents that must authorize actions without a central
 verification round-trip; spec-compliant offline operation.

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -68,6 +68,14 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!-- JCS (RFC 8785) for ATX v1.1 canonicalization. Same author as the
+             JS `canonicalize` lib the TS/JS verifiers use -> byte-agreement by
+             construction (pinned by atx-conformance/jcs-vectors). -->
+        <dependency>
+            <groupId>io.github.erdtman</groupId>
+            <artifactId>java-json-canonicalization</artifactId>
+            <version>1.1</version>
+        </dependency>
 
         <!-- Cryptography (Ed25519) -->
         <dependency>

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/Atx.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/Atx.java
@@ -1,0 +1,39 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The ATX (Agent Trust eXtension) credential, as parsed for verification. Only the
+ * fields the canonicalizer or verifier touch are typed; everything else is
+ * tolerated (fixtures carry id, transparencyLogIndex, revokedAt, createdAt, ...).
+ *
+ * <p>ATX is the current name for the credential formerly called ATC; fixtures use
+ * the {@code atcVersion} field, dual-supporting "1.0" and "1.1".
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Atx {
+    public String atcVersion;
+    public String agentId;
+    public String agentDid;
+    public String publisher;
+    public String publisherDid;
+    public String version;
+    public String contentHash;
+    public String buildAttestation;
+    public List<String> capabilities;
+    /** Observed-behavior summary; null when absent. Read field-by-field in the v1.1 TBS. */
+    public Map<String, Object> behavioralProfile;
+    public Map<String, Object> scanSummary;
+    public int trustLevel;
+    public double trustScore;
+    public String issuedAt;
+    public String expiresAt;
+    public String issuerDid;
+    public List<String> issuerChain;
+    public List<String> jurisdiction;
+    public boolean revoked;
+    public List<AtxSignature> signatures;
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
@@ -1,0 +1,164 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.erdtman.jcs.JsonCanonicalizer;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Produces the signed canonical bytes for an ATX, byte-for-byte identical to
+ * {@code @opena2a/atx-verify} (TS), {@code opena2a-registry/pkg/atcverify} (Go),
+ * and the Python reference verifier. Byte agreement is pinned by
+ * {@code atx-conformance/jcs-vectors}.
+ *
+ * <ul>
+ *   <li>v1.0 ({@link #canonicalPayload}): an 11-field pipe-delimited string.</li>
+ *   <li>v1.1 ({@link #canonicalPayloadV11}): JCS (RFC 8785) over the TBS projection.</li>
+ * </ul>
+ */
+public final class AtxCanonicalizer {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter RFC3339_SECONDS =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    private AtxCanonicalizer() {}
+
+    /**
+     * Mirror of {@code verify.go canonicalPayload()}:
+     * {@code agentId|agentDid|version|contentHash|buildAttestation|issuerDid|trustLevel|%.6f trustScore|issuedAt|expiresAt|1.0}.
+     */
+    public static byte[] canonicalPayload(Atx atx) {
+        String canonical = String.join("|",
+                ns(atx.agentId),
+                ns(atx.agentDid),
+                ns(atx.version),
+                ns(atx.contentHash),
+                ns(atx.buildAttestation),
+                ns(atx.issuerDid),
+                Long.toString((long) atx.trustLevel),
+                formatTrustScore(atx.trustScore),
+                normalizeRfc3339(atx.issuedAt),
+                normalizeRfc3339(atx.expiresAt),
+                "1.0");
+        return canonical.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Project an ATX into the v1.1 TBS and return JCS(TBS) (RFC 8785). Covers
+     * capabilities, scanSummary, issuerChain, publisher, and behavioralProfile.
+     * The projection (canonical empties, always-full scanSummary, %.6f string
+     * trustScore, root-first issuerChain) matches the reference verifiers exactly.
+     */
+    public static byte[] canonicalPayloadV11(Atx atx) {
+        ObjectNode tbs = MAPPER.createObjectNode();
+        tbs.put("atcVersion", atx.atcVersion);
+        tbs.put("agentId", atx.agentId);
+        tbs.put("agentDid", atx.agentDid);
+        tbs.put("publisher", ns(atx.publisher));
+        tbs.put("publisherDid", ns(atx.publisherDid));
+        tbs.put("version", atx.version);
+        tbs.put("contentHash", atx.contentHash);
+        tbs.put("buildAttestation", ns(atx.buildAttestation));
+        tbs.set("capabilities", arrayOf(atx.capabilities));
+        tbs.set("behavioralProfile", projectBehavioralProfile(atx.behavioralProfile));
+
+        Map<String, Object> scan = atx.scanSummary != null ? atx.scanSummary : Map.of();
+        ObjectNode scanNode = MAPPER.createObjectNode();
+        scanNode.put("hma", asString(scan.get("hma")));
+        scanNode.put("criticalFindings", asLong(scan.get("criticalFindings")));
+        scanNode.put("highFindings", asLong(scan.get("highFindings")));
+        scanNode.put("secretless", asString(scan.get("secretless")));
+        scanNode.put("cryptoServe", asString(scan.get("cryptoServe")));
+        scanNode.put("oasbLevel", asString(scan.get("oasbLevel")));
+        tbs.set("scanSummary", scanNode);
+
+        // trustScore is the %.6f string form so trustLevel is the only JSON number.
+        tbs.put("trustScore", formatTrustScore(atx.trustScore));
+        tbs.put("trustLevel", (long) atx.trustLevel);
+        tbs.put("issuedAt", normalizeRfc3339(atx.issuedAt));
+        tbs.put("expiresAt", normalizeRfc3339(atx.expiresAt));
+        tbs.put("issuerDid", atx.issuerDid);
+        tbs.set("issuerChain", arrayOf(atx.issuerChain));
+
+        try {
+            String json = MAPPER.writeValueAsString(tbs);
+            String canonical = new JsonCanonicalizer(json).getEncodedString();
+            return canonical.getBytes(StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("v1.1 canonicalization failed: " + e.getMessage(), e);
+        }
+    }
+
+    /** Normalize an RFC 3339 timestamp to UTC "YYYY-MM-DDTHH:MM:SSZ" (seconds precision). */
+    public static String normalizeRfc3339(String s) {
+        try {
+            return OffsetDateTime.parse(s).toInstant().atOffset(ZoneOffset.UTC).format(RFC3339_SECONDS);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid RFC 3339 timestamp: " + s, e);
+        }
+    }
+
+    /**
+     * behavioralProfile -> JSON null only when absent/null (matching the TS
+     * `bp === null || bp === undefined` check); a present-but-empty object still
+     * projects to the canonical three-field form.
+     */
+    private static com.fasterxml.jackson.databind.JsonNode projectBehavioralProfile(Map<String, Object> bp) {
+        if (bp == null) {
+            return MAPPER.nullNode();
+        }
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("checksum", asString(bp.get("checksum")));
+        Object generatedAt = bp.get("generatedAt");
+        node.put("generatedAt", generatedAt instanceof String g && !g.isEmpty() ? normalizeRfc3339(g) : "");
+        node.put("observationDays", asLong(bp.get("observationDays")));
+        return node;
+    }
+
+    /**
+     * Format trustScore as 6 decimals with round-half-to-even, byte-identical to
+     * Go's {@code %.6f} and Python's {@code :.6f} (the signer's format). Java's
+     * {@code String.format("%.6f")} uses HALF_UP and would diverge at the 7th
+     * decimal, false-rejecting valid credentials.
+     */
+    private static String formatTrustScore(double trustScore) {
+        if (!Double.isFinite(trustScore)) {
+            throw new IllegalArgumentException("trustScore is not finite: " + trustScore);
+        }
+        return new BigDecimal(trustScore).setScale(6, RoundingMode.HALF_EVEN).toPlainString();
+    }
+
+    private static ArrayNode arrayOf(List<String> items) {
+        ArrayNode arr = MAPPER.createArrayNode();
+        if (items != null) {
+            for (String item : items) {
+                arr.add(item);
+            }
+        }
+        return arr;
+    }
+
+    /** Null-safe string ("" when null), matching the TS `?? ''` projection. */
+    private static String ns(String v) {
+        return v == null ? "" : v;
+    }
+
+    private static String asString(Object v) {
+        return v instanceof String s ? s : "";
+    }
+
+    /** Truncate to a 64-bit integer (matching TS Math.trunc); avoids 32-bit overflow. */
+    private static long asLong(Object v) {
+        return v instanceof Number n ? n.longValue() : 0L;
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxPublicKey.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxPublicKey.java
@@ -1,0 +1,21 @@
+package org.opena2a.aim.atx;
+
+/**
+ * A public key the verifier trusts, keyed by algorithm.
+ *
+ * @param algorithm    "Ed25519" (verified) or "ML-DSA-65" (presence recorded)
+ * @param publicKeyHex hex-encoded raw public key (32 bytes for Ed25519)
+ * @param keyId        optional DID-URL identifying the key and its controller, e.g.
+ *                     {@code did:opena2a:authority:opena2a.org#key-1}. When present
+ *                     (contains '#'), the key is BOUND to its controller DID and may
+ *                     only verify credentials issued by that DID (or, for v1.1, a
+ *                     signed issuerChain authority). A key without a '#' fragment is
+ *                     unbound and eligible for any issuer (single-issuer back-compat).
+ */
+public record AtxPublicKey(String algorithm, String publicKeyHex, String keyId) {
+
+    /** Convenience for an unbound key (no controller binding). */
+    public AtxPublicKey(String algorithm, String publicKeyHex) {
+        this(algorithm, publicKeyHex, null);
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxSignature.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxSignature.java
@@ -1,0 +1,14 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * A signature reference on an ATX credential.
+ *
+ * @param keyId     identifier of the signing key (informational; binding uses the
+ *                  verifier's configured key keyId, never this attacker-supplied one)
+ * @param algorithm "Ed25519" or "ML-DSA-65"
+ * @param value     base64-encoded signature value
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AtxSignature(String keyId, String algorithm, String value) {}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxTrustAnchors.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxTrustAnchors.java
@@ -1,0 +1,35 @@
+package org.opena2a.aim.atx;
+
+import java.time.Clock;
+import java.util.List;
+
+/**
+ * Trust anchors the verifier evaluates against. In production these are fetched
+ * once from AIM/the Registry and cached; revocation rides on the short-lived,
+ * asynchronously-refreshed CRL.
+ *
+ * <p>SECURITY — multi-issuer anchor sets are safe only when each key carries a
+ * DID-URL {@code keyId}. A key bound to its controller DID may only verify
+ * credentials issued by that DID (see {@link AtxPublicKey}). For a multi-issuer
+ * anchor set, always set a DID-URL keyId on every key.
+ *
+ * @param trustedIssuers issuer DIDs the verifier trusts
+ * @param publicKeys     issuer public keys (Ed25519 verified; ML-DSA-65 recorded)
+ * @param crl            cached revocation list (may be null)
+ * @param clock          clock source (injectable for tests); when null, the system UTC clock is used
+ */
+public record AtxTrustAnchors(
+        List<String> trustedIssuers,
+        List<AtxPublicKey> publicKeys,
+        Crl crl,
+        Clock clock) {
+
+    public AtxTrustAnchors(List<String> trustedIssuers, List<AtxPublicKey> publicKeys) {
+        this(trustedIssuers, publicKeys, null, null);
+    }
+
+    /** A cached, federated certificate revocation list. */
+    public record Crl(List<Entry> entries) {
+        public record Entry(String agentId, String reason) {}
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxVerificationResult.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxVerificationResult.java
@@ -1,0 +1,28 @@
+package org.opena2a.aim.atx;
+
+/**
+ * Outcome of {@link LocalAtxVerifier#verify}. On success {@code valid} is true and
+ * {@code context} is present; on failure {@code rejectCategory} and {@code reason}
+ * explain why.
+ *
+ * @param valid          whether the credential verified
+ * @param context        present iff valid — the authorization context
+ * @param rejectCategory present iff invalid
+ * @param reason         human-readable reason (this verifier's own wording)
+ * @param mldsaPresent   whether an ML-DSA-65 signature was present (delegated, not silently skipped)
+ */
+public record AtxVerificationResult(
+        boolean valid,
+        ResolutionContext context,
+        RejectCategory rejectCategory,
+        String reason,
+        boolean mldsaPresent) {
+
+    static AtxVerificationResult reject(RejectCategory category, String reason) {
+        return new AtxVerificationResult(false, null, category, reason, false);
+    }
+
+    static AtxVerificationResult accept(ResolutionContext context, boolean mldsaPresent) {
+        return new AtxVerificationResult(true, context, null, null, mldsaPresent);
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
@@ -1,0 +1,232 @@
+package org.opena2a.aim.atx;
+
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Local, offline ATX verifier. Cryptographically real (Ed25519) and interoperable
+ * with the conformance fixtures; trust anchors are injected. Mirrors the
+ * {@code @opena2a/atx-verify} (TS), {@code pkg/atcverify} (Go), and Python
+ * reference verifiers, including key-to-issuer binding.
+ *
+ * <p>Scope: Ed25519 is verified fully. ML-DSA-65 presence is recorded but
+ * verification is delegated (matches the TS/Python reference verifiers). A
+ * production deployment wires the post-quantum half and the live
+ * trusted-issuer/CRL anchors.
+ */
+public final class LocalAtxVerifier {
+
+    private static final String SUPPORTED_V10 = "1.0";
+    private static final String SUPPORTED_V11 = "1.1";
+    private static final byte[] ED25519_SPKI_PREFIX = hexToBytes("302a300506032b6570032100");
+
+    private final AtxTrustAnchors anchors;
+
+    public LocalAtxVerifier(AtxTrustAnchors anchors) {
+        this.anchors = anchors;
+    }
+
+    public AtxVerificationResult verify(Atx atx) {
+        Clock clock = anchors.clock() != null ? anchors.clock() : Clock.systemUTC();
+        Instant now = clock.instant();
+
+        // Step 1: schema version.
+        if (!SUPPORTED_V10.equals(atx.atcVersion) && !SUPPORTED_V11.equals(atx.atcVersion)) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.UNSUPPORTED_VERSION, "unsupported atxVersion " + atx.atcVersion);
+        }
+        boolean isV11 = SUPPORTED_V11.equals(atx.atcVersion);
+
+        // Step 2: expiry.
+        Instant expires;
+        try {
+            expires = OffsetDateTime.parse(atx.expiresAt).toInstant();
+        } catch (Exception e) {
+            return AtxVerificationResult.reject(RejectCategory.MALFORMED, "expiresAt is not a valid timestamp");
+        }
+        if (now.isAfter(expires)) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.EXPIRED, "expired at " + AtxCanonicalizer.normalizeRfc3339(atx.expiresAt));
+        }
+
+        // Step 3: revocation (ATX field + federated CRL).
+        if (atx.revoked) {
+            return AtxVerificationResult.reject(RejectCategory.REVOKED, "credential revoked field is true");
+        }
+        if (anchors.crl() != null && anchors.crl().entries() != null) {
+            for (AtxTrustAnchors.Crl.Entry entry : anchors.crl().entries()) {
+                if (entry.agentId() != null && entry.agentId().equals(atx.agentId)) {
+                    return AtxVerificationResult.reject(
+                            RejectCategory.REVOKED, "agent appears on CRL: " + ns(entry.reason()));
+                }
+            }
+        }
+
+        // Step 4: issuer trust.
+        if (anchors.trustedIssuers() == null || !anchors.trustedIssuers().contains(atx.issuerDid)) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.UNTRUSTED_ISSUER, "issuer DID " + atx.issuerDid + " is not trusted");
+        }
+
+        // Step 5: signature verification (Ed25519 fully; ML-DSA-65 presence recorded).
+        byte[] payload;
+        try {
+            payload = isV11 ? AtxCanonicalizer.canonicalPayloadV11(atx) : AtxCanonicalizer.canonicalPayload(atx);
+        } catch (Exception e) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.MALFORMED,
+                    (isV11 ? "v1.1 canonicalization failed: " : "canonicalization failed: ") + e.getMessage());
+        }
+
+        // Key-to-issuer binding: a key may verify a signature for this credential
+        // only if its keyId controller DID is one of the credential's authorities.
+        Set<String> authoritySet = authoritySetFor(atx, isV11);
+        List<PublicKey> edKeys = new ArrayList<>();
+        if (anchors.publicKeys() != null) {
+            for (AtxPublicKey k : anchors.publicKeys()) {
+                if (!"Ed25519".equals(k.algorithm()) || !keyEligible(k.keyId(), authoritySet)) {
+                    continue;
+                }
+                PublicKey pk = ed25519FromRawHex(k.publicKeyHex());
+                if (pk != null) {
+                    edKeys.add(pk);
+                }
+            }
+        }
+
+        boolean edVerified = false;
+        boolean mldsaPresent = false;
+        if (atx.signatures != null) {
+            for (AtxSignature sig : atx.signatures) {
+                if ("Ed25519".equals(sig.algorithm())) {
+                    byte[] sigBytes;
+                    try {
+                        sigBytes = Base64.getDecoder().decode(sig.value());
+                    } catch (Exception e) {
+                        return AtxVerificationResult.reject(
+                                RejectCategory.SIGNATURE_INVALID,
+                                "signature " + ns(sig.keyId()) + " has invalid base64");
+                    }
+                    boolean ok = false;
+                    for (PublicKey key : edKeys) {
+                        if (ed25519Verify(key, payload, sigBytes)) {
+                            ok = true;
+                            break;
+                        }
+                    }
+                    if (!ok) {
+                        return AtxVerificationResult.reject(
+                                RejectCategory.SIGNATURE_INVALID,
+                                "Ed25519 signature " + ns(sig.keyId()) + " did not verify");
+                    }
+                    edVerified = true;
+                } else if ("ML-DSA-65".equals(sig.algorithm())) {
+                    // Presence recorded; PQC verification delegated. Not silently skipped.
+                    mldsaPresent = true;
+                } else {
+                    // Unknown algorithm: ATX defines only Ed25519 and ML-DSA-65. Reject
+                    // (rather than ignore) to block typo / Unicode-lookalike bypasses of
+                    // this switch. Matches the Go reference + conformance verifiers.
+                    return AtxVerificationResult.reject(
+                            RejectCategory.SIGNATURE_INVALID,
+                            "unsupported signature algorithm: " + sig.algorithm());
+                }
+            }
+        }
+
+        if (!edVerified) {
+            return AtxVerificationResult.reject(RejectCategory.SIGNATURE_INVALID, "no Ed25519 signature verified");
+        }
+
+        ResolutionContext context = new ResolutionContext(
+                atx.agentId,
+                atx.agentDid,
+                atx.issuerDid,
+                atx.issuerChain != null ? atx.issuerChain : List.of(atx.issuerDid),
+                atx.trustLevel,
+                atx.trustScore,
+                atx.capabilities != null ? atx.capabilities : List.of(),
+                atx.scanSummary != null && atx.scanSummary.get("oasbLevel") instanceof String s ? s : null,
+                atx.jurisdiction,
+                isV11);
+        return AtxVerificationResult.accept(context, mldsaPresent);
+    }
+
+    /**
+     * DIDs whose keys may sign this credential: the issuer always, plus the
+     * issuerChain authorities for v1.1 (where issuerChain is covered by the
+     * signature). v1.0 issuerChain is unsigned and therefore forgeable, so it is
+     * NOT trusted as a signer source — only the issuer is.
+     */
+    private static Set<String> authoritySetFor(Atx atx, boolean isV11) {
+        Set<String> set = new HashSet<>();
+        set.add(atx.issuerDid);
+        if (isV11 && atx.issuerChain != null) {
+            set.addAll(atx.issuerChain);
+        }
+        return set;
+    }
+
+    /**
+     * Whether a key may verify a signature for an issuer in {@code authoritySet}.
+     * Binding applies only to keys whose keyId is a DID-URL (contains '#'): such a
+     * key is eligible only if its controller is in the set. A key with no '#'
+     * fragment is unbound (legacy single-issuer configs) and stays eligible.
+     */
+    private static boolean keyEligible(String keyId, Set<String> authoritySet) {
+        if (keyId == null || keyId.indexOf('#') < 0) {
+            return true;
+        }
+        return authoritySet.contains(keyId.substring(0, keyId.indexOf('#')));
+    }
+
+    /** Build a public key from a raw 32-byte Ed25519 public key (hex), or null. */
+    private static PublicKey ed25519FromRawHex(String hex) {
+        try {
+            byte[] raw = hexToBytes(hex);
+            if (raw.length != 32) {
+                return null;
+            }
+            byte[] spki = new byte[ED25519_SPKI_PREFIX.length + raw.length];
+            System.arraycopy(ED25519_SPKI_PREFIX, 0, spki, 0, ED25519_SPKI_PREFIX.length);
+            System.arraycopy(raw, 0, spki, ED25519_SPKI_PREFIX.length, raw.length);
+            return KeyFactory.getInstance("Ed25519").generatePublic(new X509EncodedKeySpec(spki));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean ed25519Verify(PublicKey key, byte[] payload, byte[] signature) {
+        try {
+            Signature verifier = Signature.getInstance("Ed25519");
+            verifier.initVerify(key);
+            verifier.update(payload);
+            return verifier.verify(signature);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        int len = hex.length();
+        byte[] out = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            out[i / 2] = (byte) Integer.parseInt(hex.substring(i, i + 2), 16);
+        }
+        return out;
+    }
+
+    private static String ns(String v) {
+        return v == null ? "" : v;
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/RejectCategory.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/RejectCategory.java
@@ -1,0 +1,15 @@
+package org.opena2a.aim.atx;
+
+/**
+ * Why an ATX credential was rejected. Mirrors the {@code RejectCategory} union in
+ * {@code @opena2a/atx-verify} (TS) and the reject reasons in the Go/Python
+ * reference verifiers so the structured outcome is interoperable across SDKs.
+ */
+public enum RejectCategory {
+    UNSUPPORTED_VERSION,
+    EXPIRED,
+    REVOKED,
+    UNTRUSTED_ISSUER,
+    SIGNATURE_INVALID,
+    MALFORMED
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/ResolutionContext.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/ResolutionContext.java
@@ -1,0 +1,23 @@
+package org.opena2a.aim.atx;
+
+import java.util.List;
+
+/**
+ * Context derived from a <em>verified</em> ATX. Contains no backend information.
+ *
+ * @param signedCapabilities true when the credential is v1.1+, i.e.
+ *                           capabilities/scanSummary/issuerChain are covered by the
+ *                           signature and may be trusted for authorization. False
+ *                           for v1.0, where those fields are forgeable by the holder.
+ */
+public record ResolutionContext(
+        String agentId,
+        String agentDid,
+        String issuerDid,
+        List<String> issuerChain,
+        int trustLevel,
+        double trustScore,
+        List<String> capabilities,
+        String oasbLevel,
+        List<String> jurisdiction,
+        boolean signedCapabilities) {}

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/AtxCanonicalizerTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/AtxCanonicalizerTest.java
@@ -1,0 +1,113 @@
+package org.opena2a.aim.atx;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Byte-agreement gate: the Java canonicalizer must reproduce the exact bytes the
+ * TS/Go/Python verifiers produce. The pinned v1.1 hex comes from
+ * atx-conformance/jcs-vectors (via @opena2a/atx-verify atx.test.ts). If Java's JCS
+ * or projection is off by a byte, these fail — proving interop before any signing.
+ */
+class AtxCanonicalizerTest {
+
+    // Pinned in atx-conformance/jcs-vectors/vectors/01-baseline.json; copied verbatim
+    // from @opena2a/atx-verify src/atx.test.ts V11_BASELINE_CANONICAL_HEX.
+    private static final String V11_BASELINE_CANONICAL_HEX =
+            "7b226167656e74446964223a226469643a6f70656e6132613a6167656e743a6167656e745f636f6e666f726d616e63655f746573745f303031222c226167656e744964223a226167656e745f636f6e666f726d616e63655f746573745f303031222c2261746356657273696f6e223a22312e31222c226265686176696f72616c50726f66696c65223a7b22636865636b73756d223a227368613235363a676869373839222c2267656e6572617465644174223a22323032362d30352d31395430303a30303a30305a222c226f62736572766174696f6e44617973223a31347d2c226275696c644174746573746174696f6e223a2268747470733a2f2f736c73612e6465762f70726f76656e616e63652f7631236f70656e6132612d636f6e666f726d616e6365222c226361706162696c6974696573223a5b22726561643a7075626c6963222c2277726974653a6f776e6564225d2c22636f6e74656e7448617368223a2230303030313131313232323233333333343434343535353536363636373737373838383839393939616161616262626263636363646464646565656566666666222c22657870697265734174223a22323039392d31322d33315432333a35393a35395a222c226973737565644174223a22323032362d30352d32335430303a30303a30305a222c22697373756572436861696e223a5b226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f72672d726f6f74222c226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267225d2c22697373756572446964223a226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267222c227075626c6973686572223a226f70656e6132612d636f6e666f726d616e6365222c227075626c6973686572446964223a226469643a6f70656e6132613a7075626c69736865723a6f70656e6132612d636f6e666f726d616e6365222c227363616e53756d6d617279223a7b22637269746963616c46696e64696e6773223a302c2263727970746f5365727665223a226e6f2d7765616b2d63727970746f222c226869676846696e64696e6773223a302c22686d61223a22706173736564222c226f6173624c6576656c223a224c31222c227365637265746c657373223a22636c65616e227d2c2274727573744c6576656c223a342c22747275737453636f7265223a2238372e353030303030222c2276657273696f6e223a22312e302e30227d";
+
+    /** The credential that projects to the jcs-vectors baseline vector. */
+    private static Atx v11Baseline() {
+        Atx a = new Atx();
+        a.atcVersion = "1.1";
+        a.agentId = "agent_conformance_test_001";
+        a.agentDid = "did:opena2a:agent:agent_conformance_test_001";
+        a.publisher = "opena2a-conformance";
+        a.publisherDid = "did:opena2a:publisher:opena2a-conformance";
+        a.version = "1.0.0";
+        a.contentHash = "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff";
+        a.buildAttestation = "https://slsa.dev/provenance/v1#opena2a-conformance";
+        a.issuerDid = "did:opena2a:authority:opena2a.org";
+        a.issuerChain = List.of("did:opena2a:authority:opena2a.org-root", "did:opena2a:authority:opena2a.org");
+        a.trustLevel = 4;
+        a.trustScore = 87.5;
+        a.issuedAt = "2026-05-23T00:00:00Z";
+        a.expiresAt = "2099-12-31T23:59:59Z";
+        a.capabilities = List.of("read:public", "write:owned");
+        a.behavioralProfile = Map.of(
+                "checksum", "sha256:ghi789",
+                "generatedAt", "2026-05-19T00:00:00Z",
+                "observationDays", 14);
+        a.scanSummary = Map.of(
+                "hma", "passed",
+                "criticalFindings", 0,
+                "highFindings", 0,
+                "secretless", "clean",
+                "cryptoServe", "no-weak-crypto",
+                "oasbLevel", "L1");
+        return a;
+    }
+
+    @Test
+    void reproducesPinnedV11BaselineCanonicalBytes() {
+        String hex = HexFormat.of().formatHex(AtxCanonicalizer.canonicalPayloadV11(v11Baseline()));
+        assertEquals(V11_BASELINE_CANONICAL_HEX, hex,
+                "v1.1 JCS(TBS) bytes diverge from the cross-language pinned vector");
+    }
+
+    @Test
+    void v10PipeStringMatchesGoPythonOrder() {
+        Atx a = new Atx();
+        a.atcVersion = "1.0";
+        a.agentId = "aim_orders_reader";
+        a.agentDid = "did:opena2a:agent:acme/orders-reader";
+        a.version = "1.0.0";
+        a.contentHash = "sha256:abc123";
+        a.buildAttestation = "sha256:def456";
+        a.issuerDid = "did:opena2a:authority:opena2a.org";
+        a.trustLevel = 4;
+        a.trustScore = 0.5;
+        a.issuedAt = "2026-05-25T00:00:00Z";
+        a.expiresAt = "2026-06-08T00:00:00Z";
+
+        String payload = new String(AtxCanonicalizer.canonicalPayload(a), StandardCharsets.UTF_8);
+        assertEquals(
+                "aim_orders_reader|did:opena2a:agent:acme/orders-reader|1.0.0|sha256:abc123|"
+                        + "sha256:def456|did:opena2a:authority:opena2a.org|4|0.500000|"
+                        + "2026-05-25T00:00:00Z|2026-06-08T00:00:00Z|1.0",
+                payload);
+    }
+
+    @Test
+    void trustScoreRoundsHalfToEvenLikeGoAndPython() {
+        // 0.1234565 -> "0.123456" with round-half-even (Go %.6f, Python :.6f, JS
+        // toFixed). Java's String.format("%.6f") would give "0.123457" (HALF_UP)
+        // and false-reject. Guards the signer-parity rounding fix.
+        Atx a = new Atx();
+        a.atcVersion = "1.0";
+        a.agentId = "a";
+        a.agentDid = "d";
+        a.version = "1.0.0";
+        a.contentHash = "h";
+        a.issuerDid = "did:opena2a:authority:opena2a.org";
+        a.trustLevel = 1;
+        a.trustScore = 0.1234565;
+        a.issuedAt = "2026-05-25T00:00:00Z";
+        a.expiresAt = "2026-06-08T00:00:00Z";
+        String payload = new String(AtxCanonicalizer.canonicalPayload(a), StandardCharsets.UTF_8);
+        assertTrue(payload.contains("|0.123456|"), "expected round-half-even 0.123456, got: " + payload);
+    }
+
+    @Test
+    void normalizesRfc3339ToSecondsUtcZ() {
+        assertEquals("2026-06-08T00:00:00Z", AtxCanonicalizer.normalizeRfc3339("2026-06-08T00:00:00.123Z"));
+        assertEquals("2026-06-08T00:00:00Z", AtxCanonicalizer.normalizeRfc3339("2026-06-08T02:00:00+02:00"));
+    }
+}

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/AtxKeyBindingTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/AtxKeyBindingTest.java
@@ -1,0 +1,143 @@
+package org.opena2a.aim.atx;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Key-to-issuer binding + signature-path edge cases for the Java verifier,
+ * exercising the v1.1 verify path (which the pinned-hex/canonicalizer test does
+ * not cover). Self-signs credentials so the only variable is the binding rule.
+ */
+class AtxKeyBindingTest {
+
+    private static final String ISSUER_A = "did:opena2a:authority:a.example";
+    private static final String ISSUER_B = "did:opena2a:authority:b.example";
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+
+    private record Key(PrivateKey priv, String rawHex) {}
+
+    private static Key genKey() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] spki = kp.getPublic().getEncoded();
+        String rawHex = HexFormat.of().formatHex(Arrays.copyOfRange(spki, spki.length - 32, spki.length));
+        return new Key(kp.getPrivate(), rawHex);
+    }
+
+    private static Atx base(String version, String issuerDid, List<String> issuerChain) {
+        Atx a = new Atx();
+        a.atcVersion = version;
+        a.agentId = "agent-1";
+        a.agentDid = "did:opena2a:agent:a/agent-1";
+        a.publisher = "acme";
+        a.publisherDid = "did:opena2a:publisher:acme";
+        a.version = "1.0.0";
+        a.contentHash = "sha256:abc";
+        a.buildAttestation = "sha256:def";
+        a.issuerDid = issuerDid;
+        a.issuerChain = issuerChain;
+        a.trustLevel = 2;
+        a.trustScore = 0.9;
+        a.issuedAt = "2026-05-20T00:00:00Z";
+        a.expiresAt = "2026-06-20T00:00:00Z";
+        a.capabilities = List.of("orders:read");
+        a.scanSummary = Map.of("oasbLevel", "L2");
+        return a;
+    }
+
+    private static void sign(Atx atx, PrivateKey priv, String keyId) throws Exception {
+        byte[] payload = "1.1".equals(atx.atcVersion)
+                ? AtxCanonicalizer.canonicalPayloadV11(atx)
+                : AtxCanonicalizer.canonicalPayload(atx);
+        Signature s = Signature.getInstance("Ed25519");
+        s.initSign(priv);
+        s.update(payload);
+        atx.signatures = new ArrayList<>(List.of(
+                new AtxSignature(keyId, "Ed25519", Base64.getEncoder().encodeToString(s.sign()))));
+    }
+
+    private static AtxTrustAnchors anchors(List<String> trusted, List<AtxPublicKey> keys) {
+        return new AtxTrustAnchors(trusted, keys, null, CLOCK);
+    }
+
+    @Test
+    void rejectsCrossIssuerSignatureV10() throws Exception {
+        Key a = genKey();
+        Key b = genKey();
+        Atx atx = base("1.0", ISSUER_A, List.of(ISSUER_A));
+        sign(atx, b.priv(), ISSUER_B + "#key-1"); // A-issued, signed by B's key
+        AtxVerificationResult r = new LocalAtxVerifier(anchors(
+                List.of(ISSUER_A, ISSUER_B),
+                List.of(new AtxPublicKey("Ed25519", a.rawHex(), ISSUER_A + "#key-1"),
+                        new AtxPublicKey("Ed25519", b.rawHex(), ISSUER_B + "#key-1")))).verify(atx);
+        assertFalse(r.valid());
+        assertEquals(RejectCategory.SIGNATURE_INVALID, r.rejectCategory());
+    }
+
+    @Test
+    void rejectsCrossIssuerSignatureV11() throws Exception {
+        Key a = genKey();
+        Key b = genKey();
+        Atx atx = base("1.1", ISSUER_A, List.of(ISSUER_A)); // B not in chain
+        sign(atx, b.priv(), ISSUER_B + "#key-1");
+        AtxVerificationResult r = new LocalAtxVerifier(anchors(
+                List.of(ISSUER_A, ISSUER_B),
+                List.of(new AtxPublicKey("Ed25519", a.rawHex(), ISSUER_A + "#key-1"),
+                        new AtxPublicKey("Ed25519", b.rawHex(), ISSUER_B + "#key-1")))).verify(atx);
+        assertFalse(r.valid());
+        assertEquals(RejectCategory.SIGNATURE_INVALID, r.rejectCategory());
+    }
+
+    @Test
+    void acceptsV11CrossOrgCosignatureInSignedChain() throws Exception {
+        Key b = genKey();
+        // issuer A, but B is a cosigning authority in the (signed) issuerChain.
+        Atx atx = base("1.1", ISSUER_A, List.of(ISSUER_A, ISSUER_B));
+        sign(atx, b.priv(), ISSUER_B + "#key-1");
+        AtxVerificationResult r = new LocalAtxVerifier(anchors(
+                List.of(ISSUER_A, ISSUER_B),
+                List.of(new AtxPublicKey("Ed25519", b.rawHex(), ISSUER_B + "#key-1")))).verify(atx);
+        assertTrue(r.valid(), "expected ACCEPT: " + r.reason());
+    }
+
+    @Test
+    void unboundKeyWithoutDidUrlStaysEligible() throws Exception {
+        Key a = genKey();
+        Atx atx = base("1.0", ISSUER_A, List.of(ISSUER_A));
+        sign(atx, a.priv(), "legacy-key"); // no '#': unbound
+        AtxVerificationResult r = new LocalAtxVerifier(anchors(
+                List.of(ISSUER_A),
+                List.of(new AtxPublicKey("Ed25519", a.rawHex(), "legacy-key")))).verify(atx);
+        assertTrue(r.valid(), "expected ACCEPT for unbound key (back-compat): " + r.reason());
+    }
+
+    @Test
+    void rejectsUnknownSignatureAlgorithm() throws Exception {
+        Key a = genKey();
+        Atx atx = base("1.0", ISSUER_A, List.of(ISSUER_A));
+        sign(atx, a.priv(), ISSUER_A + "#key-1");
+        // append a signature with an unsupported algorithm — must reject, not ignore.
+        atx.signatures.add(new AtxSignature("x", "Frobnicate-9000", "AAAA"));
+        AtxVerificationResult r = new LocalAtxVerifier(anchors(
+                List.of(ISSUER_A),
+                List.of(new AtxPublicKey("Ed25519", a.rawHex(), ISSUER_A + "#key-1")))).verify(atx);
+        assertFalse(r.valid());
+        assertEquals(RejectCategory.SIGNATURE_INVALID, r.rejectCategory());
+    }
+}

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
@@ -1,0 +1,93 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.InputStream;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Conformance gate: run {@link LocalAtxVerifier} against the OpenA2A ATX
+ * conformance fixtures (verbatim copies from atx-conformance/fixtures/, including
+ * their pinned Ed25519 signatures and issuer public keys). Proves this verifier
+ * accepts/rejects exactly the credentials the Go and Python reference verifiers do.
+ *
+ * <p>We assert the machine contract (verifyResult + rejectCategory), NOT the
+ * fixtures' reasonContains — that is the reference verifiers' own wording.
+ */
+class LocalAtxVerifierConformanceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @ParameterizedTest(name = "{0} -> {1}{2}")
+    @CsvSource({
+            "baseline-valid.json,              ACCEPT, ",
+            "baseline-valid-hybrid.json,       ACCEPT, ",
+            "threshold-2of3-cosignature.json,  ACCEPT, ",
+            "tampered-signature.json,          REJECT, SIGNATURE_INVALID",
+            "expired.json,                     REJECT, EXPIRED",
+            "revoked.json,                     REJECT, REVOKED",
+            "wrong-issuer.json,                REJECT, UNTRUSTED_ISSUER",
+            "malformed-schema.json,            REJECT, UNSUPPORTED_VERSION",
+            "cross-issuer-key.json,            REJECT, SIGNATURE_INVALID",
+    })
+    void fixture(String file, String expectedResult, String expectedRejectCategory) throws Exception {
+        JsonNode fixture;
+        try (InputStream in = getClass().getResourceAsStream("/atx-fixtures/" + file.trim())) {
+            assertNotNull(in, "fixture not found: " + file);
+            fixture = MAPPER.readTree(in);
+        }
+
+        JsonNode vs = fixture.get("verifierState");
+        Atx atx = MAPPER.treeToValue(fixture.get("atx"), Atx.class);
+
+        AtxVerificationResult result = new LocalAtxVerifier(anchorsFrom(vs)).verify(atx);
+
+        if ("ACCEPT".equals(expectedResult)) {
+            assertEquals(true, result.valid(), "expected ACCEPT, got: " + result.reason());
+        } else {
+            assertEquals(false, result.valid(), "expected REJECT but verifier accepted");
+            if (expectedRejectCategory != null && !expectedRejectCategory.isBlank()) {
+                assertEquals(RejectCategory.valueOf(expectedRejectCategory.trim()), result.rejectCategory());
+            }
+        }
+    }
+
+    private static AtxTrustAnchors anchorsFrom(JsonNode vs) {
+        Clock clock = Clock.fixed(Instant.parse(vs.get("clockRfc3339").asText()), ZoneOffset.UTC);
+
+        List<String> trustedIssuers = new ArrayList<>();
+        vs.get("trustedIssuers").forEach(n -> trustedIssuers.add(n.asText()));
+
+        List<AtxPublicKey> publicKeys = new ArrayList<>();
+        for (JsonNode k : vs.get("publicKeys")) {
+            publicKeys.add(new AtxPublicKey(
+                    k.get("algorithm").asText(),
+                    k.get("publicKeyHex").asText(),
+                    k.hasNonNull("keyId") ? k.get("keyId").asText() : null));
+        }
+
+        AtxTrustAnchors.Crl crl = null;
+        JsonNode crlNode = vs.get("crl");
+        if (crlNode != null && crlNode.hasNonNull("entries")) {
+            List<AtxTrustAnchors.Crl.Entry> entries = new ArrayList<>();
+            for (JsonNode e : crlNode.get("entries")) {
+                entries.add(new AtxTrustAnchors.Crl.Entry(
+                        e.get("agentId").asText(),
+                        e.hasNonNull("reason") ? e.get("reason").asText() : null));
+            }
+            crl = new AtxTrustAnchors.Crl(entries);
+        }
+
+        return new AtxTrustAnchors(trustedIssuers, publicKeys, crl, clock);
+    }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/baseline-valid-hybrid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/baseline-valid-hybrid.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/baseline-valid-hybrid",
+  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. NOTE: the current opena2a-registry/pkg/atcverify verifier verifies Ed25519 only and silently ignores ML-DSA-65 signatures; the conformance Go verifier in ../verifiers/go DOES verify both, per spec.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-primary-pqc",
+      "path": "vectors/mldsa65-seed.json",
+      "algorithm": "ML-DSA-65",
+      "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-primary-pqc",
+        "path": "vectors/mldsa65-seed.json",
+        "algorithm": "ML-DSA-65",
+        "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc",
+        "algorithm": "ML-DSA-65",
+        "value": "4UPrwKrcCr3RlEQ15mkbzrPv3BvSOwE/3nYf5FJyKFPgRqP8ji1Jk60/uMlkxta6ixWOn5SBuLrexF3tzhaF3wcyMXM4yUmZ8V3JuATpIDzsYDTbLIg1ibAVUV3uBaOk5hsgYkXqHnOv6q9gp+XiMvDMoLIrNnCjTvw9eu8Bl7VmirOmMozV8JpmKMEzn5H7zdMZqygMdQN0t85cMl63ft3TDpu9UZ2uQ7nNM8FYsjE8LCtbSPuaiW5KYDg188aGwTJLOi1NrWN9hCTEoMXW3xPfXYovXkZpPxqXQLbvKbYxRcL3ZYr2VvGxUDgRN9Aj7DCS0bu6aH9bP9o4o10TTldVj/miOHQHwFE0trYEPDyyjE9/+Z86HCFGK0P05QSYOIYljZFd/1ZnQLxmZIm5Y7JLkW/2Jc0Z+t4i21VCiqFpw1dfOlQSy1I0iwwb91PwsftSvFR2ZAbCytNmA1vzv+gTelGAb1UDnklkngSD53hdOdD/rCkByZ4oY4obH+/it6GMaGXY019NTXiwcqNVHxMGKfFTkhvNveKc2YBV6ELWVdHpYbWXuSzTrLSJtDhRjjumWPaa3Fd0/V/ozTYBodwC1fBaGBQdXDBzmK/JyAYxc9s+5Vb7jS1hlSvwx+xBvY8qDD9HGsn1PwVxuVGjlLOk88R5uykdBkOJ79+vU3ey9WXBBjm5cqvPIvIrlXtlKo6t9sCZGz2gyFxDqW8sKSlLQmGWuoXUg54JTwvdTG1jbpremDbrPz/xM8O312JsF+TCOD4fg6TiklQJ7tfED5EJ0Zm9nSJ+A+ke70u8QW3SgU116vNDS0dzpX0hoLJCupvGPqnqPLw7VuIPGyyBoqwDA3rx1kzn+hxfFc2glKZV5tO0tEK2NVY4zcR09ZY4LDPbCS5TsOwo22nU+3GSHCT0xdYU3piiwbNhCcR1fIruZTSYpEUzFY0Vbc/ng30w8C3g8WGYvzAzk7s9ud3IgR1vnfbQCL8S4cgpl9I4EfobWrLcr6PjHtAIDY96cY4OvwPickvc46GprRzaNiMQX/uHupBesRkZatBFsOkD2u0c7S1/HTCgsbySNqkoleWNZ1naPY+8LF5YUUXeQBq8v8mjSe2SCXAVrviIn1L78Ec3Q7t6KTf6kQRGDz8mIqBk+Zypf1DRMgEedt3Mf4vNzUgvMz5hhqZlnMEeP51TW96J7XFtPCCvUcOX7odJK/atGCk16N8hfGXO6FDItu/3J56olTtziG/yGJx86zjWZpTO5vrT99YqFq1vsoolg52X5Mb9oxHKSylBbEb20gTWIC/S6k4snG6UgaTmKk2kNqT8k/rJdPwRPjWv91FMOIoYXipeBnoMbgImMTQGa29gpadoeEpgKA+leBgybHCR+TdNPI9GaOlHhisAfEOs4mFgpTdZIjpkbjDXDed9lCaQA4M8nJx/oNPHZUTRVkAhvs8XBIH3ELRzdqJJ1i/mLdiNV0gtXTYMu8ofpZ9tbH4HVbplcq+k4sK+pS92VEhx1m3MAzZH9oTVtzMN9MD/DxeksG5yGWlWtnG8cvrJVzbAPnwpKPncUYaxDr51a2vOitRxUlxiVJM/HOLLnlj4Jl5xGNJNBHukRWpQTvVXEeYF5zNB7mXXCfMNKM69DeE73B1EqYnFDCn+sS5Npru8fW4B50DYbB5/HflgFll5IjPQ1Z4OM14HlPK7ww6/dfT77NA1QkXIdI2SsrFhtSXD1h+khNNA3WbXu0EFQcO66bDgkXme0ae4pElApRj3OSZh8Y+UhQvjYUxCszAn8G5+/fFDhH9wOYcf0ODyyaEtLwuDUo+dSudJcevDSRhn6aC1QO+OFetua0MO/so5rFwV3dqOImncL0V1wqIwR9kAQpFE78t52FYWitMuSKFH3hKJKWfp/Ml85WO2pMe0E7pdRBtt7cwxX3fOnyVeWhxEmceD5xponvaAmrIgJN5hhUvS1ArnmvxsMFUlXXYAsx04RARjxrziyeHDENRmz1YqWcpyvUjbHDUiA39LX+D9vjj8DcVLSflgdDE9Mt6lgpkRkKkMrcQzLUqpXkzzKEA4pUZoJqaoSaE4ekEApkyH2Vs6f8LyvQlU2tFY1A5lWcDeCmvdTSyu8D6PSOL+YZkRc002bLKryNSY5V9uKfxdG5LPfa558VJLyNPVzYl8MPcB9FzDs6nZe8fNM2zM46sHrPl/yHct+QKW3wPJt/aiHfzQyNUp7uC5j1pAgSZ9+vUHA7gyqofRy6rQSUnHJBWxqxLRKqYKb/doXovDLxSLRry0C5vsAyiekimzchT/rSzNq2D6mjnhHccaqNri85YItJZM8PwKZJytkYBp/5alR62kT6XdelvqX5HTybJS7HqcK3OAf8sa1aHpB4Wl1YEELg3qbW40uTw47D+1y7NfhZJvGmAfOXpVng8a/ra7ku57W2hIE3Prsd9jbhYdm62XylS09F5X9OmX9jfDks/zA/bcCZtaPq7RO9VVJ0N5TtMk33U0QQpkPrvPs0m65zpaAJLN7qiirA1nBDV4oiSprY3ciebjbHvB/R5fYFhY+xOrgmvZttJ66lnPPGvs5xohfF9h7qEXwVO7pizehJSW8E3TbERebuFhf1lxpSjZbo0+/Epkk2LVFuCrSn/GBu2lQXwDFq0s5SBlQTOZC5TgArNOblvIik31N6Fr1omc8AMvzZsjHVtDxmP3CXOGH7S6hPw7J+LF1gVDTzry/wzkGGGzimEZbY0J14znXxdQn0z31N9dDNGQS2mG7s1aLfjeEbH2PS72wFIb/J20f/DRqG0Zztv0mSD4M3CP0p2WxldYSoACHcpI6qH8XHaMCVv1VAXR5lNla/l+ytKi+WvWvvlgEffjXhXAXRX6Oj+AizGJ4J8fTjjQ9+ZLlrh1CPxRRPjH2f3Z/JvgkmKJY7BTtBYnS233YWTJVQAxTV7i03SCIrsahvxZErxR0rtq7FccPA28I0VctmWsXD6uiaO2w9MxERuP8tKvIkVYuyzk4Lnt8/5J6cJf+TFTtqcaTnjq/KaTwy1KoAs7bo9QiyX1EHoXRJO8zzLZWMUZoI9KQYouDBxB0PUTZ3H15n3Z98aZQa6gqAASEiEE5G5KWw/dUhblz57qNPqaXQ4N8TiZtOh6c/VWu0jYXk9888q+cv953reqNwasD32nS73qMafspajAbrbpQ7hikYeNlTPXtMZ1qYTuM2ZNMM3xxSstOt2XCOaCbWjjWUsYIRvmdRZaDc88CwAPyJGQTWyr4Mwm4u8E2hu5zklmm+gvQI3ykGEx4HsYJVpLPhMCXSxP/BnvL5QesWkcvTA1hHcGNFYbpwmJUUzYf1Ffcj/awB2thuv3m2IzRo1GZYgQ+4bfCWIKAXrTSN1MCQjJzPbA4fcWWrxIQsgNw0M6jj7hD82AfShwVFyjWgIhCT+uf4Nxe9aWMJFQlC8ehJUiD1Itx1OjYqwzlqOjElIh9wXEtYYbdVxZ2eiqV5uq+YO7m/rMWetghe7hpHiYnWp3+d+Em0ROBSoD/JmFxNV3ysh4bYDndTWdx339hjMlDBYCRJuQui9ApycHXUhz83VzRq3NtqWRTd+MW9qTlkQOIG+JqKwxqezhRQQ8Y9fW3+iSNdJY+g+vBS2bZxV3+ik+yGQj1D8uZLq5ZrY1oi8Dz6jIOkAHzK3UqFpq50p2PHIlzXDtBmpNK1D3UCvleJXp7hgcGGu6OWGTsHrqZ8gHA1cLl7F0rRmf+Uc0UVrPyIt2SBJ2FJAVhWnzDEVHKpuSv21EpBLY4JAnXYtibkYJfkR2LKPZCW0BzoXzQDI3taUTmwFtojTj6RK7xO+nIqM+g/sG8hCQBa04d64+EahsSD01Mf5pzlRRmo7coqOuM1Ow3O0qxHOaxF88jgBcNsJpqOwAlqOCDDnIQue3JK8AP2KCn0SfNzS1pJsW7lu92sO6qC2ZdtFbhxBZEeke2Ltli5e/HY2gMPnffHEHbIRttjcqHb51l1vThnsi+a5S4mbUTOkc/Qqaq65LYiWmqpbhgCvQnhDRW62z2cgUfQ/c5LO5z1zbABjcFQ/UIIlayk3KqLKu8eoCPxp7k191tT2myKLJdwc8PooyYqDv57rabmSGErHCTm3ZyE6KbH96pyv84EYztFLzS+R8iV/hJzo5GXrEnUwa4AUFZ20wQrn/GGity5iJ34zGC87vwfxVGZM7JaKFxqyqxhPTxulNXGAf63fC9oWX4hi4wdmvfQo0eeBDqBaNzI/Bhkr+5qJ6wpX08mqm4uTeQXlGv1+H/6jFHrwBykwYgtZ1VAoYMOn+bP4RPb519AQFzKnZ3CGVsugHAVC6gBYXJY/8s+wLD5+95ejw8vb7ITBYxBk+ZqK5MT2Mn6+5y0BYvdoVNj4/dHh6mMAAAAAAAAAAAAAAAAAAAAAACg4TGh4n"
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/baseline-valid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/baseline-valid.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/baseline-valid",
+  "description": "A baseline ATX v1.0 credential issued by a single trusted authority with one Ed25519 signature. Verifier MUST ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/cross-issuer-key.json
+++ b/sdk/java/src/test/resources/atx-fixtures/cross-issuer-key.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/cross-issuer-key",
+  "description": "An ATX v1.0 credential issued by the primary authority (issuerDid = did:opena2a:authority:opena2a.org) but signed by a DIFFERENT trusted authority's key (did:opena2a:authority:partner.example#key-1). The signature is valid over the canonical payload and the signing authority is independently trusted, yet that key is not controlled by the credential's issuer and is not in its issuerChain. A verifier MUST bind each signature to a key controlled by the credential's issuer and MUST REJECT with a signature-validation reason, so a trusted authority cannot impersonate another. A verifier that tries every configured key would wrongly ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-secondary",
+      "path": "vectors/issuer-secondary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+      "keyId": "did:opena2a:authority:partner.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:partner.example"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-secondary",
+        "path": "vectors/issuer-secondary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+        "keyId": "did:opena2a:authority:partner.example#key-1"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "TYFaUp36vaF5R1RqgDirhkDSArRhH2wZRG4Cttb+LCgUVX7P00vCYap5DRd4rQtwaVKK3d1GPChqI48ErRC0Cg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/expired.json
+++ b/sdk/java/src/test/resources/atx-fixtures/expired.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/expired",
+  "description": "An otherwise-valid ATX whose ExpiresAt is earlier than the verifier's pinned clock. Verifier MUST REJECT with an expiry reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "EXPIRED",
+    "reasonContains": "expired"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2024-12-25T00:00:00Z",
+    "expiresAt": "2025-01-01T00:00:00Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "JOSQmvkgHjPMBHMOwR+EdoTSNGB0wbYZPNoEJpTmHxmfJtR3gHKUtGdBpL1YNauzzdwlouv+NEgocN6wKfJyCw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/malformed-schema.json
+++ b/sdk/java/src/test/resources/atx-fixtures/malformed-schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/malformed-schema",
+  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed using ATCVersion=\"1.0\" canonical bytes because the production canonicalPayload function hardcodes \"1.0\" in the canonical string regardless of the credential's atcVersion field. This is itself a discrepancy worth noting in the reconciliation log; the conformance fixture intentionally still produces a syntactically reasonable file so verifiers can demonstrate they reject on schema-version alone.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "UNSUPPORTED_VERSION",
+    "reasonContains": "version"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "2.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/revoked.json
+++ b/sdk/java/src/test/resources/atx-fixtures/revoked.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/revoked",
+  "description": "A previously-valid ATX whose credential-level Revoked flag is set and whose AgentID also appears in the verifier's CRL. Verifier MUST REJECT with revocation reason. Both rejection paths are exercised.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ],
+    "crl": {
+      "version": 1,
+      "issuedAt": "2026-05-23T12:00:00Z",
+      "nextUpdate": "2026-05-30T12:00:00Z",
+      "entries": [
+        {
+          "agentId": "agent_conformance_test_001",
+          "revokedAt": "2026-05-23T12:00:00Z",
+          "reason": "key compromise (test)"
+        }
+      ],
+      "signature": "TEST_ONLY_UNSIGNED_CRL"
+    }
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "REVOKED",
+    "reasonContains": "revoked"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": true,
+    "revokedAt": "2026-05-23T12:00:00Z",
+    "revocationReason": "key compromise (test)",
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/tampered-signature.json
+++ b/sdk/java/src/test/resources/atx-fixtures/tampered-signature.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/tampered-signature",
+  "description": "An ATX whose Ed25519 signature has been flipped by one bit after signing. All other fields are unchanged. Verifier MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "TutCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/threshold-2of3-cosignature.json
+++ b/sdk/java/src/test/resources/atx-fixtures/threshold-2of3-cosignature.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/threshold-2of3-cosignature",
+  "description": "An ATX cosigned by all three keys of a 2-of-3 threshold issuer (primary plus two cosigners). All three signatures are Ed25519 and cover the same canonical payload. Verifier MUST ACCEPT. A spec-conformant verifier additionally MUST validate at least two of the three signatures for trust level 4.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-cosigner-1",
+      "path": "vectors/issuer-cosigner-1.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      "keyId": "did:opena2a:authority:opena2a.org#key-2"
+    },
+    {
+      "role": "issuer-cosigner-2",
+      "path": "vectors/issuer-cosigner-2.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+      "keyId": "did:opena2a:authority:opena2a.org#key-3"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:opena2a.org-root"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "T+tCrEORj2ipWjPwZIEHxvJUw2qIEWILz6HITxrVEnw9kpnaGmp5a1YGAnKuQZC3Vp4LEmyq6RqkQCIh/C/pAg=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-2",
+        "algorithm": "Ed25519",
+        "value": "VgJM86Nfztvtt4zTMNT+wqI/fhF9bpZ5G5t8Aiq3EzLPhZ1SY0Tc9OgwjPxN7I7nB17gS7xHb7GqYP6vpHQUAw=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-3",
+        "algorithm": "Ed25519",
+        "value": "E/bK1NmDzFnaETj56KTTGkMB8d16JkdhhT0KxKaB61Mur7c4BSk87Pe+KWeaxm+J49mhvLkAPf3/WaQDdltVCg=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/wrong-issuer.json
+++ b/sdk/java/src/test/resources/atx-fixtures/wrong-issuer.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1/wrong-issuer",
+  "description": "A syntactically valid ATX signed by a real keypair, but issued under a DID that is NOT in the verifier's trusted set. The signature itself is valid; the issuer is not. Verifier MUST REJECT with an untrusted-issuer reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-untrusted",
+      "path": "vectors/issuer-untrusted.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+      "keyId": "did:opena2a:authority:attacker.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "UNTRUSTED_ISSUER",
+    "reasonContains": "untrusted"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.0",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 1,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:attacker.example",
+    "issuerChain": [
+      "did:opena2a:authority:attacker.example"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:attacker.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "7dzmtuVx5geTo2PsMEBxK+ETeMrzb2wVMPC7rswh0jpDYhfo0mdQPRfkQ4RUoo3FJMOz00pRDiG1u5dd+CT2CQ=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}


### PR DESCRIPTION
## Summary

Completes the atx-verify extraction chain: a **native Java port** of the ATX verifier into the AIM Java SDK (`org.opena2a.aim.atx`). JVM agents can now verify signed ATX credentials offline, byte-for-byte interoperable with `@opena2a/atx-verify` (TS), `opena2a-registry/pkg/atcverify` (Go), and the Python reference verifier — **including the key-to-issuer binding** shipped this cycle.

## What it does
- **`AtxCanonicalizer`** — v1.0 pipe string + v1.1 JCS(TBS) (RFC 8785 via `io.github.erdtman:java-json-canonicalization`, the same canonicalizer family the JS leg uses → byte-agreement by construction).
- **`LocalAtxVerifier`** — the 5-step pipeline (version → expiry → revocation → issuer-trust → signature) + **key-to-issuer binding** (a key whose `keyId` is a DID-URL may only verify credentials issued by its controller DID, or a signed v1.1 issuerChain authority; no-`#` keyId = unbound/back-compat). Ed25519 verified; ML-DSA-65 presence recorded (delegated, same scope as TS/Python).
- POJOs/records + `RejectCategory` enum.

## Byte-agreement gate
- Pinned v1.1 canonical hash from `atx-conformance/jcs-vectors` (`AtxCanonicalizerTest`).
- Shared conformance fixtures (`baseline-valid`, `-hybrid`, `threshold-2of3`, `tampered-signature`, `expired`, `revoked`, `wrong-issuer`, `malformed-schema`, and **`cross-issuer-key` → MUST REJECT**).
- **18 ATX tests pass.** Full suite green except 2 pre-existing live-backend integration errors (`RealWorldIntegrationTest`, environmental — 403 from a real server, unrelated to this additive change).

## Adversarial review (verifier path) — found + fixed before commit
- **CRITICAL:** `trustScore` used Java's `%.6f` (HALF_UP); Go/Python/JS use round-half-even — would false-reject valid credentials at the 7th decimal. Now `BigDecimal` round-half-even (matches the signer), with a regression test (verified empirically against Python + Node).
- **HIGH:** unknown signature algorithm was silently ignored; now rejected (matches the Go reference + conformance verifier).
- **MEDIUM:** empty `behavioralProfile {}` now projects the canonical 3-field form (matches TS); finding counts kept as `long` (no 32-bit overflow).

## Honesty
Marked Java SDK local verify as shipped in the ROADMAP (true on merge). ML-DSA verification remains delegated (presence-recorded), same as the TS/Python verifiers — callers gate on `mldsaPresent` for PQC assurance.

🤖 Verifier-path change; reviewed via adversarial pass with empirical cross-language rounding verification.