### PR TITLE
feat(fga): Step 5 intent-check observability metrics (#131)

### DIFF
--- a/apps/backend/docs/OBSERVABILITY.md
+++ b/apps/backend/docs/OBSERVABILITY.md
@@ -100,6 +100,9 @@ Spans whose check denies set status `codes.Error` with the deny reason.
 |---|---|---|---|---|
 | `fga.decisions` | counter | `fga.outcome`, `fga.denied_by` | `fga_decisions_total` | Incremented on every Authorize return. The `_total` suffix is added by Prometheus's OTLP receiver per OpenMetrics convention; do NOT include it in the OTel name (Prometheus rejects with "invalid temporality and type combination"). |
 | `fga.latency_ms` | histogram | none | `fga_latency_ms_bucket`, `_count`, `_sum` | Total Authorize latency in ms |
+| `fga.intent_checks` | counter | `fga.risk_tier`, `fga.intent_mode`, `fga.intent_status`, `fga.intent_blocked` | `fga_intent_checks_total` | Step 5 (NanoMind intent) evaluations that reached the daemon call. `intent_mode` is `sync` (HIGH) or `async` (MEDIUM); `intent_status` is `classified` (daemon returned a non-empty attack class), `abstain` (clean response, no class — the common case until NanoMind is fine-tuned on the FGA prompt), or `fail_open` (daemon unreachable, request build error, or undecodable body — the action proceeds without an intent verdict). `intent_blocked` is the Step 5 verdict; `blocked=true` on an `async` (allowed) request is a Step-5-vs-final disagreement. |
+| `fga.intent_skipped` | counter | `fga.risk_tier` | `fga_intent_skipped_total` | Authorizes where Step 5 was skipped (LOW risk, or any non-HIGH/MEDIUM level). Pair with `fga.intent_checks` to get the skip rate. |
+| `fga.async_intent_dropped` | counter | `fga.async_drop_reason` | `fga_async_intent_dropped_total` | MEDIUM-risk async intent dispatches dropped before running. `async_drop_reason` is `queue_full` (worker pool saturated) or `shutdown` (engine draining). A dropped dispatch never increments `fga.intent_checks`; sum both for total MEDIUM dispatch attempts. |
 | `agent.drift_score` | gauge | `agent.id` | `agent_drift_score` | Saturated 0-1 score from `tanh(drift_count / 2)`. Emitted on every DetectDrift call (including 0 when no drift) so dashboards distinguish "clean" from "silent". |
 
 Attributes are flattened to label names (`fga_outcome`, `agent_id`, etc.) per the OTLP-to-Prometheus convention.
@@ -146,6 +149,34 @@ P99 Authorize latency over last 5m:
 
 ```promql
 histogram_quantile(0.99, sum by (le) (rate(fga_latency_ms_bucket[5m])))
+```
+
+Step 5 classification rate (share of evaluations that produced a real class) — today this sits near zero, which is the evidence behind issue #131:
+
+```promql
+sum(rate(fga_intent_checks_total{fga_intent_status="classified"}[5m]))
+  / sum(rate(fga_intent_checks_total[5m]))
+```
+
+Step 5 fail-open rate by risk tier (daemon unreachable or undecodable):
+
+```promql
+sum by (fga_risk_tier) (rate(fga_intent_checks_total{fga_intent_status="fail_open"}[5m]))
+  / sum by (fga_risk_tier) (rate(fga_intent_checks_total[5m]))
+```
+
+Step 5 skip rate (share of authorizes that never ran the intent check):
+
+```promql
+sum(rate(fga_intent_skipped_total[5m]))
+  / (sum(rate(fga_intent_skipped_total[5m])) + sum(rate(fga_intent_checks_total[5m])))
+```
+
+Step-5-vs-final disagreement (async classifier flagged a request that was allowed):
+
+```promql
+sum(rate(fga_intent_checks_total{fga_intent_mode="async", fga_intent_blocked="true"}[5m]))
+  / sum(rate(fga_intent_checks_total{fga_intent_mode="async", fga_intent_status="classified"}[5m]))
 ```
 
 Agents in the alert band (drift > 0.7):

--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -54,19 +54,21 @@ type asyncIntentJob struct {
 // Steps 1-4 must complete in < 10ms P99 (no external calls).
 // Step 5 (NanoMind intent check) adds < 800ms for HIGH risk, async for MEDIUM, skip for LOW.
 type FGAEngine struct {
-	db              *sql.DB
-	agentSvc        *AgentService
-	daemonURL       string // NanoMind daemon URL
-	registryASCURL  string // Registry ASC endpoint
-	logger          *slog.Logger
+	db             *sql.DB
+	agentSvc       *AgentService
+	daemonURL      string // NanoMind daemon URL
+	registryASCURL string // Registry ASC endpoint
+	logger         *slog.Logger
 
 	// OTel instruments. Captured in NewFGAEngine so they bind to the
 	// real provider installed by telemetry.Init, not to the noop global
 	// at package-init time.
-	tracer       trace.Tracer
-	decisions    metric.Int64Counter
-	latency      metric.Int64Histogram
-	asyncDropped metric.Int64Counter
+	tracer        trace.Tracer
+	decisions     metric.Int64Counter
+	latency       metric.Int64Histogram
+	asyncDropped  metric.Int64Counter
+	intentChecks  metric.Int64Counter // Step 5 evaluations that reached the daemon
+	intentSkipped metric.Int64Counter // Authorizes where Step 5 was skipped (LOW)
 
 	// Async intent-check worker pool. Owned by the engine, drained by
 	// Shutdown. asyncDone is closed exactly once by Shutdown to signal
@@ -93,22 +95,38 @@ type FGARequest struct {
 
 // FGAResult represents the authorization decision.
 type FGAResult struct {
-	Allowed       bool     `json:"allowed"`
-	Outcome       string   `json:"outcome"`       // ALLOW, DENY, DENY_INTENT, DENY_CONTEXT, DENY_CHAIN, DENY_ATTRIBUTE
-	StepsTriggered []string `json:"stepsTriggered"` // which steps evaluated
-	DeniedBy      string   `json:"deniedBy,omitempty"` // which step denied
-	DeniedReason  string   `json:"deniedReason,omitempty"`
-	LatencyMs     int64    `json:"latencyMs"`
-	IntentCheck   *IntentCheckResult `json:"intentCheck,omitempty"`
+	Allowed        bool               `json:"allowed"`
+	Outcome        string             `json:"outcome"`            // ALLOW, DENY, DENY_INTENT, DENY_CONTEXT, DENY_CHAIN, DENY_ATTRIBUTE
+	StepsTriggered []string           `json:"stepsTriggered"`     // which steps evaluated
+	DeniedBy       string             `json:"deniedBy,omitempty"` // which step denied
+	DeniedReason   string             `json:"deniedReason,omitempty"`
+	LatencyMs      int64              `json:"latencyMs"`
+	IntentCheck    *IntentCheckResult `json:"intentCheck,omitempty"`
 }
 
 // IntentCheckResult contains NanoMind daemon intent verification results.
+//
+// Status records why Step 5 reached the verdict it did, so the silent
+// fail-open in #131 becomes observable: "classified" means the daemon
+// returned a non-empty attack class; "abstain" means it answered cleanly but
+// with no classification (the common case until NanoMind is fine-tuned on the
+// FGA prompt format); "fail_open" means the daemon was unreachable, the
+// request could not be built, or the response could not be decoded, so the
+// action proceeds without an intent verdict.
 type IntentCheckResult struct {
 	IntentClass string  `json:"intentClass"`
 	Confidence  float64 `json:"confidence"`
 	Blocked     bool    `json:"blocked"`
 	LatencyMs   int64   `json:"latencyMs"`
+	Status      string  `json:"status,omitempty"`
 }
+
+// Step 5 intent-check outcome statuses. See IntentCheckResult.Status.
+const (
+	intentStatusClassified = "classified"
+	intentStatusAbstain    = "abstain"
+	intentStatusFailOpen   = "fail_open"
+)
 
 // FGAPolicy represents a stored FGA policy.
 type FGAPolicy struct {
@@ -172,6 +190,30 @@ func NewFGAEngine(db *sql.DB, agentSvc *AgentService, logger *slog.Logger) *FGAE
 	if err != nil {
 		logger.Warn("fga async_intent_dropped counter init failed", "error", err)
 	}
+	// Step 5 observability (issue #131, Stage 3). intentChecks is incremented
+	// once per Step 5 evaluation that reached the daemon call, attributed by
+	// risk tier, sync/async mode, and outcome status (classified / abstain /
+	// fail_open). intentSkipped counts Authorizes where Step 5 never ran (LOW
+	// risk). Together they let operators compute Step 5's classification rate,
+	// fail-open rate, and skip rate per tier — today these show that Step 5
+	// almost never produces a real classification (it abstains or fails open),
+	// which is the evidence #131 exists to quantify. Per-agent breakdown stays
+	// in the structured fga.decision log (agent.id + trace correlation), NOT in
+	// metric labels, to keep Prometheus cardinality bounded.
+	intentChecks, err := meter.Int64Counter(
+		"fga.intent_checks",
+		metric.WithDescription("FGA Step 5 intent evaluations that reached the NanoMind daemon, by risk tier, mode, and outcome status"),
+	)
+	if err != nil {
+		logger.Warn("fga intent_checks counter init failed", "error", err)
+	}
+	intentSkipped, err := meter.Int64Counter(
+		"fga.intent_skipped",
+		metric.WithDescription("FGA authorizations where Step 5 intent check was skipped, by risk tier"),
+	)
+	if err != nil {
+		logger.Warn("fga intent_skipped counter init failed", "error", err)
+	}
 
 	e := &FGAEngine{
 		db:             db,
@@ -183,6 +225,8 @@ func NewFGAEngine(db *sql.DB, agentSvc *AgentService, logger *slog.Logger) *FGAE
 		decisions:      decisions,
 		latency:        latency,
 		asyncDropped:   asyncDropped,
+		intentChecks:   intentChecks,
+		intentSkipped:  intentSkipped,
 		asyncQueue:     make(chan asyncIntentJob, fgaAsyncQueueSize),
 		asyncDone:      make(chan struct{}),
 	}
@@ -521,6 +565,7 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 		)
 		intentResult := e.checkIntentSync(intentCtx, req)
 		result.IntentCheck = intentResult
+		e.recordIntentCheck(intentCtx, "HIGH", "sync", intentResult)
 		if intentResult != nil {
 			intentSpan.SetAttributes(
 				attribute.String("fga.intent_class", intentResult.IntentClass),
@@ -577,8 +622,18 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 			}
 		}
 		asyncSpan.End()
+	} else {
+		// LOW (or any non-HIGH/MEDIUM risk level): Step 5 is skipped entirely.
+		// Counting the skip per tier is what makes the skip rate observable —
+		// without it, a skipped check is indistinguishable from one that ran
+		// and abstained. riskTier is the raw policy value so an unexpected
+		// level shows up as its own series rather than being silently bucketed.
+		if e.intentSkipped != nil {
+			e.intentSkipped.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("fga.risk_tier", policy.RiskLevel),
+			))
+		}
 	}
-	// LOW: skip intent check entirely
 
 	// All checks passed
 	result.Allowed = true
@@ -819,7 +874,7 @@ func (e *FGAEngine) checkChain(ctx context.Context, req *FGARequest, policy *FGA
 	}
 
 	var rules struct {
-		MaxCallsPerHour    *int    `json:"maxCallsPerHour"`
+		MaxCallsPerHour     *int    `json:"maxCallsPerHour"`
 		DenyAfterCapability *string `json:"denyAfterCapability"`
 	}
 	if err := json.Unmarshal(policy.ChainRules, &rules); err != nil {
@@ -891,6 +946,7 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 			Confidence:  0,
 			Blocked:     false,
 			LatencyMs:   time.Since(start).Milliseconds(),
+			Status:      intentStatusFailOpen,
 		}
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -904,6 +960,7 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 			Confidence:  0,
 			Blocked:     false, // fail open if daemon unavailable or ctx cancelled
 			LatencyMs:   time.Since(start).Milliseconds(),
+			Status:      intentStatusFailOpen,
 		}
 	}
 	defer resp.Body.Close()
