### PR TITLE
Add Agent Trust Credential issuance delegating to the Registry

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/email"
 	infrasecrets "github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/secrets"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/metrics"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/registry"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/interfaces/http/handlers"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/interfaces/http/middleware"
@@ -611,6 +612,7 @@ type Services struct {
 	Remediation             *application.RemediationService             // For remediation tracking (agentpwn + HMA)
 	Secrets                 *application.SecretsService                 // For identity-native secrets management
 	FGA                     *application.FGAEngine                      // Fine-Grained Authorization engine (5-step decision flow)
+	ATCIssuance             *application.ATCIssuanceService             // Issues Registry-signed ATCs carrying AIM's behavioral score
 }
 
 func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCache, oauthRepo *repository.OAuthRepositoryPostgres, jwtService *auth.JWTService, emailService domain.EmailService) (*Services, *crypto.KeyVault) {
@@ -877,6 +879,16 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		)
 	}
 
+	// ATC issuance: compute the agent's 9-factor behavioral score and delegate
+	// credential signing + transparency-log recording to the Registry (the CA).
+	// Uses REGISTRY_BRIDGE_URL (shared) + REGISTRY_ATC_TOKEN (service-account bearer).
+	atcIssuanceService := application.NewATCIssuanceService(
+		repos.Agent,
+		repos.Organization,
+		trustCalculator,
+		registry.NewClientFromEnv(),
+	)
+
 	// Community Intelligence: opt-in anonymized trust factor telemetry
 	ciService := application.NewCommunityIntelligenceService(
 		repos.Organization,
@@ -1050,6 +1062,7 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		Remediation:             application.NewRemediationService(repos.Remediation), // For remediation tracking
 		Secrets:                 secretsService,                                       // For identity-native secrets management
 		FGA:                     fgaEngine,                                            // Fine-Grained Authorization engine
+		ATCIssuance:             atcIssuanceService,                                   // Registry-delegated ATC issuance
 	}, keyVault
 }
 
@@ -1091,6 +1104,7 @@ type Handlers struct {
 	Remediation             *handlers.RemediationHandler             // For remediation tracking (agentpwn + HMA)
 	Secrets                 *handlers.SecretsHandler                 // For identity-native secrets management
 	Authorize               *handlers.AuthorizeHandler               // POST /agents/:id/authorize -- FGA decision endpoint
+	ATCIssuance             *handlers.ATCIssuanceHandler             // POST /agents/:id/atc -- Registry-delegated ATC issuance
 }
 
 func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTService, keyVault *crypto.KeyVault, cfg *config.Config, db *sql.DB) *Handlers {
@@ -1281,6 +1295,11 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 			repos.Agent, // A3d-iii: namespace-path-id handlers verify namespace.AgentID -> agent.OrganizationID via LoadOwnedViaAgent
 		),
 		Authorize: handlers.NewAuthorizeHandler(services.FGA, repos.Agent),
+		ATCIssuance: handlers.NewATCIssuanceHandler(
+			services.ATCIssuance,
+			services.Agent,
+			services.Audit,
+		),
 	}
 }
 
@@ -1421,6 +1440,9 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Post("/:id/log-capability/:audit_id", h.Agent.LogCapabilityResult)
 	// Fine-Grained Authorization (5-step decision flow with OTel span tree)
 	agents.Post("/:id/authorize", h.Authorize.Authorize)
+	// Agent Trust Credential issuance - computes the behavioral score and delegates
+	// signing + transparency-log recording to the Registry (Certificate Authority)
+	agents.Post("/:id/atc", middleware.ManagerMiddleware(), h.ATCIssuance.IssueATC)
 	// SDK download endpoint - Download Python/Node.js/Go SDK with embedded credentials
 	agents.Get("/:id/sdk", h.Agent.DownloadSDK)
 	// Credentials endpoint - Get raw Ed25519 public/private keys for manual integration

