### PR TITLE
Fix: MCP drift alerts now affect the connected agent's trust score (#314)

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -667,6 +667,8 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 	trustCalculator.SetUserFeedbackRepo(repos.UserFeedback)
 	trustCalculator.SetIsolationRepo(repos.IsolationAttestation)
 	trustCalculator.SetTMEProvider(repos.NanoMindTME)
+	// Let the drift factor attribute server-keyed MCP drift alerts to connected agents (#314).
+	trustCalculator.SetMCPConnectionRepo(repos.AgentMCPConnection)
 
 	// ✅ Initialize drift detection service BEFORE verification event service
 	driftDetectionService := application.NewDriftDetectionService(

--- a/apps/backend/internal/application/trust_calculator.go
+++ b/apps/backend/internal/application/trust_calculator.go
@@ -24,6 +24,14 @@ type TrustCalculator struct {
 	isolationRepo         domain.IsolationAttestationRepository
 	userFeedbackRepo      domain.UserFeedbackRepository
 	tmeProvider           NanoMindTMEProvider
+	mcpConnRepo           MCPConnectionLister
+}
+
+// MCPConnectionLister resolves the MCP servers an agent is connected to. The drift
+// factor needs it because MCP drift alerts are keyed by server ID, not agent ID, so
+// an agent's drift signal must be gathered across the servers it actually uses (#314).
+type MCPConnectionLister interface {
+	ListByAgent(ctx context.Context, agentID uuid.UUID) ([]*domain.AgentMCPConnection, error)
 }
 
 // NewTrustCalculator creates a new trust calculator
@@ -90,6 +98,14 @@ func (c *TrustCalculator) SetIsolationRepo(repo domain.IsolationAttestationRepos
 // Optional; when not set, the user feedback factor returns a neutral 0.5 score.
 func (c *TrustCalculator) SetUserFeedbackRepo(repo domain.UserFeedbackRepository) {
 	c.userFeedbackRepo = repo
+}
+
+// SetMCPConnectionRepo sets the agent-MCP connection repository so the drift factor
+// can attribute server-keyed MCP drift alerts to the agents connected to those servers
+// (#314). Optional; when not set, the drift factor only sees agent-keyed alerts (the
+// pre-#314 behavior, in which MCP drift never affected trust).
+func (c *TrustCalculator) SetMCPConnectionRepo(repo MCPConnectionLister) {
+	c.mcpConnRepo = repo
 }
 
 // SetTMEProvider sets the NanoMind TME provider for behavioral trust enrichment.
@@ -434,10 +450,42 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 		return 0.5 // Neutral when alert repo not available
 	}
 
-	// Query recent alerts for this agent
-	alerts, err := c.alertRepo.GetByResourceID(agent.ID, 100, 0)
+	// Gather drift-relevant alerts from two key spaces:
+	//   - agent-keyed alerts (AlertTypeConfigurationDrift is created with ResourceID = agentID)
+	//   - server-keyed MCP drift alerts for every MCP server this agent is connected to
+	//     (AlertMCPCapabilityDrift / AlertMCPManifestDrift are created with ResourceID = serverID).
+	// MCP drift is a property of the server, so its alerts are server-keyed; an agent
+	// connected to a drifted server inherits that supply-chain risk. Without the
+	// connection repo wired we fall back to agent-keyed alerts only (#314).
+	seen := make(map[uuid.UUID]bool)
+	alerts := make([]*domain.Alert, 0)
+	collect := func(in []*domain.Alert) {
+		for _, a := range in {
+			if a == nil || seen[a.ID] {
+				continue
+			}
+			seen[a.ID] = true
+			alerts = append(alerts, a)
+		}
+	}
+
+	agentAlerts, err := c.alertRepo.GetByResourceID(agent.ID, 100, 0)
 	if err != nil {
 		return 0.5 // Neutral on error
+	}
+	collect(agentAlerts)
+
+	if c.mcpConnRepo != nil {
+		if conns, connErr := c.mcpConnRepo.ListByAgent(context.Background(), agent.ID); connErr == nil {
+			for _, conn := range conns {
+				if conn == nil {
+					continue
+				}
+				if serverAlerts, sErr := c.alertRepo.GetByResourceID(conn.MCPServerID, 100, 0); sErr == nil {
+					collect(serverAlerts)
+				}
+			}
+		}
 	}
 
 	if len(alerts) == 0 {
@@ -455,7 +503,8 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 
 		// Only consider drift-related alert types
 		if alert.AlertType != domain.AlertTypeConfigurationDrift &&
-			alert.AlertType != domain.AlertMCPCapabilityDrift {
+			alert.AlertType != domain.AlertMCPCapabilityDrift &&
+			alert.AlertType != domain.AlertMCPManifestDrift {
 			continue
 		}
 

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -1386,3 +1386,150 @@ func (m *MockCapabilityRepository) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUI
 	}
 	return result, nil
 }
+
+// --- #314: MCP drift alerts (server-keyed) must affect the connected agent's drift factor ---
+
+type mockMCPConnLister struct {
+	conns []*domain.AgentMCPConnection
+	err   error
+}
+
+func (m *mockMCPConnLister) ListByAgent(_ context.Context, _ uuid.UUID) ([]*domain.AgentMCPConnection, error) {
+	return m.conns, m.err
+}
+
+// The bug (#314): an agent connected to an MCP server whose manifest drifted must see
+// its drift factor reduced, even though the alert is keyed by the server ID.
+func TestCalculateDriftDetection_ConnectedServerManifestDrift_ReducesScore(t *testing.T) {
+	agentID := uuid.New()
+	serverID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil)
+	mockAlert.On("GetByResourceID", serverID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertMCPManifestDrift, Severity: domain.AlertSeverityHigh, CreatedAt: time.Now()},
+	}, nil)
+
+	c := &TrustCalculator{
+		alertRepo:   mockAlert,
+		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.InDelta(t, 0.85, score, 0.001, "a high-severity manifest drift on a connected server should subtract 0.15")
+}
+
+// Capability drift on a connected server also counts, and multiple drifts stack.
+func TestCalculateDriftDetection_ConnectedServerCapabilityDrift_Stacks(t *testing.T) {
+	agentID := uuid.New()
+	serverID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil)
+	mockAlert.On("GetByResourceID", serverID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertMCPCapabilityDrift, Severity: domain.AlertSeverityCritical, CreatedAt: time.Now()},
+		{ID: uuid.New(), AlertType: domain.AlertMCPManifestDrift, Severity: domain.AlertSeverityWarning, CreatedAt: time.Now()},
+	}, nil)
+
+	c := &TrustCalculator{
+		alertRepo:   mockAlert,
+		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.InDelta(t, 0.65, score, 0.001, "critical (-0.30) + warning (-0.05) on a connected server should subtract 0.35")
+}
+
+// No false positives: drift on a server the agent is NOT connected to must not affect it.
+func TestCalculateDriftDetection_UnconnectedServerDrift_NoEffect(t *testing.T) {
+	agentID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil)
+
+	c := &TrustCalculator{
+		alertRepo:   mockAlert,
+		mcpConnRepo: &mockMCPConnLister{conns: nil}, // agent connected to nothing
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Equal(t, 1.0, score, "drift on a server the agent is not connected to must not affect its score")
+}
+
+// Without the connection repo wired, the factor degrades to agent-keyed alerts only
+// (the pre-#314 fallback) and never throws.
+func TestCalculateDriftDetection_NoConnectionRepo_FallsBackToAgentKeyed(t *testing.T) {
+	agentID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertTypeConfigurationDrift, Severity: domain.AlertSeverityWarning, CreatedAt: time.Now()},
+	}, nil)
+
+	c := &TrustCalculator{alertRepo: mockAlert} // mcpConnRepo nil
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.InDelta(t, 0.95, score, 0.001, "agent-keyed configuration drift still counts (warning -0.05)")
+}
+
+// A connection-graph lookup failure must degrade gracefully to agent-keyed alerts,
+// not poison the whole factor (it must NOT return the 0.5 error sentinel).
+func TestCalculateDriftDetection_ConnectionLookupError_FallsBackGracefully(t *testing.T) {
+	agentID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertTypeConfigurationDrift, Severity: domain.AlertSeverityWarning, CreatedAt: time.Now()},
+	}, nil)
+
+	c := &TrustCalculator{
+		alertRepo:   mockAlert,
+		mcpConnRepo: &mockMCPConnLister{err: assert.AnError},
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.InDelta(t, 0.95, score, 0.001, "a connection lookup error degrades to agent-keyed alerts, not the 0.5 error sentinel")
+}
+
+// Server-keyed drift older than the 30-day window must not affect the score.
+func TestCalculateDriftDetection_StaleServerDrift_Ignored(t *testing.T) {
+	agentID := uuid.New()
+	serverID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil)
+	mockAlert.On("GetByResourceID", serverID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertMCPManifestDrift, Severity: domain.AlertSeverityCritical, CreatedAt: time.Now().AddDate(0, 0, -31)},
+	}, nil)
+
+	c := &TrustCalculator{
+		alertRepo:   mockAlert,
+		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Equal(t, 1.0, score, "drift older than 30 days is outside the window and must not reduce the score")
+}
+
+// Two active connections to the same server must not double-subtract (the seen guard).
+func TestCalculateDriftDetection_DuplicateServerConnections_CountedOnce(t *testing.T) {
+	agentID := uuid.New()
+	serverID := uuid.New()
+
+	mockAlert := new(TrustCalcMockAlertRepository)
+	mockAlert.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil)
+	mockAlert.On("GetByResourceID", serverID, 100, 0).Return([]*domain.Alert{
+		{ID: uuid.New(), AlertType: domain.AlertMCPManifestDrift, Severity: domain.AlertSeverityHigh, CreatedAt: time.Now()},
+	}, nil)
+
+	c := &TrustCalculator{
+		alertRepo: mockAlert,
+		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{
+			{MCPServerID: serverID},
+			{MCPServerID: serverID}, // same server again
+		}},
+	}
+
+	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.InDelta(t, 0.85, score, 0.001, "the same alert reached via two connections must subtract only once")
+}


