### PR TITLE
Rename ATC client to ATCClient to avoid cloud-build collision

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -886,7 +886,7 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.Agent,
 		repos.Organization,
 		trustCalculator,
-		registry.NewClientFromEnv(),
+		registry.NewATCClientFromEnv(),
 	)
 
 	// Community Intelligence: opt-in anonymized trust factor telemetry

--- a/apps/backend/internal/infrastructure/registry/atc_client.go
+++ b/apps/backend/internal/infrastructure/registry/atc_client.go
@@ -99,34 +99,37 @@ type AgentTrustCredential struct {
 	Raw json.RawMessage `json:"-"`
 }
 
-// Client calls the Registry's ATC issuance endpoint.
-type Client struct {
+// ATCClient calls the Registry's ATC issuance endpoint. It is named distinctly
+// from the registry bridge Client (a separate, cloud-deployment registry client
+// in this same package) so the two do not collide when the cloud build composes
+// both into package registry.
+type ATCClient struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
 }
 
-// NewClientFromEnv builds a Client from REGISTRY_BRIDGE_URL (shared with the
-// bridge service, default https://api.oa2a.org) and REGISTRY_ATC_TOKEN (the
+// NewATCClientFromEnv builds an ATCClient from REGISTRY_BRIDGE_URL (shared with
+// the bridge service, default https://api.oa2a.org) and REGISTRY_ATC_TOKEN (the
 // new service-account bearer provisioned in Phase C).
-func NewClientFromEnv() *Client {
+func NewATCClientFromEnv() *ATCClient {
 	base := strings.TrimSpace(os.Getenv("REGISTRY_BRIDGE_URL"))
 	if base == "" {
 		base = defaultRegistryURL
 	}
-	return &Client{
+	return &ATCClient{
 		baseURL:    strings.TrimRight(base, "/"),
 		token:      strings.TrimSpace(os.Getenv("REGISTRY_ATC_TOKEN")),
 		httpClient: &http.Client{Timeout: atcClientTimeout},
 	}
 }
 
-// NewClient builds a Client with explicit configuration (used by tests).
-func NewClient(baseURL, token string, httpClient *http.Client) *Client {
+// NewATCClient builds an ATCClient with explicit configuration (used by tests).
+func NewATCClient(baseURL, token string, httpClient *http.Client) *ATCClient {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: atcClientTimeout}
 	}
-	return &Client{
+	return &ATCClient{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		token:      strings.TrimSpace(token),
 		httpClient: httpClient,
@@ -136,7 +139,7 @@ func NewClient(baseURL, token string, httpClient *http.Client) *Client {
 // IssueATC POSTs the issuance request to the Registry and returns the signed
 // credential. Errors fail closed: a missing token, a transport failure, or a
 // non-2xx status all return an error rather than a partial credential.
-func (c *Client) IssueATC(ctx context.Context, req ATCIssuanceRequest) (*AgentTrustCredential, error) {
+func (c *ATCClient) IssueATC(ctx context.Context, req ATCIssuanceRequest) (*AgentTrustCredential, error) {
 	if c.token == "" {
 		return nil, ErrTokenNotConfigured
 	}

--- a/apps/backend/internal/infrastructure/registry/atc_client_test.go
+++ b/apps/backend/internal/infrastructure/registry/atc_client_test.go
@@ -65,7 +65,7 @@ func TestClient_IssueATC_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "secret-token", nil)
+	c := NewATCClient(srv.URL, "secret-token", nil)
 	cred, err := c.IssueATC(context.Background(), sampleRequest())
 	if err != nil {
 		t.Fatalf("IssueATC returned error: %v", err)
@@ -112,7 +112,7 @@ func TestClient_IssueATC_Success(t *testing.T) {
 }
 
 func TestClient_IssueATC_MissingToken(t *testing.T) {
-	c := NewClient("https://example.invalid", "", nil)
+	c := NewATCClient("https://example.invalid", "", nil)
 	_, err := c.IssueATC(context.Background(), sampleRequest())
 	if !errors.Is(err, ErrTokenNotConfigured) {
 		t.Fatalf("expected ErrTokenNotConfigured, got %v", err)
@@ -126,7 +126,7 @@ func TestClient_IssueATC_Non2xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "tok", nil)
+	c := NewATCClient(srv.URL, "tok", nil)
 	_, err := c.IssueATC(context.Background(), sampleRequest())
 	if err == nil {
 		t.Fatal("expected error on 403, got nil")


### PR DESCRIPTION
## Problem

The keystone merge (#312) broke the **AIM Cloud deploy**. The `Sync to AIM Cloud` workflow composes a cloud-only registry bridge client (`internal/infrastructure/registry/client.go`, declaring `type Client` / `func NewClient`) into the same `package registry` as the public ATC issuance client. The ATC client's generic names collided:

```
internal/infrastructure/registry/client.go:16:6: Client redeclared in this block
	internal/infrastructure/registry/atc_client.go:103:6: other declaration of Client
BUILD FAILED -- sync introduced errors.
```

The public repo has no `client.go`, so public CI never saw the collision; only the cloud sync build did.

## Fix

Rename the ATC issuance client to `ATCClient` / `NewATCClient` / `NewATCClientFromEnv`. The issuance service depends on the `atcRegistryClient` interface, so no caller logic changes — pure rename. Registry deploy (#276) already succeeded; this unblocks the AIM deploy.

Verified: `go build ./...`, `go vet`, registry + application tests green.