### PR TITLE
feat(fga): emit gen_ai.agent.* authorization attributes on the fga.authorize span

### DIFF
--- a/apps/backend/deployments/otel-demo/.gitignore
+++ b/apps/backend/deployments/otel-demo/.gitignore
@@ -1,6 +1,11 @@
 # Operator-specific port overrides — never commit
 .env
 
+# Never commit credential material into the demo dir
+*.pem
+*.key
+secrets.json
+
 # smoke-backend.sh runtime artifacts (binary + logs)
 .smoke-backend.bin
 .smoke-backend.log

--- a/apps/backend/deployments/otel-demo/README.md
+++ b/apps/backend/deployments/otel-demo/README.md
@@ -1,0 +1,63 @@
+# AIM OTel demo: `gen_ai.agent.*` authorization attributes
+
+A runnable example of the authorization-decision telemetry the AIM backend emits
+on every `fga.authorize` span. The stack (OpenTelemetry Collector → Tempo /
+Prometheus / Loki → Grafana) receives one synthetic trace, metric, and log so you
+can see the attributes land end to end.
+
+## The eight attributes
+
+AIM's fine-grained authorization engine computes an allow/deny decision from
+trust, drift, and scan signals. At that decision point it sets eight namespaced
+attributes on the `fga.authorize` span:
+
+| Attribute | Type | Example | Meaning |
+|---|---|---|---|
+| `gen_ai.agent.capability` | string | `payments:transfer` | capability the agent requested |
+| `gen_ai.agent.public_key.algorithm` | string | `Ed25519+ML-DSA-65` | agent signing-key algorithm (classical, or classical+PQC) |
+| `gen_ai.agent.trust.score` | double | `0.92` | trust score used in the decision |
+| `gen_ai.agent.trust.method` | string | `aim/trust-calculator` | how the trust score was derived |
+| `gen_ai.agent.drift.score` | double | `0.0` | configuration/behavior drift score |
+| `gen_ai.agent.drift.method` | string | `aim/drift-capability-diff` | how drift was measured |
+| `gen_ai.agent.scan.verdict` | string | `clean` | security scan verdict |
+| `gen_ai.agent.scan.method` | string | `aim/registry-asc` | source of the scan verdict |
+
+The names track the OpenTelemetry GenAI SemConv proposal
+[open-telemetry/semantic-conventions-genai#291](https://github.com/open-telemetry/semantic-conventions-genai/pull/291).
+AIM emits them because it genuinely produces these signals at its authorization
+decision point.
+
+### `*.method` semantics
+
+Each `*.method` is a stable producer label naming *how* the paired signal is
+derived — not per-record provenance. `gen_ai.agent.scan.method = aim/registry-asc`
+means AIM read the verdict replicated from the Registry Agent Security Context;
+AIM does not observe which underlying scanner produced it, so it does not claim
+one.
+
+A `*.method` is only emitted alongside its paired score/verdict — there are no
+orphan method labels.
+
+## Run it
+
+```bash
+./smoke-test.sh
+```
+
+This boots the stack, sends one trace/metric/log, verifies each landed in its
+backend, and prints `PASS` / `FAIL`. To change ports, copy `env.example` to
+`.env` first. `gen-signal.sh` is the standalone signal generator the smoke test
+uses; run it directly against a collector with
+`./gen-signal.sh <otlp-grpc-port>`.
+
+Open Grafana (default `http://localhost:3000`) and inspect the `fga.authorize`
+trace in Tempo to see the eight attributes on the span.
+
+## Notes
+
+- This example emits **only** the `gen_ai.agent.*` namespace for the eight
+  authorization attributes. The production backend additionally emits the legacy
+  `agent.*` keys in parallel during an internal dashboard-migration window; that
+  parallel set is deliberately omitted here.
+- `agent.drift_score` is also emitted as a Prometheus **gauge** (separate from the
+  span attribute) for alerting. The metric name is intentionally unchanged.

--- a/apps/backend/deployments/otel-demo/gen-signal.sh
+++ b/apps/backend/deployments/otel-demo/gen-signal.sh
@@ -93,11 +93,24 @@ func main() {
 	defer lp.Shutdown(ctx)
 
 	tracer := otel.Tracer("aim/smoke")
+	// The fga.authorize span carries the eight gen_ai.agent.* authorization
+	// attributes AIM emits at its decision point — the namespaced set proposed
+	// in open-telemetry/semantic-conventions-genai#291. This public example
+	// emits ONLY the gen_ai.agent.* namespace (no legacy agent.* signal keys);
+	// agent.id is identity and fga.* is AIM's own span shape.
 	parent, span := tracer.Start(ctx, "fga.authorize",
 		apitrace.WithAttributes(
 			attribute.String("agent.id", "00000000-0000-0000-0000-deadbeefcafe"),
-			attribute.String("agent.capability", "smoke:test"),
 			attribute.String("fga.outcome", "ALLOW"),
+			// gen_ai.agent.* — eight authorization-decision attributes.
+			attribute.String("gen_ai.agent.capability", "smoke:test"),
+			attribute.String("gen_ai.agent.public_key.algorithm", "Ed25519"),
+			attribute.Float64("gen_ai.agent.trust.score", 0.92),
+			attribute.String("gen_ai.agent.trust.method", "aim/trust-calculator"),
+			attribute.Float64("gen_ai.agent.drift.score", 0.0),
+			attribute.String("gen_ai.agent.drift.method", "aim/drift-capability-diff"),
+			attribute.String("gen_ai.agent.scan.verdict", "clean"),
+			attribute.String("gen_ai.agent.scan.method", "aim/registry-asc"),
 		),
 	)
 	traceID := span.SpanContext().TraceID()

--- a/apps/backend/internal/application/fga_engine.go
+++ b/apps/backend/internal/application/fga_engine.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/telemetry"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/util/sqlarray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -405,13 +406,16 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 			span.SetStatus(codes.Error, result.DeniedReason)
 		}
 
-		// SemConv enrichment for the May 22 talk Slide 14 / 15 proposal:
-		// agent.public_key.algorithm, agent.trust_score, agent.scan_verdict
-		// land on the fga.authorize parent span. Both lookups are local
-		// indexed reads (agents PK, agent_security_contexts PK); failures
-		// are silent so a missing ASC row or a transient repo blip never
-		// blocks an authorize decision. Hybrid-keyed agents emit the
+		// SemConv enrichment for the fga.authorize parent span. The legacy
+		// agent.* keys (agent.public_key.algorithm, agent.trust_score,
+		// agent.scan_verdict, agent.drift_score) are emitted alongside the
+		// namespaced gen_ai.agent.* set ([CHIEF-CA] D1: dual-emit until the
+		// internal Slide-14 / Grafana dashboards repoint, then retire agent.*).
+		// Both lookups are local indexed reads (agents PK, agent_security_contexts
+		// PK); failures are silent so a missing ASC row or a transient repo blip
+		// never blocks an authorize decision. Hybrid-keyed agents emit the
 		// classical+PQC pair joined with "+" (e.g. "Ed25519+ML-DSA-65").
+		genaiSignals := telemetry.AgentAuthzSignals{Capability: req.Capability}
 		if e.agentSvc != nil {
 			if agent, agErr := e.agentSvc.GetAgent(ctx, req.AgentID); agErr == nil && agent != nil {
 				keyAlgo := agent.KeyAlgorithm
@@ -424,13 +428,17 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 				}
 				if keyAlgo != "" {
 					span.SetAttributes(attribute.String("agent.public_key.algorithm", keyAlgo))
+					genaiSignals.PublicKeyAlgo = keyAlgo
 				}
 				span.SetAttributes(attribute.Float64("agent.trust_score", agent.TrustScore))
+				trustScore := agent.TrustScore
+				genaiSignals.TrustScore = &trustScore
 			}
 		}
 		if summary := e.fetchASCRiskSummary(ctx, req.AgentID); summary != nil {
 			if summary.ScanVerdict != "" {
 				span.SetAttributes(attribute.String("agent.scan_verdict", summary.ScanVerdict))
+				genaiSignals.ScanVerdict = summary.ScanVerdict
 			}
 			// agent.drift_score also lives as a Prometheus gauge
 			// (DriftDetectionService.driftScore) for alerting; emitting it
@@ -438,7 +446,10 @@ func (e *FGAEngine) Authorize(ctx context.Context, req *FGARequest) (result *FGA
 			// the span" claim while preserving the gauge shape for Prom.
 			span.SetAttributes(attribute.Float64("agent.drift_score", summary.DriftScore))
 			span.SetAttributes(attribute.Int("agent.active_alerts", summary.ActiveAlerts))
+			driftScore := summary.DriftScore
+			genaiSignals.DriftScore = &driftScore
 		}
+		telemetry.SetGenAIAgentAttributes(span, genaiSignals)
 
 		e.emitDecisionTelemetry(ctx, req, result)
 		span.End()
@@ -693,10 +704,17 @@ func (e *FGAEngine) EmitSDKVerificationSpan(
 	)
 	defer parent.End()
 
+	// Dual-emit legacy agent.* + namespaced gen_ai.agent.* ([CHIEF-CA] D1),
+	// sharing telemetry.SetGenAIAgentAttributes with the /authorize path so the
+	// two span sources cannot drift apart.
+	genaiSignals := telemetry.AgentAuthzSignals{Capability: capability}
 	if keyAlgorithm != "" {
 		parent.SetAttributes(attribute.String("agent.public_key.algorithm", keyAlgorithm))
+		genaiSignals.PublicKeyAlgo = keyAlgorithm
 	}
 	parent.SetAttributes(attribute.Float64("agent.trust_score", trustScore))
+	ts := trustScore
+	genaiSignals.TrustScore = &ts
 
 	// agent.scan_verdict + agent.drift_score + agent.active_alerts come from
 	// the local ASC summary (fail-open: if not present, those three attrs
@@ -704,10 +722,14 @@ func (e *FGAEngine) EmitSDKVerificationSpan(
 	if summary := e.fetchASCRiskSummary(ctx, agentID); summary != nil {
 		if summary.ScanVerdict != "" {
 			parent.SetAttributes(attribute.String("agent.scan_verdict", summary.ScanVerdict))
+			genaiSignals.ScanVerdict = summary.ScanVerdict
 		}
 		parent.SetAttributes(attribute.Float64("agent.drift_score", summary.DriftScore))
 		parent.SetAttributes(attribute.Int("agent.active_alerts", summary.ActiveAlerts))
+		ds := summary.DriftScore
+		genaiSignals.DriftScore = &ds
 	}
+	telemetry.SetGenAIAgentAttributes(parent, genaiSignals)
 
 	// The trace reflects the policy decision, not the SDK response.
 	// VerifyCapability returns a non-empty denialReason on both ALLOW and DENY

--- a/apps/backend/internal/application/fga_engine_genai_attrs_test.go
+++ b/apps/backend/internal/application/fga_engine_genai_attrs_test.go
@@ -1,0 +1,72 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/telemetry"
+)
+
+// TestEmitSDKVerificationSpan_DualEmitsGenAIAttrs proves the real
+// EmitSDKVerificationSpan call site dual-emits both the legacy agent.* keys and
+// the namespaced gen_ai.agent.* set on the fga.authorize span ([CHIEF-CA] D1),
+// sharing telemetry.SetGenAIAgentAttributes with the /authorize finalizer.
+//
+// db is nil, so fetchASCRiskSummary fails open and the scan/drift signals are
+// absent — exactly the behavior the legacy path has when no ASC row exists.
+func TestEmitSDKVerificationSpan_DualEmitsGenAIAttrs(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	engine := &FGAEngine{tracer: tp.Tracer("test")}
+	engine.EmitSDKVerificationSpan(
+		context.Background(),
+		uuid.New(),
+		"Ed25519",
+		0.73,
+		"payments:transfer",
+		true,
+		"Action matches registered capabilities and passes all security policies",
+	)
+
+	var auth sdktrace.ReadOnlySpan
+	for _, s := range rec.Ended() {
+		if s.Name() == "fga.authorize" {
+			auth = s
+			break
+		}
+	}
+	require.NotNil(t, auth, "expected an fga.authorize span")
+
+	attrs := make(map[string]attribute.Value)
+	for _, kv := range auth.Attributes() {
+		attrs[string(kv.Key)] = kv.Value
+	}
+
+	// Dual-emit: legacy and namespaced keys both present.
+	assert.Contains(t, attrs, "agent.trust_score", "legacy key retained (D1 dual-emit)")
+	assert.Contains(t, attrs, "agent.public_key.algorithm")
+
+	require.Contains(t, attrs, telemetry.GenAIAgentCapability)
+	assert.Equal(t, "payments:transfer", attrs[telemetry.GenAIAgentCapability].AsString())
+	require.Contains(t, attrs, telemetry.GenAIAgentPublicKeyAlgo)
+	assert.Equal(t, "Ed25519", attrs[telemetry.GenAIAgentPublicKeyAlgo].AsString())
+	require.Contains(t, attrs, telemetry.GenAIAgentTrustScore)
+	assert.Equal(t, 0.73, attrs[telemetry.GenAIAgentTrustScore].AsFloat64())
+	require.Contains(t, attrs, telemetry.GenAIAgentTrustMethod)
+	assert.Equal(t, telemetry.TrustMethodAIM, attrs[telemetry.GenAIAgentTrustMethod].AsString())
+
+	// No ASC summary (nil db) => scan/drift attrs absent, no orphan methods.
+	assert.NotContains(t, attrs, telemetry.GenAIAgentScanVerdict)
+	assert.NotContains(t, attrs, telemetry.GenAIAgentScanMethod)
+	assert.NotContains(t, attrs, telemetry.GenAIAgentDriftScore)
+	assert.NotContains(t, attrs, telemetry.GenAIAgentDriftMethod)
+}

--- a/apps/backend/internal/telemetry/genai_attrs.go
+++ b/apps/backend/internal/telemetry/genai_attrs.go
@@ -1,0 +1,101 @@
+package telemetry
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// gen_ai.agent.* span attribute keys.
+//
+// These are the eight authorization-decision attributes AIM emits on the
+// `fga.authorize` span. They are the namespaced form of the signals AIM has
+// always recorded under the legacy `agent.*` keys; both sets are emitted in
+// parallel ([CHIEF-CA] decision D1, 2026-06-26) until the internal Slide-14 /
+// Grafana dashboards repoint, after which the `agent.*` set is retired.
+//
+// The names track the OTel GenAI SemConv proposal
+// (open-telemetry/semantic-conventions-genai#291). They are emitted because AIM
+// genuinely produces these signals at its authorization decision point — not to
+// manufacture a producer for the proposal. The public otel-demo example emits
+// ONLY this namespaced set.
+const (
+	GenAIAgentCapability    = "gen_ai.agent.capability"
+	GenAIAgentPublicKeyAlgo = "gen_ai.agent.public_key.algorithm"
+	GenAIAgentTrustScore    = "gen_ai.agent.trust.score"
+	GenAIAgentTrustMethod   = "gen_ai.agent.trust.method"
+	GenAIAgentDriftScore    = "gen_ai.agent.drift.score"
+	GenAIAgentDriftMethod   = "gen_ai.agent.drift.method"
+	GenAIAgentScanVerdict   = "gen_ai.agent.scan.verdict"
+	GenAIAgentScanMethod    = "gen_ai.agent.scan.method"
+)
+
+// Producer-label method constants ([CHIEF-CA] decision D2, 2026-06-26).
+//
+// Each `*.method` attribute names HOW the paired signal is derived in AIM. They
+// are stable, honest producer labels — not per-record provenance. In
+// particular ScanMethodAIM reflects that AIM reads the scan verdict replicated
+// from the Registry Agent Security Context; AIM does not observe which
+// underlying scanner produced it, so claiming a specific scanner here would be
+// fabricated provenance. If true per-scanner provenance is ever required it
+// becomes a Registry schema change (escalation), not a constant edit here.
+const (
+	TrustMethodAIM = "aim/trust-calculator"      // TrustCalculator multi-factor trust score
+	DriftMethodAIM = "aim/drift-capability-diff" // DriftDetectionService capability/MCP diff
+	ScanMethodAIM  = "aim/registry-asc"          // verdict replicated from the Registry ASC
+)
+
+// AgentAuthzSignals carries the authorization signals available at the FGA
+// decision point. A signal is emitted only when present, so a `*.method`
+// attribute never lands without its paired score/verdict:
+//   - Capability / PublicKeyAlgo / ScanVerdict: emitted when non-empty.
+//   - TrustScore / DriftScore: emitted when non-nil (a real 0.0 is still a
+//     value, so presence is modeled with a pointer, not a zero check).
+//
+// This mirrors the fail-open semantics of the legacy `agent.*` emission: a
+// missing agent row or ASC row simply omits the corresponding attributes and
+// never blocks or alters the authorization decision.
+type AgentAuthzSignals struct {
+	Capability    string
+	PublicKeyAlgo string
+	TrustScore    *float64
+	DriftScore    *float64
+	ScanVerdict   string
+}
+
+// SetGenAIAgentAttributes sets the present gen_ai.agent.* attributes (and their
+// paired method labels) on span. It is the single source of truth for the
+// namespaced emission so the /authorize and SDK-verification span paths cannot
+// drift apart. No-op on a nil/non-recording span with no present signals.
+func SetGenAIAgentAttributes(span trace.Span, s AgentAuthzSignals) {
+	if span == nil {
+		return
+	}
+	var kv []attribute.KeyValue
+	if s.Capability != "" {
+		kv = append(kv, attribute.String(GenAIAgentCapability, s.Capability))
+	}
+	if s.PublicKeyAlgo != "" {
+		kv = append(kv, attribute.String(GenAIAgentPublicKeyAlgo, s.PublicKeyAlgo))
+	}
+	if s.TrustScore != nil {
+		kv = append(kv,
+			attribute.Float64(GenAIAgentTrustScore, *s.TrustScore),
+			attribute.String(GenAIAgentTrustMethod, TrustMethodAIM),
+		)
+	}
+	if s.DriftScore != nil {
+		kv = append(kv,
+			attribute.Float64(GenAIAgentDriftScore, *s.DriftScore),
+			attribute.String(GenAIAgentDriftMethod, DriftMethodAIM),
+		)
+	}
+	if s.ScanVerdict != "" {
+		kv = append(kv,
+			attribute.String(GenAIAgentScanVerdict, s.ScanVerdict),
+			attribute.String(GenAIAgentScanMethod, ScanMethodAIM),
+		)
+	}
+	if len(kv) > 0 {
+		span.SetAttributes(kv...)
+	}
+}

--- a/apps/backend/internal/telemetry/genai_attrs_test.go
+++ b/apps/backend/internal/telemetry/genai_attrs_test.go
@@ -1,0 +1,107 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func f64(v float64) *float64 { return &v }
+
+// recordGenAIAttrs runs SetGenAIAgentAttributes against a recorded span and
+// returns the resulting attributes keyed by name.
+func recordGenAIAttrs(t *testing.T, s AgentAuthzSignals) map[string]attribute.Value {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	_, span := tp.Tracer("test").Start(context.Background(), "fga.authorize")
+	SetGenAIAgentAttributes(span, s)
+	span.End()
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	out := make(map[string]attribute.Value, len(ended[0].Attributes()))
+	for _, kv := range ended[0].Attributes() {
+		out[string(kv.Key)] = kv.Value
+	}
+	return out
+}
+
+// TestSetGenAIAgentAttributes_Full asserts all eight gen_ai.agent.* attributes
+// land with the right values, and that each *.method carries the [CHIEF-CA] D2
+// producer-label constant.
+func TestSetGenAIAgentAttributes_Full(t *testing.T) {
+	attrs := recordGenAIAttrs(t, AgentAuthzSignals{
+		Capability:    "payments:transfer",
+		PublicKeyAlgo: "Ed25519+ML-DSA-65",
+		TrustScore:    f64(0.73),
+		DriftScore:    f64(0.12),
+		ScanVerdict:   "clean",
+	})
+
+	require.Len(t, attrs, 8, "expected exactly the eight gen_ai.agent.* attrs")
+
+	assert.Equal(t, "payments:transfer", attrs[GenAIAgentCapability].AsString())
+	assert.Equal(t, "Ed25519+ML-DSA-65", attrs[GenAIAgentPublicKeyAlgo].AsString())
+	assert.Equal(t, 0.73, attrs[GenAIAgentTrustScore].AsFloat64())
+	assert.Equal(t, TrustMethodAIM, attrs[GenAIAgentTrustMethod].AsString())
+	assert.Equal(t, 0.12, attrs[GenAIAgentDriftScore].AsFloat64())
+	assert.Equal(t, DriftMethodAIM, attrs[GenAIAgentDriftMethod].AsString())
+	assert.Equal(t, "clean", attrs[GenAIAgentScanVerdict].AsString())
+	assert.Equal(t, ScanMethodAIM, attrs[GenAIAgentScanMethod].AsString())
+
+	// Method labels are honest, stable producer identifiers.
+	assert.Equal(t, "aim/trust-calculator", TrustMethodAIM)
+	assert.Equal(t, "aim/drift-capability-diff", DriftMethodAIM)
+	assert.Equal(t, "aim/registry-asc", ScanMethodAIM)
+}
+
+// TestSetGenAIAgentAttributes_Empty asserts a fully-empty signal set emits
+// nothing — no orphan method labels, no zero-valued scores.
+func TestSetGenAIAgentAttributes_Empty(t *testing.T) {
+	attrs := recordGenAIAttrs(t, AgentAuthzSignals{})
+	assert.Empty(t, attrs, "no signals present => no gen_ai.agent.* attributes")
+}
+
+// TestSetGenAIAgentAttributes_Partial asserts a *.method never lands without
+// its paired score/verdict: trust present, drift and scan absent.
+func TestSetGenAIAgentAttributes_Partial(t *testing.T) {
+	attrs := recordGenAIAttrs(t, AgentAuthzSignals{
+		Capability: "fs:read",
+		TrustScore: f64(0.5),
+	})
+
+	assert.Contains(t, attrs, GenAIAgentCapability)
+	assert.Contains(t, attrs, GenAIAgentTrustScore)
+	assert.Contains(t, attrs, GenAIAgentTrustMethod)
+
+	assert.NotContains(t, attrs, GenAIAgentDriftScore)
+	assert.NotContains(t, attrs, GenAIAgentDriftMethod, "no orphan drift.method without drift.score")
+	assert.NotContains(t, attrs, GenAIAgentScanVerdict)
+	assert.NotContains(t, attrs, GenAIAgentScanMethod, "no orphan scan.method without scan.verdict")
+	assert.NotContains(t, attrs, GenAIAgentPublicKeyAlgo)
+}
+
+// TestSetGenAIAgentAttributes_ZeroScoreIsEmitted asserts a real 0.0 score is a
+// value (presence is modeled with a pointer, not a zero check), so trust.score
+// and its method still land.
+func TestSetGenAIAgentAttributes_ZeroScoreIsEmitted(t *testing.T) {
+	attrs := recordGenAIAttrs(t, AgentAuthzSignals{
+		TrustScore: f64(0.0),
+		DriftScore: f64(0.0),
+	})
+
+	require.Contains(t, attrs, GenAIAgentTrustScore)
+	assert.Equal(t, 0.0, attrs[GenAIAgentTrustScore].AsFloat64())
+	assert.Contains(t, attrs, GenAIAgentTrustMethod)
+	require.Contains(t, attrs, GenAIAgentDriftScore)
+	assert.Equal(t, 0.0, attrs[GenAIAgentDriftScore].AsFloat64())
+	assert.Contains(t, attrs, GenAIAgentDriftMethod)
+}


### PR DESCRIPTION
## What

The FGA engine now emits the agent authorization decision's own signals as
namespaced `gen_ai.agent.*` attributes on the `fga.authorize` span, so the
inputs to an allow/deny decision are visible in the trace next to the outcome.

Eight attributes are set at the decision point:

| Attribute | Source |
|---|---|
| `gen_ai.agent.capability` | requested capability |
| `gen_ai.agent.public_key.algorithm` | agent signing-key algorithm (classical, or classical+PQC, e.g. `Ed25519+ML-DSA-65`) |
| `gen_ai.agent.trust.{score,method}` | trust score + producer label |
| `gen_ai.agent.drift.{score,method}` | drift score + producer label |
| `gen_ai.agent.scan.{verdict,method}` | scan verdict + producer label |

## How

- Signals come from the `FGAResult` decision object plus the agent and ASC risk
  summary that the span finalizer already reads — no new lookups, same fail-open
  semantics (a missing agent/ASC row simply omits the attributes and never blocks
  or alters the decision).
- A shared `telemetry.SetGenAIAgentAttributes` helper is the single source of
  truth, used by both span sources (the `/authorize` finalizer and the
  `EmitSDKVerificationSpan` path) so the two cannot drift apart.
- `*.method` values are stable producer labels (`aim/trust-calculator`,
  `aim/drift-capability-diff`, `aim/registry-asc`). A method never lands without
  its paired score/verdict. `scan.method = aim/registry-asc` reflects that AIM
  reads the verdict replicated from the Registry Agent Security Context; it does
  not observe the underlying scanner, so it does not claim one.
- The legacy `agent.*` keys are retained in parallel until the internal
  dashboards repoint; the Prometheus `agent.drift_score` gauge is unchanged.
- The `otel-demo` example and its new README emit only the `gen_ai.agent.*`
  namespace and document the eight-attribute contract.

## Why

Product observability of AIM's real authorization decision. The attribute names
track the OpenTelemetry GenAI SemConv proposal
[open-telemetry/semantic-conventions-genai#291](https://github.com/open-telemetry/semantic-conventions-genai/pull/291);
this change is justified on its own merits (decision-path observability) and does
not depend on that proposal landing.

## Tests

- `internal/telemetry`: unit coverage for all eight attributes plus
  presence/absence semantics (full / empty / partial / real-zero score).
- `internal/application`: asserts dual-emit on the real `EmitSDKVerificationSpan`
  span path.
- `go build ./...`, `go vet`, `go test -race` on the touched packages, and gofmt
  all green. The runnable `otel-demo` was verified end to end — all eight
  attributes land in Tempo.