@@ -914,22 +971,64 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 		AttackClass string  `json:"attackClass"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&inferResp); err != nil {
-		return nil
+		// Undecodable response is one of the fail-open modes #131 is about.
+		// Return a measured fail_open result (decision unchanged: not blocked)
+		// rather than nil, so this path is counted instead of vanishing.
+		e.logger.Debug("intent check response decode failed", "error", err)
+		return &IntentCheckResult{
+			IntentClass: "unknown",
+			Confidence:  0,
+			Blocked:     false,
+			LatencyMs:   time.Since(start).Milliseconds(),
+			Status:      intentStatusFailOpen,
+		}
 	}
 
 	blocked := inferResp.AttackClass != "" && inferResp.Confidence > 0.8
+
+	status := intentStatusClassified
+	if inferResp.AttackClass == "" {
+		status = intentStatusAbstain
+	}
 
 	return &IntentCheckResult{
 		IntentClass: inferResp.AttackClass,
 		Confidence:  inferResp.Confidence,
 		Blocked:     blocked,
 		LatencyMs:   time.Since(start).Milliseconds(),
+		Status:      status,
 	}
+}
+
+// recordIntentCheck emits the fga.intent_checks counter for one Step 5
+// evaluation. mode is "sync" (HIGH) or "async" (MEDIUM); riskTier is the
+// policy risk level that triggered the check. result carries the status set by
+// checkIntentSync. Safe to call with a nil result (counted as fail_open) or a
+// nil instrument (no-op).
+func (e *FGAEngine) recordIntentCheck(ctx context.Context, riskTier, mode string, result *IntentCheckResult) {
+	if e.intentChecks == nil {
+		return
+	}
+	status := intentStatusFailOpen
+	blocked := false
+	if result != nil {
+		if result.Status != "" {
+			status = result.Status
+		}
+		blocked = result.Blocked
+	}
+	e.intentChecks.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("fga.risk_tier", riskTier),
+		attribute.String("fga.intent_mode", mode),
+		attribute.String("fga.intent_status", status),
+		attribute.Bool("fga.intent_blocked", blocked),
+	))
 }
 
 func (e *FGAEngine) checkIntentAsync(ctx context.Context, req *FGARequest) {
 	// Fire-and-forget intent check for MEDIUM risk
 	result := e.checkIntentSync(ctx, req)
+	e.recordIntentCheck(ctx, "MEDIUM", "async", result)
 	if result != nil && result.Blocked {
 		e.logger.Warn("async intent check flagged suspicious activity",
 			"agentId", req.AgentID,
@@ -1090,4 +1189,3 @@ func (s *pqStringArray) parse(str string) error {
 	*s.arr = result
 	return nil
 }
-

--- a/apps/backend/internal/application/fga_engine_step5_metrics_test.go
+++ b/apps/backend/internal/application/fga_engine_step5_metrics_test.go
@@ -1,0 +1,183 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Step 5 observability (issue #131, Stage 3). These tests pin two things:
+//  1. checkIntentSync labels every outcome with the right Status, so the
+//     silent fail-open becomes measurable (classified / abstain / fail_open).
+//  2. recordIntentCheck emits fga.intent_checks with the risk-tier / mode /
+//     status / blocked attributes operators derive the rates from.
+
+// TestCheckIntentSyncStatus asserts the Status field for the daemon response
+// shapes Step 5 can encounter. fail_open has two sub-modes (daemon unreachable
+// and undecodable body); both must be counted, not dropped.
+func TestCheckIntentSyncStatus(t *testing.T) {
+	req := &FGARequest{
+		AgentID:    uuid.New(),
+		Capability: "file:read",
+		Resource:   "/tmp/step5-status-test",
+		Action:     "read",
+	}
+
+	t.Run("non-empty class is classified", func(t *testing.T) {
+		srv := stubDaemon(t, map[string]interface{}{
+			"attackClass": "exfiltration_pattern",
+			"confidence":  0.95,
+		})
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusClassified, got.Status)
+		assert.True(t, got.Blocked)
+	})
+
+	t.Run("empty class is abstain", func(t *testing.T) {
+		srv := stubDaemon(t, map[string]interface{}{
+			"attackClass": "",
+			"confidence":  0.95,
+		})
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusAbstain, got.Status)
+		assert.False(t, got.Blocked)
+	})
+
+	t.Run("daemon unreachable is fail_open", func(t *testing.T) {
+		// Reserved-TEST-net address that refuses fast; the 800ms client
+		// timeout is the upper bound.
+		engine := &FGAEngine{daemonURL: "http://127.0.0.1:1", logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusFailOpen, got.Status)
+		assert.False(t, got.Blocked)
+	})
+
+	t.Run("undecodable body is fail_open not nil", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("this is not json"))
+		}))
+		t.Cleanup(srv.Close)
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		// Previously this returned nil and the fail-open vanished from
+		// telemetry. It must now be a measured fail_open result.
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusFailOpen, got.Status)
+		assert.False(t, got.Blocked)
+	})
+}
+
+// TestRecordIntentCheckEmitsCounter asserts fga.intent_checks carries the four
+// attributes per evaluation, and that a nil result is counted as fail_open
+// (the worst case must never be a silent no-op).
+func TestRecordIntentCheckEmitsCounter(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	// Instruments bind at construction, so build the engine after the
+	// provider is installed. db/agentSvc nil is fine for this path.
+	engine := NewFGAEngine(nil, nil, nil)
+	t.Cleanup(func() { _ = engine.Shutdown(context.Background()) })
+
+	ctx := context.Background()
+	engine.recordIntentCheck(ctx, "HIGH", "sync", &IntentCheckResult{Status: intentStatusClassified, Blocked: true})
+	engine.recordIntentCheck(ctx, "MEDIUM", "async", &IntentCheckResult{Status: intentStatusAbstain, Blocked: false})
+	engine.recordIntentCheck(ctx, "HIGH", "sync", nil) // worst case: count as fail_open
+
+	dps := collectCounter(t, reader, "fga.intent_checks")
+	require.Len(t, dps, 3, "expected one series per distinct attribute set")
+
+	classified := findDP(dps, "HIGH", "sync", intentStatusClassified, true)
+	require.NotNil(t, classified, "missing classified/sync/HIGH/blocked series")
+	assert.Equal(t, int64(1), classified.Value)
+
+	abstain := findDP(dps, "MEDIUM", "async", intentStatusAbstain, false)
+	require.NotNil(t, abstain, "missing abstain/async/MEDIUM series")
+	assert.Equal(t, int64(1), abstain.Value)
+
+	failOpen := findDP(dps, "HIGH", "sync", intentStatusFailOpen, false)
+	require.NotNil(t, failOpen, "nil result must be counted as fail_open")
+	assert.Equal(t, int64(1), failOpen.Value)
+}
+
+// --- helpers ---
+
+func stubDaemon(t *testing.T, resp map[string]interface{}) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/infer" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func collectCounter(t *testing.T, reader sdkmetric.Reader, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, "metric %s is not an int64 Sum", name)
+				return sum.DataPoints
+			}
+		}
+	}
+	t.Fatalf("metric %s not collected", name)
+	return nil
+}
+
+func findDP(dps []metricdata.DataPoint[int64], tier, mode, status string, blocked bool) *metricdata.DataPoint[int64] {
+	for i := range dps {
+		set := dps[i].Attributes
+		if attrStr(set, "fga.risk_tier") == tier &&
+			attrStr(set, "fga.intent_mode") == mode &&
+			attrStr(set, "fga.intent_status") == status &&
+			attrBool(set, "fga.intent_blocked") == blocked {
+			return &dps[i]
+		}
+	}
+	return nil
+}
+
+func attrStr(set attribute.Set, key string) string {
+	v, ok := set.Value(attribute.Key(key))
+	if !ok {
+		return ""
+	}
+	return v.AsString()
+}
+
+func attrBool(set attribute.Set, key string) bool {
+	v, ok := set.Value(attribute.Key(key))
+	if !ok {
+		return false
+	}
+	return v.AsBool()
+}


### PR DESCRIPTION
## What

Stage 3 of #131 — make FGA Step 5 (the NanoMind intent classifier) observable so operators can see how often it actually classifies versus abstains, fails open, or is skipped. Today Step 5 fails open silently: the dev daemon does not reliably return a classification and the base model is not fine-tuned for the FGA prompt, so the check almost never produces a real verdict. This PR quantifies that gap instead of hiding it.

This is observability only. It does **not** re-enable the live classification/blocking line and does **not** change any allow/deny decision.

## Changes

- **`fga.intent_checks`** counter — one increment per Step 5 evaluation that reached the daemon call. Labels:
  - `fga.risk_tier` (HIGH | MEDIUM), `fga.intent_mode` (sync | async)
  - `fga.intent_status` — `classified` (non-empty attack class) | `abstain` (clean response, no class) | `fail_open` (daemon unreachable / build error / undecodable body)
  - `fga.intent_blocked` — the Step 5 verdict; `blocked=true` on an async (allowed) request is a Step-5-vs-final disagreement
- **`fga.intent_skipped`** counter — Authorizes where Step 5 was skipped (LOW / non-HIGH-MEDIUM), labeled by risk tier.
- `checkIntentSync` now stamps `IntentCheckResult.Status` at every return branch, and returns a measured `fail_open` result on an undecodable body instead of `nil`, so that fail-open path is counted rather than vanishing. The allow/deny decision on every path is unchanged (verified: not-blocked in/out).
- `OBSERVABILITY.md` documents both counters plus the previously-undocumented `fga.async_intent_dropped`, with PromQL for classification rate, fail-open rate, skip rate, and async agreement rate.

## Why per-agent is not a metric label

Per-agent breakdown stays in the structured `fga.decision` log (agent.id + trace correlation), not in metric labels, to keep Prometheus cardinality bounded — matching how `fga.decisions` already avoids agent labels.

## Tests

- `TestCheckIntentSyncStatus` — pins Status for classified / abstain / two fail_open sub-modes (daemon unreachable, undecodable body), and proves the old `nil` path is gone.
- `TestRecordIntentCheckEmitsCounter` — manual-reader assertion that `fga.intent_checks` carries the four attributes per series and counts a nil result as `fail_open`.
- Existing `TestFGAIntentContract` unchanged and green (`checkIntentSync` signature preserved).

`go build ./...`, `go vet`, `go test -race` on the application package all pass.

## Scope note

Stages 1 (daemon contract / deterministic fallback) and 2 (fine-tune NanoMind to F1 > 0.85 on the OASB benchmark before re-enabling the live line) remain open and are separate model-training work. This PR is the baseline that will show those stages landed.

Closes none — #131 stays open until Stages 1–2 land; this is the first of the three.