### PR TITLE
Honeytoken capabilities: high-severity alert + audit on verification (#293)

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -706,6 +706,10 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.Organization,       // ✅ NEW: Inject OrganizationRepository for checking enforcement mode
 		capabilityRequestService, // NEW: For mode-aware capability approval workflow on re-registration
 	)
+	// Wire the audit-log repo so a honeytoken verification hit records an audit
+	// event alongside the high-severity alert (issue #293). Setter-injected to keep
+	// the constructor signature stable.
+	agentService.SetHoneytokenAuditing(repos.AuditLog)
 
 	apiKeyService := application.NewAPIKeyService(
 		repos.APIKey,
@@ -1751,6 +1755,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Get("/:id/capabilities", h.Capability.GetAgentCapabilities)
 	agents.Post("/:id/capabilities", middleware.ManagerMiddleware(), h.Capability.GrantCapability)
 	agents.Delete("/:id/capabilities/:capabilityId", middleware.ManagerMiddleware(), h.Capability.RevokeCapability)
+	agents.Put("/:id/capabilities/:capabilityId/honeytoken", middleware.ManagerMiddleware(), h.Capability.MarkHoneytoken) // issue #293: operator marks/unmarks a granted capability as a honeytoken decoy
 
 	// Agent violation routes (under /agents/:id/violations)
 	agents.Get("/:id/violations", h.Capability.GetViolationsByAgent)

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -43,6 +43,16 @@ type AgentService struct {
 	userRepo                 domain.UserRepository         // ✅ For looking up user details (audit trail)
 	orgRepo                  domain.OrganizationRepository // ✅ For checking enforcement mode
 	capabilityRequestService *CapabilityRequestService     // For routing re-registration capability adds through the mode-aware approval workflow (monitoring auto-approves, strict creates pending request)
+	auditRepo                domain.AuditLogRepository      // Optional (issue #293): records the audit event on a honeytoken verification hit; injected via SetHoneytokenAuditing
+}
+
+// SetHoneytokenAuditing wires an audit-log repository so a honeytoken verification
+// hit records an audit event in addition to the high-severity alert (issue #293).
+// Injected via a setter — mirroring SetAlerting on the MCP manifest service (#275)
+// — so the constructor and its many callers/tests stay unchanged. When unset, a
+// honeytoken hit still raises the alert; only the audit-log write is skipped.
+func (s *AgentService) SetHoneytokenAuditing(auditRepo domain.AuditLogRepository) {
+	s.auditRepo = auditRepo
 }
 
 // NewAgentService creates a new agent service
@@ -882,14 +892,170 @@ func (s *AgentService) HasCapability(ctx context.Context, agentID uuid.UUID, cap
 		return false, nil
 	}
 
-	// Check if capability matches any granted capability
+	// Check if capability matches any granted capability. We scan every granted
+	// capability (rather than returning on the first match) so a honeytoken match
+	// is never missed when a non-honeytoken capability happens to match first.
+	hasCapability := false
+	hasHoneytokenMatch := false
+	for _, cap := range capabilities {
+		if !s.matchesCapability(capabilityToCheck, resource, cap.CapabilityType) {
+			continue
+		}
+		hasCapability = true
+		if cap.Honeytoken {
+			hasHoneytokenMatch = true
+		}
+	}
+
+	// 🍯 Honeytoken tripwire (issue #293): a match on a decoy capability is a
+	// high-confidence compromise indicator. Raise the alert/audit but keep the
+	// normal authorization result (indistinguishability — the caller, e.g. the
+	// FGA engine, gets the same answer it would without the flag). Best-effort:
+	// the agent is fetched lazily only on a (rare) honeytoken hit.
+	if hasHoneytokenMatch {
+		if agent, aerr := s.agentRepo.GetByID(agentID); aerr == nil {
+			s.detectHoneytoken(agent, capabilities, capabilityToCheck, resource, "")
+		}
+	}
+
+	return hasCapability, nil
+}
+
+// HasCapabilityNoAlert reports whether the agent has a granted capability matching
+// the request WITHOUT firing honeytoken detection. It exists for a secondary
+// has-capability check inside a request that has ALREADY run detection — notably the
+// SDK /verify handler (CreateVerification), which calls VerifyCapability first and
+// then needs the raw boolean to decide capability-violation alerting. Using
+// HasCapability there would double-fire the honeytoken alert/audit for one request.
+func (s *AgentService) HasCapabilityNoAlert(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error) {
+	capabilities, err := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get capabilities: %w", err)
+	}
 	for _, cap := range capabilities {
 		if s.matchesCapability(capabilityToCheck, resource, cap.CapabilityType) {
 			return true, nil
 		}
 	}
-
 	return false, nil
+}
+
+// detectHoneytoken scans an agent's granted capabilities for a honeytoken that
+// matches this verification request and, on a match, raises a high-severity alert
+// and records an audit event (issue #293). Side-effect-only and best-effort: it
+// never changes the authorization decision, and an alert/audit write failure never
+// fails verification. A honeytoken is a decoy no legitimate workflow exercises, so
+// a match is a high-confidence compromise indicator with near-zero false-positive
+// cost. The zero-FP property rests on the operator keeping the decoy out of real
+// workflows; MarkHoneytoken refuses to flag a type that overlaps a live grant
+// (capability_service.go) so the common footgun cannot create false positives.
+func (s *AgentService) detectHoneytoken(
+	agent *domain.Agent,
+	capabilities []*domain.AgentCapability,
+	requestedCapability string,
+	resource string,
+	sourceIP string,
+) {
+	if agent == nil {
+		return
+	}
+	for _, cap := range capabilities {
+		if cap == nil || !cap.Honeytoken {
+			continue
+		}
+		if !s.matchesCapability(requestedCapability, resource, cap.CapabilityType) {
+			continue
+		}
+		raiseHoneytokenAlert(s.alertRepo, s.auditRepo, agent, cap, requestedCapability, resource, sourceIP)
+	}
+}
+
+// raiseHoneytokenAlert records the audit event and the high-severity alert for a
+// honeytoken verification hit (issue #293). Package-level so both the AgentService
+// verification paths and CapabilityService.VerifyAction raise an identical tripwire.
+// Mirrors the best-effort, nil-safe alert wiring used for MCP manifest drift (#275):
+// write failures are logged and swallowed so capability verification is never blocked
+// by alerting. The audit event is written first (when an audit repo is wired) so the
+// alert can link to it through Alert.AuditID.
+func raiseHoneytokenAlert(
+	alertRepo domain.AlertRepository,
+	auditRepo domain.AuditLogRepository,
+	agent *domain.Agent,
+	cap *domain.AgentCapability,
+	requestedCapability string,
+	resource string,
+	sourceIP string,
+) {
+	if agent == nil || cap == nil {
+		return
+	}
+
+	// Audit event first so the alert can reference it.
+	var auditID *uuid.UUID
+	if auditRepo != nil {
+		entry := &domain.AuditLog{
+			ID:             uuid.New(),
+			OrganizationID: agent.OrganizationID,
+			AgentID:        &agent.ID,
+			Action:         domain.AuditActionHoneytokenTriggered,
+			ResourceType:   "capability",
+			ResourceID:     cap.ID,
+			IPAddress:      sourceIP,
+			Metadata: map[string]interface{}{
+				"honeytoken":           true,
+				"capabilityId":         cap.ID.String(),
+				"honeytokenCapability": cap.CapabilityType,
+				"requestedCapability":  requestedCapability,
+				"resource":             resource,
+				"agentName":            agent.DisplayName,
+			},
+			Timestamp: time.Now().UTC(),
+		}
+		if err := auditRepo.Create(entry); err != nil {
+			fmt.Printf("⚠️  Failed to record honeytoken audit event for capability %s: %v\n", cap.ID, err)
+		} else {
+			id := entry.ID
+			auditID = &id
+		}
+	}
+
+	if alertRepo == nil {
+		return
+	}
+	alert := &domain.Alert{
+		ID:             uuid.New(),
+		OrganizationID: agent.OrganizationID,
+		AlertType:      domain.AlertHoneytokenTriggered,
+		Severity:       domain.AlertSeverityHigh,
+		Title:          fmt.Sprintf("Honeytoken capability triggered: %s", agent.DisplayName),
+		Description: fmt.Sprintf(
+			"Agent '%s' issued a verification request against honeytoken capability '%s' "+
+				"(requested: '%s', resource: '%s'). No legitimate workflow exercises a honeytoken, "+
+				"so this is a high-confidence compromise indicator. The authorization decision was "+
+				"left unchanged; this alert is a tripwire only.",
+			agent.DisplayName, cap.CapabilityType, requestedCapability, resource),
+		ResourceType: "capability",
+		ResourceID:   cap.ID,
+		AuditID:      auditID,
+		AgentName:    agent.DisplayName,
+		SourceIP:     sourceIP,
+		Metadata: map[string]interface{}{
+			"honeytoken":           true,
+			"agentId":              agent.ID.String(),
+			"capabilityId":         cap.ID.String(),
+			"honeytokenCapability": cap.CapabilityType,
+			"requestedCapability":  requestedCapability,
+			"resource":             resource,
+		},
+		IsAcknowledged: false,
+		CreatedAt:      time.Now().UTC(),
+	}
+	if err := alertRepo.Create(alert); err != nil {
+		fmt.Printf("⚠️  Failed to create honeytoken alert for capability %s: %v\n", cap.ID, err)
+		return
+	}
+	fmt.Printf("🚨 Honeytoken triggered: agent %s matched honeytoken capability %s (severity=high)\n",
+		agent.DisplayName, cap.CapabilityType)
 }
 
 // VerifyCapability verifies if an agent can use a capability
