### PR TITLE
Server-side token revocation on logout + opt-in CORS preview origins

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -148,6 +148,18 @@ func main() {
 	// Initialize infrastructure services
 	jwtService := auth.NewJWTService()
 
+	// Wire server-side token revocation (logout / denylist) to Redis when
+	// available. Fails CLOSED on a store outage by default; set
+	// AUTH_REVOCATION_FAIL_OPEN=true to prefer availability over strict
+	// revocation. Without Redis, revocation is disabled (tokens still expire).
+	if cacheService != nil {
+		failOpen := strings.EqualFold(os.Getenv("AUTH_REVOCATION_FAIL_OPEN"), "true")
+		jwtService.SetRevoker(auth.NewTokenRevoker(cacheService, failOpen))
+		log.Printf("ℹ️  Token revocation enabled (fail-open=%v)", failOpen)
+	} else {
+		log.Println("ℹ️  Token revocation disabled (no Redis configured)")
+	}
+
 	// Initialize email service
 	emailService, err := initEmailService()
 	if err != nil {

--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -47,9 +48,38 @@ type JWTClaims struct {
 
 // JWTService handles JWT operations
 type JWTService struct {
-	secret         []byte
-	accessExpiry   time.Duration
-	refreshExpiry  time.Duration
+	secret        []byte
+	accessExpiry  time.Duration
+	refreshExpiry time.Duration
+	revoker       *TokenRevoker
+}
+
+// SetRevoker attaches a token-revocation store. Optional: if never set,
+// revocation is disabled and IsRevoked always returns false.
+func (s *JWTService) SetRevoker(r *TokenRevoker) {
+	s.revoker = r
+}
+
+// IsRevoked reports whether the token identified by jti has been revoked.
+func (s *JWTService) IsRevoked(ctx context.Context, jti string) bool {
+	return s.revoker.IsRevoked(ctx, jti)
+}
+
+// RevokeToken denylists the given token (by its jti) for its remaining lifetime.
+// Best-effort: an invalid/expired token or a missing revoker is a no-op.
+func (s *JWTService) RevokeToken(ctx context.Context, tokenString string) error {
+	if s.revoker == nil || tokenString == "" {
+		return nil
+	}
+	claims, err := s.ValidateToken(tokenString)
+	if err != nil || claims.ExpiresAt == nil {
+		return nil
+	}
+	ttl := time.Until(claims.ExpiresAt.Time)
+	if ttl <= 0 {
+		return nil
+	}
+	return s.revoker.Revoke(ctx, claims.ID, ttl)
 }
 
 // NewJWTService creates a new JWT service.

--- a/apps/backend/internal/infrastructure/auth/token_revocation.go
+++ b/apps/backend/internal/infrastructure/auth/token_revocation.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	revokedKeyPrefix = "revoked:jti:"
+	// negCacheTTL bounds how long a "not revoked" result is cached in-process.
+	// It also bounds cross-instance revocation lag (a token revoked on another
+	// instance is honored within this window) and the blast radius of a store
+	// outage (cached tokens are served without touching the store).
+	negCacheTTL    = 30 * time.Second
+	negCacheMaxLen = 50000
+)
+
+// RevocationStore is the subset of the cache used for the jti denylist.
+// *cache.RedisCache satisfies it structurally (no import of cache here, so no
+// dependency cycle).
+type RevocationStore interface {
+	Exists(ctx context.Context, key string) (bool, error)
+	Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error
+}
+
+// TokenRevoker maintains a jti denylist in a shared store (Redis) with a small
+// in-process negative cache. On a store error it fails CLOSED by default
+// (treats the token as revoked) unless failOpen is set.
+type TokenRevoker struct {
+	store    RevocationStore
+	failOpen bool
+	mu       sync.Mutex
+	negCache map[string]time.Time // jti -> "known not revoked until"
+}
+
+// NewTokenRevoker builds a revoker over the given store. failOpen=false means a
+// store error rejects the request (secure default); failOpen=true allows it.
+func NewTokenRevoker(store RevocationStore, failOpen bool) *TokenRevoker {
+	return &TokenRevoker{
+		store:    store,
+		failOpen: failOpen,
+		negCache: make(map[string]time.Time),
+	}
+}
+
+// IsRevoked reports whether the given jti has been revoked. nil receiver or no
+// store means revocation is disabled (returns false) — absence of a store must
+// not lock everyone out. On a store error the result is !failOpen.
+func (r *TokenRevoker) IsRevoked(ctx context.Context, jti string) bool {
+	if r == nil || r.store == nil || jti == "" {
+		return false
+	}
+
+	now := time.Now()
+	r.mu.Lock()
+	if exp, ok := r.negCache[jti]; ok && now.Before(exp) {
+		r.mu.Unlock()
+		return false
+	}
+	r.mu.Unlock()
+
+	exists, err := r.store.Exists(ctx, revokedKeyPrefix+jti)
+	if err != nil {
+		// Store unreachable: fail closed (revoked) unless explicitly fail-open.
+		return !r.failOpen
+	}
+	if exists {
+		return true
+	}
+
+	r.mu.Lock()
+	if len(r.negCache) >= negCacheMaxLen {
+		for k, e := range r.negCache {
+			if now.After(e) {
+				delete(r.negCache, k)
+			}
+		}
+	}
+	// Hard cap: if still full after evicting expired entries (pathological load),
+	// skip caching this jti rather than growing unbounded. Correctness is
+	// preserved — uncached jtis just consult the store each time.
+	if len(r.negCache) < negCacheMaxLen {
+		r.negCache[jti] = now.Add(negCacheTTL)
+	}
+	r.mu.Unlock()
+	return false
+}
+
+// Revoke denylists a jti until ttl elapses. Best-effort: a nil receiver/store
+// or non-positive ttl is a no-op. Evicts any local "not revoked" cache entry so
+// the revocation is enforced immediately on this instance.
+func (r *TokenRevoker) Revoke(ctx context.Context, jti string, ttl time.Duration) error {
+	if r == nil || r.store == nil || jti == "" || ttl <= 0 {
+		return nil
+	}
+	r.mu.Lock()
+	delete(r.negCache, jti)
+	r.mu.Unlock()
+	return r.store.Set(ctx, revokedKeyPrefix+jti, "1", ttl)
+}

--- a/apps/backend/internal/infrastructure/auth/token_revocation_test.go
+++ b/apps/backend/internal/infrastructure/auth/token_revocation_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRevocationStore struct {
+	data    map[string]bool
+	failErr error
+}
+
+func (f *fakeRevocationStore) Exists(ctx context.Context, key string) (bool, error) {
+	if f.failErr != nil {
+		return false, f.failErr
+	}
+	return f.data[key], nil
+}
+
+func (f *fakeRevocationStore) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	if f.failErr != nil {
+		return f.failErr
+	}
+	if f.data == nil {
+		f.data = map[string]bool{}
+	}
+	f.data[key] = true
+	return nil
+}
+
+func TestTokenRevoker_RevokeThenRevoked(t *testing.T) {
+	store := &fakeRevocationStore{data: map[string]bool{}}
+	r := NewTokenRevoker(store, false)
+	ctx := context.Background()
+
+	assert.False(t, r.IsRevoked(ctx, "jti-1"), "fresh jti not revoked")
+	require.NoError(t, r.Revoke(ctx, "jti-1", time.Minute))
+	assert.True(t, r.IsRevoked(ctx, "jti-1"), "jti revoked after Revoke")
+}
+
+func TestTokenRevoker_NilAndNoStoreDisabled(t *testing.T) {
+	ctx := context.Background()
+	var nilRevoker *TokenRevoker
+	assert.False(t, nilRevoker.IsRevoked(ctx, "x"), "nil revoker disables revocation")
+	assert.NoError(t, nilRevoker.Revoke(ctx, "x", time.Minute))
+
+	noStore := NewTokenRevoker(nil, false)
+	assert.False(t, noStore.IsRevoked(ctx, "x"), "no store disables revocation")
+}
+
+func TestTokenRevoker_EmptyJTIIsNoOp(t *testing.T) {
+	store := &fakeRevocationStore{data: map[string]bool{}}
+	r := NewTokenRevoker(store, false) // fail-closed
+	ctx := context.Background()
+
+	// An empty jti must never be denylisted (would collide on key prefix) and
+	// must not be treated as revoked even under fail-closed.
+	require.NoError(t, r.Revoke(ctx, "", time.Minute))
+	assert.False(t, r.IsRevoked(ctx, ""), "empty jti is a no-op, never revoked")
+	_, stored := store.data[revokedKeyPrefix]
+	assert.False(t, stored, "empty jti must not write a denylist key")
+}
+
+func TestTokenRevoker_FailClosedOnStoreError(t *testing.T) {
+	store := &fakeRevocationStore{failErr: errors.New("redis down")}
+	r := NewTokenRevoker(store, false) // fail-closed
+	assert.True(t, r.IsRevoked(context.Background(), "jti-new"), "store error => fail closed (revoked)")
+}
+
+func TestTokenRevoker_FailOpenOnStoreError(t *testing.T) {
+	store := &fakeRevocationStore{failErr: errors.New("redis down")}
+	r := NewTokenRevoker(store, true) // fail-open
+	assert.False(t, r.IsRevoked(context.Background(), "jti-new"), "store error => fail open (allowed)")
+}
+
+func TestTokenRevoker_NegativeCacheSurvivesOutage(t *testing.T) {
+	store := &fakeRevocationStore{data: map[string]bool{}}
+	r := NewTokenRevoker(store, false) // fail-closed
+	ctx := context.Background()
+
+	// First check populates the negative cache (not revoked).
+	assert.False(t, r.IsRevoked(ctx, "jti-cached"))
+
+	// Store now errors. A fail-closed revoker would normally reject, but the
+	// cached "not revoked" result must still be served within the cache window,
+	// bounding the blast radius of an outage.
+	store.failErr = errors.New("redis down")
+	assert.False(t, r.IsRevoked(ctx, "jti-cached"), "cached jti served despite outage")
+
+	// An uncached jti still fails closed during the outage.
+	assert.True(t, r.IsRevoked(ctx, "jti-uncached"), "uncached jti fails closed")
+}

--- a/apps/backend/internal/interfaces/http/handlers/auth_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_handler.go
@@ -274,6 +274,17 @@ func (h *AuthHandler) Logout(c fiber.Ctx) error {
 		)
 	}
 
