### PR TITLE
ci: make Go security linters blocking; fix authenticated config-path file read

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -252,8 +252,15 @@ jobs:
           npm ci
           npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-1.0;AGPL-3.0;SSPL-1.0" --summary
 
-  go-lint:
-    name: Go Lint
+  # The security linters (gosec audit mode, bodyclose, sqlclosecheck) are BLOCKING: this
+  # is the class we cannot ship regressions in. The broader quality linters (staticcheck,
+  # unused) run as a separate NON-BLOCKING job while their pre-existing backlog is burned
+  # down. action@v8 installs golangci-lint v2 (the v6 line caps at v1, whose binary is
+  # built on go1.24 and refuses our go1.25 target); pin the linter explicitly so CI and
+  # local runs use the identical build. Both jobs share one .golangci.yml; the linter set
+  # is selected per job via --default=none --enable=... (security) vs the full config.
+  go-lint-security:
+    name: Go Lint (security)
     needs: changes
     if: >-
       github.event_name == 'schedule' ||
@@ -270,17 +277,37 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: apps/backend/go.sum
 
-      - name: Run golangci-lint
-        # action@v8 installs golangci-lint v2 (the v6 line caps at v1, whose binary is
-        # built on go1.24 and refuses our go1.25 target — that guard failure was being
-        # swallowed by continue-on-error and reported green). Pin the linter explicitly so
-        # CI and local runs use the identical build.
+      - name: Run golangci-lint (security linters, blocking)
         uses: golangci/golangci-lint-action@v8
-        # NON-BLOCKING on purpose: the v2 migration surfaced a 177-finding backlog
-        # (153 staticcheck + 13 unused + 8 gosec + 3 bodyclose). Findings post as inline
-        # PR annotations so they're visible, but don't wedge every backend PR while the
-        # backlog is triaged. Flip to blocking (security linters first) per
-        # todo/2026-06-26-aim-golangci-lint-silently-disabled.md once findings are resolved.
+        with:
+          version: v2.12.2
+          working-directory: apps/backend
+          args: --config ../../.golangci.yml --default=none --enable=gosec,bodyclose,sqlclosecheck
+
+  go-lint-quality:
+    name: Go Lint (quality)
+    needs: changes
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/backend/go.sum
+
+      - name: Run golangci-lint (full set, non-blocking)
+        # NON-BLOCKING: staticcheck/unused carry a pre-existing 166-finding backlog.
+        # Findings post as inline PR annotations so they stay visible; this job is made
+        # blocking once the backlog reaches zero. Tracked in
+        # todo/2026-06-26-aim-golangci-lint-silently-disabled.md.
+        uses: golangci/golangci-lint-action@v8
         continue-on-error: true
         with:
           version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,12 @@ linters:
         - G115  # Integer overflow int->int32 (low risk, noisy)
         - G201  # SQL string formatting (pre-existing, uses parameterized queries)
         - G402  # TLS MinVersion (SMTP email service, tracked separately)
+        - G118  # context.Background in goroutines: our fire-and-forget background
+                # tasks (capability detection, anomaly detection, liveness, expiry)
+                # MUST outlive the request, so detaching from the request ctx is
+                # intentional. Style/observability rule, not a vuln class; excluded
+                # repo-wide because the pattern recurs. (G117 is suppressed per-site
+                # at the one legitimate token-bundle site; G204/G304 stay active.)
       severity: medium
       confidence: medium
     govet:
@@ -43,9 +49,13 @@ linters:
       locale: US
   exclusions:
     generated: lax
+    # NOTE: golangci-lint's `common-false-positives` preset disables gosec
+    # EXC0007 (G204, subprocess with variable) and EXC0010 (G304, file inclusion
+    # via variable) repo-wide. For a security gate that is intentionally omitted —
+    # those injection classes must stay enforced. Legitimate single sites are
+    # suppressed per-line with //nolint:gosec and a rationale instead.
     presets:
       - comments
-      - common-false-positives
       - legacy
       - std-error-handling
     rules:
@@ -58,6 +68,12 @@ linters:
           - bodyclose
           - gosec
         path: _test\.go