@@ -909,6 +1075,19 @@ func (s *AgentService) VerifyCapability(
 	agent, err := s.agentRepo.GetByID(agentID)
 	if err != nil {
 		return false, "Agent not found", uuid.Nil, err
+	}
+
+	// 🍯 HONEYTOKEN DETECTION (issue #293) — runs before the status/enforcement
+	// branches so ANY verification request matching a honeytoken capability is
+	// caught regardless of the downstream allow/deny decision (including the
+	// monitoring-mode and unverified early returns below). The fetched slice is
+	// reused by the CBAC check (step 4), so this adds no extra query on the hot
+	// path. Detection is a tripwire only: it never changes the authorization
+	// outcome (indistinguishability — a probing attacker gets the normal decision
+	// and no signal that the decoy was tripped).
+	activeCapabilities, capFetchErr := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
+	if capFetchErr == nil {
+		s.detectHoneytoken(agent, activeCapabilities, capability, resource, sourceIP)
 	}
 
 	// 2. Check agent status - MUST be verified (unless MONITORING mode)
@@ -1004,10 +1183,11 @@ func (s *AgentService) VerifyCapability(
 	// - Scope violations like CVE-2025-32711 (EchoLeak)
 	// - Unclear approval chains (full audit trail via granted_by, granted_at)
 
-	// ✅ Fetch GRANTED capabilities (single source of truth for enforcement)
-	activeCapabilities, err := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
-	if err != nil {
-		return false, fmt.Sprintf("Failed to fetch agent capabilities: %v", err), auditID, err
+	// ✅ Fetch GRANTED capabilities (single source of truth for enforcement).
+	// Reuses the slice fetched above for honeytoken detection to avoid a second
+	// query on the hot verification path.
+	if capFetchErr != nil {
+		return false, fmt.Sprintf("Failed to fetch agent capabilities: %v", capFetchErr), auditID, capFetchErr
 	}
 
 	// Build list of granted capability types for error messages

--- a/apps/backend/internal/application/agent_service_honeytoken_test.go
+++ b/apps/backend/internal/application/agent_service_honeytoken_test.go
@@ -1,0 +1,198 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #293: a verification request that matches a honeytoken capability must raise
+// a high-severity alert and record an audit event, while leaving the authorization
+// decision unchanged (indistinguishability). Normal traffic against non-honeytoken
+// capabilities must produce zero alerts/audits (no false positives).
+
+// HasCapability is the FGA-engine verification path. A honeytoken match raises the
+// alert + audit and links them, and the boolean result is unchanged.
+func TestAgentService_HasCapability_Honeytoken_RaisesHighSeverityAlertAndAudit(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(MockAlertRepository)
+	mockAuditRepo := new(SharedMockAuditLogRepository)
+
+	service := &AgentService{
+		agentRepo:      mockAgentRepo,
+		capabilityRepo: mockCapabilityRepo,
+		alertRepo:      mockAlertRepo,
+		auditRepo:      mockAuditRepo,
+	}
+
+	agentID := uuid.New()
+	orgID := uuid.New()
+	honeytokenCapID := uuid.New()
+	// The honeytoken is the second grant so the test also proves detection is not
+	// short-circuited by an earlier non-honeytoken match.
+	capabilities := []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: "file:read"},
+		{ID: honeytokenCapID, AgentID: agentID, CapabilityType: "admin:exfiltrate", Honeytoken: true},
+	}
+
+	mockCapabilityRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return(capabilities, nil)
+	mockAgentRepo.On("GetByID", agentID).Return(
+		&domain.Agent{ID: agentID, OrganizationID: orgID, DisplayName: "decoy-agent"}, nil)
+
+	var capturedAlert *domain.Alert
+	mockAlertRepo.On("Create", mock.AnythingOfType("*domain.Alert")).Run(func(args mock.Arguments) {
+		capturedAlert = args.Get(0).(*domain.Alert)
+	}).Return(nil)
+
+	var capturedAudit *domain.AuditLog
+	mockAuditRepo.On("Create", mock.AnythingOfType("*domain.AuditLog")).Run(func(args mock.Arguments) {
+		capturedAudit = args.Get(0).(*domain.AuditLog)
+	}).Return(nil)
+
+	allowed, err := service.HasCapability(context.Background(), agentID, "admin:exfiltrate", "/secrets")
+	require.NoError(t, err)
+
+	// Decision preserved: a granted (honeytoken) capability still authorizes — the
+	// tripwire must be indistinguishable from a real grant to a probing attacker.
+	assert.True(t, allowed, "honeytoken must not change the allow/deny decision")
+
+	// Exactly one high-severity alert of the honeytoken type.
+	mockAlertRepo.AssertNumberOfCalls(t, "Create", 1)
+	require.NotNil(t, capturedAlert)
+	assert.Equal(t, domain.AlertHoneytokenTriggered, capturedAlert.AlertType)
+	assert.Equal(t, domain.AlertSeverityHigh, capturedAlert.Severity)
+	assert.Equal(t, orgID, capturedAlert.OrganizationID)
+	assert.Equal(t, honeytokenCapID, capturedAlert.ResourceID)
+
+	// Exactly one audit event, linked to the alert.
+	mockAuditRepo.AssertNumberOfCalls(t, "Create", 1)
+	require.NotNil(t, capturedAudit)
+	assert.Equal(t, domain.AuditActionHoneytokenTriggered, capturedAudit.Action)
+	assert.Equal(t, honeytokenCapID, capturedAudit.ResourceID)
+	require.NotNil(t, capturedAlert.AuditID, "alert should link to the audit event")
+	assert.Equal(t, capturedAudit.ID, *capturedAlert.AuditID)
+}
+
+// No false positives: a verification request that matches only non-honeytoken
+// capabilities raises no alert, records no audit, and never even fetches the agent.
+func TestAgentService_HasCapability_NonHoneytoken_NoAlertNoAudit(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(MockAlertRepository)
+	mockAuditRepo := new(SharedMockAuditLogRepository)
+
+	service := &AgentService{
+		agentRepo:      mockAgentRepo,
+		capabilityRepo: mockCapabilityRepo,
+		alertRepo:      mockAlertRepo,
+		auditRepo:      mockAuditRepo,
+	}
+
+	agentID := uuid.New()
+	capabilities := []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: "file:read"},
+	}
+	mockCapabilityRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return(capabilities, nil)
+
+	allowed, err := service.HasCapability(context.Background(), agentID, "file:read", "/test.txt")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	mockAlertRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockAuditRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockAgentRepo.AssertNotCalled(t, "GetByID", mock.Anything)
+}
+
+// VerifyCapability is the primary /verify path. Detection runs before the
+// status/enforcement branches, so the alert+audit fire even when the request is
+// ultimately denied for an unrelated reason (here: the agent is compromised). This
+// proves "any verification request against a honeytoken" is covered and that the
+// honeytoken is not what changed the decision.
+func TestAgentService_VerifyCapability_Honeytoken_FiresBeforeDecision(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(MockAlertRepository)
+	mockAuditRepo := new(SharedMockAuditLogRepository)
+
+	service := &AgentService{
+		agentRepo:      mockAgentRepo,
+		capabilityRepo: mockCapabilityRepo,
+		alertRepo:      mockAlertRepo,
+		auditRepo:      mockAuditRepo,
+	}
+
+	agentID := uuid.New()
+	orgID := uuid.New()
+	honeytokenCapID := uuid.New()
+	capabilities := []*domain.AgentCapability{
+		{ID: honeytokenCapID, AgentID: agentID, CapabilityType: "admin:exfiltrate", Honeytoken: true},
+	}
+
+	// Verified (so the status branch is skipped) but compromised (so the request
+	// returns at step 3 — after honeytoken detection — without reaching the policy
+	// engine). Detection is independent of this outcome.
+	mockAgentRepo.On("GetByID", agentID).Return(&domain.Agent{
+		ID:             agentID,
+		OrganizationID: orgID,
+		DisplayName:    "decoy-agent",
+		Status:         domain.AgentStatusVerified,
+		IsCompromised:  true,
+	}, nil)
+	mockCapabilityRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return(capabilities, nil)
+
+	var capturedAlert *domain.Alert
+	mockAlertRepo.On("Create", mock.AnythingOfType("*domain.Alert")).Run(func(args mock.Arguments) {
+		capturedAlert = args.Get(0).(*domain.Alert)
+	}).Return(nil)
+	mockAuditRepo.On("Create", mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+
+	allowed, _, _, err := service.VerifyCapability(
+		context.Background(), agentID, "admin:exfiltrate", "/secrets", nil, "203.0.113.7")
+	require.NoError(t, err)
+	assert.False(t, allowed, "decision is driven by the compromised flag, not the honeytoken")
+
+	mockAlertRepo.AssertNumberOfCalls(t, "Create", 1)
+	mockAuditRepo.AssertNumberOfCalls(t, "Create", 1)
+	require.NotNil(t, capturedAlert)
+	assert.Equal(t, domain.AlertHoneytokenTriggered, capturedAlert.AlertType)
+	assert.Equal(t, domain.AlertSeverityHigh, capturedAlert.Severity)
+	assert.Equal(t, "203.0.113.7", capturedAlert.SourceIP)
+}
+
+// HasCapabilityNoAlert is the non-detecting variant used for a secondary
+// has-capability check inside a request that already ran detection (the SDK /verify
+// handler calls VerifyCapability first). It must NOT fire the honeytoken tripwire,
+// otherwise a single verification double-alerts.
+func TestAgentService_HasCapabilityNoAlert_DoesNotFireHoneytoken(t *testing.T) {
+	mockAgentRepo := new(MockAgentRepository)
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(MockAlertRepository)
+	mockAuditRepo := new(SharedMockAuditLogRepository)
+
+	service := &AgentService{
+		agentRepo:      mockAgentRepo,
+		capabilityRepo: mockCapabilityRepo,
+		alertRepo:      mockAlertRepo,
+		auditRepo:      mockAuditRepo,
+	}
+
+	agentID := uuid.New()
+	capabilities := []*domain.AgentCapability{
+		{ID: uuid.New(), AgentID: agentID, CapabilityType: "admin:exfiltrate", Honeytoken: true},
+	}
+	mockCapabilityRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return(capabilities, nil)
+
+	allowed, err := service.HasCapabilityNoAlert(context.Background(), agentID, "admin:exfiltrate", "/secrets")
+	require.NoError(t, err)
+	assert.True(t, allowed, "decision must match HasCapability")
+
+	mockAlertRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockAuditRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockAgentRepo.AssertNotCalled(t, "GetByID", mock.Anything)
+}

--- a/apps/backend/internal/application/capability_request_service_test.go
+++ b/apps/backend/internal/application/capability_request_service_test.go
@@ -154,6 +154,15 @@ func (m *MockCapabilityRepoForCapReq) RevokeCapability(id uuid.UUID, revokedAt t
 	return nil
 }
 
+func (m *MockCapabilityRepoForCapReq) SetHoneytoken(id uuid.UUID, honeytoken bool) error {
+	cap, ok := m.capabilities[id]
+	if !ok {
+		return errors.New("capability not found")
+	}
+	cap.Honeytoken = honeytoken
+	return nil
+}
+
 func (m *MockCapabilityRepoForCapReq) DeleteCapability(id uuid.UUID) error {
 	delete(m.capabilities, id)
 	return nil

--- a/apps/backend/internal/application/capability_service.go
+++ b/apps/backend/internal/application/capability_service.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
+
+// ErrHoneytokenNotAllowed is returned by MarkHoneytoken when a capability cannot be
+// flagged as a honeytoken without creating false positives (a wildcard type, or a
+// type that collides with another active grant). It is a client/validation error —
+// handlers should map it to HTTP 400, not 500 (issue #293).
+var ErrHoneytokenNotAllowed = errors.New("capability cannot be marked as a honeytoken")
 
 // VerificationResult represents the result of an action verification
 type VerificationResult struct {
@@ -93,6 +101,20 @@ func (s *CapabilityService) VerifyAction(
 	}
 
 	inScope := s.hasCapability(capabilities, requestedCapability)
+
+	// 🍯 Honeytoken tripwire (issue #293): if this verification matches a honeytoken
+	// decoy, raise a high-severity alert + audit. Side-effect only — the authorization
+	// outcome below is unchanged (indistinguishability). Honeytokens are exact types
+	// (MarkHoneytoken rejects wildcards), matching this path's exact-match semantics.
+	for _, cap := range capabilities {
+		if cap != nil && cap.Honeytoken && cap.CapabilityType == requestedCapability {
+			sip := ""
+			if sourceIP != nil {
+				sip = *sourceIP
+			}
+			raiseHoneytokenAlert(s.alertRepo, s.auditRepo, agent, cap, requestedCapability, "", sip)
+		}
+	}
 
 	if !inScope {
 		// 4. Record violation
@@ -395,6 +417,87 @@ func (s *CapabilityService) RevokeCapability(
 	}
 
 	return nil
+}
+
+// MarkHoneytoken marks (or unmarks) a granted capability as a honeytoken (issue #293).
+// A honeytoken is a decoy that no legitimate workflow should ever exercise; any later
+// verification request that matches it raises a high-severity alert and records an
+// audit event. This is an operator action — exposed only on the admin grant surface,
+// never the SDK self-register path, so an agent can neither set nor discover the flag.
+// Returns the updated capability for the caller to echo back.
+func (s *CapabilityService) MarkHoneytoken(
+	ctx context.Context,
+	capabilityID uuid.UUID,
+	honeytoken bool,
+	markedBy *uuid.UUID,
+) (*domain.AgentCapability, error) {
+	capability, err := s.capabilityRepo.GetCapabilityByID(capabilityID)
+	if err != nil {
+		return nil, fmt.Errorf("capability not found: %w", err)
+	}
+
+	agent, err := s.agentRepo.GetByID(capability.AgentID)
+	if err != nil {
+		return nil, fmt.Errorf("agent not found: %w", err)
+	}
+
+	// Guard the zero-false-positive contract at mark time (issue #293). A honeytoken
+	// only works if no legitimate workflow ever exercises it, so refuse the two ways
+	// a mark could create false positives:
+	//   1. A wildcard type (e.g. "file:*") matches broad real traffic — a decoy must
+	//      be a specific, never-used capability.
+	//   2. Another ACTIVE non-honeytoken grant on the same agent has the same type, so
+	//      real use of that type would trip the alert.
+	// (A later duplicate grant of the same type remains the operator's responsibility;
+	// this guard covers the state observable at mark time.)
+	if honeytoken {
+		if strings.Contains(capability.CapabilityType, "*") {
+			return nil, fmt.Errorf("%w: '%s' is a wildcard that would match legitimate traffic; use a specific decoy capability", ErrHoneytokenNotAllowed, capability.CapabilityType)
+		}
+		siblings, sErr := s.capabilityRepo.GetActiveCapabilitiesByAgentID(capability.AgentID)
+		if sErr != nil {
+			return nil, fmt.Errorf("failed to check for conflicting capabilities: %w", sErr)
+		}
+		for _, sib := range siblings {
+			if sib == nil || sib.ID == capabilityID || sib.Honeytoken {
+				continue
+			}
+			if sib.CapabilityType == capability.CapabilityType {
+				return nil, fmt.Errorf("%w: agent has another active grant of type '%s', so legitimate use would raise false alerts", ErrHoneytokenNotAllowed, capability.CapabilityType)
+			}
+		}
+	}
+
+	if err := s.capabilityRepo.SetHoneytoken(capabilityID, honeytoken); err != nil {
+		return nil, err
+	}
+	capability.Honeytoken = honeytoken
+
+	// Audit the operator action so there is a record of who turned the tripwire on/off.
+	action := "marked as honeytoken"
+	if !honeytoken {
+		action = "unmarked as honeytoken"
+	}
+	auditLog := &domain.AuditLog{
+		OrganizationID: agent.OrganizationID,
+		UserID:         markedBy,
+		Action:         domain.AuditActionHoneytokenMarked,
+		ResourceType:   "capability",
+		ResourceID:     capabilityID,
+		Metadata: map[string]interface{}{
+			"capabilityType": capability.CapabilityType,
+			"capabilityId":   capabilityID.String(),
+			"agentId":        capability.AgentID.String(),
+			"honeytoken":     honeytoken,
+			"description":    fmt.Sprintf("Capability '%s' on agent %s %s", capability.CapabilityType, agent.DisplayName, action),
+		},
+	}
+	if err := s.auditRepo.Create(auditLog); err != nil {
+		// Log error but don't fail the request — the flag is already persisted.
+		fmt.Printf("Warning: failed to create honeytoken-mark audit log: %v\n", err)
+	}
+
+	return capability, nil
 }
 
 // AutoDetectCapabilities attempts to automatically detect and register capabilities for MCP servers

--- a/apps/backend/internal/application/capability_service_honeytoken_test.go
+++ b/apps/backend/internal/application/capability_service_honeytoken_test.go
@@ -1,0 +1,154 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #293: MarkHoneytoken guards the zero-false-positive contract at mark time and
+// CapabilityService.VerifyAction fires the same tripwire as the AgentService paths.
+
+func newHoneytokenCapService() (*CapabilityService, *MockCapabilityRepoForService, *MockAgentRepoForCapability, *SharedMockAuditLogRepository, *MockAlertRepository) {
+	capRepo := new(MockCapabilityRepoForService)
+	agentRepo := new(MockAgentRepoForCapability)
+	auditRepo := new(SharedMockAuditLogRepository)
+	alertRepo := new(MockAlertRepository)
+	svc := &CapabilityService{
+		capabilityRepo: capRepo,
+		agentRepo:      agentRepo,
+		auditRepo:      auditRepo,
+		alertRepo:      alertRepo,
+	}
+	return svc, capRepo, agentRepo, auditRepo, alertRepo
+}
+
+func TestCapabilityService_MarkHoneytoken_HappyPath(t *testing.T) {
+	svc, capRepo, agentRepo, auditRepo, _ := newHoneytokenCapService()
+
+	capID := uuid.New()
+	agentID := uuid.New()
+	orgID := uuid.New()
+	cap := &domain.AgentCapability{ID: capID, AgentID: agentID, CapabilityType: "admin:exfiltrate"}
+
+	capRepo.On("GetCapabilityByID", capID).Return(cap, nil)
+	agentRepo.On("GetByID", agentID).Return(&domain.Agent{ID: agentID, OrganizationID: orgID, DisplayName: "decoy"}, nil)
+	// Only the capability itself is active — no collision.
+	capRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return([]*domain.AgentCapability{cap}, nil)
+	capRepo.On("SetHoneytoken", capID, true).Return(nil)
+	auditRepo.On("Create", mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+
+	updated, err := svc.MarkHoneytoken(context.Background(), capID, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.True(t, updated.Honeytoken)
+	capRepo.AssertCalled(t, "SetHoneytoken", capID, true)
+	auditRepo.AssertNumberOfCalls(t, "Create", 1)
+}
+
+func TestCapabilityService_MarkHoneytoken_RejectsWildcard(t *testing.T) {
+	svc, capRepo, agentRepo, _, _ := newHoneytokenCapService()
+
+	capID := uuid.New()
+	agentID := uuid.New()
+	cap := &domain.AgentCapability{ID: capID, AgentID: agentID, CapabilityType: "file:*"}
+
+	capRepo.On("GetCapabilityByID", capID).Return(cap, nil)
+	agentRepo.On("GetByID", agentID).Return(&domain.Agent{ID: agentID, DisplayName: "decoy"}, nil)
+
+	_, err := svc.MarkHoneytoken(context.Background(), capID, true, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHoneytokenNotAllowed)
+	assert.Contains(t, err.Error(), "wildcard")
+	capRepo.AssertNotCalled(t, "SetHoneytoken", mock.Anything, mock.Anything)
+}
+
+func TestCapabilityService_MarkHoneytoken_RejectsCollisionWithLiveGrant(t *testing.T) {
+	svc, capRepo, agentRepo, _, _ := newHoneytokenCapService()
+
+	capID := uuid.New()
+	agentID := uuid.New()
+	cap := &domain.AgentCapability{ID: capID, AgentID: agentID, CapabilityType: "file:read"}
+	// A separate ACTIVE, non-honeytoken grant of the same type → marking would
+	// make legitimate file:read traffic trip the alert.
+	sibling := &domain.AgentCapability{ID: uuid.New(), AgentID: agentID, CapabilityType: "file:read"}
+
+	capRepo.On("GetCapabilityByID", capID).Return(cap, nil)
+	agentRepo.On("GetByID", agentID).Return(&domain.Agent{ID: agentID, DisplayName: "decoy"}, nil)
+	capRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return([]*domain.AgentCapability{cap, sibling}, nil)
+
+	_, err := svc.MarkHoneytoken(context.Background(), capID, true, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHoneytokenNotAllowed)
+	assert.Contains(t, err.Error(), "another active grant")
+	capRepo.AssertNotCalled(t, "SetHoneytoken", mock.Anything, mock.Anything)
+}
+
+// Unmarking (honeytoken=false) must skip the guards so an operator can always clear
+// the flag, even on a wildcard or colliding type.
+func TestCapabilityService_MarkHoneytoken_UnmarkSkipsGuards(t *testing.T) {
+	svc, capRepo, agentRepo, auditRepo, _ := newHoneytokenCapService()
+
+	capID := uuid.New()
+	agentID := uuid.New()
+	cap := &domain.AgentCapability{ID: capID, AgentID: agentID, CapabilityType: "file:*", Honeytoken: true}
+
+	capRepo.On("GetCapabilityByID", capID).Return(cap, nil)
+	agentRepo.On("GetByID", agentID).Return(&domain.Agent{ID: agentID, DisplayName: "decoy"}, nil)
+	capRepo.On("SetHoneytoken", capID, false).Return(nil)
+	auditRepo.On("Create", mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+
+	updated, err := svc.MarkHoneytoken(context.Background(), capID, false, nil)
+	require.NoError(t, err)
+	assert.False(t, updated.Honeytoken)
+	capRepo.AssertCalled(t, "SetHoneytoken", capID, false)
+}
+
+// VerifyAction (a verification path on CapabilityService) must raise the high-severity
+// alert + audit when the request matches a honeytoken capability, without changing the
+// authorization result.
+func TestCapabilityService_VerifyAction_Honeytoken_RaisesAlertAndAudit(t *testing.T) {
+	svc, capRepo, agentRepo, auditRepo, alertRepo := newHoneytokenCapService()
+
+	agentID := uuid.New()
+	orgID := uuid.New()
+	honeyCapID := uuid.New()
+	// PublicKey nil → signature check skipped. Honeytoken capability granted (in scope).
+	agentRepo.On("GetByID", agentID).Return(&domain.Agent{
+		ID: agentID, OrganizationID: orgID, DisplayName: "decoy", TrustScore: 0.9,
+	}, nil)
+	caps := []*domain.AgentCapability{
+		{ID: honeyCapID, AgentID: agentID, CapabilityType: "admin:exfiltrate", Honeytoken: true},
+	}
+	capRepo.On("GetActiveCapabilitiesByAgentID", agentID).Return(caps, nil)
+	// No capability definition → trust-threshold check is skipped.
+	capRepo.On("GetCapabilityDefinition", "admin", "exfiltrate", mock.Anything).Return(nil, errors.New("not found"))
+	agentRepo.On("Update", mock.AnythingOfType("*domain.Agent")).Return(nil)
+
+	var capturedAlert *domain.Alert
+	alertRepo.On("Create", mock.AnythingOfType("*domain.Alert")).Run(func(args mock.Arguments) {
+		capturedAlert = args.Get(0).(*domain.Alert)
+	}).Return(nil)
+	auditRepo.On("Create", mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+
+	ip := "203.0.113.9"
+	result, err := svc.VerifyAction(context.Background(), agentID, "admin:exfiltrate", nil, nil, &ip, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// Decision preserved: a granted honeytoken still authorizes.
+	assert.True(t, result.IsAuthorized, "honeytoken must not change the authorization result")
+
+	alertRepo.AssertNumberOfCalls(t, "Create", 1)
+	auditRepo.AssertNumberOfCalls(t, "Create", 1)
+	require.NotNil(t, capturedAlert)
+	assert.Equal(t, domain.AlertHoneytokenTriggered, capturedAlert.AlertType)
+	assert.Equal(t, domain.AlertSeverityHigh, capturedAlert.Severity)
+	assert.Equal(t, honeyCapID, capturedAlert.ResourceID)
+	assert.Equal(t, ip, capturedAlert.SourceIP)
+}

--- a/apps/backend/internal/application/capability_service_test.go
+++ b/apps/backend/internal/application/capability_service_test.go
@@ -666,6 +666,11 @@ func (m *MockCapabilityRepoForService) RevokeCapability(id uuid.UUID, revokedAt 
 	return args.Error(0)
 }
 
+func (m *MockCapabilityRepoForService) SetHoneytoken(id uuid.UUID, honeytoken bool) error {
+	args := m.Called(id, honeytoken)
+	return args.Error(0)
+}
+
 func (m *MockCapabilityRepoForService) DeleteCapability(id uuid.UUID) error {
 	args := m.Called(id)
 	return args.Error(0)

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -420,6 +420,11 @@ func (m *SharedMockCapabilityRepository) DeleteCapability(id uuid.UUID) error {
 	return args.Error(0)
 }
 
+func (m *SharedMockCapabilityRepository) SetHoneytoken(id uuid.UUID, honeytoken bool) error {
+	args := m.Called(id, honeytoken)
+	return args.Error(0)
+}
+
 func (m *SharedMockCapabilityRepository) UpdateCapability(capability *domain.AgentCapability) error {
 	args := m.Called(capability)
 	return args.Error(0)

--- a/apps/backend/internal/application/secrets_service_test.go
+++ b/apps/backend/internal/application/secrets_service_test.go
@@ -144,6 +144,7 @@ func (m *mockCapabilityRepo) CreateCapability(_ *domain.AgentCapability) error  
 func (m *mockCapabilityRepo) GetCapabilityByID(_ uuid.UUID) (*domain.AgentCapability, error)       { return nil, nil }
 func (m *mockCapabilityRepo) GetCapabilitiesByAgentID(_ uuid.UUID) ([]*domain.AgentCapability, error) { return nil, nil }
 func (m *mockCapabilityRepo) RevokeCapability(_ uuid.UUID, _ time.Time) error                      { return nil }
+func (m *mockCapabilityRepo) SetHoneytoken(_ uuid.UUID, _ bool) error                              { return nil }
 func (m *mockCapabilityRepo) DeleteCapability(_ uuid.UUID) error                                   { return nil }
 func (m *mockCapabilityRepo) CreateViolation(_ *domain.CapabilityViolation) error                  { return nil }
 func (m *mockCapabilityRepo) GetViolationByID(_ uuid.UUID) (*domain.CapabilityViolation, error)    { return nil, nil }

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -57,6 +57,11 @@ func (m *MockCapabilityRepository) RevokeCapability(id uuid.UUID, revokedAt time
 	return args.Error(0)
 }
 
+func (m *MockCapabilityRepository) SetHoneytoken(id uuid.UUID, honeytoken bool) error {
+	args := m.Called(id, honeytoken)
+	return args.Error(0)
+}
+
 func (m *MockCapabilityRepository) DeleteCapability(id uuid.UUID) error {
 	args := m.Called(id)
 	return args.Error(0)

--- a/apps/backend/internal/domain/alert.go
+++ b/apps/backend/internal/domain/alert.go
@@ -21,6 +21,7 @@ const (
 	AlertLowTrustAttestation      AlertType = "low_trust_attestation"       // Low-trust agent attempted MCP attestation
 	AlertLowTrustAttestationBlock AlertType = "low_trust_attestation_block" // Low-trust agent blocked from attestation
 	AlertMCPCapabilityDrift       AlertType = "mcp_capability_drift"        // MCP server capability added/removed/stale
+	AlertHoneytokenTriggered      AlertType = "honeytoken_triggered"        // A verification request matched a honeytoken capability (a decoy no real workflow uses)
 
 	// Authentication failure alerts
 	AlertAuthFailurePattern  AlertType = "auth_failure_pattern"  // Multiple failed auth attempts detected

--- a/apps/backend/internal/domain/audit_log.go
+++ b/apps/backend/internal/domain/audit_log.go
@@ -22,6 +22,11 @@ const (
 	AuditActionAttest AuditAction = "attest" // ✅ For agent attestation of MCPs
 	AuditActionView   AuditAction = "view"
 
+	// Honeytoken (issue #293): a verification request matched a decoy capability
+	AuditActionHoneytokenTriggered AuditAction = "honeytoken_triggered"
+	// Honeytoken flag set/cleared on a granted capability by an operator
+	AuditActionHoneytokenMarked AuditAction = "honeytoken_marked"
+
 	// API Key actions
 	AuditActionRevoke AuditAction = "revoke"
 

--- a/apps/backend/internal/domain/capability.go
+++ b/apps/backend/internal/domain/capability.go
@@ -23,8 +23,13 @@ type AgentCapability struct {
 	GrantedBy       *uuid.UUID             `json:"grantedBy,omitempty"`
 	GrantedAt       time.Time              `json:"grantedAt"`
 	RevokedAt       *time.Time             `json:"revokedAt,omitempty"`
-	CreatedAt       time.Time              `json:"createdAt"`
-	UpdatedAt       time.Time              `json:"updatedAt"`
+	// Honeytoken marks this grant as a decoy that no legitimate workflow should
+	// ever exercise (issue #293). Operator-set only; when a verification request
+	// matches a honeytoken capability the verification path raises a high-severity
+	// alert and records an audit event without changing the allow/deny decision.
+	Honeytoken bool      `json:"honeytoken"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
 }
 
 // CapabilityViolation represents an attempt to perform an action outside capability scope
@@ -52,6 +57,8 @@ type CapabilityRepository interface {
 	GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*AgentCapability, error)
 	RevokeCapability(id uuid.UUID, revokedAt time.Time) error
 	DeleteCapability(id uuid.UUID) error
+	// SetHoneytoken marks or unmarks a granted capability as a honeytoken (issue #293).
+	SetHoneytoken(id uuid.UUID, honeytoken bool) error
 
 	// Violation tracking
 	CreateViolation(violation *CapabilityViolation) error

--- a/apps/backend/internal/infrastructure/repository/capability_repository.go
+++ b/apps/backend/internal/infrastructure/repository/capability_repository.go
@@ -28,8 +28,8 @@ func (r *CapabilityRepositoryPostgres) CreateCapability(capability *domain.Agent
 
 	query := `
 		INSERT INTO agent_capabilities (
-			id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, created_at, updated_at, honeytoken
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	`
 
 	capability.ID = uuid.New()
@@ -49,6 +49,7 @@ func (r *CapabilityRepositoryPostgres) CreateCapability(capability *domain.Agent
 		capability.GrantedAt,
 		capability.CreatedAt,
 		capability.UpdatedAt,
+		capability.Honeytoken,
 	)
 
 	return err
@@ -57,7 +58,7 @@ func (r *CapabilityRepositoryPostgres) CreateCapability(capability *domain.Agent
 // GetCapabilityByID retrieves a capability by ID
 func (r *CapabilityRepositoryPostgres) GetCapabilityByID(id uuid.UUID) (*domain.AgentCapability, error) {
 	query := `
-		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at
+		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at, honeytoken
 		FROM agent_capabilities
 		WHERE id = $1
 	`
@@ -78,6 +79,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilityByID(id uuid.UUID) (*domain.
 		&revokedAt,
 		&capability.CreatedAt,
 		&capability.UpdatedAt,
+		&capability.Honeytoken,
 	)
 
 	if err != nil {
@@ -100,7 +102,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilityByID(id uuid.UUID) (*domain.
 // GetCapabilitiesByAgentID retrieves all capabilities for an agent
 func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentID(agentID uuid.UUID) ([]*domain.AgentCapability, error) {
 	query := `
-		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at
+		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at, honeytoken
 		FROM agent_capabilities
 		WHERE agent_id = $1
 		ORDER BY created_at DESC
@@ -130,6 +132,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentID(agentID uuid.UUI
 			&revokedAt,
 			&capability.CreatedAt,
 			&capability.UpdatedAt,
+			&capability.Honeytoken,
 		)
 
 		if err != nil {
@@ -155,7 +158,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentID(agentID uuid.UUI
 // GetActiveCapabilitiesByAgentID retrieves only non-revoked capabilities
 func (r *CapabilityRepositoryPostgres) GetActiveCapabilitiesByAgentID(agentID uuid.UUID) ([]*domain.AgentCapability, error) {
 	query := `
-		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at
+		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at, honeytoken
 		FROM agent_capabilities
 		WHERE agent_id = $1 AND revoked_at IS NULL
 		ORDER BY created_at DESC
@@ -185,6 +188,7 @@ func (r *CapabilityRepositoryPostgres) GetActiveCapabilitiesByAgentID(agentID uu
 			&revokedAt,
 			&capability.CreatedAt,
 			&capability.UpdatedAt,
+			&capability.Honeytoken,
 		)
 
 		if err != nil {
@@ -225,7 +229,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentIDs(agentIDs []uuid
 	}
 
 	query := fmt.Sprintf(`
-		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at
+		SELECT id, agent_id, capability_type, capability_scope, execution_mode, granted_by, granted_at, revoked_at, created_at, updated_at, honeytoken
 		FROM agent_capabilities
 		WHERE agent_id IN (%s)`, strings.Join(placeholders, ","))
 	if activeOnly {
@@ -256,6 +260,7 @@ func (r *CapabilityRepositoryPostgres) GetCapabilitiesByAgentIDs(agentIDs []uuid
 			&revokedAt,
 			&capability.CreatedAt,
 			&capability.UpdatedAt,
+			&capability.Honeytoken,
 		)
 
 		if err != nil {
@@ -287,6 +292,18 @@ func (r *CapabilityRepositoryPostgres) RevokeCapability(id uuid.UUID, revokedAt 
 	`
 
 	_, err := r.db.Exec(query, revokedAt, time.Now(), id)
+	return err
+}
+
+// SetHoneytoken marks or unmarks a granted capability as a honeytoken (issue #293).
+func (r *CapabilityRepositoryPostgres) SetHoneytoken(id uuid.UUID, honeytoken bool) error {
+	query := `
+		UPDATE agent_capabilities
+		SET honeytoken = $1, updated_at = $2
+		WHERE id = $3
+	`
+
+	_, err := r.db.Exec(query, honeytoken, time.Now(), id)
 	return err
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/capability_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strconv"
 
 	"github.com/gofiber/fiber/v3"
@@ -469,6 +470,87 @@ func (h *CapabilityHandler) RevokeCapability(c fiber.Ctx) error {
 	})
 }
 
+// MarkHoneytoken godoc
+// @Summary Mark a capability as a honeytoken
+// @Description Mark (or unmark) a granted capability as a honeytoken decoy (issue #293). Any later verification request that matches a honeytoken capability raises a high-severity alert and records an audit event. Operator-only.
+// @Tags capabilities
+// @Accept json
+// @Produce json
+// @Param agentId path string true "Agent ID"
+// @Param capabilityId path string true "Capability ID"
+// @Param request body MarkHoneytokenRequest true "Honeytoken flag"
+// @Success 200 {object} domain.AgentCapability
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /agents/{agentId}/capabilities/{capabilityId}/honeytoken [put]
+func (h *CapabilityHandler) MarkHoneytoken(c fiber.Ctx) error {
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
+	}
+
+	capabilityID, err := uuid.Parse(c.Params("capabilityId"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Error: "Invalid capability ID",
+		})
+	}
+
+	var req MarkHoneytokenRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Error: "Invalid request body",
+		})
+	}
+
+	userID, err := h.getUserIDFromContext(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Error: "Unauthorized",
+		})
+	}
+
+	// SECURITY: tenant-scope the capability before mutating it. MarkHoneytoken
+	// does NOT enforce org scoping internally — without this check a caller in
+	// org A could flag a capability in org B by passing the foreign UUID. Load
+	// the capability, resolve its owning agent, verify the agent's org matches
+	// the caller's. Returns 404 (not 403) for both "not found" and "exists in
+	// another org" to avoid a cross-tenant existence side channel (mirrors
+	// RevokeCapability).
+	capSvc := h.getCapabilityService()
+	capability, err := capSvc.GetCapabilityByID(c.Context(), capabilityID)
+	if err != nil || capability == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	agent, err := h.agentRepo.GetByID(capability.AgentID)
+	if err != nil || agent == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	if agent.OrganizationID != orgID {
+		respondResourceNotFound(c)
+		return nil
+	}
+
+	updated, err := capSvc.MarkHoneytoken(c.Context(), capabilityID, req.Honeytoken, &userID)
+	if err != nil {
+		// Wildcard/collision rejections are client validation errors -> 400, not 500.
+		if errors.Is(err, application.ErrHoneytokenNotAllowed) {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Error: err.Error(),
+			})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Error: err.Error(),
+		})
+	}
+
+	return c.JSON(updated)
+}
+
 // VerifyAction godoc
 // @Summary Verify an action
 // @Description Verify if an agent is authorized to perform a specific action
@@ -672,6 +754,11 @@ type GrantCapabilityRequest struct {
 	CapabilityType string                 `json:"capabilityType" validate:"required"`
 	Scope          map[string]interface{} `json:"scope,omitempty"`
 	ExecutionMode  string                 `json:"executionMode,omitempty"` // auto, notify, review
+}
+
+// MarkHoneytokenRequest toggles the honeytoken flag on a granted capability (issue #293).
+type MarkHoneytokenRequest struct {
+	Honeytoken bool `json:"honeytoken"`
 }
 
 type VerifyActionRequest struct {

--- a/apps/backend/internal/interfaces/http/handlers/interfaces.go
+++ b/apps/backend/internal/interfaces/http/handlers/interfaces.go
@@ -38,6 +38,7 @@ type AgentServicer interface {
 	VerifyCapability(ctx context.Context, agentID uuid.UUID, capability string, resource string, metadata map[string]interface{}, sourceIP string) (allowed bool, reason string, auditID uuid.UUID, err error)
 	LogCapabilityResult(ctx context.Context, agentID uuid.UUID, auditID uuid.UUID, success bool, errorMsg string, result map[string]interface{}) error
 	HasCapability(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
+	HasCapabilityNoAlert(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
 	UpdateLastActive(ctx context.Context, agentID uuid.UUID) error
 	DetectMCPServersFromConfig(ctx context.Context, agentID uuid.UUID, req *application.DetectMCPServersRequest, mcpService *application.MCPService, orgID, userID uuid.UUID) (*application.DetectMCPServersResult, error)
 	// PQC (Post-Quantum Cryptography) methods
@@ -75,6 +76,7 @@ type CapabilityServicer interface {
 	VerifyAction(ctx context.Context, agentID uuid.UUID, requestedCapability string, signature []byte, payload []byte, sourceIP *string, metadata map[string]interface{}) (*application.VerificationResult, error)
 	GrantCapability(ctx context.Context, agentID uuid.UUID, capabilityType string, scope map[string]interface{}, grantedBy *uuid.UUID, executionMode string) (*domain.AgentCapability, error)
 	RevokeCapability(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
+	MarkHoneytoken(ctx context.Context, capabilityID uuid.UUID, honeytoken bool, markedBy *uuid.UUID) (*domain.AgentCapability, error)
 	GetCapabilityByID(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilities(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
 	GetCapabilitiesByAgentIDs(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error)

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -38,6 +38,7 @@ type MockAgentServiceImpl struct {
 	VerifyCapabilityFunc           func(ctx context.Context, agentID uuid.UUID, capability string, resource string, metadata map[string]interface{}, sourceIP string) (allowed bool, reason string, auditID uuid.UUID, err error)
 	LogCapabilityResultFunc        func(ctx context.Context, agentID uuid.UUID, auditID uuid.UUID, success bool, errorMsg string, result map[string]interface{}) error
 	HasCapabilityFunc              func(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
+	HasCapabilityNoAlertFunc       func(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error)
 	UpdateLastActiveFunc           func(ctx context.Context, agentID uuid.UUID) error
 	DetectMCPServersFromConfigFunc func(ctx context.Context, agentID uuid.UUID, req *application.DetectMCPServersRequest, mcpService *application.MCPService, orgID, userID uuid.UUID) (*application.DetectMCPServersResult, error)
 	// PQC methods
@@ -197,6 +198,16 @@ func (m *MockAgentServiceImpl) LogCapabilityResult(ctx context.Context, agentID 
 }
 
 func (m *MockAgentServiceImpl) HasCapability(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error) {
+	if m.HasCapabilityFunc != nil {
+		return m.HasCapabilityFunc(ctx, agentID, capabilityToCheck, resource)
+	}
+	return true, nil
+}
+
+func (m *MockAgentServiceImpl) HasCapabilityNoAlert(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error) {
+	if m.HasCapabilityNoAlertFunc != nil {
+		return m.HasCapabilityNoAlertFunc(ctx, agentID, capabilityToCheck, resource)
+	}
 	if m.HasCapabilityFunc != nil {
 		return m.HasCapabilityFunc(ctx, agentID, capabilityToCheck, resource)
 	}
@@ -387,6 +398,7 @@ type MockCapabilityServiceImpl struct {
 	VerifyActionFunc                  func(ctx context.Context, agentID uuid.UUID, requestedCapability string, signature []byte, payload []byte, sourceIP *string, metadata map[string]interface{}) (*application.VerificationResult, error)
 	GrantCapabilityFunc               func(ctx context.Context, agentID uuid.UUID, capabilityType string, scope map[string]interface{}, grantedBy *uuid.UUID, executionMode string) (*domain.AgentCapability, error)
 	RevokeCapabilityFunc              func(ctx context.Context, capabilityID uuid.UUID, revokedBy *uuid.UUID) error
+	MarkHoneytokenFunc                func(ctx context.Context, capabilityID uuid.UUID, honeytoken bool, markedBy *uuid.UUID) (*domain.AgentCapability, error)
 	GetCapabilityByIDFunc             func(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error)
 	GetAgentCapabilitiesFunc          func(ctx context.Context, agentID uuid.UUID, activeOnly bool) ([]*domain.AgentCapability, error)
 	GetCapabilitiesByAgentIDsFunc     func(ctx context.Context, agentIDs []uuid.UUID, activeOnly bool) (map[uuid.UUID][]*domain.AgentCapability, error)
@@ -417,6 +429,13 @@ func (m *MockCapabilityServiceImpl) RevokeCapability(ctx context.Context, capabi
 		return m.RevokeCapabilityFunc(ctx, capabilityID, revokedBy)
 	}
 	return nil
+}
+
+func (m *MockCapabilityServiceImpl) MarkHoneytoken(ctx context.Context, capabilityID uuid.UUID, honeytoken bool, markedBy *uuid.UUID) (*domain.AgentCapability, error) {
+	if m.MarkHoneytokenFunc != nil {
+		return m.MarkHoneytokenFunc(ctx, capabilityID, honeytoken, markedBy)
+	}
+	return nil, nil
 }
 
 func (m *MockCapabilityServiceImpl) GetCapabilityByID(ctx context.Context, capabilityID uuid.UUID) (*domain.AgentCapability, error) {

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler.go
@@ -297,7 +297,10 @@ func (h *VerificationHandler) CreateVerification(c fiber.Ctx) error {
 	// Medium/High-risk actions: Alert if action is denied or lacks capability
 	// SECURITY: No debug logging to prevent information leakage
 	shouldCreateAlert := false
-	hasCapability, err := h.getAgentService().HasCapability(c.Context(), agentID, req.Capability, req.Resource)
+	// HasCapabilityNoAlert (not HasCapability): VerifyCapability above already ran
+	// honeytoken detection for this request; using the alerting variant here would
+	// double-fire the honeytoken alert/audit for a single verification (#293).
+	hasCapability, err := h.getAgentService().HasCapabilityNoAlert(c.Context(), agentID, req.Capability, req.Resource)
 	if err == nil && !hasCapability {
 		// Determine if this action warrants an alert based on risk level and approval status
 		isLowRisk := isLowRiskCapability(req.Capability)

--- a/apps/backend/migrations/102_add_honeytoken_to_agent_capabilities.sql
+++ b/apps/backend/migrations/102_add_honeytoken_to_agent_capabilities.sql
@@ -1,0 +1,18 @@
+-- Migration 102: Mark a granted capability as a honeytoken (issue #293)
+-- A honeytoken capability is a decoy that no legitimate workflow should ever
+-- exercise. Any verification request that matches it is a high-confidence
+-- compromise indicator: the verification path raises a high-severity alert and
+-- records an audit event. The flag is operator-set only (never derived from the
+-- capability type and never settable via the SDK self-register path), so it never
+-- fires in normal operation. Defaults to FALSE so every existing grant is a
+-- non-honeytoken and behaviour is unchanged until an operator opts a grant in.
+
+ALTER TABLE agent_capabilities
+    ADD COLUMN IF NOT EXISTS honeytoken BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index: honeytoken grants are rare, so index only the TRUE rows. Keeps
+-- operator "which capabilities are honeytokens" lookups cheap without weighing on
+-- the hot verification path (which filters by agent_id, not honeytoken).
+CREATE INDEX IF NOT EXISTS idx_agent_capabilities_honeytoken
+    ON agent_capabilities (agent_id)
+    WHERE honeytoken = TRUE;


### PR DESCRIPTION
Closes #293.

## What

Let an operator mark a granted capability as a **honeytoken** — a decoy that no legitimate workflow should ever exercise. Any verification request that matches a honeytoken capability raises a **high-severity alert** and records an **audit event**, while the authorization decision is left unchanged so the tripwire is indistinguishable from a real grant to a probing agent.

## How

- **Schema:** `agent_capabilities.honeytoken` (migration 102), surfaced on `domain.AgentCapability`, hydrated across every repository read.
- **Detection** at every capability-matching verification path — `AgentService.VerifyCapability` (the `/verify` path), `HasCapability` (the FGA-engine path), and `CapabilityService.VerifyAction`. In `VerifyCapability` the active-capabilities fetch is hoisted above the status branches and reused, so detection also covers monitoring-mode/unverified agents with no extra query.
- **No double-fire:** the SDK `/verify` handler's secondary has-capability check now uses a non-detecting `HasCapabilityNoAlert`, so one verification produces exactly one alert + one audit event.
- **Alert + audit** reuse the existing `AlertRepository` (new `AlertHoneytokenTriggered` type, severity `high`) and `AuditLogRepository` (new `honeytoken_triggered` action) via a shared, best-effort, nil-safe helper — a write failure never fails verification. The audit repo is setter-injected (`SetHoneytokenAuditing`) to avoid constructor churn, mirroring the #275 manifest-drift alert wiring.
- **Operator surface:** `PUT /agents/:id/capabilities/:capabilityId/honeytoken` (Manager role only, never the SDK self-register path). `MarkHoneytoken` guards the no-false-positive contract at mark time: it rejects wildcard types and types that collide with another active grant on the same agent (HTTP 400); unmark always succeeds.

## Zero false positives

The alert fires only on a match against a decoy the operator keeps out of real workflows; the mark-time guards reject the common footguns (wildcards, type collisions) so a misconfiguration can't silently produce false alerts.

## Tests

Regression tests cover the alert+audit+decision-preserved contract on the `HasCapability`, `VerifyCapability`, and `VerifyAction` paths, the no-false-positive case, the no-double-fire secondary check, and the mark-time guards. `go build`, `go vet`, and `go test -race` on the affected packages are green.

## Decision (CA/CSR)

Honeytoken is a detection side-channel, not an enforcement change — preserving the authorization outcome keeps the decoy indistinguishable from a real grant (no deny-signal that would leak which capabilities are honeytokens). Storage is operator-set only; agents can neither set nor discover the flag.