### PR TITLE
Fix AIM Cloud sync: move HasCapabilityNoAlert to a synced file

### DIFF
--- a/apps/backend/internal/application/agent_has_capability_no_alert.go
+++ b/apps/backend/internal/application/agent_has_capability_no_alert.go
@@ -1,0 +1,35 @@
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// HasCapabilityNoAlert reports whether the agent has a granted capability matching
+// the request WITHOUT firing honeytoken detection. It exists for a secondary
+// has-capability check inside a request that has ALREADY run detection — notably the
+// SDK /verify handler (CreateVerification), which calls VerifyCapability first and
+// then needs the raw boolean to decide capability-violation alerting. Using
+// HasCapability there would double-fire the honeytoken alert/audit for one request.
+//
+// This method lives in its own file (not agent_service.go) on purpose: agent_service.go
+// is protected from the AIM Cloud sync (the cloud keeps a divergent copy and skips the
+// synced version), but the synced AgentServicer / AgentServicerForVerification handler
+// interfaces require this method. Defining it in a synced file lets *AgentService satisfy
+// those interfaces in the cloud build. Its body only touches s.capabilityRepo and
+// s.matchesCapability, both present since the initial release, so the cloud's divergent
+// AgentService still compiles.
+func (s *AgentService) HasCapabilityNoAlert(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error) {
+	capabilities, err := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get capabilities: %w", err)
+	}
+	for _, cap := range capabilities {
+		if s.matchesCapability(capabilityToCheck, resource, cap.CapabilityType) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -921,25 +921,6 @@ func (s *AgentService) HasCapability(ctx context.Context, agentID uuid.UUID, cap
 	return hasCapability, nil
 }
 
-// HasCapabilityNoAlert reports whether the agent has a granted capability matching
-// the request WITHOUT firing honeytoken detection. It exists for a secondary
-// has-capability check inside a request that has ALREADY run detection — notably the
-// SDK /verify handler (CreateVerification), which calls VerifyCapability first and
-// then needs the raw boolean to decide capability-violation alerting. Using
-// HasCapability there would double-fire the honeytoken alert/audit for one request.
-func (s *AgentService) HasCapabilityNoAlert(ctx context.Context, agentID uuid.UUID, capabilityToCheck string, resource string) (bool, error) {
-	capabilities, err := s.capabilityRepo.GetActiveCapabilitiesByAgentID(agentID)
-	if err != nil {
-		return false, fmt.Errorf("failed to get capabilities: %w", err)
-	}
-	for _, cap := range capabilities {
-		if s.matchesCapability(capabilityToCheck, resource, cap.CapabilityType) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // detectHoneytoken scans an agent's granted capabilities for a honeytoken that
 // matches this verification request and, on a match, raises a high-severity alert
 // and records an audit event (issue #293). Side-effect-only and best-effort: it


### PR DESCRIPTION
## Problem

Follow-up to #319. With the `raiseHoneytokenAlert` relocation merged, the `Sync to AIM Cloud` build advanced past that error and surfaced the next instance of the same root cause:

```
*application.AgentService does not implement AgentServicer (missing method HasCapabilityNoAlert)
```

across every handler that holds an `AgentServicer` / `AgentServicerForVerification`. The honeytoken feature (#316) added the `HasCapabilityNoAlert` method to `AgentService` in `agent_service.go`, which the cloud sync marks **protected** (keeps a divergent copy). The synced handler interfaces require the method, but the cloud's `AgentService` never receives it.

## Fix

Move the method verbatim into a new synced file `agent_has_capability_no_alert.go` (same package). The method body only uses `s.capabilityRepo` and `s.matchesCapability`, both present since the initial AIM release, so the cloud's divergent `AgentService` compiles. Byte-identical relocation, no logic change, identical public build.

This is the last cross-sync-boundary symbol #316 introduced: `SetHoneytokenAuditing` is only called from the protected `main.go` (cloud never references it) and `detectHoneytoken` is unexported and protected-only.

## Verification
- `go build ./...`, `go vet ./...` clean
- `go test ./internal/application/... ./internal/interfaces/http/handlers/...` pass
- Relocated method diffed byte-identical against the original
- Post-merge: `Sync to AIM Cloud` should finally go green (will confirm)