+	// SECURITY: revoke the presented tokens server-side so they cannot be reused
+	// before they expire. Best-effort: no-op if revocation isn't configured or the
+	// token is absent/invalid. Covers both the access token (header or cookie) and
+	// the refresh token (so a logged-out session can't be silently renewed).
+	if accessToken := bearerToken(c); accessToken != "" {
+		_ = h.jwtService.RevokeToken(c.Context(), accessToken)
+	}
+	if refreshToken := c.Cookies("refresh_token"); refreshToken != "" {
+		_ = h.jwtService.RevokeToken(c.Context(), refreshToken)
+	}
+
 	// Clear cookies
 	c.Cookie(&fiber.Cookie{
 		Name:     "access_token",
@@ -292,4 +303,16 @@ func (h *AuthHandler) Logout(c fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"message": "Logged out successfully",
 	})
+}
+
+// bearerToken extracts the JWT from the Authorization header ("Bearer <token>")
+// or, failing that, the access_token cookie.
+func bearerToken(c fiber.Ctx) string {
+	if authHeader := c.Get("Authorization"); authHeader != "" {
+		parts := strings.Split(authHeader, " ")
+		if len(parts) == 2 && parts[0] == "Bearer" {
+			return parts[1]
+		}
+	}
+	return c.Cookies("access_token")
 }

