### PR TITLE
sync-to-cloud: respect .sync-protect in sync_migrations()

### DIFF
--- a/scripts/sync-to-cloud.sh
+++ b/scripts/sync-to-cloud.sh
@@ -354,6 +354,16 @@ sync_migrations() {
     local fname
     fname=$(basename "$src_file")
     local dst_file="$dst_migrations/$fname"
+    local relpath="apps/backend/migrations/$fname"
+
+    # Respect .sync-protect: cloud pins some upstream migrations out of its tree
+    # (renamed/renumbered duplicates, bring-up-only test data). The basename
+    # guard below only skips identical filenames -- it misses a protected
+    # migration that was renumbered in cloud, re-syncing a duplicate number.
+    if is_protected "$relpath"; then
+      log_skip "$relpath (protected)"
+      continue
+    fi
 
     if [[ -f "$dst_file" ]]; then
       # Already exists -- do not overwrite (migrations are immutable)


### PR DESCRIPTION
## Problem

The org→cloud sync (`scripts/sync-to-cloud.sh`) re-added migrations that aim-cloud
pins out of its tree via `.sync-protect`. `sync_migrations()` only skipped a migration
when an *identical basename* already existed in the target — it never called
`is_protected()`, unlike every other sync stage (`sync_backend`, `sync_frontend`,
root-file loop).

Cloud renumbered five upstream migrations (075/076/077/089/090). Because the
filenames differ, the basename guard missed them and the sync re-added duplicate
migration numbers, corrupting the migration sequence on every run. This was the
root cause of aim-cloud PR #52's failing Test Backend CI.

## Fix

Add an `is_protected()` guard at the top of the migration loop, mirroring the other
sync stages. Protected migrations are now skipped and logged.

## Verification

Dry-run against a local aim-cloud checkout — all five protected migrations now skip:

```
[SKIP] apps/backend/migrations/075_add_min_trust_score_to_capability_definitions.sql (protected)
[SKIP] apps/backend/migrations/076_add_execution_mode_to_agent_capabilities.sql (protected)
[SKIP] apps/backend/migrations/077_add_trust_attenuation_to_a2a_delegation.sql (protected)
[SKIP] apps/backend/migrations/089_cleanup_test_users_pre_platform_admin.sql (protected)
[SKIP] apps/backend/migrations/090_add_execution_isolation.sql (protected)
```

`bash -n` clean. Pre-push review gate passed.