### PR DESCRIPTION
Closes #314.

## Bug

The trust calculator's drift factor (`calculateDriftDetection`) queried alerts by **agent** ID (`GetByResourceID(agent.ID, ...)`), but MCP drift alerts are created with `ResourceID = serverID` (`ResourceType: "mcp_server"`). A server ID is never an agent ID, so `AlertMCPCapabilityDrift` and `AlertMCPManifestDrift` (#313) were in the drift allow-list but **never matched any agent** — MCP drift silently never reduced any trust score. Only agent-keyed `AlertTypeConfigurationDrift` ever fired.

## Fix — CHIEF-CA/CSR option 2

Keep drift alerts **server-keyed** (a manifest/capability drift is a property of the server — single source of truth, no alert duplication, no fan-out storm), and resolve the **connection graph** in the factor. `calculateDriftDetection` now gathers agent-keyed alerts **and**, for every MCP server the agent is connected to (`AgentMCPConnection.ListByAgent`), that server's drift alerts — deduped by alert ID. `AlertMCPManifestDrift` is added to the allow-list.

An agent connected to a server whose trusted tool-manifest drifted **inherits that supply-chain risk** (the rug-pull / EchoLeak pattern) — which is the signal we want in trust.

- New `MCPConnectionLister` interface + `SetMCPConnectionRepo` setter on `TrustCalculator` (mirrors the existing optional-repo setter pattern); wired in `main.go`.
- **Best-effort / graceful degradation:** unwired, or on a connection-lookup or per-server query error, the factor falls back to agent-keyed alerts only and never returns the `0.5` error sentinel.
- Scoring math (30-day window, severity steps, `math.Max(0)` floor) is **unchanged**; the drift factor remains 3% weight and floors at 0, so the blast radius is bounded.

## Decision

Rejected option 1 (per-agent alert fan-out at raise time — duplicates alerts, conflates "server drifted" with "agent acted", storms when a server has many agents) and option 3 (drop MCP drift from trust — discards a real supply-chain signal).

## Tests

`go build` / `go vet` / `go test -race` green. New cases: connected manifest/capability drift lowers the score (and stacks); drift on an unconnected server has no effect; nil-repo and connection-lookup-error degrade gracefully; stale (>30d) server drift is ignored; duplicate connections to one server subtract once. Adversarial review found no CRITICAL/HIGH.