### PR TITLE
ci: make Go linting actually run (golangci-lint v2 + action v8)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -271,9 +271,18 @@ jobs:
           cache-dependency-path: apps/backend/go.sum
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # action@v8 installs golangci-lint v2 (the v6 line caps at v1, whose binary is
+        # built on go1.24 and refuses our go1.25 target — that guard failure was being
+        # swallowed by continue-on-error and reported green). Pin the linter explicitly so
+        # CI and local runs use the identical build.
+        uses: golangci/golangci-lint-action@v8
+        # NON-BLOCKING on purpose: the v2 migration surfaced a 177-finding backlog
+        # (153 staticcheck + 13 unused + 8 gosec + 3 bodyclose). Findings post as inline
+        # PR annotations so they're visible, but don't wedge every backend PR while the
+        # backlog is triaged. Flip to blocking (security linters first) per
+        # todo/2026-06-26-aim-golangci-lint-silently-disabled.md once findings are resolved.
         continue-on-error: true
         with:
-          version: latest
+          version: v2.12.2
           working-directory: apps/backend
           args: --config ../../.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,80 +1,81 @@
-# golangci-lint configuration for AIM
+# golangci-lint configuration for AIM (v2 schema).
 # Security-focused linting with gosec in audit mode.
-
+# Migrated from v1 on 2026-06-26 (`golangci-lint migrate`); govet/staticcheck/unused are
+# enabled by default in v2 so they no longer need an explicit `enable` entry. gosimple was
+# folded into staticcheck and typecheck is no longer a togglable linter.
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
+output:
+  formats:
+    text:
+      path: stdout
+  sort-order:
+    - linter
+    - severity
+    - file
 linters:
   enable:
     # Security
     - gosec
     - bodyclose
     - sqlclosecheck
-
-    # Code quality
-    - govet
-    - staticcheck
-    - unused
-    - typecheck
-
   disable:
     - errcheck    # Widespread unchecked returns — enable incrementally
-    - gosimple    # Stylistic suggestions (S1009, S1039) — not security-relevant
     - ineffassign # Pre-existing ineffectual assignments — fix in code cleanup PR
     - misspell    # Pre-existing misspellings — fix in code cleanup PR
-
-linters-settings:
-  gosec:
-    # Audit mode: report all issues without filtering
-    config:
-      global:
-        audit: true
-    excludes:
-      - G101  # Hardcoded credentials in tests
-      - G115  # Integer overflow int->int32 (low risk, noisy)
-      - G201  # SQL string formatting (pre-existing, uses parameterized queries)
-      - G402  # TLS MinVersion (SMTP email service, tracked separately)
-    severity: medium
-    confidence: medium
-
-  govet:
-    enable-all: false
-
-  misspell:
-    locale: US
-
+  settings:
+    gosec:
+      # Audit mode: report all issues without filtering.
+      config:
+        global:
+          audit: true
+      excludes:
+        - G101  # Hardcoded credentials in tests
+        - G115  # Integer overflow int->int32 (low risk, noisy)
+        - G201  # SQL string formatting (pre-existing, uses parameterized queries)
+        - G402  # TLS MinVersion (SMTP email service, tracked separately)
+      severity: medium
+      confidence: medium
+    govet:
+      enable-all: false
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Allow unused params in interface implementations
+      - linters:
+          - unused
+        source: '^func \(.*\) '
+      # Relax security checks in test files
+      - linters:
+          - bodyclose
+          - gosec
+        path: _test\.go
+      # CLI entrypoints — interactive prompts, bootstrapping
+      - linters:
+          - gosec
+        path: cmd/
+    paths:
+      - vendor
+      - testdata
+      - node_modules
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-dirs:
-    - vendor
-    - testdata
-    - node_modules
-
-  exclude-rules:
-    # Allow unused params in interface implementations
-    - linters:
-        - unused
-      source: "^func \\(.*\\) "
-
-    # Relax security checks in test files
-    - path: _test\.go
-      linters:
-        - gosec
-        - bodyclose
-
-    # CLI entrypoints — interactive prompts, bootstrapping
-    - path: cmd/
-      linters:
-        - gosec
-
   max-issues-per-linter: 0
   max-same-issues: 0
-
-output:
-  formats:
-    - format: colored-line-number
-  sort-results: true
-  sort-order:
-    - linter
-    - severity
-    - file
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Problem

The **Go Lint** check was a false green. `golangci-lint-action@v6` only installs golangci-lint **v1**, whose binary is built on go1.24 and refuses our go1.25 target (`the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)`). That load error exited non-zero but was swallowed by `continue-on-error: true`, so **gosec (audit mode), bodyclose, and sqlclosecheck were never enforced** while the check reported pass. Separately, the v1-schema `.golangci.yml` is rejected by golangci-lint v2 (`output.formats expected a map, got 'slice'`), so developers on v2 couldn't run it locally either — `go vet` was the only Go static check executing anywhere.

## Change

- **Migrate `.golangci.yml` to the v2 schema** (`config verify` clean). `govet`/`staticcheck`/`unused` remain enabled (they are v2 defaults); gosec audit mode and the `G101/G115/G201/G402` excludes plus every path/test exclusion are preserved. Verified no coverage loss versus the v1 config — the four added exclusion presets exactly reproduce v1's implicit default exclusion set.
- **Bump `golangci-lint-action` v6 → v8** and **pin `version: v2.12.2`** (built on go1.26.2, clears the go-version guard; matches the local toolchain so CI and local runs are identical).

## Finding backlog (now visible)

Lint now runs and surfaces **177 findings**: 153 staticcheck, 13 unused, 8 gosec, 3 bodyclose. The 11 security-relevant findings (8 gosec + 3 bodyclose) were triaged — all are false positives or low-risk:

- gosec **G703/G122** path-traversal/TOCTOU on `sdkType`: false positives — `sdkType` is gated by a strict `python`/`java` allowlist (400 otherwise) before the filesystem call.
- gosec **G117** (RefreshToken matches secret pattern): by-design for an auth SDK.
- gosec **G118 ×4** (goroutine uses `context.Background`): code-quality, not a vuln.
- bodyclose ×3: all in `tests/integration/test_helper.go` (test infra).

`continue-on-error` is **kept intentionally** so this pre-existing backlog does not wedge every backend PR; findings post as inline annotations. Flipping to blocking (security linters first) is a tracked follow-up once the backlog is resolved.