### PR TITLE
Wire the 9-factor agent trust score to real data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Available in Self-hosted and AIM Cloud modes.
 *Agent registry with trust scores and verification status per agent.*
 
 ![Per-agent trust score breakdown](docs/images/agent-trust-score.png)
-*Per-agent 8-factor trust score breakdown with weighted signal contributions.*
+*Per-agent 9-factor trust score breakdown with weighted signal contributions.*
 
 ![MCP supply chain](docs/images/supply-chain.png)
 *MCP server dependencies with multi-agent attestation status.*

--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -512,6 +512,12 @@ type Repositories struct {
 	SecretCredential    *repository.SecretCredentialRepository
 	SecretAudit         *repository.SecretAuditRepository
 	SecretBackendConfig *repository.SecretBackendConfigRepository
+	// Trust score integrity repositories (factors 5, 8, 9 + TME enrichment)
+	ComplianceSnapshot   *repository.ComplianceSnapshotRepository   // Factor 5: compliance reader
+	ComplianceEvidence   *repository.ComplianceEvidenceRepository   // Compliance evidence (full compliance service)
+	IsolationAttestation *repository.IsolationAttestationRepository // Factor 9: execution isolation
+	UserFeedback         *repository.UserFeedbackRepository         // Factor 8: user feedback
+	NanoMindTME          *repository.NanoMindTMERepository          // TME enrichment of security alerts
 }
 
 func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPostgres) {
@@ -566,6 +572,12 @@ func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPos
 		SecretCredential:    repository.NewSecretCredentialRepository(db),
 		SecretAudit:         repository.NewSecretAuditRepository(db),
 		SecretBackendConfig: repository.NewSecretBackendConfigRepository(db),
+		// Trust score integrity
+		ComplianceSnapshot:   repository.NewComplianceSnapshotRepository(db),
+		ComplianceEvidence:   repository.NewComplianceEvidenceRepository(db),
+		IsolationAttestation: repository.NewIsolationAttestationRepository(db),
+		UserFeedback:         repository.NewUserFeedbackRepository(db),
+		NanoMindTME:          repository.NewNanoMindTMERepository(db),
 	}, oauthRepo
 }
 
@@ -642,6 +654,16 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.Alert,             // For security alerts scoring
 		repos.VerificationEvent, // For real verification statistics
 	)
+	// Wire the remaining trust factors so the 9-factor score computes honestly
+	// instead of falling back to neutral hardcodes:
+	//   Factor 5 (compliance):  read the latest AIM compliance snapshot
+	//   Factor 8 (user feedback): read sentiment-bucketed feedback counts
+	//   Factor 9 (execution isolation): read the latest isolation attestation
+	//   TME enrichment: blend NanoMind threat-model evaluation into security alerts
+	trustCalculator.SetSnapshotRepo(repos.ComplianceSnapshot)
+	trustCalculator.SetUserFeedbackRepo(repos.UserFeedback)
+	trustCalculator.SetIsolationRepo(repos.IsolationAttestation)
+	trustCalculator.SetTMEProvider(repos.NanoMindTME)
 
 	// ✅ Initialize drift detection service BEFORE verification event service
 	driftDetectionService := application.NewDriftDetectionService(
@@ -710,10 +732,15 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 	// ✅ Wire DataTransferRepository into SecurityPolicyService for exfiltration detection
 	securityPolicyService.SetDataTransferRepository(repos.DataTransfer)
 
-	complianceService := application.NewComplianceService(
+	// Full compliance service: wires the snapshot repo so RecordComplianceSnapshot
+	// persists the point-in-time AIM score that trust factor 5 reads back.
+	complianceService := application.NewComplianceServiceFull(
 		repos.AuditLog,
 		repos.Agent,
 		repos.User,
+		repos.Alert,
+		repos.ComplianceEvidence,
+		repos.ComplianceSnapshot,
 		repos.MCPServer,
 	)
 
@@ -1442,6 +1469,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	trust.Get("/agents/:id", h.TrustScore.GetTrustScore)
 	trust.Get("/agents/:id/breakdown", h.TrustScore.GetTrustScoreBreakdown) // Detailed breakdown with weights and contributions
 	trust.Get("/agents/:id/history", h.TrustScore.GetTrustScoreHistory)
+	trust.Post("/agents/:id/feedback", h.TrustScore.SubmitUserFeedback) // Submit a 1-5 user rating (feeds the user feedback trust factor)
 
 	// Remediation tracking (public, rate-limited, no auth -- receives reports from agentpwn and HMA)
 	remediation := v1.Group("/remediation")

--- a/apps/backend/deployments/otel-demo/smoke-backend.sh
+++ b/apps/backend/deployments/otel-demo/smoke-backend.sh
@@ -68,6 +68,20 @@ SMOKE_PG_CONTAINER="${SMOKE_PG_CONTAINER:-aim-smoke-postgres}"
 SMOKE_PG_PASSWORD="${SMOKE_PG_PASSWORD:-smoke_postgres_password}"
 SMOKE_PG_DB="${SMOKE_PG_DB:-identity}"
 
+# These two flow into `docker run` arguments and the psql connection below.
+# They default to safe constants but are env-overridable, so validate them
+# against a strict allow-list before use — a value containing shell
+# metacharacters or whitespace must never reach a command line. Fail closed on
+# anything outside the pattern.
+case "$SMOKE_PG_CONTAINER" in
+    *[!A-Za-z0-9_.-]*|"")
+        echo "FAIL: SMOKE_PG_CONTAINER must match [A-Za-z0-9_.-]+ (got '$SMOKE_PG_CONTAINER')"; exit 1 ;;
+esac
+case "$SMOKE_PG_DB" in
+    *[!A-Za-z0-9_]*|"")
+        echo "FAIL: SMOKE_PG_DB must match [A-Za-z0-9_]+ (got '$SMOKE_PG_DB')"; exit 1 ;;
+esac
+
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@opena2a.org}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-AIM2025!Smoke}"
 
