### PR TITLE
Run vitest once in sdk/typescript test script

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Problem
`sdk/typescript`'s `test` script is `vitest` (watch mode). Any local `npm test` or the git pre-push hook hangs ("Waiting for file changes...") unless `CI=true` is set. CI passes only because GitHub Actions sets `CI=true`.

## Fix
- `test`: `vitest` → `vitest run` (one-shot, exits with a status code)
- add `test:watch`: `vitest` for local watch-mode development

No test or source changes. Syncs to aim-cloud via the SDK directory sync.