### PR TITLE
ci: add fan-in CI Gate so the full test suite can be a required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ concurrency:
 
 permissions:
   contents: read
+  # dorny/paths-filter lists PR files via the REST API on pull_request
+  # events (the checkout only serves push-event detection). That API call
+  # succeeds without this permission only because the repo is public; if
+  # visibility ever changes it 403s, the changes job fails, and the gate
+  # fails closed — wedging every PR. Keep the permission explicit.
+  pull-requests: read
 
 jobs:
   # Reject ${VAR:-fallback} patterns for secret-shaped env vars in any
@@ -58,11 +64,20 @@ jobs:
         id: filter
         with:
           filters: |
+            # ci.yml is in both filters: a PR that edits this workflow must
+            # run the full suite under the edited workflow, not skip it.
+            # Root package.json/package-lock.json feed apps/web via npm
+            # workspaces (apps/web has no lockfile of its own) — a root dep
+            # bump that skipped the frontend build would merge unvalidated.
             backend:
               - 'apps/backend/**'
               - '.golangci.yml'
+              - '.github/workflows/ci.yml'
             frontend:
               - 'apps/web/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
 
   backend:
     name: Backend (Go)
@@ -183,6 +198,61 @@ jobs:
       - name: Build
         working-directory: apps/web
         run: npm run build
+
+  # Fan-in gate so branch protection can require ONE check that always
+  # reports. The path-filtered jobs (backend/frontend/e2e) legitimately skip
+  # when nothing relevant changed — a skip counts as a pass here — but a
+  # required check pointed directly at them would sit forever on
+  # "Expected — waiting for status" for PRs that don't touch code.
+  # Change-detection itself MUST succeed; otherwise the expensive jobs were
+  # skipped for the wrong reason and a code change could slip through
+  # untested — fail closed. New jobs added to this workflow must be added to
+  # `needs` below or the gate silently stops covering them. This job must
+  # keep `if: always()` and the workflow must never gain a top-level
+  # `paths:` filter — GitHub counts a skipped or never-reported required
+  # check as satisfied or wedges the PR, respectively.
+  ci-gate:
+    name: CI Gate
+    needs:
+      [
+        secrets-lint,
+        tenant-scoping-lint,
+        changes,
+        backend,
+        frontend,
+        e2e-empty-state,
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no required job failed
+        run: |
+          sl='${{ needs.secrets-lint.result }}'
+          tl='${{ needs.tenant-scoping-lint.result }}'
+          ch='${{ needs.changes.result }}'
+          be='${{ needs.backend.result }}'
+          fe='${{ needs.frontend.result }}'
+          ee='${{ needs.e2e-empty-state.result }}'
+          echo "secrets-lint=$sl tenant-scoping-lint=$tl changes=$ch"
+          echo "backend=$be frontend=$fe e2e-empty-state=$ee"
+          fail=0
+          # Unconditional jobs must succeed outright.
+          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "changes:$ch"; do
+            if [ "${pair#*:}" != "success" ]; then
+              echo "::error::${pair%%:*} did not succeed (${pair#*:}); failing closed."
+              fail=1
+            fi
+          done
+          # Path-filtered jobs pass on success or skip; failure/cancel fails.
+          for pair in "backend:$be" "frontend:$fe" "e2e-empty-state:$ee"; do
+            r="${pair#*:}"
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              echo "::error::${pair%%:*} failed or was cancelled ($r)."
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "CI Gate: all jobs green (or legitimately skipped)."
 
   # End-to-end Playwright suite covering empty-state rendering on every
   # dashboard panel of the agent and MCP server detail pages — the binding

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -20,15 +20,30 @@ gh api -X PATCH "repos/$REPO" \
 
 echo "✓ Auto-delete head branches after merge: enabled"
 
-# Set branch protection on main
+# Set branch protection on main.
+#
+# This PUT replaces the entire protection object — the checks list below is
+# the single source of truth. If a required check is added via the API and
+# not mirrored here, re-running this script silently removes it.
+#
+# Checks are app-pinned (app_id 15368 = GitHub Actions) rather than
+# name-matched: with the deprecated bare-contexts form, ANY app or commit
+# status posting the same context name would satisfy the requirement.
+#
+# "CI Gate" is the fan-in job in ci.yml that fails closed unless every CI
+# job (backend tests + coverage, frontend, e2e, both repo lints,
+# change-detection) succeeded or was legitimately path-skipped.
 gh api -X PUT "repos/$REPO/branches/main/protection" \
   --input - <<'EOF'
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": [
-      "Secret Detection",
-      "Dependency Audit"
+    "checks": [
+      { "context": "Secret Detection", "app_id": 15368 },
+      { "context": "Dependency Audit", "app_id": 15368 },
+      { "context": "Claude Code Review", "app_id": 15368 },
+      { "context": "Go Lint (security)", "app_id": 15368 },
+      { "context": "CI Gate", "app_id": 15368 }
     ]
   },
   "enforce_admins": true,