+      # Integration test helpers (e.g. tests/integration/test_helper.go) aren't
+      # named *_test.go but are test infra. The bodyclose hits here are false
+      # positives: the shared Request helper reads and closes the body itself.
+      - linters:
+          - bodyclose
+        path: tests/integration/
       # CLI entrypoints — interactive prompts, bootstrapping
       - linters:
           - gosec

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -1930,19 +1931,65 @@ func (s *AgentService) DetectMCPServersFromConfig(
 	}, nil
 }
 
+// knownClaudeDesktopConfigPaths returns the standard per-OS locations of the
+// Claude Desktop config file, all under the current user's home directory.
+func knownClaudeDesktopConfigPaths() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	return []string{
+		// macOS
+		filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+		// Linux
+		filepath.Join(home, ".config", "Claude", "claude_desktop_config.json"),
+		// Windows
+		filepath.Join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json"),
+	}, nil
+}
+
+// validateClaudeDesktopConfigPath resolves a user-supplied config path and
+// allowlists it against the standard Claude Desktop config locations. The
+// detect-MCP endpoint is authenticated but member-level, and without this an
+// authenticated caller could point os.ReadFile at any file on the server
+// (arbitrary file read / LFI, e.g. /etc/passwd or /proc/self/environ). The
+// feature only ever needs to read the Claude Desktop config in its standard
+// location, so we accept nothing else. A leading "~" is expanded; the cleaned
+// path must exactly match a known location (which also rejects ".." traversal).
+func validateClaudeDesktopConfigPath(configPath string) (string, error) {
+	if configPath == "" {
+		return "", fmt.Errorf("config path is required")
+	}
+	if configPath == "~" || strings.HasPrefix(configPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		configPath = home + strings.TrimPrefix(configPath, "~")
+	}
+	cleaned := filepath.Clean(configPath)
+	allowed, err := knownClaudeDesktopConfigPaths()
+	if err != nil {
+		return "", err
+	}
+	for _, p := range allowed {
+		if cleaned == p {
+			return cleaned, nil
+		}
+	}
+	return "", fmt.Errorf("config path is not a recognized Claude Desktop config location")
+}
+
 // parseClaudeDesktopConfig parses Claude Desktop config JSON file
 func (s *AgentService) parseClaudeDesktopConfig(configPath string) ([]DetectedMCPServer, error) {
-	// Expand tilde (~) in path to home directory
-	if len(configPath) > 0 && configPath[0] == '~' {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %w", err)
-		}
-		configPath = homeDir + configPath[1:]
+	validatedPath, err := validateClaudeDesktopConfigPath(configPath)
+	if err != nil {
+		return nil, err
 	}
 
-	// Read config file
-	data, err := os.ReadFile(configPath)
+	// Read config file. validatedPath is allowlisted to the standard Claude
+	// Desktop config location above, so this is not attacker-controlled.
+	data, err := os.ReadFile(validatedPath) //nolint:gosec // G304: validatedPath is allowlisted to the standard Claude Desktop config location by validateClaudeDesktopConfigPath
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/apps/backend/internal/application/agent_service_config_path_test.go
+++ b/apps/backend/internal/application/agent_service_config_path_test.go
@@ -1,0 +1,66 @@
+package application
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validateClaudeDesktopConfigPath is the allowlist guard that prevents the
+// authenticated, member-level detect-MCP endpoint from being turned into an
+// arbitrary server-side file read (LFI). These tests pin that behavior so a
+// future refactor can't silently re-open the hole.
+func TestValidateClaudeDesktopConfigPath_RejectsArbitraryPaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	rejected := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"etc passwd", "/etc/passwd"},
+		{"proc environ (env secret leak)", "/proc/self/environ"},
+		{"ssh key", "/root/.ssh/id_rsa"},
+		{"relative traversal", "../../../../etc/passwd"},
+		{"tilde traversal escape", "~/../../etc/passwd"},
+		{"right basename wrong dir", "/tmp/claude_desktop_config.json"},
+		{"known dir wrong basename", filepath.Join(home, ".config", "Claude", "passwd")},
+		{"trailing traversal to sibling", filepath.Join(home, ".config", "Claude", "..", "secrets.json")},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateClaudeDesktopConfigPath(tc.path)
+			assert.Error(t, err, "expected %q to be rejected", tc.path)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestValidateClaudeDesktopConfigPath_AcceptsStandardLocations(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	accepted := []string{
+		filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"), // macOS
+		filepath.Join(home, ".config", "Claude", "claude_desktop_config.json"),                        // Linux
+		filepath.Join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json"),             // Windows
+	}
+	for _, p := range accepted {
+		got, err := validateClaudeDesktopConfigPath(p)
+		assert.NoError(t, err, "expected %q to be accepted", p)
+		assert.Equal(t, p, got)
+	}
+}
+
+func TestValidateClaudeDesktopConfigPath_ExpandsTilde(t *testing.T) {
+	got, err := validateClaudeDesktopConfigPath("~/.config/Claude/claude_desktop_config.json")
+	require.NoError(t, err)
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config", "Claude", "claude_desktop_config.json"), got)
+}

