### PR TITLE
Rename dashboard heading to 'Security Overview'

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -268,7 +268,7 @@ function DashboardContent() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Executive Dashboard
+            Security Overview
           </h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Security posture overview for agents and MCP servers


### PR DESCRIPTION
## What

Renames the dashboard `<h1>` from **"Executive Dashboard"** to **"Security Overview"**. Subtitle unchanged ("Security posture overview for agents and MCP servers").

## Why

"Executive Dashboard" is off-voice corporate framing. The page is a security posture overview for agents and MCP servers; the heading now matches its actual content and the project's technical/neutral voice.

## Scope

- Single line: `apps/web/app/dashboard/page.tsx` — JSX text content only.
- This is the shared OSS dashboard page; the change flows to aim-cloud via the sync pipeline (editing it directly in aim-cloud would be reverted on the next sync).

Part of the AIM Cloud dashboard UI/UX pass (companion to aim-cloud#58, the identity-badge tier split).