--- a/apps/backend/internal/application/atc_issuance_service.go
+++ b/apps/backend/internal/application/atc_issuance_service.go
@@ -1,0 +1,224 @@
+package application
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/registry"
+)
+
+// defaultATCVersion is used when an agent has no declared version. The credential
+// carries a non-empty version so downstream verifiers never see an empty field.
+const defaultATCVersion = "agent-v1"
+
+// atcAgentReader loads the agent being credentialed.
+type atcAgentReader interface {
+	GetByID(id uuid.UUID) (*domain.Agent, error)
+}
+
+// atcOrgReader resolves the publisher name for the credential. Optional: when
+// nil or on lookup failure the service falls back to the organization UUID.
+type atcOrgReader interface {
+	GetByID(id uuid.UUID) (*domain.Organization, error)
+}
+
+// atcTrustScorer computes the agent's 9-factor behavioral trust score. This is
+// the score the credential carries — NOT the Registry's supply-chain package
+// score (see todo/roadmap/aim-atx-issuer.md).
+type atcTrustScorer interface {
+	CalculateTrustScore(ctx context.Context, agentID uuid.UUID) (*domain.TrustScore, error)
+}
+
+// atcRegistryClient delegates signing + transparency-log recording to the
+// Registry's ATC issuance endpoint.
+type atcRegistryClient interface {
+	IssueATC(ctx context.Context, req registry.ATCIssuanceRequest) (*registry.AgentTrustCredential, error)
+}
+
+// ATCIssuanceResult bundles the signed credential with the unsigned provenance
+// AIM is honest about but cannot yet carry in the signed credential (ATX v1.2).
+type ATCIssuanceResult struct {
+	Credential *registry.AgentTrustCredential `json:"credential"`
+
+	// Confidence is the score's self-reported confidence (0-1) from the 9-factor
+	// calculator. It is informational context for the badge consumer, not a
+	// signed field.
+	Confidence float64 `json:"confidence"`
+
+	// IsolationSelfReported is true while factor 9 (execution isolation) is
+	// self-reported. AIM has no verified isolation writer until the
+	// aim-isolation-verification track ships; surfacing this keeps the badge
+	// honest about the one factor whose provenance is not yet attested.
+	IsolationSelfReported bool `json:"isolationSelfReported"`
+}
+
+// ATCIssuanceService computes an AIM agent's behavioral trust score and delegates
+// Agent Trust Credential issuance to the Registry. AIM does not sign or store
+// ATCs itself; the Registry is the Certificate Authority.
+type ATCIssuanceService struct {
+	agents atcAgentReader
+	orgs   atcOrgReader
+	scorer atcTrustScorer
+	client atcRegistryClient
+}
+
+// NewATCIssuanceService wires the issuance trigger.
+func NewATCIssuanceService(
+	agents atcAgentReader,
+	orgs atcOrgReader,
+	scorer atcTrustScorer,
+	client atcRegistryClient,
+) *ATCIssuanceService {
+	return &ATCIssuanceService{
+		agents: agents,
+		orgs:   orgs,
+		scorer: scorer,
+		client: client,
+	}
+}
+
+// IssueForAgent computes the agent's behavioral score, builds the issuance
+// request, and calls the Registry. It returns the signed credential plus the
+// unsigned provenance context.
+//
+// Side effect: CalculateTrustScore recomputes and persists the agent's current
+// trust score, so an issuance attempt updates stored trust state even if the
+// subsequent Registry call fails. This is intentional — the credential carries
+// the freshly-computed score — but it means /atc is not a side-effect-free read.
+func (s *ATCIssuanceService) IssueForAgent(ctx context.Context, agentID uuid.UUID) (*ATCIssuanceResult, error) {
+	agent, err := s.agents.GetByID(agentID)
+	if err != nil {
+		return nil, fmt.Errorf("atc issuance: load agent: %w", err)
+	}
+
+	score, err := s.scorer.CalculateTrustScore(ctx, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("atc issuance: calculate trust score: %w", err)
+	}
+
+	req := buildATCIssuanceRequest(agent, score, s.resolvePublisher(agent), time.Now().UTC())
+
+	cred, err := s.client.IssueATC(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("atc issuance: registry issue: %w", err)
+	}
+
+	return &ATCIssuanceResult{
+		Credential:            cred,
+		Confidence:            score.Confidence,
+		IsolationSelfReported: true,
+	}, nil
+}
+
+// resolvePublisher returns the organization name as the credential publisher,
+// falling back to the organization UUID when the name is unavailable.
+func (s *ATCIssuanceService) resolvePublisher(agent *domain.Agent) string {
+	if s.orgs != nil {
+		if org, err := s.orgs.GetByID(agent.OrganizationID); err == nil && org != nil && org.Name != "" {
+			return org.Name
+		}
+	}
+	return agent.OrganizationID.String()
+}
+
+// buildATCIssuanceRequest assembles the Registry issuance request from an agent
+// and its behavioral score. Pure (no I/O) so it is directly unit-testable. now
+// is injected for the same reason.
+func buildATCIssuanceRequest(agent *domain.Agent, score *domain.TrustScore, publisher string, now time.Time) registry.ATCIssuanceRequest {
+	version := agent.Version
+	if version == "" {
+		version = defaultATCVersion
+	}
+
+	level := atcTrustLevel(score.Score)
+	scoreVal := score.Score
+
+	generatedAt := score.LastCalculated
+	if generatedAt.IsZero() {
+		generatedAt = now
+	}
+
+	return registry.ATCIssuanceRequest{
+		AgentID:      agent.ID.String(),
+		AgentDID:     domain.BuildAgentDID(agent.ID),
+		Publisher:    publisher,
+		Version:      version,
+		ContentHash:  atcContentHash(agent),
+		Capabilities: agent.Capabilities,
+		TrustScore:   &scoreVal,
+		TrustLevel:   &level,
+		BehavioralProfile: &registry.ATCBehavioralProfile{
+			Checksum:        atcBehavioralChecksum(score.Factors),
+			GeneratedAt:     generatedAt.UTC(),
+			ObservationDays: atcObservationDays(agent.CreatedAt, now),
+		},
+	}
+}
+
+// atcTrustLevel maps a 0-1 behavioral score to the 0-4 trust level. CDS-documented
+// mapping (calibration-subject), aligned with the five trust levels:
+// >=0.90 -> 4, >=0.75 -> 3, >=0.50 -> 2, >=0.25 -> 1, otherwise 0.
+func atcTrustLevel(score float64) int {
+	switch {
+	case score >= 0.90:
+		return 4
+	case score >= 0.75:
+		return 3
+	case score >= 0.50:
+		return 2
+	case score >= 0.25:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// atcContentHash binds the credential to the agent's public key. The key is the
+// stable identity material for an AIM agent (there is no package artifact). When
+// no public key is set yet, we hash the agent ID so the field is never empty.
+func atcContentHash(agent *domain.Agent) string {
+	var data []byte
+	switch {
+	case agent.PublicKey != nil && *agent.PublicKey != "":
+		if decoded, err := base64.StdEncoding.DecodeString(*agent.PublicKey); err == nil {
+			data = decoded
+		} else {
+			data = []byte(*agent.PublicKey)
+		}
+	default:
+		idBytes := agent.ID
+		data = idBytes[:]
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// atcBehavioralChecksum is the SHA-256 of the canonical 9-factor breakdown. It
+// binds the behavioral profile to the exact factor values that produced the
+// score without putting the raw factors on the wire. encoding/json marshals
+// struct fields in declaration order, so this is deterministic.
+func atcBehavioralChecksum(factors domain.TrustScoreFactors) string {
+	b, _ := json.Marshal(factors)
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// atcObservationDays is the whole-day age of the agent at issuance time, used as
+// the behavioral profile's observation window. Clamped to >= 0.
+func atcObservationDays(createdAt, now time.Time) int {
+	if createdAt.IsZero() {
+		return 0
+	}
+	days := int(now.Sub(createdAt).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}

--- a/apps/backend/internal/application/atc_issuance_service_test.go
+++ b/apps/backend/internal/application/atc_issuance_service_test.go
@@ -1,0 +1,225 @@
+package application
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/registry"
+)
+
+func TestATCTrustLevel(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  int
+	}{
+		{0.95, 4},
+		{0.90, 4},
+		{0.89, 3},
+		{0.75, 3},
+		{0.74, 2},
+		{0.50, 2},
+		{0.49, 1},
+		{0.25, 1},
+		{0.24, 0},
+		{0.0, 0},
+	}
+	for _, c := range cases {
+		if got := atcTrustLevel(c.score); got != c.want {
+			t.Errorf("atcTrustLevel(%v) = %d, want %d", c.score, got, c.want)
+		}
+	}
+}
+
+func TestATCObservationDays(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	if got := atcObservationDays(now.Add(-72*time.Hour), now); got != 3 {
+		t.Errorf("observationDays = %d, want 3", got)
+	}
+	if got := atcObservationDays(time.Time{}, now); got != 0 {
+		t.Errorf("zero createdAt should give 0, got %d", got)
+	}
+	if got := atcObservationDays(now.Add(24*time.Hour), now); got != 0 {
+		t.Errorf("future createdAt should clamp to 0, got %d", got)
+	}
+}
+
+func TestATCContentHash_PublicKeyVsFallback(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	// No public key -> hash of the agent ID bytes.
+	noKey := &domain.Agent{ID: id}
+	idSum := sha256.Sum256(id[:])
+	wantFallback := "sha256:" + hex.EncodeToString(idSum[:])
+	if got := atcContentHash(noKey); got != wantFallback {
+		t.Errorf("fallback contentHash = %q, want %q", got, wantFallback)
+	}
+
+	// With a public key, the hash must differ from the fallback.
+	pk := "dGhpcyBpcyBhIGZha2Uga2V5" // base64
+	withKey := &domain.Agent{ID: id, PublicKey: &pk}
+	if got := atcContentHash(withKey); got == wantFallback {
+		t.Error("contentHash with public key should differ from ID fallback")
+	}
+}
+
+func TestATCBehavioralChecksum_Deterministic(t *testing.T) {
+	f := domain.TrustScoreFactors{VerificationStatus: 1, Uptime: 0.9, Compliance: 0.5}
+	a := atcBehavioralChecksum(f)
+	b := atcBehavioralChecksum(f)
+	if a != b {
+		t.Errorf("checksum not deterministic: %q vs %q", a, b)
+	}
+	raw, _ := json.Marshal(f)
+	sum := sha256.Sum256(raw)
+	if want := "sha256:" + hex.EncodeToString(sum[:]); a != want {
+		t.Errorf("checksum = %q, want %q", a, want)
+	}
+	// A different breakdown must produce a different checksum.
+	if atcBehavioralChecksum(domain.TrustScoreFactors{VerificationStatus: 0.1}) == a {
+		t.Error("different factors should produce different checksum")
+	}
+}
+
+func TestBuildATCIssuanceRequest(t *testing.T) {
+	id := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	now := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	agent := &domain.Agent{
+		ID:           id,
+		Version:      "", // exercise default
+		Capabilities: []string{"file:read", "api:call"},
+		CreatedAt:    now.Add(-240 * time.Hour), // 10 days
+	}
+	score := &domain.TrustScore{
+		Score:          0.82,
+		Confidence:     0.7,
+		LastCalculated: now.Add(-time.Hour),
+		Factors:        domain.TrustScoreFactors{VerificationStatus: 1},
+	}
+
+	req := buildATCIssuanceRequest(agent, score, "Acme Org", now)
+
+	if req.AgentDID != "did:aip:aim_"+id.String() {
+		t.Errorf("agentDid = %q", req.AgentDID)
+	}
+	if req.Version != defaultATCVersion {
+		t.Errorf("version = %q, want default %q", req.Version, defaultATCVersion)
+	}
+	if req.Publisher != "Acme Org" {
+		t.Errorf("publisher = %q", req.Publisher)
+	}
+	if req.TrustScore == nil || *req.TrustScore != 0.82 {
+		t.Errorf("trustScore = %+v", req.TrustScore)
+	}
+	if req.TrustLevel == nil || *req.TrustLevel != 3 {
+		t.Errorf("trustLevel = %+v, want 3", req.TrustLevel)
+	}
+	if req.BehavioralProfile == nil || req.BehavioralProfile.ObservationDays != 10 {
+		t.Errorf("observationDays = %+v, want 10", req.BehavioralProfile)
+	}
+	if len(req.Capabilities) != 2 {
+		t.Errorf("capabilities = %v", req.Capabilities)
+	}
+}
+
+// --- fakes for IssueForAgent end-to-end ---
+
+type fakeAgentReader struct {
+	agent *domain.Agent
+	err   error
+}
+
+func (f *fakeAgentReader) GetByID(id uuid.UUID) (*domain.Agent, error) { return f.agent, f.err }
+
+type fakeOrgReader struct{ org *domain.Organization }
+
+func (f *fakeOrgReader) GetByID(id uuid.UUID) (*domain.Organization, error) { return f.org, nil }
+
+type fakeScorer struct {
+	score *domain.TrustScore
+	err   error
+}
+
+func (f *fakeScorer) CalculateTrustScore(ctx context.Context, id uuid.UUID) (*domain.TrustScore, error) {
+	return f.score, f.err
+}
+
+type fakeRegistryClient struct {
+	gotReq registry.ATCIssuanceRequest
+	cred   *registry.AgentTrustCredential
+	err    error
+}
+
+func (f *fakeRegistryClient) IssueATC(ctx context.Context, req registry.ATCIssuanceRequest) (*registry.AgentTrustCredential, error) {
+	f.gotReq = req
+	return f.cred, f.err
+}
+
+func TestIssueForAgent_HappyPath(t *testing.T) {
+	id := uuid.New()
+	agent := &domain.Agent{ID: id, OrganizationID: uuid.New(), Capabilities: []string{"x"}}
+	score := &domain.TrustScore{Score: 0.91, Confidence: 0.6}
+	client := &fakeRegistryClient{cred: &registry.AgentTrustCredential{TransparencyLogIndex: 5, TrustLevel: 4}}
+
+	svc := NewATCIssuanceService(
+		&fakeAgentReader{agent: agent},
+		&fakeOrgReader{org: &domain.Organization{Name: "Acme"}},
+		&fakeScorer{score: score},
+		client,
+	)
+
+	res, err := svc.IssueForAgent(context.Background(), id)
+	if err != nil {
+		t.Fatalf("IssueForAgent: %v", err)
+	}
+	if client.gotReq.Publisher != "Acme" {
+		t.Errorf("publisher resolved = %q, want Acme", client.gotReq.Publisher)
+	}
+	if client.gotReq.TrustLevel == nil || *client.gotReq.TrustLevel != 4 {
+		t.Errorf("level in request = %+v, want 4", client.gotReq.TrustLevel)
+	}
+	if res.Credential.TransparencyLogIndex != 5 {
+		t.Errorf("credential index = %d, want 5", res.Credential.TransparencyLogIndex)
+	}
+	if res.Confidence != 0.6 {
+		t.Errorf("confidence = %v, want 0.6", res.Confidence)
+	}
+	if !res.IsolationSelfReported {
+		t.Error("IsolationSelfReported should be true until aim-isolation-verification")
+	}
+}
+
+func TestIssueForAgent_PublisherFallbackToOrgID(t *testing.T) {
+	id := uuid.New()
+	orgID := uuid.New()
+	agent := &domain.Agent{ID: id, OrganizationID: orgID}
+	client := &fakeRegistryClient{cred: &registry.AgentTrustCredential{}}
+
+	// nil org reader -> fall back to org UUID string.
+	svc := NewATCIssuanceService(&fakeAgentReader{agent: agent}, nil, &fakeScorer{score: &domain.TrustScore{Score: 0.3}}, client)
+	if _, err := svc.IssueForAgent(context.Background(), id); err != nil {
+		t.Fatalf("IssueForAgent: %v", err)
+	}
+	if client.gotReq.Publisher != orgID.String() {
+		t.Errorf("publisher = %q, want org UUID %q", client.gotReq.Publisher, orgID.String())
+	}
+}
+
+func TestIssueForAgent_ScoreErrorPropagates(t *testing.T) {
+	id := uuid.New()
+	svc := NewATCIssuanceService(
+		&fakeAgentReader{agent: &domain.Agent{ID: id}},
+		nil,
+		&fakeScorer{err: errors.New("boom")},
+		&fakeRegistryClient{cred: &registry.AgentTrustCredential{}},
+	)
+	if _, err := svc.IssueForAgent(context.Background(), id); err == nil {
+		t.Fatal("expected score error to propagate")
+	}
+}

--- a/apps/backend/internal/domain/agent_did.go
+++ b/apps/backend/internal/domain/agent_did.go
@@ -1,0 +1,22 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// AgentDIDPrefix is the AIM-specific DID prefix. AIM agents are identified by the
+// did:aip method, and the AIM namespace identifier is "aim_" followed by the
+// agent's UUID (see internal/interfaces/http/handlers/aip_handler.go for the
+// resolver that maps a did:aip:aim_<uuid> back to GetByID).
+const AgentDIDPrefix = "did:aip:aim_"
+
+// BuildAgentDID returns the canonical did:aip identifier for an AIM agent:
+// did:aip:aim_<uuid>. This is the single source of truth for AIM's DID format,
+// shared by the DID resolver (aip_handler) and the ATC issuance trigger so the
+// agentDid carried into a credential is byte-identical to the one the resolver
+// answers for.
+func BuildAgentDID(agentID uuid.UUID) string {
+	return fmt.Sprintf("%s%s", AgentDIDPrefix, agentID.String())
+}

--- a/apps/backend/internal/domain/agent_did_test.go
+++ b/apps/backend/internal/domain/agent_did_test.go
@@ -1,0 +1,30 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildAgentDID asserts the canonical did:aip:aim_<uuid> shape and that the
+// emitted DID is byte-identical to prefix + the agent UUID, so the agentDid
+// carried into an issued credential matches what the did:aip resolver answers.
+func TestBuildAgentDID(t *testing.T) {
+	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+
+	got := BuildAgentDID(id)
+
+	assert.Equal(t, "did:aip:aim_11111111-2222-3333-4444-555555555555", got)
+	assert.Equal(t, AgentDIDPrefix+id.String(), got)
+	assert.True(t, len(got) > len(AgentDIDPrefix), "DID must carry the UUID after the prefix")
+}
+
+// TestBuildAgentDID_DistinctPerAgent guards against a constant/shared-DID bug:
+// two different agent UUIDs must map to two different DIDs.
+func TestBuildAgentDID_DistinctPerAgent(t *testing.T) {
+	a := BuildAgentDID(uuid.MustParse("11111111-1111-1111-1111-111111111111"))
+	b := BuildAgentDID(uuid.MustParse("22222222-2222-2222-2222-222222222222"))
+
+	assert.NotEqual(t, a, b)
+}

--- a/apps/backend/internal/infrastructure/registry/atc_client.go
+++ b/apps/backend/internal/infrastructure/registry/atc_client.go
@@ -1,0 +1,190 @@
+// Package registry contains clients for AIM's outbound calls to the OpenA2A
+// Registry. The Registry is the binding-decision Certificate Authority for Agent
+// Trust Credentials (ATCs): AIM does NOT issue ATCs itself. Instead it computes
+// an agent's 9-factor behavioral trust score and delegates issuance to the
+// Registry's POST /internal/atc/issue endpoint, which signs (threshold Ed25519 +
+// ML-DSA-65), records the issuance to the RFC 6962 transparency log, and returns
+// the portable credential. See todo/roadmap/aim-atx-issuer.md (CA decision).
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultRegistryURL is used when REGISTRY_BRIDGE_URL is unset. It matches the
+	// default already used by RegistryBridgeService so both outbound integrations
+	// target the same Registry.
+	defaultRegistryURL = "https://api.oa2a.org"
+
+	// issueATCPath is the Registry's internal issuance endpoint (scope
+	// internal:threats:write on the service-account bearer token).
+	issueATCPath = "/internal/atc/issue"
+
+	atcClientTimeout = 30 * time.Second
+	atcClientUA      = "aim-server/atc-issuer"
+)
+
+// ErrTokenNotConfigured is returned when REGISTRY_ATC_TOKEN is unset. Issuance is
+// a privileged Registry call; without the service-account bearer there is no
+// credential to attempt, so we fail closed rather than send an unauthenticated
+// request.
+var ErrTokenNotConfigured = errors.New("registry: REGISTRY_ATC_TOKEN is not set")
+
+// ATCBehavioralProfile mirrors the Registry's behavioral profile shape. It
+// summarizes observed runtime behavior; the checksum binds the credential to a
+// specific 9-factor score breakdown without carrying the raw factors on the wire.
+type ATCBehavioralProfile struct {
+	Checksum        string    `json:"checksum"`
+	GeneratedAt     time.Time `json:"generatedAt"`
+	ObservationDays int       `json:"observationDays"`
+}
+
+// ATCIssuanceRequest mirrors the Registry's ATCIssuanceRequest. TrustScore,
+// TrustLevel, and BehavioralProfile are the optional behavioral overrides the
+// Registry applies when the subject is a did:aip agent (rather than a package).
+// For an AIM agent they are always set: they carry AIM's behavioral score, not
+// the Registry's supply-chain package score.
+type ATCIssuanceRequest struct {
+	AgentID           string                `json:"agentId"`
+	AgentDID          string                `json:"agentDid"`
+	Publisher         string                `json:"publisher"`
+	Version           string                `json:"version"`
+	ContentHash       string                `json:"contentHash"`
+	Capabilities      []string              `json:"capabilities,omitempty"`
+	TrustScore        *float64              `json:"trustScore,omitempty"`
+	TrustLevel        *int                  `json:"trustLevel,omitempty"`
+	BehavioralProfile *ATCBehavioralProfile `json:"behavioralProfile,omitempty"`
+}
+
+// ATCSignature mirrors a single signature on the returned credential.
+type ATCSignature struct {
+	KeyID     string `json:"keyId"`
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
+}
+
+// AgentTrustCredential mirrors the subset of the Registry's response that AIM
+// surfaces to callers. The full response is also retained in Raw so the handler
+// can return the Registry's exact signed bytes without lossy re-marshalling.
+type AgentTrustCredential struct {
+	ID                   string                `json:"id"`
+	ATCVersion           string                `json:"atcVersion"`
+	AgentID              string                `json:"agentId"`
+	AgentDID             string                `json:"agentDid"`
+	Publisher            string                `json:"publisher"`
+	Version              string                `json:"version"`
+	ContentHash          string                `json:"contentHash"`
+	TransparencyLogIndex int64                 `json:"transparencyLogIndex"`
+	Capabilities         []string              `json:"capabilities"`
+	BehavioralProfile    *ATCBehavioralProfile `json:"behavioralProfile,omitempty"`
+	TrustScore           float64               `json:"trustScore"`
+	TrustLevel           int                   `json:"trustLevel"`
+	IssuedAt             time.Time             `json:"issuedAt"`
+	ExpiresAt            time.Time             `json:"expiresAt"`
+	IssuerDID            string                `json:"issuerDid"`
+	Signatures           []ATCSignature        `json:"signatures"`
+
+	// Raw is the verbatim JSON the Registry returned, populated by the client so
+	// callers can pass the signed credential through unchanged.
+	Raw json.RawMessage `json:"-"`
+}
+
+// Client calls the Registry's ATC issuance endpoint.
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// NewClientFromEnv builds a Client from REGISTRY_BRIDGE_URL (shared with the
+// bridge service, default https://api.oa2a.org) and REGISTRY_ATC_TOKEN (the
+// new service-account bearer provisioned in Phase C).
+func NewClientFromEnv() *Client {
+	base := strings.TrimSpace(os.Getenv("REGISTRY_BRIDGE_URL"))
+	if base == "" {
+		base = defaultRegistryURL
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(base, "/"),
+		token:      strings.TrimSpace(os.Getenv("REGISTRY_ATC_TOKEN")),
+		httpClient: &http.Client{Timeout: atcClientTimeout},
+	}
+}
+
+// NewClient builds a Client with explicit configuration (used by tests).
+func NewClient(baseURL, token string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: atcClientTimeout}
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      strings.TrimSpace(token),
+		httpClient: httpClient,
+	}
+}
+
+// IssueATC POSTs the issuance request to the Registry and returns the signed
+// credential. Errors fail closed: a missing token, a transport failure, or a
+// non-2xx status all return an error rather than a partial credential.
+func (c *Client) IssueATC(ctx context.Context, req ATCIssuanceRequest) (*AgentTrustCredential, error) {
+	if c.token == "" {
+		return nil, ErrTokenNotConfigured
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("registry: marshal issuance request: %w", err)
+	}
+
+	url := c.baseURL + issueATCPath
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("registry: build issuance request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+	httpReq.Header.Set("User-Agent", atcClientUA)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("registry: issuance request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("registry: read issuance response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("registry: issuance returned status %d: %s", resp.StatusCode, snippet(respBody))
+	}
+
+	var cred AgentTrustCredential
+	if err := json.Unmarshal(respBody, &cred); err != nil {
+		return nil, fmt.Errorf("registry: decode credential: %w", err)
+	}
+	cred.Raw = json.RawMessage(respBody)
+	return &cred, nil
+}
+
+// snippet trims an error body so a large or HTML error page does not flood logs.
+func snippet(b []byte) string {
+	const max = 256
+	s := strings.TrimSpace(string(b))
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
+}

--- a/apps/backend/internal/infrastructure/registry/atc_client_test.go
+++ b/apps/backend/internal/infrastructure/registry/atc_client_test.go
@@ -1,0 +1,134 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func float64Ptr(v float64) *float64 { return &v }
+func intPtr(v int) *int             { return &v }
+
+func sampleRequest() ATCIssuanceRequest {
+	return ATCIssuanceRequest{
+		AgentID:      "11111111-1111-1111-1111-111111111111",
+		AgentDID:     "did:aip:aim_11111111-1111-1111-1111-111111111111",
+		Publisher:    "Acme Org",
+		Version:      "agent-v1",
+		ContentHash:  "sha256:abc",
+		Capabilities: []string{"file:read"},
+		TrustScore:   float64Ptr(0.82),
+		TrustLevel:   intPtr(3),
+		BehavioralProfile: &ATCBehavioralProfile{
+			Checksum:        "sha256:deadbeef",
+			GeneratedAt:     time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+			ObservationDays: 42,
+		},
+	}
+}
+
+func TestClient_IssueATC_Success(t *testing.T) {
+	var gotAuth, gotCT, gotPath string
+	var gotReq ATCIssuanceRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		// Include signed TBS fields the AIM mirror struct does NOT model
+		// (scanSummary, issuerChain, publisherDid) so the Raw-fidelity assertion
+		// below proves the verbatim bytes — the ones a consumer verifies against —
+		// survive the client even though the struct drops these fields.
+		_, _ = w.Write([]byte(`{
+			"id":"22222222-2222-2222-2222-222222222222",
+			"atcVersion":"1.1",
+			"agentId":"11111111-1111-1111-1111-111111111111",
+			"agentDid":"did:aip:aim_11111111-1111-1111-1111-111111111111",
+			"publisherDid":"did:web:registry.oa2a.org",
+			"transparencyLogIndex":7,
+			"scanSummary":{"hma":"pass","criticalFindings":0,"highFindings":0},
+			"issuerChain":["did:web:registry.oa2a.org"],
+			"trustScore":0.82,
+			"trustLevel":3,
+			"expiresAt":"2026-06-27T00:00:00Z",
+			"signatures":[{"keyId":"k1","algorithm":"Ed25519","value":"sig"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret-token", nil)
+	cred, err := c.IssueATC(context.Background(), sampleRequest())
+	if err != nil {
+		t.Fatalf("IssueATC returned error: %v", err)
+	}
+
+	if gotPath != issueATCPath {
+		t.Errorf("path = %q, want %q", gotPath, issueATCPath)
+	}
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer secret-token")
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if gotReq.AgentDID != sampleRequest().AgentDID {
+		t.Errorf("agentDid round-trip = %q", gotReq.AgentDID)
+	}
+	if gotReq.TrustScore == nil || *gotReq.TrustScore != 0.82 {
+		t.Errorf("trustScore not carried in request body: %+v", gotReq.TrustScore)
+	}
+	if cred.TransparencyLogIndex != 7 {
+		t.Errorf("transparencyLogIndex = %d, want 7", cred.TransparencyLogIndex)
+	}
+	if cred.TrustLevel != 3 {
+		t.Errorf("trustLevel = %d, want 3", cred.TrustLevel)
+	}
+	if len(cred.Raw) == 0 {
+		t.Error("expected Raw to be populated with verbatim response bytes")
+	}
+	// Raw must preserve signed TBS fields the mirror struct does not model. The
+	// handler returns cred.Raw (not the parsed struct) precisely so a consumer can
+	// re-project the full TBS and verify the signature; if Raw dropped these, the
+	// returned credential would be unverifiable.
+	var rawObj map[string]json.RawMessage
+	if err := json.Unmarshal(cred.Raw, &rawObj); err != nil {
+		t.Fatalf("Raw is not valid JSON: %v", err)
+	}
+	for _, field := range []string{"scanSummary", "issuerChain", "publisherDid"} {
+		if _, ok := rawObj[field]; !ok {
+			t.Errorf("Raw is missing signed field %q that the mirror struct does not model; "+
+				"returning the parsed struct instead of Raw would yield an unverifiable credential", field)
+		}
+	}
+}
+
+func TestClient_IssueATC_MissingToken(t *testing.T) {
+	c := NewClient("https://example.invalid", "", nil)
+	_, err := c.IssueATC(context.Background(), sampleRequest())
+	if !errors.Is(err, ErrTokenNotConfigured) {
+		t.Fatalf("expected ErrTokenNotConfigured, got %v", err)
+	}
+}
+
+func TestClient_IssueATC_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"insufficient_scope"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok", nil)
+	_, err := c.IssueATC(context.Background(), sampleRequest())
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/aip_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/aip_handler.go
@@ -36,6 +36,7 @@ func (h *AIPHandler) WellKnownAIP(c fiber.Ctx) error {
 			"verify":       "/api/v1/agents/{agentId}/verify",
 			"capabilities": "/api/v1/capabilities",
 			"trustScore":   "/api/v1/agents/{agentId}/trust",
+			"atc":          "/api/v1/agents/{agentId}/atc",
 			"audit":        "/api/v1/agents/{agentId}/audit",
 			"didResolve":   "/api/v1/did/{did}",
 		},
@@ -104,7 +105,7 @@ func (h *AIPHandler) ResolveDID(c fiber.Ctx) error {
 	}
 
 	// Build W3C DID Document (https://www.w3.org/TR/did-core/)
-	did := fmt.Sprintf("did:aip:aim_%s", agent.ID.String())
+	did := domain.BuildAgentDID(agent.ID)
 
 	// Build verification methods from agent's public key
 	verificationMethods := []fiber.Map{}

--- a/apps/backend/internal/interfaces/http/handlers/atc_issuance_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/atc_issuance_handler.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/registry"
+)
+
+// ATCIssuanceHandler exposes POST /agents/:id/atc. It issues a portable Agent
+// Trust Credential carrying AIM's behavioral trust score, by delegating signing +
+// transparency-log recording to the Registry (the Certificate Authority).
+type ATCIssuanceHandler struct {
+	service      *application.ATCIssuanceService
+	agentService *application.AgentService
+	auditService *application.AuditService
+}
+
+// NewATCIssuanceHandler wires the handler.
+func NewATCIssuanceHandler(
+	service *application.ATCIssuanceService,
+	agentService *application.AgentService,
+	auditService *application.AuditService,
+) *ATCIssuanceHandler {
+	return &ATCIssuanceHandler{
+		service:      service,
+		agentService: agentService,
+		auditService: auditService,
+	}
+}
+
+// IssueATC handles POST /agents/:id/atc.
+func (h *ATCIssuanceHandler) IssueATC(c fiber.Ctx) error {
+	orgID, ok := c.Locals("organization_id").(uuid.UUID)
+	// Reject a missing or zero organization. A Nil orgID would otherwise compare
+	// equal to an agent whose OrganizationID is also Nil, collapsing the tenant
+	// check below — fail closed instead of issuing a credential cross-tenant.
+	if !ok || orgID == uuid.Nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+	userID, _ := c.Locals("user_id").(uuid.UUID)
+
+	agentID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid agent ID"})
+	}
+
+	// Authorize: the agent must belong to the caller's organization. This mirrors
+	// the trust-score endpoints' tenant check so a credential can only be issued
+	// for an agent the caller owns.
+	agent, err := h.agentService.GetAgent(c.Context(), agentID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Agent not found"})
+	}
+	if agent.OrganizationID != orgID {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "Access denied"})
+	}
+
+	result, err := h.service.IssueForAgent(c.Context(), agentID)
+	if err != nil {
+		// A missing service-account token is a server configuration problem, not a
+		// client error — surface it distinctly so operators can spot an unprovisioned
+		// REGISTRY_ATC_TOKEN (Phase C) rather than misreading it as a bad request.
+		if errors.Is(err, registry.ErrTokenNotConfigured) {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"error": "ATC issuance is not configured (registry service-account token missing)",
+			})
+		}
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": "Failed to issue Agent Trust Credential",
+		})
+	}
+
+	cred := result.Credential
+
+	// Audit the issuance. Best-effort: a logging failure must not fail an
+	// otherwise-successful issuance.
+	_ = h.auditService.LogAction(
+		c.Context(),
+		orgID,
+		userID,
+		domain.AuditActionGenerate,
+		"atc",
+		agentID,
+		c.IP(),
+		c.Get("User-Agent"),
+		map[string]interface{}{
+			"agentName":            agent.Name,
+			"agentDid":             cred.AgentDID,
+			"trustScore":           cred.TrustScore,
+			"trustLevel":           cred.TrustLevel,
+			"transparencyLogIndex": cred.TransparencyLogIndex,
+		},
+	)
+
+	// Return the Registry's VERBATIM signed credential bytes (cred.Raw), not the
+	// parsed mirror struct. The hybrid signature covers JCS(TBS) over the full field
+	// set (scanSummary, issuerChain, publisherDid, buildAttestation, declaredPurpose);
+	// AIM's AgentTrustCredential models only the subset it needs for audit/UX, so
+	// re-marshalling it would strip signed fields and yield a credential whose
+	// signature no longer verifies. AIM is a pass-through for the signed artifact;
+	// the Registry is the CA. The parsed struct above is used only for the audit log.
+	//
+	// The unsigned provenance context (confidence, isolation caveat) keeps the badge
+	// honest about factor 9 until the verified isolation writer ships
+	// (aim-isolation-verification).
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"credential": cred.Raw,
+		"provenance": fiber.Map{
+			"confidence":            result.Confidence,
+			"isolationSelfReported": result.IsolationSelfReported,
+			"note":                  "trustScore is AIM's 9-factor behavioral score; factor 9 (execution isolation) is self-reported until verified-isolation attestation ships.",
+		},
+	})
+}

--- a/apps/backend/internal/interfaces/http/handlers/atc_issuance_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/atc_issuance_handler_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+// These tests are a no-DB route-registration smoke for POST /agents/:id/atc.
+// They exercise the authz + validation paths that return before any service or
+// repository call, so the handler can be wired with nil dependencies. Live
+// end-to-end verification (against Postgres + the Registry) is Phase D.
+
+func TestATCIssuanceHandler_MissingOrg_Unauthorized(t *testing.T) {
+	h := NewATCIssuanceHandler(nil, nil, nil)
+	app := fiber.New()
+	app.Post("/agents/:id/atc", h.IssueATC)
+
+	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/atc", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 when organization_id is absent", resp.StatusCode)
+	}
+}
+
+func TestATCIssuanceHandler_NilOrg_Unauthorized(t *testing.T) {
+	h := NewATCIssuanceHandler(nil, nil, nil)
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		// A malformed token could set a zero-value org. It must not authorize: a
+		// Nil orgID would compare equal to a Nil-org agent and collapse the tenant
+		// check.
+		c.Locals("organization_id", uuid.Nil)
+		c.Locals("user_id", uuid.New())
+		return c.Next()
+	})
+	app.Post("/agents/:id/atc", h.IssueATC)
+
+	req := httptest.NewRequest("POST", "/agents/"+uuid.New().String()+"/atc", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 when organization_id is the zero UUID", resp.StatusCode)
+	}
+}
+
+func TestATCIssuanceHandler_BadAgentID_BadRequest(t *testing.T) {
+	h := NewATCIssuanceHandler(nil, nil, nil)
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals("organization_id", uuid.New())
+		c.Locals("user_id", uuid.New())
+		return c.Next()
+	})
+	app.Post("/agents/:id/atc", h.IssueATC)
+
+	req := httptest.NewRequest("POST", "/agents/not-a-uuid/atc", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for an invalid agent ID", resp.StatusCode)
+	}
+}

--- a/apps/web/components/agent/trust-score-breakdown.tsx
+++ b/apps/web/components/agent/trust-score-breakdown.tsx
@@ -13,6 +13,7 @@ import {
   Clock,
   TrendingUp,
   ThumbsUp,
+  Lock,
   Info,
   History
 } from 'lucide-react';
@@ -134,7 +135,26 @@ const factorMetadata = {
     color: 'text-pink-600',
     bgColor: 'bg-pink-500/10',
   },
+  executionIsolation: {
+    icon: Lock,
+    label: 'Execution Isolation',
+    description: 'Sandboxing and runtime isolation of agent execution (self-reported until isolation verification ships)',
+    color: 'text-amber-600',
+    bgColor: 'bg-amber-500/10',
+  },
 };
+
+// Fallback rendering metadata for any factor key the backend emits that is not
+// yet in factorMetadata. Prevents a newly added trust factor from crashing the
+// entire breakdown tab (regression guard: the 9th factor "executionIsolation"
+// shipped server-side before this map was updated).
+const fallbackFactorMetadata = {
+  icon: Shield,
+  label: 'Trust Factor',
+  description: 'Contributing trust factor',
+  color: 'text-gray-600',
+  bgColor: 'bg-gray-500/10',
+} as const;
 
 export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScoreUpdate }: TrustScoreBreakdownProps) {
   const [breakdown, setBreakdown] = useState<TrustScoreBreakdown | null>(null);
@@ -271,7 +291,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
           </CardHeader>
           <CardContent className="space-y-4">
             {Object.entries(breakdown.factors).map(([key, value]) => {
-              const metadata = factorMetadata[key as keyof typeof factorMetadata];
+              const metadata = factorMetadata[key as keyof typeof factorMetadata] ?? fallbackFactorMetadata;
               const Icon = metadata.icon;
               const weight = breakdown.weights[key as keyof typeof breakdown.weights];
               const contribution = breakdown.contributions[key as keyof typeof breakdown.contributions];


### PR DESCRIPTION
## Summary

AIM computes an agent's 9-factor **behavioral** trust score and delegates Agent Trust Credential signing + transparency-log recording to the Registry's `POST /internal/atc/issue` endpoint (the Certificate Authority). AIM does not sign or store credentials itself. This wires the issuance trigger, the Registry client, the public endpoint, and discovery.

## What changed (all under `apps/backend/`)

- **`domain.BuildAgentDID`** — single source of truth for `did:aip:aim_<uuid>`; the DID resolver (`aip_handler`) now reuses it instead of an inline `fmt.Sprintf`.
- **`infrastructure/registry.Client`** — `IssueATC` POSTs the issuance request with a service-account bearer (`REGISTRY_ATC_TOKEN`), 30s timeout. Fails **closed**: a missing token (`ErrTokenNotConfigured`), a non-2xx status, or a transport error returns an error, never a partial credential. Retains the verbatim signed response in `Raw`.
- **`application.ATCIssuanceService`** — `IssueForAgent` loads the agent, computes the score, builds the request, and calls the Registry. The credential carries the **behavioral** score (not the supply-chain package score). Score `[0,1]` → level `[0,4]` via the CDS-documented map. Factor 9 (execution isolation) is flagged self-reported in the unsigned provenance until verified-isolation attestation ships.
- **`POST /api/v1/agents/:id/atc`** — organization-ownership authorization (rejects a missing or zero org), audit logging, and a distinct **503** when the service-account token is unprovisioned (vs. 502 for other issuance failures).
- **`/.well-known/aip`** advertises the `atc` endpoint for consumer discovery.

## Credential integrity (verbatim pass-through)

The handler returns the Registry's **verbatim signed bytes** (`cred.Raw`), not AIM's parsed mirror struct. The hybrid Ed25519 + ML-DSA-65 signature covers JCS over the full TBS field set (`scanSummary`, `issuerChain`, `publisherDid`, `buildAttestation`, `declaredPurpose`). AIM's struct intentionally models only the subset it needs for audit/UX, so returning it would strip signed fields and yield a credential whose signature **no longer verifies**. A regression test asserts `Raw` preserves fields the struct does not model.

## Tests

`go build`, `go vet`, and `go test -race` on the touched packages are green:
- Client: header/path/body round-trip, missing-token, 403, and Raw-fidelity (preserves un-modeled signed fields).
- Service: level map, observation days, content-hash key-vs-fallback, deterministic checksum, request builder, happy/publisher-fallback/score-error.
- Handler: no-DB authz smoke — 401 (missing org), 401 (zero org), 400 (bad id).

## Merge coordination

Touches `cmd/server/main.go` (service/handler struct fields, assembly, and one route in the agents group ~L1445). **PR #311 (`feat/aim-isolation-ingest`)** also edits `main.go` in a different region — expect a trivial merge-time touch; coordinate at merge.

## Notes / follow-ups

- New environment variable **`REGISTRY_ATC_TOKEN`** — provisioned operationally (service-account bearer, scope `internal:threats:write`); the endpoint returns 503 until it is set.
- Pre-existing `gofmt` drift in `main.go` / `aip_handler.go` (present on `main`, ~300 lines of comment-alignment) is left untouched to avoid burying this change in unrelated reformatting; all new files are `gofmt`-clean. A separate `gofmt` cleanup is worth doing.
- `behavioralProfile.observationDays` is the agent's age in whole days (documented); sourcing it from first/last verification-event timestamps is a possible refinement.
- A clean signed `behavioralTrustScore`/`behavioralTrustLevel` two-field split is an ATX v1.2 item (coordinated with the Registry issuer + `pkg/atcverify` + atx-spec).