--- a/apps/backend/internal/application/agent_service_test.go
+++ b/apps/backend/internal/application/agent_service_test.go
@@ -184,7 +184,7 @@ func TestAgentService_GetAgent_Success(t *testing.T) {
 	mockAlertRepo := new(MockAlertRepository)
 	mockCapabilityRepo := new(MockCapabilityRepository)
 	mockPolicyRepo := new(AgentServiceMockSecurityPolicyRepository)
-	
+
 	policyService := &SecurityPolicyService{
 		policyRepo: mockPolicyRepo,
 		alertRepo:  mockAlertRepo,
@@ -1304,12 +1304,29 @@ func TestNewAgentService_WithMockedDependencies(t *testing.T) {
 // parseClaudeDesktopConfig Tests
 // ===========================
 
-func TestParseClaudeDesktopConfig_ValidConfig(t *testing.T) {
-	// Create a temp file with valid Claude Desktop config
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "claude_desktop_config.json")
+// writeClaudeConfigUnderTempHome points HOME at a temp dir and writes content to
+// the standard Linux Claude Desktop config location under it, returning that
+// path. parseClaudeDesktopConfig now allowlists the path (see
+// validateClaudeDesktopConfigPath), so the parse tests must use the canonical
+// location rather than an arbitrary temp file — this writes it without touching
+// the developer's real home.
+func writeClaudeConfigUnderTempHome(t *testing.T, content string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "Claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	path := filepath.Join(dir, "claude_desktop_config.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return path
+}
 
-	configJSON := `{
+func TestParseClaudeDesktopConfig_ValidConfig(t *testing.T) {
+	configPath := writeClaudeConfigUnderTempHome(t, `{
 		"mcpServers": {
 			"memory": {
 				"command": "npx",
@@ -1323,10 +1340,7 @@ func TestParseClaudeDesktopConfig_ValidConfig(t *testing.T) {
 				}
 			}
 		}
-	}`
-
-	err := os.WriteFile(configPath, []byte(configJSON), 0644)
-	assert.NoError(t, err)
+	}`)
 
 	service := &AgentService{}
 	servers, err := service.parseClaudeDesktopConfig(configPath)
@@ -1346,15 +1360,9 @@ func TestParseClaudeDesktopConfig_ValidConfig(t *testing.T) {
 }
 
 func TestParseClaudeDesktopConfig_EmptyMCPServers(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "claude_desktop_config.json")
-
-	configJSON := `{
+	configPath := writeClaudeConfigUnderTempHome(t, `{
 		"mcpServers": {}
-	}`
-
-	err := os.WriteFile(configPath, []byte(configJSON), 0644)
-	assert.NoError(t, err)
+	}`)
 
 	service := &AgentService{}
 	servers, err := service.parseClaudeDesktopConfig(configPath)
@@ -1364,32 +1372,32 @@ func TestParseClaudeDesktopConfig_EmptyMCPServers(t *testing.T) {
 }
 
 func TestParseClaudeDesktopConfig_FileNotFound(t *testing.T) {
+	// An allowlisted location where no file exists still surfaces a read error
+	// (not a validation error). Arbitrary non-allowlisted paths are covered by
+	// TestValidateClaudeDesktopConfigPath_RejectsArbitraryPaths.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	allowedButMissing := filepath.Join(home, ".config", "Claude", "claude_desktop_config.json")
+
 	service := &AgentService{}
-	_, err := service.parseClaudeDesktopConfig("/nonexistent/path/config.json")
+	_, err := service.parseClaudeDesktopConfig(allowedButMissing)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read config file")
 }
 
 func TestParseClaudeDesktopConfig_InvalidJSON(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "invalid_config.json")
-
-	err := os.WriteFile(configPath, []byte("not valid json"), 0644)
-	assert.NoError(t, err)
+	configPath := writeClaudeConfigUnderTempHome(t, "not valid json")
 
 	service := &AgentService{}
-	_, err = service.parseClaudeDesktopConfig(configPath)
+	_, err := service.parseClaudeDesktopConfig(configPath)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse config JSON")
 }
 
 func TestParseClaudeDesktopConfig_WithEnvVars(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config_with_env.json")
-
-	configJSON := `{
+	configPath := writeClaudeConfigUnderTempHome(t, `{
 		"mcpServers": {
 			"database": {
 				"command": "python",
@@ -1401,10 +1409,7 @@ func TestParseClaudeDesktopConfig_WithEnvVars(t *testing.T) {
 				}
 			}
 		}
-	}`
-
-	err := os.WriteFile(configPath, []byte(configJSON), 0644)
-	assert.NoError(t, err)
+	}`)
 
 	service := &AgentService{}
 	servers, err := service.parseClaudeDesktopConfig(configPath)
