### PR TITLE
Retire empty-typ grace on the access path (keep it for refresh)

### DIFF
--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -25,10 +25,12 @@ const (
 // Token types. The `typ` claim separates access tokens (valid as a bearer) from
 // refresh tokens (valid only at /auth/refresh), so a refresh token cannot be
 // replayed as a session token.
-// GRACE: tokens minted before this claim existed have an empty TokenType; the
-// access middleware and refresh endpoint treat an empty type as legacy and
-// allow it, so this rolls out without breaking live sessions. Newly issued
-// tokens always carry a type and are enforced immediately.
+// GRACE: tokens minted before this claim existed have an empty TokenType.
+// The access middleware no longer accepts an empty type (retired once all
+// short-lived legacy access tokens had aged out within their TTL). The refresh
+// endpoint still treats an empty type as a legacy refresh/SDK token and allows
+// it, so long-lived (up to 90-day SDK) tokens keep working until they age out.
+// Newly issued tokens always carry a type and are enforced immediately.
 const (
 	TokenTypeAccess  = "access"
 	TokenTypeRefresh = "refresh"

--- a/apps/backend/internal/interfaces/http/middleware/auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth.go
@@ -76,10 +76,12 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		}
 
 		// SECURITY: only access tokens are valid bearers. A refresh token (or any
-		// non-access type) must not be replayed as a session token. An empty type
-		// is a legacy token issued before the `typ` claim existed — allowed during
-		// the rollout grace window; legacy tokens age out within their TTL.
-		if claims.TokenType != "" && claims.TokenType != auth.TokenTypeAccess {
+		// non-access type) must not be replayed as a session token. The empty-type
+		// rollout grace has been retired on the access path: every live access token
+		// carries typ="access" (issued post-rollout), so an empty type here can only
+		// be a legacy refresh token replayed as access — reject it. (The refresh
+		// endpoint keeps the empty-type grace until long-lived SDK tokens age out.)
+		if claims.TokenType != auth.TokenTypeAccess {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 				"error": "This token cannot be used for API access",
 			})
@@ -154,9 +156,10 @@ func OptionalAuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		}
 
 		// SECURITY: only access tokens authenticate. A non-access type (e.g. a