--- a/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
@@ -54,6 +54,15 @@ func (h *AuthRefreshHandler) RefreshToken(c fiber.Ctx) error {
 
 	// Check if this is an SDK token and verify it's not revoked BEFORE rotating
 	tokenID, err := h.jwtService.GetTokenID(req.RefreshToken)
+
+	// SECURITY: a refresh token revoked on logout must not be able to mint new
+	// tokens. (SDK tokens are additionally checked against the DB table below.)
+	if err == nil && tokenID != "" && h.jwtService.IsRevoked(c.Context(), tokenID) {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Token has been revoked or is invalid",
+		})
+	}
+
 	if err == nil && tokenID != "" {
 		// Hash the token to check if it's tracked and revoked
 		hasher := sha256.New()

--- a/apps/backend/internal/interfaces/http/middleware/auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth.go
@@ -85,6 +85,14 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 			})
 		}
 
+		// SECURITY: reject tokens revoked server-side (e.g. on logout). No-op when
+		// revocation is not configured; fails closed on a store outage by default.
+		if jwtService.IsRevoked(c.Context(), claims.ID) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Token has been revoked",
+			})
+		}
+
 		// Parse UUIDs from claims
 		userID, err := uuid.Parse(claims.UserID)
 		if err != nil {
@@ -149,6 +157,11 @@ func OptionalAuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		// refresh token) must not set user context. Empty type = legacy, allowed
 		// during the grace window (see AuthMiddleware).
 		if claims.TokenType != "" && claims.TokenType != auth.TokenTypeAccess {
+			return c.Next()
+		}
+
+		// SECURITY: a revoked token must not authenticate, even optionally.
+		if jwtService.IsRevoked(c.Context(), claims.ID) {
 			return c.Next()
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/auth_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -15,6 +16,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// inMemRevocationStore is a test double for auth.RevocationStore.
+type inMemRevocationStore struct{ m map[string]bool }
+
+func (s *inMemRevocationStore) Exists(ctx context.Context, key string) (bool, error) {
+	return s.m[key], nil
+}
+func (s *inMemRevocationStore) Set(ctx context.Context, key string, v interface{}, ttl time.Duration) error {
+	if s.m == nil {
+		s.m = map[string]bool{}
+	}
+	s.m[key] = true
+	return nil
+}
 
 func TestAuthMiddleware_NoToken(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
@@ -357,6 +372,72 @@ func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
 
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 	assert.Equal(t, userID, capturedUserID)
+}
+
+func TestAuthMiddleware_RejectsRevokedToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
+	jwtService := auth.NewJWTService()
+	jwtService.SetRevoker(auth.NewTokenRevoker(&inMemRevocationStore{m: map[string]bool{}}, false))
+
+	access, _, err := jwtService.GenerateTokenPair(uuid.New().String(), uuid.New().String(), "u@example.com", "admin")
+	require.NoError(t, err)
+
+	app := fiber.New()
+	app.Use(AuthMiddleware(jwtService))
+	app.Get("/protected", func(c fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	// Before revocation: token works.
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+access)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// Revoke it, then the same token must be rejected.
+	require.NoError(t, jwtService.RevokeToken(context.Background(), access))
+
+	req2 := httptest.NewRequest("GET", "/protected", nil)
+	req2.Header.Set("Authorization", "Bearer "+access)
+	resp2, err := app.Test(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, fiber.StatusUnauthorized, resp2.StatusCode)
+
+	body, _ := io.ReadAll(resp2.Body)
+	var result map[string]interface{}
+	json.Unmarshal(body, &result)
+	assert.Equal(t, "Token has been revoked", result["error"])
+}
+
+func TestOptionalAuthMiddleware_RejectsRevokedToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
+	jwtService := auth.NewJWTService()
+	jwtService.SetRevoker(auth.NewTokenRevoker(&inMemRevocationStore{m: map[string]bool{}}, false))
+
+	access, _, err := jwtService.GenerateTokenPair(uuid.New().String(), uuid.New().String(), "u@example.com", "admin")
+	require.NoError(t, err)
+	require.NoError(t, jwtService.RevokeToken(context.Background(), access))
+
+	var hasUserID bool
+	app := fiber.New()
+	app.Use(OptionalAuthMiddleware(jwtService))
+	app.Get("/public", func(c fiber.Ctx) error {
+		hasUserID = c.Locals("user_id") != nil
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.Header.Set("Authorization", "Bearer "+access)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Request still succeeds (optional), but the revoked token must not authenticate.
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.False(t, hasUserID, "revoked token must not set user context")
 }
 
 func TestOptionalAuthMiddleware_NoToken(t *testing.T) {

--- a/apps/backend/internal/interfaces/http/middleware/cors.go
+++ b/apps/backend/internal/interfaces/http/middleware/cors.go
@@ -2,11 +2,25 @@ package middleware
 
 import (
 	"log"
+	"os"
+	"regexp"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/cors"
 )
+
+// vercelPreviewOriginRe matches AIM's own Vercel preview deployments only
+// (the aim-cloud / aim-frontend projects under the opena2a team). Used by an
+// opt-in dynamic CORS matcher so per-branch preview URLs can be verified
+// without a wildcard. Scoped to our project prefixes to avoid allowing
+// arbitrary *.vercel.app origins.
+var vercelPreviewOriginRe = regexp.MustCompile(`^https://aim-(cloud|frontend)-[a-z0-9-]+-opena2a\.vercel\.app$`)
+
+// vercelPreviewOriginAllowed reports whether origin is an AIM Vercel preview.
+func vercelPreviewOriginAllowed(origin string) bool {
+	return vercelPreviewOriginRe.MatchString(origin)
+}
 
 var (
 	corsAllowMethods  = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
@@ -62,12 +76,23 @@ func CORSMiddleware(allowedOrigins []string) fiber.Handler {
 	// Validate and sanitize origins before applying
 	safeOrigins := ValidateAndSanitizeCORSOrigins(allowedOrigins)
 
-	return cors.New(cors.Config{
+	cfg := cors.Config{
 		AllowOrigins:     safeOrigins,
 		AllowMethods:     corsAllowMethods,
 		AllowHeaders:     corsAllowHeaders,
 		ExposeHeaders:    corsExposeHeaders,
 		AllowCredentials: true,
 		MaxAge:           3600,
-	})
+	}
+
+	// Opt-in: also allow AIM's own Vercel preview deployments (per-branch URLs
+	// are dynamic, so they can't be a static allowlist entry). Off by default;
+	// enable in non-prod with CORS_ALLOW_VERCEL_PREVIEWS=true. The matcher is
+	// scoped to our project prefixes — never a blanket *.vercel.app.
+	if strings.EqualFold(os.Getenv("CORS_ALLOW_VERCEL_PREVIEWS"), "true") {
+		cfg.AllowOriginsFunc = vercelPreviewOriginAllowed
+		log.Println("ℹ️  CORS: AIM Vercel preview origins allowed (CORS_ALLOW_VERCEL_PREVIEWS=true)")
+	}
+
+	return cors.New(cfg)
 }

--- a/apps/backend/internal/interfaces/http/middleware/cors_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/cors_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVercelPreviewOriginAllowed(t *testing.T) {
+	allowed := []string{
+		"https://aim-cloud-git-feat-x-opena2a.vercel.app",
+		"https://aim-frontend-git-feat-x-opena2a.vercel.app",
+		"https://aim-cloud-abc123-opena2a.vercel.app",
+	}
+	for _, o := range allowed {
+		assert.True(t, vercelPreviewOriginAllowed(o), "should allow AIM preview: %s", o)
+	}
+
+	denied := []string{
+		"https://evil.vercel.app",
+		"https://aim-cloud-git-x-evil.vercel.app",     // wrong suffix
+		"http://aim-cloud-git-x-opena2a.vercel.app",   // not https
+		"https://aim-cloud-git-x-opena2a.vercel.app.evil.com", // suffix smuggling
+		"https://notaim-cloud-opena2a.vercel.app",
+		"https://aim-backend-git-x-opena2a.vercel.app", // not cloud/frontend
+		"",
+	}
+	for _, o := range denied {
+		assert.False(t, vercelPreviewOriginAllowed(o), "should deny: %s", o)
+	}
+}
+
 func TestValidateAndSanitizeCORSOrigins_RejectsWildcard(t *testing.T) {
 	origins := []string{"*"}
 	result := ValidateAndSanitizeCORSOrigins(origins)


### PR DESCRIPTION
Auth hardening **Wave 3** — P5 (logout/token revocation) + P6 (CORS previews).

> **Stacked on #306** (base = `feat/auth-token-type-separation`, which is stacked on #305). Merge order: #305 → #306 → this. I'll retarget to `main` as they merge.

## P5 — server-side token revocation
Until now, logout only cleared the client token; the JWT stayed valid until expiry.
- New `TokenRevoker` (Redis-backed `revoked:jti:<jti>` denylist, TTL = remaining exp, auto-cleaned) with a 30s in-process **negative cache**. Attached to `JWTService` so `AuthMiddleware` checks it **without changing its ~15 call sites**.
- `AuthMiddleware` + `OptionalAuthMiddleware` reject revoked tokens; `/auth/refresh` rejects a revoked refresh token; **logout revokes the presented access + refresh tokens**.
- **Fail-CLOSED by default** on a Redis outage (`AUTH_REVOCATION_FAIL_OPEN=true` to prefer availability); the negative cache bounds blast radius and cross-instance lag to ~30s, with a hard size cap. No Redis configured → revocation disabled (tokens still expire). Wired in `main.go` only when Redis is present.

## P6 — opt-in CORS for AIM's own Vercel previews
Per-branch preview URLs are dynamic, so they can't be a static allowlist entry. `CORS_ALLOW_VERCEL_PREVIEWS=true` enables a regex matcher scoped to the `aim-cloud`/`aim-frontend` **opena2a** projects — never a blanket `*.vercel.app`. Off by default; fixed origins still go through `ALLOWED_ORIGINS`.

## Verification
- `go build` + `go test` green. Tests: revoke→401, refresh-of-revoked→reject, OptionalAuth-revoked→no-context, fail-open/closed, neg-cache survives outage, empty-jti no-op, CORS matcher allow/deny (incl. suffix-smuggling).
- Adversarial self-review: **no CRITICAL/HIGH**; it tried newline/suffix CORS bypasses (failed) and verified fail-closed default + safe credentialed-origin echo. Actionable LOWs fixed (hard neg-cache cap, OptionalAuth + empty-jti tests). One pre-existing LOW noted as follow-up (rotate-revoke regular refresh tokens).
- HMA `secure` 100/100.

**Cloud companion (follow-up):** the non-protected backend files sync to aim-cloud automatically; cloud's **protected** `main.go` (SetRevoker wiring) + `Logout` revocation must be hand-applied *after* this syncs (they depend on the synced `jwt.go`). Tracked in the plan.