@@ -87,7 +101,10 @@ echo "    Tempo HTTP  : localhost:${TEMPO_HTTP_PORT}"
 # 1. Pre-flight.
 echo
 echo "==> [1/8] Pre-flight"
-for tool in docker curl jq go; do
+# psql + pg_isready let us reach the throwaway Postgres over its published
+# TCP port instead of `docker exec`-ing into the container. Talking to the
+# published port keeps shell variables out of any docker exec argument list.
+for tool in docker curl jq go psql pg_isready; do
     command -v "$tool" >/dev/null || { echo "FAIL: $tool not on PATH"; exit 1; }
 done
 
@@ -120,7 +137,7 @@ docker run -d --name "$SMOKE_PG_CONTAINER" \
     timescale/timescaledb:latest-pg16 >/dev/null || { echo "FAIL: docker run postgres"; exit 2; }
 attempt=0
 while [ $attempt -lt 30 ]; do
-    if docker exec "$SMOKE_PG_CONTAINER" pg_isready -U postgres -d "$SMOKE_PG_DB" >/dev/null 2>&1; then
+    if pg_isready -h 127.0.0.1 -p "$SMOKE_POSTGRES_PORT" -U postgres -d "$SMOKE_PG_DB" >/dev/null 2>&1; then
         echo "    postgres ready"
         break
     fi
@@ -242,8 +259,7 @@ echo "    admin seeded"
 # 5. Reset force_password_change.
 echo
 echo "==> [5/8] Reset admin force_password_change"
-docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
-    psql -U postgres -d "$SMOKE_PG_DB" -c \
+PGPASSWORD="$SMOKE_PG_PASSWORD" psql -h 127.0.0.1 -p "$SMOKE_POSTGRES_PORT" -U postgres -d "$SMOKE_PG_DB" -c \
     "UPDATE users SET force_password_change = FALSE WHERE email = '${ADMIN_EMAIL}';" >/dev/null
 
 # 6. HTTP exercise.
@@ -278,8 +294,7 @@ echo "    agent created id=${AGENT_ID}"
 # The fga_engine reads it via fetchASCRiskSummary; missing rows fail open
 # silently, which would let agent.scan_verdict drop off the parent span
 # unnoticed and weaken the Slide 14 SemConv proposal credibility.
-docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
-    psql -U postgres -d "$SMOKE_PG_DB" -v ON_ERROR_STOP=1 -c \
+PGPASSWORD="$SMOKE_PG_PASSWORD" psql -h 127.0.0.1 -p "$SMOKE_POSTGRES_PORT" -U postgres -d "$SMOKE_PG_DB" -v ON_ERROR_STOP=1 -c \
     "CREATE TABLE IF NOT EXISTS agent_security_contexts (
         agent_id        UUID PRIMARY KEY,
         overall_risk    TEXT NOT NULL DEFAULT 'LOW',
@@ -289,8 +304,7 @@ docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
         atx_trust_level INTEGER,
         scan_verdict    TEXT NOT NULL DEFAULT 'UNKNOWN'
      );" >/dev/null
-docker exec -e PGPASSWORD="$SMOKE_PG_PASSWORD" "$SMOKE_PG_CONTAINER" \
-    psql -U postgres -d "$SMOKE_PG_DB" -v ON_ERROR_STOP=1 -c \
+PGPASSWORD="$SMOKE_PG_PASSWORD" psql -h 127.0.0.1 -p "$SMOKE_POSTGRES_PORT" -U postgres -d "$SMOKE_PG_DB" -v ON_ERROR_STOP=1 -c \
     "INSERT INTO agent_security_contexts (agent_id, overall_risk, drift_score, active_alerts, atc_trust_level, scan_verdict)
      VALUES ('${AGENT_ID}', 'LOW', 0.05, 0, 3, 'CLEAN')
      ON CONFLICT (agent_id) DO UPDATE SET scan_verdict='CLEAN';" >/dev/null

--- a/apps/backend/internal/application/trust_calculator.go
+++ b/apps/backend/internal/application/trust_calculator.go
@@ -22,6 +22,7 @@ type TrustCalculator struct {
 	verificationEventRepo  domain.VerificationEventRepository
 	snapshotRepo           domain.ComplianceSnapshotRepository
 	isolationRepo          domain.IsolationAttestationRepository
+	userFeedbackRepo       domain.UserFeedbackRepository
 	tmeProvider            NanoMindTMEProvider
 }
 
@@ -85,6 +86,12 @@ func (c *TrustCalculator) SetIsolationRepo(repo domain.IsolationAttestationRepos
 	c.isolationRepo = repo
 }
 
