### PR TITLE
docs(python-sdk): cross-link aicomply as content-compliance companion

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -302,6 +302,7 @@ See [CHANGELOG.md](CHANGELOG.md) for history, [docs/VERSIONING.md](docs/VERSIONI
 - [TypeScript SDK](../typescript/README.md) — local-or-server mode
 - [opena2a CLI](https://github.com/opena2a-org/opena2a) — codebase auditing, credential migration, runtime monitoring
 - [AIM backend](../../README.md) — server, dashboard, deployment
+- [aicomply](https://github.com/opena2a-org/aicomply) — content-compliance companion (`pip install aicomply`); `@guard_io`/`@guard_output` scan the PII, credentials, and regulated data an agent reads and emits, complementing AIM's `@agent.perform_action` capability checks (AIM authorizes the action; aicomply inspects the content)
 
 ## License
 


### PR DESCRIPTION
Adds a one-line cross-link to [aicomply](https://github.com/opena2a-org/aicomply) in the AIM Python SDK README `## Related` section.

The two are genuinely complementary, and the line says so precisely:
- **AIM** (`@agent.perform_action` / capability decorators) authorizes the *action* an agent takes.
- **aicomply** (`@guard_io` / `@guard_output`, `pip install aicomply`) inspects the *content* the agent reads and emits — PII, credentials, regulated data — before it reaches an LLM.

A Python agent dev wiring AIM decorators is exactly who should know aicomply exists for the content layer.

Docs-only, progressive-disclosure (existing `## Related` list). No code, no version bump.

Part of the aicomply visibility work (org plan `todo/2026-06-18-aicomply-adoption-and-pypi-port.md`, Step 2 cross-links).