-		// refresh token) must not set user context. Empty type = legacy, allowed
-		// during the grace window (see AuthMiddleware).
-		if claims.TokenType != "" && claims.TokenType != auth.TokenTypeAccess {
+		// refresh token) must not set user context. The empty-type access grace is
+		// retired (see AuthMiddleware): an empty type here is a legacy refresh token,
+		// so continue unauthenticated rather than trusting it.
+		if claims.TokenType != auth.TokenTypeAccess {
 			return c.Next()
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/auth_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth_test.go
@@ -299,6 +299,49 @@ func TestOptionalAuthMiddleware_RejectsSDKToken(t *testing.T) {
 	assert.False(t, hasUserID, "SDK token must not set user context")
 }
 
+func TestOptionalAuthMiddleware_LegacyTokenWithoutTypeIsAnonymous(t *testing.T) {
+	const secret = "test-secret-key-for-testing-purposes-32chars"
+	t.Setenv("JWT_SECRET", secret)
+	jwtService := auth.NewJWTService()
+
+	now := time.Now()
+	// Legacy token (no `typ` claim). The access-path grace is retired, so on an
+	// optional endpoint a typ-less token must NOT set user context — the request
+	// continues anonymously rather than trusting a possible legacy refresh token.
+	legacyClaims := auth.JWTClaims{
+		UserID:         uuid.New().String(),
+		OrganizationID: uuid.New().String(),
+		Email:          "legacy@example.com",
+		Role:           "admin",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			Issuer:    auth.IssuerUser,
+		},
+	}
+	legacyToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacyClaims).SignedString([]byte(secret))
+	require.NoError(t, err)
+
+	var hasUserID bool
+	app := fiber.New()
+	app.Use(OptionalAuthMiddleware(jwtService))
+	app.Get("/public", func(c fiber.Ctx) error {
+		hasUserID = c.Locals("user_id") != nil
+		return c.JSON(fiber.Map{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.Header.Set("Authorization", "Bearer "+legacyToken)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.False(t, hasUserID, "legacy typ-less token must not set user context")
+}
+
 func TestAuthMiddleware_RejectsRefreshToken(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-key-for-testing-purposes-32chars")
 	jwtService := auth.NewJWTService()
@@ -328,7 +371,7 @@ func TestAuthMiddleware_RejectsRefreshToken(t *testing.T) {
 	assert.Equal(t, "This token cannot be used for API access", result["error"])
 }
 
-func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
+func TestAuthMiddleware_RejectsLegacyTokenWithoutTypeOnAccessPath(t *testing.T) {
 	const secret = "test-secret-key-for-testing-purposes-32chars"
 	t.Setenv("JWT_SECRET", secret)
 	jwtService := auth.NewJWTService()
@@ -338,7 +381,10 @@ func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
 	now := time.Now()
 
 	// Craft a legacy token (no `typ` claim) the way tokens were minted before
-	// token-type separation. The grace window must still accept these.
+	// token-type separation. The access-path grace has been retired: every live
+	// access token now carries typ="access", so an empty type on the access path
+	// can only be a legacy refresh token replayed as access and must be rejected.
+	// (The refresh endpoint keeps its empty-type grace until SDK tokens age out.)
 	legacyClaims := auth.JWTClaims{
 		UserID:         userID.String(),
 		OrganizationID: orgID.String(),
@@ -355,11 +401,9 @@ func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
 	legacyToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacyClaims).SignedString([]byte(secret))
 	require.NoError(t, err)
 
-	var capturedUserID uuid.UUID
 	app := fiber.New()
 	app.Use(AuthMiddleware(jwtService))
 	app.Get("/protected", func(c fiber.Ctx) error {
-		capturedUserID = c.Locals("user_id").(uuid.UUID)
 		return c.JSON(fiber.Map{"message": "success"})
 	})
 
@@ -370,8 +414,7 @@ func TestAuthMiddleware_AllowsLegacyTokenWithoutType(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
-	assert.Equal(t, userID, capturedUserID)
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
 }
 
 func TestAuthMiddleware_RejectsRevokedToken(t *testing.T) {


### PR DESCRIPTION
## What
Closes the F1 residual (P1-phase-2, access half). The access middleware (`AuthMiddleware` + `OptionalAuthMiddleware`) previously accepted a JWT with an empty `typ` claim as an access token during the token-type rollout grace. Short-lived legacy access tokens (2h TTL) have aged out, so the access path now requires `typ="access"`. An empty type on the access path can now only be a legacy **refresh** token replayed as a bearer — which is exactly the vector we close.

The **refresh endpoint** (`RefreshTokenPair`) intentionally **keeps** the empty-`typ` grace so long-lived legacy refresh/SDK tokens (up to 90 days) keep working until they age out (~2026-09).

## Changes
- `middleware/auth.go`: drop the `!= ""` allowance in both access middlewares (`if claims.TokenType != auth.TokenTypeAccess`).
- `middleware/auth_test.go`: flip the legacy-access test to assert 401; add an `OptionalAuthMiddleware` test asserting a typ-less token stays anonymous.
- `jwt.go`: correct the stale package grace comment.

## Verification
- `go build ./...`, `go vet`, `go test ./internal/interfaces/http/middleware/... ./internal/infrastructure/auth/...` ✓
- HMA `secure` 100/100 ✓
- Adversarial review: LOW findings (stale comment, missing Optional test) fixed; MEDIUM (deploy timing) handled — see below.

## Deploy gate (IMPORTANT)
Safe only once ≥1 access-TTL (2h) has elapsed since prod started issuing `typ`'d access tokens (#63 deploy 03:02Z) — i.e. the cloud deploy must land **after ~05:05Z** so no valid pre-deploy empty-`typ` access token can still be in use. Merge to public anytime; gate the **cloud** sync merge on that window.