+// SetUserFeedbackRepo sets the user feedback repository for the user feedback factor.
+// Optional; when not set, the user feedback factor returns a neutral 0.5 score.
+func (c *TrustCalculator) SetUserFeedbackRepo(repo domain.UserFeedbackRepository) {
+	c.userFeedbackRepo = repo
+}
+
 // SetTMEProvider sets the NanoMind TME provider for behavioral trust enrichment.
 // Optional; when not set, TME has no effect on scoring.
 func (c *TrustCalculator) SetTMEProvider(provider NanoMindTMEProvider) {
@@ -92,7 +99,7 @@ func (c *TrustCalculator) SetTMEProvider(provider NanoMindTMEProvider) {
 }
 
 // Calculate calculates trust score for an agent
-// Implements the 8-factor algorithm with weighted average
+// Implements the 9-factor algorithm with weighted average
 func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, error) {
 	factors, err := c.CalculateFactors(agent)
 	if err != nil {
@@ -469,23 +476,40 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 }
 
 // Factor 8: User Feedback (2% weight)
-// Measures explicit feedback from users.
+// Measures explicit feedback from users, scored by sentiment-bucket counts.
 //
-// Currently returns 0.5 (neutral) because no user feedback collection
-// mechanism exists yet. To implement real feedback scoring:
-//   - Add a UserFeedback domain entity with agent_id, rating (1-5), comment
-//   - Add a UserFeedbackRepository with GetByAgentID, GetAverageRating
-//   - Wire the repository into TrustCalculator
-//   - Scoring formula from documentation:
-//     negative_feedback > 5: 0.0
-//     negative_feedback > 2: 0.50
-//     positive_feedback > 10: 1.0
-//     else: 0.75
+// Returns 0.5 (neutral) when no feedback repository is wired or no feedback
+// exists, so agents are neither penalized nor rewarded without real data.
+//
+// Scoring formula (sentiment buckets from domain.FeedbackSentiment, rating 1-5):
+//
+//	negative_feedback > 5:  0.00  (sustained dissatisfaction)
+//	negative_feedback > 2:  0.50  (some dissatisfaction)
+//	positive_feedback > 10: 1.00  (strong positive track record)
+//	else:                   0.75  (mild positive / mixed)
+//
+// Negative checks precede positive so that an agent with many positives AND
+// many negatives is not rewarded; sustained complaints dominate.
 func (c *TrustCalculator) calculateUserFeedback(agent *domain.Agent) float64 {
-	// No user feedback collection mechanism exists yet.
-	// Return neutral score so agents are not penalized or rewarded
-	// without actual feedback data.
-	return 0.5
+	if c.userFeedbackRepo == nil {
+		return 0.5 // Neutral when feedback collection not configured
+	}
+
+	stats, err := c.userFeedbackRepo.GetStats(agent.ID)
+	if err != nil || stats == nil || stats.Total == 0 {
+		return 0.5 // Neutral when no feedback data exists
+	}
+
+	if stats.NegativeCount > 5 {
+		return 0.0
+	}
+	if stats.NegativeCount > 2 {
+		return 0.5
+	}
+	if stats.PositiveCount > 10 {
+		return 1.0
+	}
+	return 0.75
 }
 
 // Factor 9: Execution Isolation (10% weight)
@@ -619,4 +643,32 @@ func (c *TrustCalculator) GetTrustScoreHistory(ctx context.Context, agentID uuid
 // This includes who changed it, when, and why - for frontend UI display
 func (c *TrustCalculator) GetTrustScoreHistoryAuditTrail(ctx context.Context, agentID uuid.UUID, limit int) ([]*domain.TrustScoreHistoryEntry, error) {
 	return c.trustScoreRepo.GetHistoryAuditTrail(agentID, limit)
+}
+
+// RecordUserFeedback persists a user's explicit rating for an agent. This is the
+// collection side of the user feedback factor (factor 8): without it the factor
+// has nothing to read and stays at the neutral 0.5 baseline. Rating must be 1-5.
+func (c *TrustCalculator) RecordUserFeedback(ctx context.Context, agentID, orgID uuid.UUID, userID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error) {
+	if c.userFeedbackRepo == nil {
+		return nil, fmt.Errorf("user feedback repository not configured")
+	}
+	if rating < 1 || rating > 5 {
+		return nil, fmt.Errorf("rating must be between 1 and 5, got %d", rating)
+	}
+
+	feedback := &domain.UserFeedback{
+		ID:             uuid.New(),
+		AgentID:        agentID,
+		OrganizationID: orgID,
+		UserID:         userID,
+		Rating:         rating,
+		Comment:        comment,
+		CreatedAt:      time.Now(),
+	}
+
+	if err := c.userFeedbackRepo.Create(feedback); err != nil {
+		return nil, fmt.Errorf("failed to record user feedback: %w", err)
+	}
+
+	return feedback, nil
 }

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockCapabilityRepository for testing
@@ -744,8 +745,126 @@ func TestTrustCalculator_CalculateUserFeedback_Baseline(t *testing.T) {
 
 	feedback := calculator.calculateUserFeedback(agent)
 
-	// Should return neutral 0.5 when no feedback collection mechanism exists
-	assert.Equal(t, 0.5, feedback, "User feedback should return neutral 0.5 when no feedback data exists")
+	// Should return neutral 0.5 when no feedback repository is wired
+	assert.Equal(t, 0.5, feedback, "User feedback should return neutral 0.5 when no feedback repo is configured")
+}
+
+// MockUserFeedbackRepository mocks domain.UserFeedbackRepository for trust calculator tests
+type MockUserFeedbackRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserFeedbackRepository) Create(feedback *domain.UserFeedback) error {
+	args := m.Called(feedback)
+	return args.Error(0)
+}
+
+func (m *MockUserFeedbackRepository) GetByAgentID(agentID uuid.UUID, limit, offset int) ([]*domain.UserFeedback, error) {
+	args := m.Called(agentID, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.UserFeedback), args.Error(1)
+}
+
+func (m *MockUserFeedbackRepository) GetStats(agentID uuid.UUID) (*domain.UserFeedbackStats, error) {
+	args := m.Called(agentID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.UserFeedbackStats), args.Error(1)
+}
+
+func TestTrustCalculator_CalculateUserFeedback_Formula(t *testing.T) {
+	agentID := uuid.New()
+	agent := &domain.Agent{ID: agentID}
+
+	cases := []struct {
+		name  string
+		stats *domain.UserFeedbackStats
+		want  float64
+	}{
+		{"no feedback rows -> neutral", &domain.UserFeedbackStats{Total: 0}, 0.5},
+		{"sustained negatives (>5) -> 0.0", &domain.UserFeedbackStats{Total: 6, NegativeCount: 6}, 0.0},
+		{"some negatives (>2) -> 0.5", &domain.UserFeedbackStats{Total: 4, NegativeCount: 3}, 0.5},
+		{"strong positives (>10) -> 1.0", &domain.UserFeedbackStats{Total: 11, PositiveCount: 11}, 1.0},
+		{"mild positive / mixed -> 0.75", &domain.UserFeedbackStats{Total: 3, PositiveCount: 2, NeutralCount: 1}, 0.75},
+		// Negatives dominate: many positives AND many negatives must NOT reward.
+		{"many positives but >5 negatives -> 0.0", &domain.UserFeedbackStats{Total: 20, PositiveCount: 14, NegativeCount: 6}, 0.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := new(MockUserFeedbackRepository)
+			repo.On("GetStats", agentID).Return(tc.stats, nil)
+
+			calc := &TrustCalculator{}
+			calc.SetUserFeedbackRepo(repo)
+
+			got := calc.calculateUserFeedback(agent)
+			assert.Equal(t, tc.want, got, tc.name)
+		})
+	}
+}
+
+func TestTrustCalculator_CalculateUserFeedback_RepoError_Neutral(t *testing.T) {
+	agentID := uuid.New()
+	agent := &domain.Agent{ID: agentID}
+
+	repo := new(MockUserFeedbackRepository)
+	repo.On("GetStats", agentID).Return(nil, assert.AnError)
+
+	calc := &TrustCalculator{}
+	calc.SetUserFeedbackRepo(repo)
+
+	// A failed stats query must not penalize or reward the agent.
+	assert.Equal(t, 0.5, calc.calculateUserFeedback(agent))
+}
+
+func TestTrustCalculator_RecordUserFeedback(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	t.Run("persists a valid rating scoped to agent+org", func(t *testing.T) {
+		repo := new(MockUserFeedbackRepository)
+		var saved *domain.UserFeedback
+		repo.On("Create", mock.Anything).Run(func(args mock.Arguments) {
+			saved = args.Get(0).(*domain.UserFeedback)
+		}).Return(nil)
+
+		calc := &TrustCalculator{}
+		calc.SetUserFeedbackRepo(repo)
+
+		fb, err := calc.RecordUserFeedback(ctx, agentID, orgID, &userID, 4, "solid")
+		require.NoError(t, err)
+		require.NotNil(t, fb)
+		assert.Equal(t, agentID, saved.AgentID)
+		assert.Equal(t, orgID, saved.OrganizationID)
+		assert.Equal(t, 4, saved.Rating)
+		assert.Equal(t, "solid", saved.Comment)
+		assert.NotEqual(t, uuid.Nil, saved.ID)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("rejects out-of-range ratings without touching the repo", func(t *testing.T) {
+		repo := new(MockUserFeedbackRepository)
+		calc := &TrustCalculator{}
+		calc.SetUserFeedbackRepo(repo)
+
+		for _, r := range []int{0, 6, -1} {
+			_, err := calc.RecordUserFeedback(ctx, agentID, orgID, &userID, r, "")
+			assert.Error(t, err, "rating %d must be rejected", r)
+		}
+		repo.AssertNotCalled(t, "Create", mock.Anything)
+	})
+
+	t.Run("errors when no repo is configured", func(t *testing.T) {
+		calc := &TrustCalculator{}
+		_, err := calc.RecordUserFeedback(ctx, agentID, orgID, &userID, 5, "")
+		assert.Error(t, err)
+	})
 }
 
 // ===========================

--- a/apps/backend/internal/domain/user_feedback.go
+++ b/apps/backend/internal/domain/user_feedback.go
@@ -1,0 +1,54 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserFeedback represents an explicit rating a user gave an agent.
+// Used by the trust score's User Feedback factor (factor 8, 2% weight).
+type UserFeedback struct {
+	ID             uuid.UUID  `json:"id"`
+	AgentID        uuid.UUID  `json:"agentId"`
+	OrganizationID uuid.UUID  `json:"organizationId"`
+	UserID         *uuid.UUID `json:"userId,omitempty"` // who left the feedback (nil if anonymous/system)
+	Rating         int        `json:"rating"`           // 1-5 stars
+	Comment        string     `json:"comment,omitempty"`
+	CreatedAt      time.Time  `json:"createdAt"`
+}
+
+// UserFeedbackStats aggregates feedback for an agent so the trust calculator
+// can apply the documented count-threshold scoring formula without loading
+// every row.
+//
+// Sentiment buckets (rating is 1-5):
+//   - Positive: rating >= 4
+//   - Neutral:  rating == 3
+//   - Negative: rating <= 2
+type UserFeedbackStats struct {
+	Total         int     `json:"total"`
+	PositiveCount int     `json:"positiveCount"`
+	NeutralCount  int     `json:"neutralCount"`
+	NegativeCount int     `json:"negativeCount"`
+	AverageRating float64 `json:"averageRating"`
+}
+
+// FeedbackSentiment classifies a 1-5 rating into a sentiment bucket.
+func FeedbackSentiment(rating int) string {
+	switch {
+	case rating >= 4:
+		return "positive"
+	case rating <= 2:
+		return "negative"
+	default:
+		return "neutral"
+	}
+}
+
+// UserFeedbackRepository defines persistence for user feedback.
+type UserFeedbackRepository interface {
+	Create(feedback *UserFeedback) error
+	GetByAgentID(agentID uuid.UUID, limit, offset int) ([]*UserFeedback, error)
+	GetStats(agentID uuid.UUID) (*UserFeedbackStats, error)
+}

--- a/apps/backend/internal/infrastructure/repository/isolation_attestation_repository.go
+++ b/apps/backend/internal/infrastructure/repository/isolation_attestation_repository.go
@@ -1,0 +1,114 @@
+package repository
+
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// IsolationAttestationRepository implements domain.IsolationAttestationRepository.
+// Backs trust factor 9 (execution_isolation, 10% weight). Agents self-report
+// their runtime isolation posture; the score is computed by domain.ScoreIsolation
+// at write time and stored on the attestation.
+type IsolationAttestationRepository struct {
+	db *sql.DB
+}
+
+// NewIsolationAttestationRepository creates a new isolation attestation repository
+func NewIsolationAttestationRepository(db *sql.DB) *IsolationAttestationRepository {
+	return &IsolationAttestationRepository{db: db}
+}
+
+func (r *IsolationAttestationRepository) Create(attestation *domain.IsolationAttestation) error {
+	query := `
+		INSERT INTO isolation_attestations (
+			id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
+	_, err := r.db.Exec(query,
+		attestation.ID,
+		attestation.AgentID,
+		string(attestation.Sandbox),
+		string(attestation.Network),
+		string(attestation.Filesystem),
+		string(attestation.Process),
+		attestation.Score,
+		attestation.ReportedAt,
+		attestation.CreatedAt,
+	)
+	return err
+}
+
+func (r *IsolationAttestationRepository) GetLatest(agentID uuid.UUID) (*domain.IsolationAttestation, error) {
+	query := `
+		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
+		FROM isolation_attestations
+		WHERE agent_id = $1
+		ORDER BY reported_at DESC
+		LIMIT 1
+	`
+	row := r.db.QueryRow(query, agentID)
+	att, err := scanIsolationAttestation(row)
+	if err == sql.ErrNoRows {
+		return nil, nil // No attestation yet; caller treats nil as "use baseline"
+	}
+	if err != nil {
+		return nil, err
+	}
+	return att, nil
+}
+
+func (r *IsolationAttestationRepository) GetHistory(agentID uuid.UUID, limit int) ([]*domain.IsolationAttestation, error) {
+	query := `
+		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
+		FROM isolation_attestations
+		WHERE agent_id = $1
+		ORDER BY reported_at DESC
+		LIMIT $2
+	`
+	rows, err := r.db.Query(query, agentID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	attestations := make([]*domain.IsolationAttestation, 0)
+	for rows.Next() {
+		att, err := scanIsolationAttestation(rows)
+		if err != nil {
+			return nil, err
+		}
+		attestations = append(attestations, att)
+	}
+	return attestations, rows.Err()
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanIsolationAttestation(s rowScanner) (*domain.IsolationAttestation, error) {
+	var att domain.IsolationAttestation
+	var sandbox, network, filesystem, process string
+	err := s.Scan(
+		&att.ID,
+		&att.AgentID,
+		&sandbox,
+		&network,
+		&filesystem,
+		&process,
+		&att.Score,
+		&att.ReportedAt,
+		&att.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	att.Sandbox = domain.SandboxType(sandbox)
+	att.Network = domain.NetworkIsolation(network)
+	att.Filesystem = domain.FilesystemIsolation(filesystem)
+	att.Process = domain.ProcessIsolation(process)
+	return &att, nil
+}

--- a/apps/backend/internal/infrastructure/repository/nanomind_tme_repository.go
+++ b/apps/backend/internal/infrastructure/repository/nanomind_tme_repository.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+)
+
+// NanoMindTMERepository reads the latest NanoMind Threat Model Evaluation (TME)
+// score per agent from the nanomind_tme_evaluations table (migration 090).
+//
+// It satisfies application.NanoMindTMEProvider structurally (GetLatestTMEScore),
+// so it can be wired into the trust calculator without an import cycle. The TME
+// score (0-1, higher = safer) blends 30% into the security alerts factor.
+type NanoMindTMERepository struct {
+	db *sql.DB
+}
+
+// NewNanoMindTMERepository creates a new NanoMind TME repository
+func NewNanoMindTMERepository(db *sql.DB) *NanoMindTMERepository {
+	return &NanoMindTMERepository{db: db}
+}
+
+// GetLatestTMEScore returns the latest TME score for an agent (0-1).
+// Returns -1 (with nil error) when no evaluation exists, signalling the trust
+// calculator to leave the security alerts factor untouched.
+func (r *NanoMindTMERepository) GetLatestTMEScore(agentID uuid.UUID) (float64, error) {
+	query := `
+		SELECT tme_score
+		FROM nanomind_tme_evaluations
+		WHERE agent_id = $1
+		ORDER BY evaluated_at DESC
+		LIMIT 1
+	`
+	var score float64
+	err := r.db.QueryRow(query, agentID).Scan(&score)
+	if err == sql.ErrNoRows {
+		return -1, nil
+	}
+	if err != nil {
+		return -1, err
+	}
+	return score, nil
+}

--- a/apps/backend/internal/infrastructure/repository/user_feedback_repository.go
+++ b/apps/backend/internal/infrastructure/repository/user_feedback_repository.go
@@ -1,0 +1,96 @@
+package repository
+
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// UserFeedbackRepository implements domain.UserFeedbackRepository
+type UserFeedbackRepository struct {
+	db *sql.DB
+}
+
+// NewUserFeedbackRepository creates a new user feedback repository
+func NewUserFeedbackRepository(db *sql.DB) *UserFeedbackRepository {
+	return &UserFeedbackRepository{db: db}
+}
+
+func (r *UserFeedbackRepository) Create(feedback *domain.UserFeedback) error {
+	query := `
+		INSERT INTO user_feedback (
+			id, agent_id, organization_id, user_id, rating, comment, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	_, err := r.db.Exec(query,
+		feedback.ID,
+		feedback.AgentID,
+		feedback.OrganizationID,
+		feedback.UserID,
+		feedback.Rating,
+		feedback.Comment,
+		feedback.CreatedAt,
+	)
+	return err
+}
+
+func (r *UserFeedbackRepository) GetByAgentID(agentID uuid.UUID, limit, offset int) ([]*domain.UserFeedback, error) {
+	query := `
+		SELECT id, agent_id, organization_id, user_id, rating, comment, created_at
+		FROM user_feedback
+		WHERE agent_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2 OFFSET $3
+	`
+	rows, err := r.db.Query(query, agentID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	feedback := make([]*domain.UserFeedback, 0)
+	for rows.Next() {
+		var f domain.UserFeedback
+		if err := rows.Scan(
+			&f.ID,
+			&f.AgentID,
+			&f.OrganizationID,
+			&f.UserID,
+			&f.Rating,
+			&f.Comment,
+			&f.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		feedback = append(feedback, &f)
+	}
+	return feedback, rows.Err()
+}
+
+// GetStats aggregates sentiment buckets in a single query so the trust
+// calculator can apply the count-threshold formula cheaply.
+func (r *UserFeedbackRepository) GetStats(agentID uuid.UUID) (*domain.UserFeedbackStats, error) {
+	query := `
+		SELECT
+			COUNT(*)                                            AS total,
+			COUNT(*) FILTER (WHERE rating >= 4)                 AS positive,
+			COUNT(*) FILTER (WHERE rating = 3)                  AS neutral,
+			COUNT(*) FILTER (WHERE rating <= 2)                 AS negative,
+			COALESCE(AVG(rating), 0)                            AS avg_rating
+		FROM user_feedback
+		WHERE agent_id = $1
+	`
+	stats := &domain.UserFeedbackStats{}
+	err := r.db.QueryRow(query, agentID).Scan(
+		&stats.Total,
+		&stats.PositiveCount,
+		&stats.NeutralCount,
+		&stats.NegativeCount,
+		&stats.AverageRating,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -309,6 +309,7 @@ type TrustCalculatorServicer interface {
 	CalculateTrustScore(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
 	GetLatestTrustScore(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
 	GetTrustScoreHistoryAuditTrail(ctx context.Context, agentID uuid.UUID, limit int) ([]*domain.TrustScoreHistoryEntry, error)
+	RecordUserFeedback(ctx context.Context, agentID, orgID uuid.UUID, userID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error)
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -1523,6 +1523,7 @@ type MockTrustCalculatorServicerImpl struct {
 	CalculateTrustScoreFunc            func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
 	GetLatestTrustScoreFunc            func(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
 	GetTrustScoreHistoryAuditTrailFunc func(ctx context.Context, agentID uuid.UUID, limit int) ([]*domain.TrustScoreHistoryEntry, error)
+	RecordUserFeedbackFunc             func(ctx context.Context, agentID, orgID uuid.UUID, userID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error)
 }
 
 func (m *MockTrustCalculatorServicerImpl) CalculateTrustScore(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error) {
@@ -1556,6 +1557,21 @@ func (m *MockTrustCalculatorServicerImpl) GetTrustScoreHistoryAuditTrail(ctx con
 		return m.GetTrustScoreHistoryAuditTrailFunc(ctx, agentID, limit)
 	}
 	return []*domain.TrustScoreHistoryEntry{}, nil
+}
+
+func (m *MockTrustCalculatorServicerImpl) RecordUserFeedback(ctx context.Context, agentID, orgID uuid.UUID, userID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error) {
+	if m.RecordUserFeedbackFunc != nil {
+		return m.RecordUserFeedbackFunc(ctx, agentID, orgID, userID, rating, comment)
+	}
+	return &domain.UserFeedback{
+		ID:             uuid.New(),
+		AgentID:        agentID,
+		OrganizationID: orgID,
+		UserID:         userID,
+		Rating:         rating,
+		Comment:        comment,
+		CreatedAt:      time.Now(),
+	}, nil
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
@@ -215,7 +215,7 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 	}
 	// NOTE: We intentionally do NOT auto-sync/recalculate trust scores here.
 	// The agent.TrustScore may differ from stored score.Score due to direct penalties
-	// from violations. Recalculating would cause double-counting because the 8-factor
+	// from violations. Recalculating would cause double-counting because the 9-factor
 	// algorithm also considers security alerts created by violations.
 	// Trust score recalculation should only happen on explicit user request or scheduled intervals.
 
@@ -226,16 +226,19 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 		})
 	}
 
-	// Define weights (matches trust_calculator.go weights)
+	// Define weights (must match the 9-factor weights in trust_calculator.go;
+	// these sum to exactly 1.0). Age, drift, and user feedback were reduced to
+	// make room for the 10% execution isolation factor.
 	weights := map[string]float64{
 		"verificationStatus": 0.25,
 		"uptime":             0.15,
 		"successRate":        0.15,
 		"securityAlerts":     0.15,
 		"compliance":         0.10,
-		"age":                0.10,
-		"driftDetection":     0.05,
-		"userFeedback":       0.05,
+		"age":                0.05,
+		"driftDetection":     0.03,
+		"userFeedback":       0.02,
+		"executionIsolation": 0.10,
 	}
 
 	// Calculate contributions (factor value × weight)
@@ -248,6 +251,7 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 		"age":                score.Factors.Age * weights["age"],
 		"driftDetection":     score.Factors.DriftDetection * weights["driftDetection"],
 		"userFeedback":       score.Factors.UserFeedback * weights["userFeedback"],
+		"executionIsolation": score.Factors.ExecutionIsolation * weights["executionIsolation"],
 	}
 
 	return c.JSON(fiber.Map{
@@ -263,11 +267,84 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 			"age":                score.Factors.Age,
 			"driftDetection":     score.Factors.DriftDetection,
 			"userFeedback":       score.Factors.UserFeedback,
+			"executionIsolation": score.Factors.ExecutionIsolation,
 		},
 		"weights":       weights,
 		"contributions": contributions,
 		"confidence":    score.Confidence,
 		"calculatedAt":  score.LastCalculated,
+	})
+}
+
+// SubmitUserFeedback records an explicit user rating (1-5) for an agent. This is
+// the collection side of the user feedback trust factor: ratings persisted here
+// are what calculateUserFeedback reads on the next score computation.
+func (h *TrustScoreHandler) SubmitUserFeedback(c fiber.Ctx) error {
+	orgID := c.Locals("organization_id").(uuid.UUID)
+	userID := c.Locals("user_id").(uuid.UUID)
+	agentID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid agent ID",
+		})
+	}
+
+	// Verify agent belongs to the caller's organization before accepting feedback
+	agent, err := h.getAgentService().GetAgent(c.Context(), agentID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Agent not found",
+		})
+	}
+	if agent.OrganizationID != orgID {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"error": "Access denied",
+		})
+	}
+
+	var body struct {
+		Rating  int    `json:"rating"`
+		Comment string `json:"comment"`
+	}
+	if err := c.Bind().JSON(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+	if body.Rating < 1 || body.Rating > 5 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Rating must be an integer between 1 and 5",
+		})
+	}
+
+	feedback, err := h.getTrustCalculator().RecordUserFeedback(c.Context(), agentID, orgID, &userID, body.Rating, body.Comment)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to record user feedback",
+		})
+	}
+
+	h.getAuditService().LogAction(
+		c.Context(),
+		orgID,
+		userID,
+		domain.AuditActionCreate,
+		"user_feedback",
+		agentID,
+		c.IP(),
+		c.Get("User-Agent"),
+		map[string]interface{}{
+			"agentName": agent.Name,
+			"rating":    body.Rating,
+		},
+	)
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"id":        feedback.ID,
+		"agentId":   feedback.AgentID,
+		"rating":    feedback.Rating,
+		"comment":   feedback.Comment,
+		"createdAt": feedback.CreatedAt,
 	})
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/trust_score_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/trust_score_handler_integration_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -808,4 +810,115 @@ func TestTrustScoreHandler_getAuditService_ReturnsInterface(t *testing.T) {
 
 	result := handler.getAuditService()
 	assert.Equal(t, auditMock, result)
+}
+
+// ===========================
+// SubmitUserFeedback Tests
+// ===========================
+
+func submitFeedbackRequest(agentID uuid.UUID, jsonBody string) *http.Request {
+	req := httptest.NewRequest("POST", "/agents/"+agentID.String()+"/feedback", strings.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestTrustScoreHandler_SubmitUserFeedback_Success(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+
+	agentMock := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID, Name: "test-agent"}, nil
+		},
+	}
+
+	var captured struct {
+		agentID, orgID uuid.UUID
+		userID         *uuid.UUID
+		rating         int
+		comment        string
+	}
+	trustMock := &MockTrustCalculatorServicerImpl{
+		RecordUserFeedbackFunc: func(ctx context.Context, aID, oID uuid.UUID, uID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error) {
+			captured.agentID, captured.orgID, captured.userID, captured.rating, captured.comment = aID, oID, uID, rating, comment
+			return &domain.UserFeedback{ID: uuid.New(), AgentID: aID, OrganizationID: oID, UserID: uID, Rating: rating, Comment: comment, CreatedAt: time.Now()}, nil
+		},
+	}
+
+	handler := NewTrustScoreHandlerWithInterfaces(trustMock, agentMock, &MockAuditServiceImpl{})
+	app := createTrustScoreTestApp(handler.SubmitUserFeedback, orgID, userID)
+	app.Post("/agents/:id/feedback", handler.SubmitUserFeedback)
+
+	resp, err := app.Test(submitFeedbackRequest(agentID, `{"rating":5,"comment":"great agent"}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode)
+	// The handler must scope persistence to the caller's org + agent, not trust the body.
+	assert.Equal(t, agentID, captured.agentID)
+	assert.Equal(t, orgID, captured.orgID)
+	require.NotNil(t, captured.userID)
+	assert.Equal(t, userID, *captured.userID)
+	assert.Equal(t, 5, captured.rating)
+	assert.Equal(t, "great agent", captured.comment)
+}
+
+func TestTrustScoreHandler_SubmitUserFeedback_InvalidRating(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+
+	agentMock := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID, Name: "test-agent"}, nil
+		},
+	}
+	// RecordUserFeedback must NOT be called for an out-of-range rating.
+	trustMock := &MockTrustCalculatorServicerImpl{
+		RecordUserFeedbackFunc: func(ctx context.Context, aID, oID uuid.UUID, uID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error) {
+			t.Fatalf("RecordUserFeedback should not be called for invalid rating %d", rating)
+			return nil, nil
+		},
+	}
+
+	handler := NewTrustScoreHandlerWithInterfaces(trustMock, agentMock, &MockAuditServiceImpl{})
+	app := createTrustScoreTestApp(handler.SubmitUserFeedback, orgID, userID)
+	app.Post("/agents/:id/feedback", handler.SubmitUserFeedback)
+
+	for _, body := range []string{`{"rating":0}`, `{"rating":6}`, `{"rating":-1}`} {
+		resp, err := app.Test(submitFeedbackRequest(agentID, body))
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode, "body %s should be rejected", body)
+		resp.Body.Close()
+	}
+}
+
+func TestTrustScoreHandler_SubmitUserFeedback_CrossOrgDenied(t *testing.T) {
+	orgID := uuid.New()
+	otherOrgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+
+	// Agent belongs to a different org than the caller.
+	agentMock := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: otherOrgID, Name: "other-org-agent"}, nil
+		},
+	}
+	trustMock := &MockTrustCalculatorServicerImpl{
+		RecordUserFeedbackFunc: func(ctx context.Context, aID, oID uuid.UUID, uID *uuid.UUID, rating int, comment string) (*domain.UserFeedback, error) {
+			t.Fatal("RecordUserFeedback should not be called for a cross-org agent")
+			return nil, nil
+		},
+	}
+
+	handler := NewTrustScoreHandlerWithInterfaces(trustMock, agentMock, &MockAuditServiceImpl{})
+	app := createTrustScoreTestApp(handler.SubmitUserFeedback, orgID, userID)
+	app.Post("/agents/:id/feedback", handler.SubmitUserFeedback)
+
+	resp, err := app.Test(submitFeedbackRequest(agentID, `{"rating":5}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }

--- a/apps/backend/migrations/101_create_user_feedback.sql
+++ b/apps/backend/migrations/101_create_user_feedback.sql
@@ -1,0 +1,17 @@
+-- Migration 101: User feedback for the trust score User Feedback factor
+-- Backs trust factor 8 (user_feedback, 2% weight). Replaces the hardcoded
+-- 0.5 neutral the calculator returned when no feedback collection existed.
+
+CREATE TABLE IF NOT EXISTS user_feedback (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    comment TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_feedback_agent_id ON user_feedback(agent_id);
+CREATE INDEX IF NOT EXISTS idx_user_feedback_agent_created ON user_feedback(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_user_feedback_organization_id ON user_feedback(organization_id);


### PR DESCRIPTION
## What

AIM's 9-factor agent trust score had four factors returning neutral hardcodes because their data sources were never connected, and the score-breakdown endpoint reported stale 8-factor weights that summed to 0.90. This connects the factors to real data and corrects the breakdown, so the score reflects real signals before any credential carries it.

Roadmap: `aim-score-integrity` (P1). Phase 0 confirmed all five defects with file:line evidence before any change.

## Honest scope — what is genuinely live vs reader-wired

"Wire a reader" is not the same as "end-to-end honest" for a factor whose table nothing writes. Of the four factors touched:

**Genuinely end-to-end (factor moves on real data):**
- **Compliance (factor 5)** — wired the snapshot repo on both ends. The reader (`SetSnapshotRepo`) reads the latest AIM compliance snapshot instead of returning 0.5; the writer swaps `NewComplianceService` → `NewComplianceServiceFull`, so `POST /compliance/snapshot` actually persists. Writer stores framework `"aim"`, reader queries `FrameworkAIM` — verified match.
- **User feedback (factor 8)** — new `UserFeedback` entity + repository + `user_feedback` table (migration 101), real sentiment-bucket scoring (negatives checked first so positives can't mask sustained complaints), **and** the collection endpoint `POST /trust-score/agents/:id/feedback` (org-scoped, rating 1-5, audit-logged).

**Reader-wired only (factor sits at its documented neutral baseline until a separate writer ships):**
- **Execution isolation (factor 9)** — `SetIsolationRepo` + new attestation repository read `isolation_attestations`; returns the 0.3 baseline because no SDK ingest endpoint writes it yet. *Follow-up.*
- **NanoMind TME** — `SetTMEProvider` + new repository read `nanomind_tme_evaluations`; no effect until the NanoMind monitor pipeline populates that table. *Follow-up (NanoMind track).*

These two emit documented neutral baselines, not faked data — so the score stays honest; they simply don't move yet.

**Breakdown handler** — corrected from stale 8-factor (sum 0.90, missing isolation) to the real 9 factors (sum 1.0) including `executionIsolation`. Also fixed stale "8-factor" code comments and the README breakdown caption.

## CDS note

The 9 weights were already committed and sum to 1.0 — the defect was wiring, not weighting, so weights are unchanged. The user-feedback scoring uses the documented count-threshold formula (neg>5→0.0, neg>2→0.5, pos>10→1.0, else 0.75).

## Tests

- 9-factor weight-sum (pre-existing) + new `MockUserFeedbackRepository` formula-threshold table test + repo-error-neutral fallback
- `RecordUserFeedback` validation/scoping
- Collection endpoint: success, invalid rating, cross-org denial
- `go build ./...`, `go vet`, and application/handlers/domain/repository suites green (incl. `-race`)

## Pre-push review

Passed the 8-phase gate. Notable: `hackmyagent secure` now 98/100 — the prior HIGH (`docker exec` variable interpolation in `deployments/otel-demo/smoke-backend.sh`, a pre-existing dev smoke script) is fixed at root in a separate commit by reaching Postgres over its published TCP port instead of `docker exec`. Remaining 1 LOW is a pre-existing missing-`.gitignore` INFO. hma-hunter (Phase 5) deferred — backend needs a provisioned Postgres+secrets env; the changed endpoints are covered by handler integration tests.

## Follow-ups (not blocking)

- SDK ingest endpoint for agents to self-report isolation posture (`domain.ScoreIsolation` already exists)
- Frontend breakdown UI should surface the new `executionIsolation` factor