@@ -49,12 +64,11 @@ echo "  - PRs required (no direct push)"
 echo "  - 1 approving review required"
 echo "  - Stale reviews dismissed on new push"
 echo "  - Last pusher cannot self-approve"
-echo "  - Required checks: Secret Detection, Dependency Audit"
+echo "  - Required checks: Secret Detection, Dependency Audit, Claude Code Review, Go Lint (security), CI Gate"
 echo "  - Strict status checks (branch must be up-to-date)"
 echo "  - Linear history enforced (squash merge)"
 echo "  - Force push and branch deletion blocked"
 echo "  - Admins included (no bypass)"
 echo ""
-echo "Done. To add more required checks later:"
-echo "  gh api -X PATCH repos/$REPO/branches/main/protection/required_status_checks \\"
-echo "    -f 'contexts[]=Secret Detection' -f 'contexts[]=Dependency Audit' -f 'contexts[]=Backend (Go)'"
+echo "Done. To add a required check later: add it to the checks array in this"
+echo "script (app-pinned, never the deprecated bare contexts[] form) and re-run."


### PR DESCRIPTION
## What

Branch protection requires only Secret Detection, Dependency Audit, Claude Code Review, and Go Lint (security). The `Backend (Go)` job — `go test -race` plus the coverage thresholds — along with Frontend, e2e-empty-state, and the two repo lints are path-filtered or simply not required, so a PR can merge with any of them red.

A required check pointed directly at a path-filtered job would wedge PRs that touch no relevant paths (stuck on "Expected — waiting for status"). This adds the fan-in `CI Gate` job instead — the same pattern already gating nanomind:

- fails closed if change-detection or either unconditional lint did not succeed
- treats a skipped path-filtered job (backend/frontend/e2e) as a pass
- fails on any failed or cancelled job

## Path-filter hardening

The gate's guarantee is only as good as the `changes` filters, so two blind spots are closed in the same commit:

- `.github/workflows/ci.yml` is now in both filters — a PR editing the CI workflow runs the full suite under the edited workflow instead of skipping every path-filtered job
- root `package.json` / `package-lock.json` are now in the frontend filter — `apps/web` resolves dependencies through the root npm workspace lockfile (it has no lockfile of its own), so a root dependency bump previously skipped the frontend build and e2e entirely

Also grants `pull-requests: read` (paths-filter lists PR files via the REST API; it only works ungranted because this repo is public), and updates `scripts/setup-branch-protection.sh` to the real required-check set — it previously PUT only 2 of the 4 live checks, so re-running it would have silently stripped the others. Checks in the script are now pinned to the Actions app rather than name-matched.

## After merge

"CI Gate" gets added to the required status checks on `main` (app-pinned, via the `checks[]` form). This PR itself exercises the skip path: it touches `.github/workflows/ci.yml`, which now triggers the full suite under the new filters.