### PR TITLE
Harden auth: block SDK tokens as bearer + session timeout + /auth/me org name

### DIFF
--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -10,6 +10,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// Token issuers. The issuer doubles as a coarse token-type marker so that a
+// long-lived SDK refresh token cannot be presented as a user access token.
+// SECURITY: the access-auth middleware rejects tokens minted with IssuerSDK.
+const (
+	// IssuerUser is the issuer for interactive user access + refresh tokens.
+	IssuerUser = "agent-identity-management"
+	// IssuerSDK is the issuer for the long-lived (90-day) SDK refresh token,
+	// which is only valid at the /auth/refresh endpoint — never as a bearer.
+	IssuerSDK = "agent-identity-management-sdk"
+)
+
 // JWTClaims represents JWT token claims
 type JWTClaims struct {
 	UserID         string `json:"user_id"`
@@ -26,9 +37,10 @@ type JWTService struct {
 	refreshExpiry  time.Duration
 }
 
-// NewJWTService creates a new JWT service
-// SECURITY: Default access token expiry reduced to 15 minutes for enterprise security
-// Users should use refresh tokens to obtain new access tokens
+// NewJWTService creates a new JWT service.
+// Access tokens default to 2h (JWT_ACCESS_TTL); refresh tokens to 7d
+// (JWT_REFRESH_TTL) with rotation. The client enforces a shorter idle timeout
+// on top of the absolute access-token expiry.
 func NewJWTService() *JWTService {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
@@ -64,6 +76,13 @@ func NewJWTService() *JWTService {
 	}
 }
 
+// AccessTTLSeconds returns the configured access-token lifetime in seconds.
+// Used so the refresh endpoint reports the real expiry to clients instead of
+// a hard-coded value.
+func (s *JWTService) AccessTTLSeconds() int {
+	return int(s.accessExpiry.Seconds())
+}
+
 // getEnv is a helper function to get env var with fallback
 func getEnv(key, fallback string) string {
 	if value := os.Getenv(key); value != "" {
@@ -88,7 +107,7 @@ func (s *JWTService) GenerateSDKRefreshToken(userID, orgID, email, role string) 
 			ExpiresAt: jwt.NewNumericDate(now.Add(sdkExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
-			Issuer:    "agent-identity-management-sdk",
+			Issuer:    IssuerSDK,
 			Subject:   userID,
 			ID:        uuid.New().String(),
 		},
@@ -127,7 +146,7 @@ func (s *JWTService) GenerateAccessToken(userID, orgID, email, role string) (str
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.accessExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
-			Issuer:    "agent-identity-management",
+			Issuer:    IssuerUser,
 			Subject:   userID,
 			ID:        uuid.New().String(),
 		},
@@ -147,7 +166,7 @@ func (s *JWTService) GenerateRefreshToken(userID, orgID string) (string, error) 
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.refreshExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
-			Issuer:    "agent-identity-management",
+			Issuer:    IssuerUser,
 			Subject:   userID,
 			ID:        uuid.New().String(),
 		},
@@ -200,7 +219,7 @@ func (s *JWTService) RefreshTokenPair(refreshToken string) (string, string, erro
 	}
 
 	// Check if this is an SDK token (different issuer)
-	isSDKToken := claims.Issuer == "agent-identity-management-sdk"
+	isSDKToken := claims.Issuer == IssuerSDK
 
 	var newAccessToken, newRefreshToken string
 

--- a/apps/backend/internal/interfaces/http/handlers/auth_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_handler.go
@@ -56,15 +56,23 @@ func (h *AuthHandler) Me(c fiber.Ctx) error {
 		})
 	}
 
+	// Resolve the organization name so clients can show the user's org scope
+	// without a second request. Best-effort: omit on lookup failure.
+	var organizationName string
+	if org, orgErr := h.orgRepo.GetByID(user.OrganizationID); orgErr == nil && org != nil {
+		organizationName = org.Name
+	}
+
 	return c.JSON(fiber.Map{
-		"id":             user.ID,
-		"email":          user.Email,
-		"name":           user.Name,
-		"role":           user.Role,
-		"organizationId": user.OrganizationID,
-		"lastLoginAt":    user.LastLoginAt,
-		"createdAt":      user.CreatedAt,
-		"status":         user.Status,
+		"id":               user.ID,
+		"email":            user.Email,
+		"name":             user.Name,
+		"role":             user.Role,
+		"organizationId":   user.OrganizationID,
+		"organizationName": organizationName,
+		"lastLoginAt":      user.LastLoginAt,
+		"createdAt":        user.CreatedAt,
+		"status":           user.Status,
 	})
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
@@ -167,14 +167,13 @@ func (h *AuthRefreshHandler) RefreshToken(c fiber.Ctx) error {
 		}
 	}
 
