### PR TITLE
feat(fga): consume daemon classify/abstain signal in Step 5 intent check (#131)

### DIFF
--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -107,12 +107,18 @@ type FGAResult struct {
 // IntentCheckResult contains NanoMind daemon intent verification results.
 //
 // Status records why Step 5 reached the verdict it did, so the silent
-// fail-open in #131 becomes observable: "classified" means the daemon
-// returned a non-empty attack class; "abstain" means it answered cleanly but
-// with no classification (the common case until NanoMind is fine-tuned on the
-// FGA prompt format); "fail_open" means the daemon was unreachable, the
-// request could not be built, or the response could not be decoded, so the
-// action proceeds without an intent verdict.
+// fail-open in #131 becomes observable. As of @nanomind/daemon 0.4.0 (Stage 1)
+// the daemon emits an explicit `classification` field that drives this:
+//   - "classified": the daemon produced a usable verdict — a confident benign
+//     (attackClass "") OR a non-empty attack class. Step 5 blocks only on the
+//     latter, above the confidence threshold.
+//   - "abstain": the daemon ran but could not produce a usable verdict (its
+//     classification was "abstain", or — for a pre-0.4.0 daemon — it returned an
+//     empty attack class, the legacy fallback). Action proceeds; the abstain is
+//     now distinct from a confident benign, which was the #131 conflation.
+//   - "fail_open": the daemon was unreachable, returned a non-2xx status, the
+//     request could not be built, or the response could not be decoded, so the
+//     action proceeds without an intent verdict.
 type IntentCheckResult struct {
 	IntentClass string  `json:"intentClass"`
 	Confidence  float64 `json:"confidence"`
@@ -127,6 +133,13 @@ const (
 	intentStatusAbstain    = "abstain"
 	intentStatusFailOpen   = "fail_open"
 )
+
+// intentBlockConfidence is the minimum daemon confidence (strictly greater) for
+// a non-empty attack class to block in Step 5. The @nanomind/daemon v0.5.0
+// classifier saturates confidence near 1.0, so 0.8 is effectively binary today;
+// the daemon README recommends 0.95. Raising it is a calibration call owned by
+// CDS/CA and is tracked as a separate follow-up, not changed here.
+const intentBlockConfidence = 0.8
 
 // FGAPolicy represents a stored FGA policy.
 type FGAPolicy struct {
@@ -965,10 +978,32 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 	}
 	defer resp.Body.Close()
 
+	// A non-2xx response means the daemon ran but could not classify (the
+	// engine-error 500 path: model not loaded, ORT failure). That is an
+	// operational failure — recorded as fail_open, distinct from a healthy
+	// model that deliberately abstained on a usable input. Before #131 Stage 1
+	// the 500 body decoded to attackClass:"" and was silently counted as a
+	// clean abstain, hiding the infrastructure failure; checking the status
+	// code closes that hole. The daemon's 500 body also carries
+	// classification:"abstain" as a fallback for consumers that don't inspect
+	// the status code — we inspect it, so the status wins. Decision unchanged:
+	// not blocked.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		e.logger.Debug("NanoMind daemon returned non-2xx for intent check", "status", resp.StatusCode)
+		return &IntentCheckResult{
+			IntentClass: "unknown",
+			Confidence:  0,
+			Blocked:     false,
+			LatencyMs:   time.Since(start).Milliseconds(),
+			Status:      intentStatusFailOpen,
+		}
+	}
+
 	var inferResp struct {
-		Result      string  `json:"result"`
-		Confidence  float64 `json:"confidence"`
-		AttackClass string  `json:"attackClass"`
+		Result         string  `json:"result"`
+		Confidence     float64 `json:"confidence"`
+		AttackClass    string  `json:"attackClass"`
+		Classification string  `json:"classification"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&inferResp); err != nil {
 		// Undecodable response is one of the fail-open modes #131 is about.
@@ -984,11 +1019,43 @@ func (e *FGAEngine) checkIntentSync(ctx context.Context, req *FGARequest) *Inten
 		}
 	}
 
-	blocked := inferResp.AttackClass != "" && inferResp.Confidence > 0.8
+	// Map the daemon's explicit classification (@nanomind/daemon 0.4.0+) to the
+	// Step 5 status. This is the #131 Stage 1 fix: a confident benign
+	// ("classified", attackClass "") is now distinguishable from "model couldn't
+	// answer" ("abstain", attackClass ""), which previously both read as abstain.
+	//
+	// Evidence beats label: a concrete attack class above the block threshold
+	// blocks regardless of the classification label. A well-behaved 0.4.0 daemon
+	// forces attackClass="" whenever it abstains, so this only matters for a
+	// buggy / downgraded / mixed-version daemon that sends a self-contradictory
+	// response (classification:"abstain" carrying a live attackClass) — there we
+	// fail closed rather than dropping the attack evidence, which also keeps this
+	// from being a weakening vs the pre-#131 criterion. It mirrors the 500-path
+	// "status wins" defense, applied here to the 2xx body.
+	blocked := inferResp.AttackClass != "" && inferResp.Confidence > intentBlockConfidence
 
-	status := intentStatusClassified
-	if inferResp.AttackClass == "" {
+	var status string
+	switch {
+	case blocked:
+		// A usable, blocking verdict is always classified, whatever the label says.
+		status = intentStatusClassified
+	case inferResp.Classification == intentStatusClassified:
+		// A usable verdict that does not block — a confident benign, or a
+		// non-empty class below the threshold.
+		status = intentStatusClassified
+	case inferResp.Classification == intentStatusAbstain:
+		// The model could not produce a usable verdict (and carried no blocking
+		// attack class, per the blocked check above).
 		status = intentStatusAbstain
+	default:
+		// Pre-0.4.0 daemon (no classification field, or JSON null): fall back to
+		// the legacy heuristic (empty attackClass == abstain) so a mixed-version
+		// deploy keeps working.
+		if inferResp.AttackClass == "" {
+			status = intentStatusAbstain
+		} else {
+			status = intentStatusClassified
+		}
 	}
 
 	return &IntentCheckResult{

--- a/apps/backend/internal/application/fga_engine_intent_contract_test.go
+++ b/apps/backend/internal/application/fga_engine_intent_contract_test.go
@@ -13,55 +13,134 @@ import (
 // TestFGAIntentContract pins the wire contract between the NanoMind daemon's
 // /v1/infer response and FGA Step 5's blocking decision.
 //
-// Per @nanomind/daemon 0.1.1 (CHANGELOG), the daemon always emits
-// attackClass as a string (default ""). Per fga_engine.go::checkIntentSync,
-// the FGA blocking criterion is:
+// Per @nanomind/daemon 0.4.0 the daemon emits an explicit `classification`
+// field ("classified" | "abstain") alongside `attackClass`. Per
+// fga_engine.go::checkIntentSync, the FGA blocking criterion is:
 //
-//	blocked := attackClass != "" && confidence > 0.8
+//	blocked := classification == "classified" && attackClass != "" && confidence > 0.8
 //
-// These tests exercise checkIntentSync directly against an httptest server
-// that mimics three daemon response shapes. They are deliberately scoped to
-// the contract under test and do not depend on the running backend, the
-// database, or a real daemon — that is the point.
+// A pre-0.4.0 daemon omits `classification`; the consumer then falls back to the
+// legacy heuristic (empty attackClass == abstain). Both the explicit-field and
+// the legacy-fallback shapes are exercised below (daemonClassification == ""
+// means "omit the field", i.e. an older daemon).
+//
+// These tests exercise checkIntentSync directly against an httptest server that
+// mimics the daemon response shapes. They are deliberately scoped to the
+// contract under test and do not depend on the running backend, the database,
+// or a real daemon — that is the point.
 func TestFGAIntentContract(t *testing.T) {
 	cases := []struct {
-		name              string
-		daemonAttackClass string
-		daemonConfidence  float64
-		wantBlocked       bool
-		wantIntentClass   string
-		wantConfidence    float64
+		name                 string
+		daemonAttackClass    string
+		daemonConfidence     float64
+		daemonClassification string // "" => omit the field (pre-0.4.0 daemon)
+		wantBlocked          bool
+		wantIntentClass      string
+		wantConfidence       float64
+		wantStatus           string
 	}{
 		{
-			// Case (a): production classifier flags a malicious intent at
-			// high confidence — FGA Step 5 must block.
-			name:              "non-empty class with high confidence blocks",
-			daemonAttackClass: "exfiltration_pattern",
-			daemonConfidence:  0.91,
-			wantBlocked:       true,
-			wantIntentClass:   "exfiltration_pattern",
-			wantConfidence:    0.91,
+			// Case (a): classifier flags a malicious intent at high confidence
+			// with an explicit "classified" — FGA Step 5 must block.
+			name:                 "classified non-empty class with high confidence blocks",
+			daemonAttackClass:    "exfiltration_pattern",
+			daemonConfidence:     0.91,
+			daemonClassification: "classified",
+			wantBlocked:          true,
+			wantIntentClass:      "exfiltration_pattern",
+			wantConfidence:       0.91,
+			wantStatus:           intentStatusClassified,
 		},
 		{
-			// Case (b): the always-emitted default. This is what every
-			// response carries today (until Bug 2 wires the production
-			// classifier). FGA Step 5 must allow.
-			name:              "empty class with high confidence allows",
-			daemonAttackClass: "",
-			daemonConfidence:  0.91,
-			wantBlocked:       false,
-			wantIntentClass:   "",
-			wantConfidence:    0.91,
+			// Case (b): a confident benign — explicit "classified" with an empty
+			// attack class. This must NOT be conflated with abstain (the #131
+			// fix): status is classified, decision is allow.
+			name:                 "classified empty class is a confident benign allow",
+			daemonAttackClass:    "",
+			daemonConfidence:     0.91,
+			daemonClassification: "classified",
+			wantBlocked:          false,
+			wantIntentClass:      "",
+			wantConfidence:       0.91,
+			wantStatus:           intentStatusClassified,
 		},
 		{
-			// Case (c): classifier flagged something but confidence is below
-			// the 0.8 threshold — FGA Step 5 must allow.
-			name:              "non-empty class with low confidence allows",
-			daemonAttackClass: "exfiltration_pattern",
-			daemonConfidence:  0.7,
-			wantBlocked:       false,
-			wantIntentClass:   "exfiltration_pattern",
-			wantConfidence:    0.7,
+			// Case (c): the model could not produce a usable verdict — explicit
+			// "abstain" (attackClass forced to "" by the daemon). Allow, but
+			// recorded as abstain, not benign.
+			name:                 "explicit abstain allows and is recorded as abstain",
+			daemonAttackClass:    "",
+			daemonConfidence:     0.31,
+			daemonClassification: "abstain",
+			wantBlocked:          false,
+			wantIntentClass:      "",
+			wantConfidence:       0.31,
+			wantStatus:           intentStatusAbstain,
+		},
+		{
+			// Case (d): classified but confidence below the 0.8 block threshold
+			// — FGA Step 5 must allow.
+			name:                 "classified non-empty class with low confidence allows",
+			daemonAttackClass:    "exfiltration_pattern",
+			daemonConfidence:     0.7,
+			daemonClassification: "classified",
+			wantBlocked:          false,
+			wantIntentClass:      "exfiltration_pattern",
+			wantConfidence:       0.7,
+			wantStatus:           intentStatusClassified,
+		},
+		{
+			// Case (e): legacy daemon (no classification field), non-empty class
+			// at high confidence — the fallback heuristic still blocks.
+			name:                 "legacy daemon non-empty class blocks via fallback",
+			daemonAttackClass:    "prompt_injection",
+			daemonConfidence:     0.95,
+			daemonClassification: "",
+			wantBlocked:          true,
+			wantIntentClass:      "prompt_injection",
+			wantConfidence:       0.95,
+			wantStatus:           intentStatusClassified,
+		},
+		{
+			// Case (f): legacy daemon, empty class — the fallback heuristic
+			// records abstain (the pre-#131-Stage-1 behavior, preserved for
+			// mixed-version deploys).
+			name:                 "legacy daemon empty class is abstain via fallback",
+			daemonAttackClass:    "",
+			daemonConfidence:     0.95,
+			daemonClassification: "",
+			wantBlocked:          false,
+			wantIntentClass:      "",
+			wantConfidence:       0.95,
+			wantStatus:           intentStatusAbstain,
+		},
+		{
+			// Case (g): self-contradictory daemon response — "abstain" label but
+			// a live high-confidence attack class. Evidence beats label: Step 5
+			// fails closed (blocks) rather than dropping the attack. A
+			// well-behaved 0.4.0 daemon never sends this; the guard is for a
+			// buggy / downgraded / mixed-version daemon.
+			name:                 "abstain label with live high-confidence attack fails closed",
+			daemonAttackClass:    "exfiltration_pattern",
+			daemonConfidence:     0.99,
+			daemonClassification: "abstain",
+			wantBlocked:          true,
+			wantIntentClass:      "exfiltration_pattern",
+			wantConfidence:       0.99,
+			wantStatus:           intentStatusClassified,
+		},
+		{
+			// Case (h): malformed classification value (unknown string) with a
+			// live high-confidence attack class — must fall through to the
+			// fallback and still block, never silently allow a real attack.
+			name:                 "malformed classification with live attack still blocks",
+			daemonAttackClass:    "prompt_injection",
+			daemonConfidence:     0.95,
+			daemonClassification: "CLASSIFIED-typo",
+			wantBlocked:          true,
+			wantIntentClass:      "prompt_injection",
+			wantConfidence:       0.95,
+			wantStatus:           intentStatusClassified,
 		},
 	}
 
@@ -73,14 +152,18 @@ func TestFGAIntentContract(t *testing.T) {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				body := map[string]interface{}{
 					"intent":       "INTENT_CHECK",
 					"result":       "stub",
 					"confidence":   tc.daemonConfidence,
 					"attackClass":  tc.daemonAttackClass,
 					"latencyMs":    1,
 					"modelVersion": "test-stub",
-				})
+				}
+				if tc.daemonClassification != "" {
+					body["classification"] = tc.daemonClassification
+				}
+				_ = json.NewEncoder(w).Encode(body)
 			}))
 			t.Cleanup(srv.Close)
 
@@ -107,6 +190,9 @@ func TestFGAIntentContract(t *testing.T) {
 			}
 			if got.Confidence != tc.wantConfidence {
 				t.Errorf("Confidence: got %v, want %v", got.Confidence, tc.wantConfidence)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("Status: got %q, want %q", got.Status, tc.wantStatus)
 			}
 		})
 	}

--- a/apps/backend/internal/application/fga_engine_step5_metrics_test.go
+++ b/apps/backend/internal/application/fga_engine_step5_metrics_test.go
@@ -34,10 +34,11 @@ func TestCheckIntentSyncStatus(t *testing.T) {
 		Action:     "read",
 	}
 
-	t.Run("non-empty class is classified", func(t *testing.T) {
+	t.Run("classified non-empty class is classified and blocks", func(t *testing.T) {
 		srv := stubDaemon(t, map[string]interface{}{
-			"attackClass": "exfiltration_pattern",
-			"confidence":  0.95,
+			"attackClass":    "exfiltration_pattern",
+			"confidence":     0.95,
+			"classification": "classified",
 		})
 		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
 		got := engine.checkIntentSync(context.Background(), req)
@@ -46,7 +47,38 @@ func TestCheckIntentSyncStatus(t *testing.T) {
 		assert.True(t, got.Blocked)
 	})
 
-	t.Run("empty class is abstain", func(t *testing.T) {
+	t.Run("classified empty class is a confident benign, not abstain", func(t *testing.T) {
+		// The #131 Stage 1 distinction: an explicit "classified" with an empty
+		// attack class is a confident benign — it must NOT read as abstain.
+		srv := stubDaemon(t, map[string]interface{}{
+			"attackClass":    "",
+			"confidence":     0.95,
+			"classification": "classified",
+		})
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusClassified, got.Status)
+		assert.False(t, got.Blocked)
+	})
+
+	t.Run("explicit abstain is abstain", func(t *testing.T) {
+		srv := stubDaemon(t, map[string]interface{}{
+			"attackClass":    "",
+			"confidence":     0.31,
+			"classification": "abstain",
+		})
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusAbstain, got.Status)
+		assert.False(t, got.Blocked)
+	})
+
+	t.Run("legacy empty class is abstain via fallback", func(t *testing.T) {
+		// Pre-0.4.0 daemon: no classification field. The fallback heuristic
+		// (empty attackClass == abstain) preserves behavior for mixed-version
+		// deploys.
 		srv := stubDaemon(t, map[string]interface{}{
 			"attackClass": "",
 			"confidence":  0.95,
@@ -55,6 +87,47 @@ func TestCheckIntentSyncStatus(t *testing.T) {
 		got := engine.checkIntentSync(context.Background(), req)
 		require.NotNil(t, got)
 		assert.Equal(t, intentStatusAbstain, got.Status)
+		assert.False(t, got.Blocked)
+	})
+
+	t.Run("abstain label with live high-confidence attack fails closed", func(t *testing.T) {
+		// A self-contradictory daemon response (abstain label + live attack
+		// class) must not be silently allowed. Evidence beats label: it blocks
+		// and is recorded as classified. This is the symmetric defense to the
+		// 500-path "status wins" guard, applied to the 2xx body.
+		srv := stubDaemon(t, map[string]interface{}{
+			"attackClass":    "exfiltration_pattern",
+			"confidence":     0.99,
+			"classification": "abstain",
+		})
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.True(t, got.Blocked, "a live high-confidence attack must block regardless of an abstain label")
+		assert.Equal(t, intentStatusClassified, got.Status)
+	})
+
+	t.Run("daemon non-2xx is fail_open not abstain", func(t *testing.T) {
+		// The closed hole: a daemon HTTP 500 (engine error) used to decode to
+		// attackClass:"" and be counted as a clean abstain, hiding the infra
+		// failure. It must now be fail_open. The daemon's 500 body still carries
+		// classification:"abstain" as a fallback for dumber consumers; the
+		// status code wins here.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":          "inference_error",
+				"attackClass":    "",
+				"classification": "abstain",
+				"confidence":     0,
+			})
+		}))
+		t.Cleanup(srv.Close)
+		engine := &FGAEngine{daemonURL: srv.URL, logger: slog.Default()}
+		got := engine.checkIntentSync(context.Background(), req)
+		require.NotNil(t, got)
+		assert.Equal(t, intentStatusFailOpen, got.Status)
 		assert.False(t, got.Blocked)
 	})
 


### PR DESCRIPTION
## Summary

FGA Step 5's intent check now consumes the NanoMind daemon's explicit `classification` signal (`@nanomind/daemon` 0.4.0) and checks the daemon's HTTP status code, so the check fails *closed or explicit-abstain* rather than silently open (issue #131). Previously a confident benign and an unusable verdict both arrived as `attackClass: ""` and were indistinguishable, and a daemon HTTP 500 body decoded to a clean `abstain` that hid the infrastructure failure.

## What changed (`checkIntentSync`)

- **Non-2xx daemon responses are now `fail_open`.** Previously the 500 body decoded to `attackClass:""` and was silently recorded as a clean `abstain`, masking the daemon being unhealthy. The status code is now inspected before the body.
- **Reads the daemon `classification` field** (`"classified" | "abstain"`) to set the Step 5 status, so a confident benign (`classified`, `""`) is distinct from "model couldn't answer" (`abstain`) — the #131 conflation.
- **Evidence beats label.** A non-empty attack class above the block threshold blocks regardless of the classification label, so a self-contradictory or downgraded daemon (an `abstain` label carrying a live high-confidence attack class) fails closed rather than dropping the attack. This also keeps the criterion from being a weakening versus the pre-#131 behavior, and mirrors the 500-path "status wins" defense applied to the 2xx body.
- **Block threshold extracted** to a named const `intentBlockConfidence = 0.8`; raising it toward the daemon's recommended 0.95 (the v0.5.0 classifier saturates confidence) is a separate calibration call, noted in-code.

## Compatibility

Backward compatible. A daemon that omits `classification` (or sends JSON `null`) falls back to the legacy `attackClass==""?abstain:classified` heuristic, so mixed-version deploys keep working. No request/response contract shape changed (the `IntentCheckResult` JSON fields are unchanged); no routes touched.

## Decision is unchanged for the common case

Today the daemon abstains/fail-opens near 100% (pre-fine-tune), so Step 5 still allows almost everything — but the outcome is now explicit and observable (`abstain` vs `fail_open` vs `classified`) rather than masquerading as a benign classification. Failing closed on abstain is intentionally NOT enabled here (it would deny legitimate traffic against a model that can't yet classify); that is gated on the model fine-tune.

## Tests

Contract + status tests extended (confident-benign ≠ abstain; explicit abstain; HTTP 500 → fail_open not abstain; legacy fallback both directions; the self-contradictory `abstain`+live-attack fail-closed shape; malformed-label fallback). Full `internal/application` package passes `go test -race`. HMA static scan 100/100.

Pairs with the producer change in `nanomind` (`@nanomind/daemon` adds the `classification` field to `/v1/infer`).