@@ -1419,15 +1424,9 @@ func TestParseClaudeDesktopConfig_WithEnvVars(t *testing.T) {
 }
 
 func TestParseClaudeDesktopConfig_NoMCPServersKey(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "no_mcp_servers.json")
-
-	configJSON := `{
+	configPath := writeClaudeConfigUnderTempHome(t, `{
 		"someOtherKey": "value"
-	}`
-
-	err := os.WriteFile(configPath, []byte(configJSON), 0644)
-	assert.NoError(t, err)
+	}`)
 
 	service := &AgentService{}
 	servers, err := service.parseClaudeDesktopConfig(configPath)
@@ -1474,8 +1473,8 @@ func TestAgentService_CreateAgent_Success(t *testing.T) {
 	mockAgentRepo.On("Update", mock.AnythingOfType("*domain.Agent")).Return(nil)
 
 	newTrustScore := &domain.TrustScore{
-		ID:      uuid.New(),
-		Score:   0.75,
+		ID:    uuid.New(),
+		Score: 0.75,
 	}
 	mockTrustCalc.On("Calculate", mock.AnythingOfType("*domain.Agent")).Return(newTrustScore, nil)
 	mockTrustScoreRepo.On("Create", mock.AnythingOfType("*domain.TrustScore")).Return(nil)
@@ -1816,7 +1815,7 @@ func TestAgentService_CreateAgent_DuplicateName(t *testing.T) {
 		Name:        "duplicate-agent",
 		DisplayName: "Duplicate Agent",
 		AgentType:   domain.AgentTypeAI,
-		PublicKey:    "test-key",
+		PublicKey:   "test-key",
 	}
 
 	// Simulate PostgreSQL unique constraint violation

--- a/apps/backend/internal/application/mcp_service.go
+++ b/apps/backend/internal/application/mcp_service.go
@@ -532,7 +532,8 @@ func (s *MCPService) VerifyMCPServer(ctx context.Context, id uuid.UUID, userID u
 		// After successful verification, automatically detect MCP server capabilities
 		if s.capabilityService != nil {
 			go func() {
-				// Run asynchronously to avoid blocking verification
+				// Run asynchronously to avoid blocking verification; detached
+				// context so the caller returning does not cancel detection.
 				bgCtx := context.Background()
 				if err := s.capabilityService.DetectCapabilities(bgCtx, id); err != nil {
 					fmt.Printf("⚠️  Failed to detect capabilities for MCP server %s: %v\n", server.Name, err)

--- a/apps/backend/internal/interfaces/http/handlers/sdk_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_handler.go
@@ -275,14 +275,14 @@ func (h *SDKHandler) createSDKZip(credentials SDKCredentials, sdkType string) ([
 	// Read VERSION file to get SDK version
 	version := "1.0.0" // Default version
 	versionPath := filepath.Join(sdkRoot, "VERSION")
-	if versionData, err := os.ReadFile(versionPath); err == nil {
+	if versionData, err := os.ReadFile(versionPath); err == nil { //nolint:gosec // G304/G703: sdkType is allowlist-gated (python/java only, 400 otherwise) in DownloadSDK before this runs; no attacker-controlled path component
 		version = strings.TrimSpace(string(versionData))
 	}
 
 	zipPrefix := fmt.Sprintf("aim-sdk-%s", sdkType)
 
 	// Add SDK files to zip
-	err := filepath.Walk(sdkRoot, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(sdkRoot, func(path string, info os.FileInfo, err error) error { //nolint:gosec // G703: sdkRoot derives from allowlist-gated sdkType (see DownloadSDK); no attacker-controlled path component
 		if err != nil {
 			return err
 		}
@@ -329,7 +329,7 @@ func (h *SDKHandler) createSDKZip(credentials SDKCredentials, sdkType string) ([
 		}
 
 		// Read and write file content
-		fileData, err := os.ReadFile(path)
+		fileData, err := os.ReadFile(path) //nolint:gosec // G304: path comes from Walk over the allowlist-gated SDK tree; the server reads its own bundled files, not symlink-attacker input
 		if err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func (h *SDKHandler) createSDKZip(credentials SDKCredentials, sdkType string) ([
 	}
 
 	// Create credentials file in .aim directory
-	credentialsJSON, err := json.MarshalIndent(credentials, "", "  ")
+	credentialsJSON, err := json.MarshalIndent(credentials, "", "  ") //nolint:gosec // G117: the SDK credentials bundle intentionally includes the refresh token; it is delivered only to the authenticated owner in their downloaded .aim/sdk_credentials.json
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal credentials: %w", err)
 	}


### PR DESCRIPTION
Builds on #325 (which made golangci-lint actually run). Follow-up that makes the security linters enforce, and fixes a real bug they surfaced.

## What changed

- **Split the Go lint CI into two jobs.** `Go Lint (security)` (gosec audit mode, bodyclose, sqlclosecheck) is now **blocking**; `Go Lint (quality)` (staticcheck, unused — a 166-finding pre-existing backlog) stays non-blocking until burned down. The linter set is selected per job via `--default=none --enable=...` against one shared `.golangci.yml`.
- **Restored the gate's teeth.** golangci-lint's `common-false-positives` preset disables gosec **G204** (subprocess with variable) and **G304** (file inclusion via variable) repo-wide — so command-injection and file-inclusion were unenforced even after #325. Removed the preset; confirmed the gate now fails a newly introduced `exec.Command(..., userInput)`.

## Security fix surfaced by re-enabling G304

`POST /api/v1/agents/:id/mcp-servers/detect` (authenticated, member-level) read `req.ConfigPath` from the request body and `os.ReadFile`'d it (tilde-expanded) with **no validation** — an authenticated arbitrary server-side file read (e.g. `/etc/passwd`, `/proc/self/environ` env secrets, other tenants' on-disk files). Content exfiltration is constrained by the MCP-config JSON schema, but it is a clear file-existence/permission oracle plus a DoS vector.

**Fix:** `validateClaudeDesktopConfigPath` allowlists the path to the standard Claude Desktop config locations only (exact match after `~` expansion + `filepath.Clean`) and rejects everything else. The feature still works for local/self-hosted use (reads the real config) and safely no-ops in a multi-tenant deployment where the file is absent. New `agent_service_config_path_test.go` covers `/etc/passwd`, `/proc`, relative + tilde-escape traversal, wrong dir, and wrong basename, plus the accepted standard locations; the existing parse tests were updated to the allowlisted location.

## Remaining findings (all verified)

- **G304/G703 ×3** (SDK download path reads): per-site `//nolint:gosec` — `sdkType` is allowlist-gated (`python`/`java`, 400 otherwise) before the read.
- **G117 ×1** (token in SDK bundle): per-site `//nolint:gosec` — delivered only to the authenticated owner.
- **G118 ×4** (detached goroutine context): repo-wide config exclude with rationale — intentional fire-and-forget tasks that must outlive the request.
- **bodyclose ×3** (`tests/integration/test_helper.go`): config rule — false positive, the shared `Request` helper reads and closes the body itself.

## Verification

- `Go Lint (security)` is clean (0) on the full backend; build, vet, and touched-package tests pass.
- Two independent adversarial reviews: (1) the path validator has no remote bypass (canonicalization / `~` / `HOME` / TOCTOU all rejected or local-only); (2) the blocking gate fails on a scratch G204 + G304.
- Live-server (hma-hunter) exercise of the endpoint is deferred to CI/integration (needs a running backend + DB); compensated by the validator unit tests and the adversarial confirmation.

## Follow-up

- Add `Go Lint (security)` to branch-protection required checks once it is green on `main` (the next backend PR triggers it).