-	// Return new tokens
-	// SECURITY: Access token expires in 15 minutes (900 seconds) by default
-	// This matches the JWT_ACCESS_TTL setting for short-lived access tokens
+	// Return new tokens. Report the REAL access-token lifetime (JWT_ACCESS_TTL)
+	// so clients schedule their refresh on the correct cadence.
 	return c.JSON(RefreshTokenResponse{
 		AccessToken:  newAccessToken,
 		RefreshToken: newRefreshToken,
 		TokenType:    "Bearer",
-		ExpiresIn:    900, // 15 minutes in seconds (configurable via JWT_ACCESS_TTL env)
+		ExpiresIn:    h.jwtService.AccessTTLSeconds(),
 	})
 }
 

--- a/apps/backend/internal/interfaces/http/middleware/auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth.go
@@ -65,6 +65,16 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 			})
 		}
 
+		// SECURITY: SDK refresh tokens (90-day) must never be accepted as bearer
+		// access tokens. They are only valid at the /auth/refresh endpoint, where
+		// they are exchanged for a short-lived access token. Rejecting them here
+		// stops a long-lived SDK token from being used as a session token.
+		if claims.Issuer == auth.IssuerSDK {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "SDK tokens cannot be used for API access; exchange it at /auth/refresh",
+			})
+		}
+
 		// Parse UUIDs from claims
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {
@@ -116,6 +126,12 @@ func OptionalAuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		claims, err := jwtService.ValidateToken(token)
 		if err != nil {
 			// Invalid token, but don't fail - just continue without auth
+			return c.Next()
+		}
+
+		// SECURITY: never treat an SDK refresh token as an authenticated bearer
+		// (see AuthMiddleware). Continue unauthenticated instead.
+		if claims.Issuer == auth.IssuerSDK {
 			return c.Next()
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/auth_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth_test.go
@@ -215,6 +215,73 @@ func TestAuthMiddleware_SkipsIfAPIKeyAuthenticated(t *testing.T) {
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
 
+func TestAuthMiddleware_RejectsSDKToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
+	jwtService := auth.NewJWTService()
+
+	// A 90-day SDK refresh token must NOT be usable as a bearer access token.
+	sdkToken, err := jwtService.GenerateSDKRefreshToken(
+		uuid.New().String(),
+		uuid.New().String(),
+		"sdk@example.com",
+		"admin",
+	)
+	require.NoError(t, err)
+
+	app := fiber.New()
+	app.Use(AuthMiddleware(jwtService))
+	app.Get("/protected", func(c fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+sdkToken)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	json.Unmarshal(body, &result)
+	assert.Equal(t, "SDK tokens cannot be used for API access; exchange it at /auth/refresh", result["error"])
+}
+
+func TestOptionalAuthMiddleware_RejectsSDKToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
+	jwtService := auth.NewJWTService()
+
+	sdkToken, err := jwtService.GenerateSDKRefreshToken(
+		uuid.New().String(),
+		uuid.New().String(),
+		"sdk@example.com",
+		"admin",
+	)
+	require.NoError(t, err)
+
+	var hasUserID bool
+
+	app := fiber.New()
+	app.Use(OptionalAuthMiddleware(jwtService))
+	app.Get("/public", func(c fiber.Ctx) error {
+		hasUserID = c.Locals("user_id") != nil
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.Header.Set("Authorization", "Bearer "+sdkToken)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Request still succeeds (optional), but the SDK token must not authenticate.
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.False(t, hasUserID, "SDK token must not set user context")
+}
+
 func TestOptionalAuthMiddleware_NoToken(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
 	jwtService := auth.NewJWTService()

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Sidebar } from "@/components/sidebar";
 import { DashboardHeader } from "@/components/dashboard-header";
+import { IdleTimeoutGuard } from "@/components/idle-timeout-guard";
 import { useDeactivationCheck } from "@/hooks/use-deactivation-check";
 
 export default function DashboardLayout({
@@ -14,6 +15,8 @@ export default function DashboardLayout({
 
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-gray-950">
+      {/* Idle / absolute session timeout (30m idle, 8h cap) */}
+      <IdleTimeoutGuard />
       <Sidebar />
 
       {/* Main Content Area with Header */}

--- a/apps/web/components/idle-timeout-guard.tsx
+++ b/apps/web/components/idle-timeout-guard.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useIdleTimeout } from "@/hooks/use-idle-timeout";
+
+/**
+ * Mounts the idle/absolute session timeout and renders a "Stay signed in?"
+ * warning modal during the final 2 minutes before auto-logout.
+ * Render once inside the authenticated dashboard layout.
+ */
+export function IdleTimeoutGuard() {
+  const { showWarning, secondsLeft, stayActive } = useIdleTimeout();
+
+  if (!showWarning) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="idle-timeout-title"
+      aria-describedby="idle-timeout-desc"
+    >
+      <div className="w-full max-w-sm rounded-lg bg-white dark:bg-gray-800 shadow-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2
+          id="idle-timeout-title"
+          className="text-lg font-semibold text-gray-900 dark:text-white"
+        >
+          Still there?
+        </h2>
+        <p
+          id="idle-timeout-desc"
+          className="mt-2 text-sm text-gray-600 dark:text-gray-400"
+        >
+          You&apos;ll be signed out in{" "}
+          <span className="font-semibold text-gray-900 dark:text-white tabular-nums">
+            {secondsLeft}s
+          </span>{" "}
+          due to inactivity, to keep your account secure.
+        </p>
+        <div className="mt-5 flex justify-end">
+          <button
+            type="button"
+            onClick={stayActive}
+            className="inline-flex items-center px-4 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+            autoFocus
+          >
+            Stay signed in
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/use-idle-timeout.ts
+++ b/apps/web/hooks/use-idle-timeout.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+import { toast } from "sonner";
+
+// Session-timeout policy (CSR/CPO, 2026-06-19):
+//   - 30 min of inactivity -> auto-logout, with a 2-min warning beforehand.
+//   - 8 h absolute cap regardless of activity.
+// These are CLIENT-side convenience boundaries; the real security boundaries
+// are the server access-token exp and the refresh-token expiry. Values are
+// overridable via env for testing.
+const num = (v: string | undefined, fallback: number) => {
+  const n = v ? Number(v) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+const IDLE_LIMIT_MS = num(process.env.NEXT_PUBLIC_IDLE_TIMEOUT_MS, 30 * 60 * 1000);
+const WARN_BEFORE_MS = num(process.env.NEXT_PUBLIC_IDLE_WARN_MS, 2 * 60 * 1000);
+const ABSOLUTE_CAP_MS = num(process.env.NEXT_PUBLIC_SESSION_CAP_MS, 8 * 60 * 60 * 1000);
+const TICK_MS = 5 * 1000;
+const ACTIVITY_THROTTLE_MS = 5 * 1000;
+
+const TOKEN_KEY = "auth_token";
+const LAST_ACTIVITY_KEY = "last_activity";
+const SESSION_START_KEY = "session_start";
+
+const PUBLIC_ROUTE_PREFIXES = [
+  "/auth/login",
+  "/auth/register",
+  "/auth/callback",
+  "/auth/registration-pending",
+  "/auth/error",
+];
+
+type IdleState = { showWarning: boolean; secondsLeft: number };
+
+function now() {
+  return Date.now();
+}
+
+function readLS(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drives idle/absolute session timeout on the dashboard shell.
+ * Returns warning state so a UI component can show a "Stay signed in?" prompt.
+ */
+export function useIdleTimeout(): IdleState & { stayActive: () => void } {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [state, setState] = useState<IdleState>({ showWarning: false, secondsLeft: 0 });
+  const lastWriteRef = useRef(0);
+  const warningActiveRef = useRef(false);
+  const loggingOutRef = useRef(false);
+
+  const isPublicRoute = PUBLIC_ROUTE_PREFIXES.some((p) => pathname?.startsWith(p));
+
+  const clearWarning = useCallback(() => {
+    if (warningActiveRef.current) {
+      warningActiveRef.current = false;
+      setState({ showWarning: false, secondsLeft: 0 });
+    }
+  }, []);
+
+  const recordActivity = useCallback(() => {
+    const t = now();
+    // Real activity must dismiss an active warning AND reset the idle clock
+    // immediately — bypass the write throttle in that case so the user is not
+    // logged out while interacting.
+    if (warningActiveRef.current) {
+      clearWarning();
+      lastWriteRef.current = 0;
+    }
+    if (t - lastWriteRef.current < ACTIVITY_THROTTLE_MS) return;
+    lastWriteRef.current = t;
+    try {
+      localStorage.setItem(LAST_ACTIVITY_KEY, String(t));
+    } catch {
+      /* ignore storage failures */
+    }
+  }, [clearWarning]);
+
+  const stayActive = useCallback(() => {
+    lastWriteRef.current = 0; // force the write through the throttle
+    clearWarning();
+    recordActivity();
+  }, [clearWarning, recordActivity]);
+
+  useEffect(() => {
+    if (isPublicRoute) return;
+    // Only run for an authenticated session.
+    if (!readLS(TOKEN_KEY)) return;
+
+    // Seed activity + absolute-session start if absent. (api.setToken also
+    // resets these on login so a stale window can't carry across sessions.)
+    try {
+      if (!readLS(LAST_ACTIVITY_KEY)) localStorage.setItem(LAST_ACTIVITY_KEY, String(now()));
+      if (!readLS(SESSION_START_KEY)) localStorage.setItem(SESSION_START_KEY, String(now()));
+    } catch {
+      /* ignore */
+    }
+
+    const redirectToLogin = (reason?: "idle" | "cap") => {
+      if (loggingOutRef.current) return;
+      loggingOutRef.current = true;
+      if (reason) {
+        toast.info(
+          reason === "idle"
+            ? "Signed out after 30 minutes of inactivity."
+            : "Your 8-hour session ended. Please sign in again.",
+          { duration: 6000 }
+        );
+      }
+      router.replace(reason ? "/auth/login?reason=timeout" : "/auth/login");
+    };
+
+    const doLogout = async (reason: "idle" | "cap") => {
+      if (loggingOutRef.current) return;
+      try {
+        await api.logout();
+      } catch {
+        api.clearToken();
+      }
+      redirectToLogin(reason);
+    };
+
+    const activityEvents = ["pointerdown", "keydown", "scroll", "touchstart"];
+    activityEvents.forEach((e) =>
+      window.addEventListener(e, recordActivity, { passive: true })
+    );
+
+    // Cross-tab coordination via storage events.
+    const onStorage = (e: StorageEvent) => {
+      // Signed out in another tab -> follow suit (the other tab cleared keys).
+      if (e.key === TOKEN_KEY && e.newValue === null) {
+        redirectToLogin();
+        return;
+      }
+      // Another tab recorded activity -> clear our warning.
+      if (e.key === LAST_ACTIVITY_KEY) clearWarning();
+    };
+    window.addEventListener("storage", onStorage);
+
+    const interval = setInterval(() => {
+      // If the token vanished (logged out in this or another tab), bail out.
+      if (!readLS(TOKEN_KEY)) {
+        redirectToLogin();
+        return;
+      }
+      const t = now();
+      const last = Number(readLS(LAST_ACTIVITY_KEY)) || t;
+      const start = Number(readLS(SESSION_START_KEY)) || t;
+      const idle = t - last;
+      const sessionAge = t - start;
+
+      if (sessionAge >= ABSOLUTE_CAP_MS) {
+        void doLogout("cap");
+        return;
+      }
+      if (idle >= IDLE_LIMIT_MS) {
+        void doLogout("idle");
+        return;
+      }
+      if (idle >= IDLE_LIMIT_MS - WARN_BEFORE_MS) {
+        warningActiveRef.current = true;
+        const secondsLeft = Math.max(0, Math.ceil((IDLE_LIMIT_MS - idle) / 1000));
+        setState({ showWarning: true, secondsLeft });
+      } else {
+        clearWarning();
+      }
+    }, TICK_MS);
+
+    return () => {
+      clearInterval(interval);
+      activityEvents.forEach((e) => window.removeEventListener(e, recordActivity));
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [isPublicRoute, recordActivity, clearWarning, router]);
+
+  return { ...state, stayActive };
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -520,12 +520,23 @@ class APIClient {
   }
 
   setToken(token: string, refreshToken?: string) {
+    // Detect a fresh login (logged-out -> logged-in) vs a token refresh, so the
+    // absolute session-timeout window is started on login but NOT reset on every
+    // refresh (which would defeat the 8h cap).
+    const isFreshLogin =
+      !this.token &&
+      (typeof window === "undefined" || !localStorage.getItem("auth_token"));
     this.token = token;
     if (typeof window !== "undefined") {
       localStorage.setItem("auth_token", token);
       if (refreshToken) {
         this.refreshToken = refreshToken;
         localStorage.setItem("refresh_token", refreshToken);
+      }
+      if (isFreshLogin) {
+        const t = String(Date.now());
+        localStorage.setItem("session_start", t);
+        localStorage.setItem("last_activity", t);
       }
     }
   }
@@ -552,6 +563,10 @@ class APIClient {
     if (typeof window !== "undefined") {
       localStorage.removeItem("auth_token");
       localStorage.removeItem("refresh_token");
+      // Clear idle/absolute session-timeout bookkeeping so the next login
+      // starts a fresh session window instead of inheriting a stale start time.
+      localStorage.removeItem("session_start");
+      localStorage.removeItem("last_activity");
     }
   }
 


### PR DESCRIPTION
Auth & session hardening — **Wave 1** (plan: threat-modeled remediation, CSR/CA).

## Changes
1. **Block SDK tokens used as bearer access tokens** (HIGH). The access middleware (`AuthMiddleware` + `OptionalAuthMiddleware`) now rejects any token minted with the SDK issuer (`agent-identity-management-sdk`). A 90-day SDK refresh token can no longer act as a session token — it remains valid only at `/auth/refresh`, where it's exchanged for a short-lived access token. Adds `IssuerUser`/`IssuerSDK` constants + regression tests (`TestAuthMiddleware_RejectsSDKToken`, `TestOptionalAuthMiddleware_RejectsSDKToken`).
2. **Idle / absolute session timeout** (HIGH — the "proper session timeout" ask). New `useIdleTimeout` hook + `IdleTimeoutGuard` mounted in the dashboard layout: 30-min inactivity → 2-min "Stay signed in?" warning → auto-logout; **8h absolute cap**. Cross-tab via storage events; toast + redirect to `/auth/login?reason=timeout`. `clearToken` clears the session bookkeeping and `setToken` starts a fresh window only on real login (not on refresh, so the cap survives refreshes).
3. **`/auth/me` returns `organizationName`** so clients can show org scope without a second request.
4. **Honest token TTL** — the refresh response now reports the real access TTL (`AccessTTLSeconds()`) instead of a hard-coded `900`; removed stale "15 minutes" comments. (No behavior change — the access TTL was already 2h.)

## Out of scope (planned separately)
httpOnly-only token storage migration (P7), server-side logout revocation (P5), CORS preview allowlist (P6).

## Verification
- `go build ./...` + `go test` on middleware/auth/handlers green (incl. new SDK-reject tests).
- Adversarial self-review run; 2 MEDIUM idle-hook bugs found & fixed (login not resetting the window; cross-tab logout disabling surviving tabs) and re-verified.
- Idle timeout verified live (Playwright, short-TTL env): warning → "Stay signed in" reset → full idle → auto-logout to `/auth/login?reason=timeout`, token + `session_start` cleared.
- HMA `secure` 100/100.

Cloud companion (deployed supersets + frontend): aim-cloud#<follows>.