### PR TITLE
Separate access vs refresh tokens with a typ claim (grace rollout)

### DIFF
--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -21,12 +21,27 @@ const (
 	IssuerSDK = "agent-identity-management-sdk"
 )
 
+// Token types. The `typ` claim separates access tokens (valid as a bearer) from
+// refresh tokens (valid only at /auth/refresh), so a refresh token cannot be
+// replayed as a session token.
+// GRACE: tokens minted before this claim existed have an empty TokenType; the
+// access middleware and refresh endpoint treat an empty type as legacy and
+// allow it, so this rolls out without breaking live sessions. Newly issued
+// tokens always carry a type and are enforced immediately.
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
+	TokenTypeSDK     = "sdk"
+)
+
 // JWTClaims represents JWT token claims
 type JWTClaims struct {
 	UserID         string `json:"user_id"`
 	OrganizationID string `json:"organization_id"`
 	Email          string `json:"email"`
 	Role           string `json:"role"`
+	// TokenType is "access" | "refresh" | "sdk". Empty on legacy tokens.
+	TokenType string `json:"typ,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -103,6 +118,7 @@ func (s *JWTService) GenerateSDKRefreshToken(userID, orgID, email, role string) 
 		OrganizationID: orgID,
 		Email:          email,
 		Role:           role,
+		TokenType:      TokenTypeSDK,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(sdkExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -142,6 +158,7 @@ func (s *JWTService) GenerateAccessToken(userID, orgID, email, role string) (str
 		OrganizationID: orgID,
 		Email:          email,
 		Role:           role,
+		TokenType:      TokenTypeAccess,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.accessExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -162,6 +179,7 @@ func (s *JWTService) GenerateRefreshToken(userID, orgID string) (string, error) 
 	claims := JWTClaims{
 		UserID:         userID,
 		OrganizationID: orgID,
+		TokenType:      TokenTypeRefresh,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.refreshExpiry)),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -203,6 +221,12 @@ func (s *JWTService) RefreshAccessToken(refreshToken string) (string, error) {
 		return "", err
 	}
 
+	// An access token must not be usable to mint another access token. (Empty
+	// TokenType = legacy token issued before this claim; allowed during grace.)
+	if claims.TokenType == TokenTypeAccess {
+		return "", fmt.Errorf("access token cannot be used to refresh")
+	}
+
 	// Generate new access token
 	return s.GenerateAccessToken(claims.UserID, claims.OrganizationID, claims.Email, claims.Role)
 }
@@ -216,6 +240,12 @@ func (s *JWTService) RefreshTokenPair(refreshToken string) (string, string, erro
 	claims, err := s.ValidateToken(refreshToken)
 	if err != nil {
 		return "", "", err
+	}
+
+	// An access token must not be replayed at the refresh endpoint. (Empty
+	// TokenType = legacy token issued before this claim; allowed during grace.)
+	if claims.TokenType == TokenTypeAccess {
+		return "", "", fmt.Errorf("access token cannot be used to refresh")
 	}
 
 	// Check if this is an SDK token (different issuer)

--- a/apps/backend/internal/infrastructure/auth/jwt_test.go
+++ b/apps/backend/internal/infrastructure/auth/jwt_test.go
@@ -290,6 +290,49 @@ func TestJWTService_RefreshTokenPair(t *testing.T) {
 	assert.Equal(t, userID, refreshClaims.UserID)
 }
 
+func TestJWTService_RefreshTokenPair_RejectsAccessToken(t *testing.T) {
+	cleanup := setupJWTTest(t)
+	defer cleanup()
+
+	service := NewJWTService()
+	userID := uuid.New().String()
+	orgID := uuid.New().String()
+
+	// An access token must not be replayable at the refresh endpoint.
+	accessToken, err := service.GenerateAccessToken(userID, orgID, "test@example.com", "admin")
+	require.NoError(t, err)
+
+	_, _, err = service.RefreshTokenPair(accessToken)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access token cannot be used to refresh")
+}
+
+func TestJWTService_TokenTypesAreSet(t *testing.T) {
+	cleanup := setupJWTTest(t)
+	defer cleanup()
+
+	service := NewJWTService()
+	userID := uuid.New().String()
+	orgID := uuid.New().String()
+
+	access, refresh, err := service.GenerateTokenPair(userID, orgID, "t@example.com", "admin")
+	require.NoError(t, err)
+	sdk, err := service.GenerateSDKRefreshToken(userID, orgID, "t@example.com", "admin")
+	require.NoError(t, err)
+
+	ac, err := service.ValidateToken(access)
+	require.NoError(t, err)
+	assert.Equal(t, TokenTypeAccess, ac.TokenType)
+
+	rc, err := service.ValidateToken(refresh)
+	require.NoError(t, err)
+	assert.Equal(t, TokenTypeRefresh, rc.TokenType)
+
+	sc, err := service.ValidateToken(sdk)
+	require.NoError(t, err)
+	assert.Equal(t, TokenTypeSDK, sc.TokenType)
+}
+
 func TestJWTService_RefreshTokenPair_SDKToken(t *testing.T) {
 	cleanup := setupJWTTest(t)
 	defer cleanup()

--- a/apps/backend/internal/interfaces/http/middleware/auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth.go
@@ -75,6 +75,16 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 			})
 		}
 
+		// SECURITY: only access tokens are valid bearers. A refresh token (or any
+		// non-access type) must not be replayed as a session token. An empty type
+		// is a legacy token issued before the `typ` claim existed — allowed during
+		// the rollout grace window; legacy tokens age out within their TTL.
+		if claims.TokenType != "" && claims.TokenType != auth.TokenTypeAccess {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "This token cannot be used for API access",
+			})
+		}
+
 		// Parse UUIDs from claims
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {
@@ -132,6 +142,13 @@ func OptionalAuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		// SECURITY: never treat an SDK refresh token as an authenticated bearer
 		// (see AuthMiddleware). Continue unauthenticated instead.
 		if claims.Issuer == auth.IssuerSDK {
+			return c.Next()
+		}
+
+		// SECURITY: only access tokens authenticate. A non-access type (e.g. a
+		// refresh token) must not set user context. Empty type = legacy, allowed
+		// during the grace window (see AuthMiddleware).
+		if claims.TokenType != "" && claims.TokenType != auth.TokenTypeAccess {
 			return c.Next()
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/auth_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
 	"github.com/stretchr/testify/assert"
@@ -280,6 +282,81 @@ func TestOptionalAuthMiddleware_RejectsSDKToken(t *testing.T) {
 	// Request still succeeds (optional), but the SDK token must not authenticate.
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 	assert.False(t, hasUserID, "SDK token must not set user context")
+}
+
+func TestAuthMiddleware_RejectsRefreshToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
+	jwtService := auth.NewJWTService()
+
+	// A refresh token (typ=refresh) must not be usable as a bearer access token.
+	refreshToken, err := jwtService.GenerateRefreshToken(uuid.New().String(), uuid.New().String())
+	require.NoError(t, err)
+
+	app := fiber.New()
+	app.Use(AuthMiddleware(jwtService))
+	app.Get("/protected", func(c fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+refreshToken)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	json.Unmarshal(body, &result)
+	assert.Equal(t, "This token cannot be used for API access", result["error"])
+}
+
+func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
+	const secret = "test-secret-key-for-testing-purposes-32chars"
+	t.Setenv("JWT_SECRET", secret)
+	jwtService := auth.NewJWTService()
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	now := time.Now()
+
+	// Craft a legacy token (no `typ` claim) the way tokens were minted before
+	// token-type separation. The grace window must still accept these.
+	legacyClaims := auth.JWTClaims{
+		UserID:         userID.String(),
+		OrganizationID: orgID.String(),
+		Email:          "legacy@example.com",
+		Role:           "admin",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			Issuer:    auth.IssuerUser,
+			Subject:   userID.String(),
+		},
+	}
+	legacyToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacyClaims).SignedString([]byte(secret))
+	require.NoError(t, err)
+
+	var capturedUserID uuid.UUID
+	app := fiber.New()
+	app.Use(AuthMiddleware(jwtService))
+	app.Get("/protected", func(c fiber.Ctx) error {
+		capturedUserID = c.Locals("user_id").(uuid.UUID)
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+legacyToken)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, userID, capturedUserID)
 }
 
 func TestOptionalAuthMiddleware_NoToken(t *testing.T) {


### PR DESCRIPTION
Auth hardening **Wave 2** — closes the remaining half of the token-confusion gap (F1).

> **Stacked on #305** (base = `feat/auth-session-hardening-wave1`). Review/merge #305 first, or I'll retarget this to `main` once it merges. The diff shown here is Wave 2 only.

## Problem
Wave 1 (#305) blocked the **SDK** issuer at the access middleware. But a regular **user refresh token** (7-day) shares the user issuer with access tokens, so `ValidateToken` couldn't tell them apart — a refresh token could still be replayed as a bearer access token.

## Fix — `typ` claim with a grace window
- New `typ` claim on every token: `access` | `refresh` | `sdk` (set in all three generators).
- **Access middleware** (`AuthMiddleware` + `OptionalAuthMiddleware`) accepts only `typ=access`; rejects `refresh`/other types.
- **`/auth/refresh`** rejects a presented token whose `typ=access`.
- **GRACE (no broken sessions):** tokens minted before this claim have an empty `typ` and are treated as legacy — still accepted as access / allowed to refresh. So every currently-logged-in user and every deployed SDK keeps working; legacy tokens age out within their TTL (≤7d user / ≤90d SDK). Newly issued tokens carry a type and are enforced immediately, so the gap is closed for all new tokens on day one.

### Why grace instead of hard enforcement
A hard cutover would 401 every live session and every deployed SDK at once. The grace window closes the gap for new tokens immediately while letting legacy tokens expire naturally. A later phase can drop the empty-`typ` allowance once all legacy tokens have aged out.

## Verification
- `go build ./...` + `go test` green. New tests: refresh-as-bearer → 401; **legacy no-`typ` token still authenticates** (grace); `RefreshTokenPair` rejects an access token; all generators stamp `typ`.
- Manual bypass review: no alt token-minting path (ATC uses separate EdDSA key + its own verifier, rejected by HMAC alg-pinning); exact string compares; grace is the only intentional residual.
- HMA `secure` 100/100.

Backend-only, non-protected files → syncs to aim-cloud (no cloud-direct companion needed).