### PR TITLE
AIP §6.1 composition rule with anti-gaming ceiling + atx-conformance CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,16 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: apps/backend/go.sum
 
+      # The test t.Skips when ATX_CONFORMANCE_DIR is unset (so local
+      # `go test ./...` needs no suite checkout) — the grep guards against
+      # this step ever passing on a silent skip if the env line is dropped.
       - name: Go issuance byte-match vs pinned fixtures
         working-directory: apps/backend
         env:
           ATX_CONFORMANCE_DIR: /tmp/atx-conformance/fixtures
-        run: go test ./internal/infrastructure/registry/ -run TestATCIssuance_ConformanceByteMatch -v
+        run: |
+          go test ./internal/infrastructure/registry/ -run TestATCIssuance_ConformanceByteMatch -v | tee /tmp/atc-conformance.out
+          grep -q -- "--- PASS: TestATCIssuance_ConformanceByteMatch/baseline-valid.json" /tmp/atc-conformance.out
 
   frontend:
     name: Frontend (Next.js)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      conformance: ${{ steps.filter.outputs.conformance }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -77,6 +78,13 @@ jobs:
               - 'apps/web/**'
               - 'package.json'
               - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+            # ATX credential paths gated by the pinned atx-conformance suite:
+            # the Java LocalAtxVerifier (+ its vendored fixtures) and the Go
+            # issuance client whose Raw pass-through must stay byte-preserving.
+            conformance:
+              - 'sdk/java/**'
+              - 'apps/backend/internal/infrastructure/registry/**'
               - '.github/workflows/ci.yml'
 
   backend:
@@ -174,6 +182,89 @@ jobs:
           name: backend-coverage
           path: apps/backend/coverage.out
 
+  # Conformance gate: AIM's ATX credential paths must accept/reject exactly
+  # what the pinned opena2a-standards/atx-conformance fixtures say (the suite
+  # the Go/Python reference verifiers and @opena2a/atx-verify are gated on).
+  # Two paths are gated here:
+  #   1. sdk/java LocalAtxVerifier — runs the conformance fixture set (vendored
+  #      copies, byte-checked against the pinned suite below so they cannot
+  #      silently drift).
+  #   2. apps/backend Go issuance client — replays every pinned credential as
+  #      a Registry response and asserts the signed bytes survive AIM's
+  #      issuance path unmodified (Raw pass-through byte-match).
+  atx-conformance:
+    name: ATX conformance
+    needs: changes
+    if: needs.changes.outputs.conformance == 'true'
+    runs-on: ubuntu-latest
+    env:
+      # Pinned suite ref. Bump deliberately when the suite grows; the vendored
+      # Java fixture copies must be refreshed in the same PR or the drift gate
+      # below fails.
+      ATX_CONFORMANCE_REF: b2de78387e5b9e70af5efbef28f46e7732016c82
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone pinned atx-conformance suite
+        run: |
+          git clone --no-checkout https://github.com/opena2a-standards/atx-conformance.git /tmp/atx-conformance
+          git -C /tmp/atx-conformance checkout "$ATX_CONFORMANCE_REF"
+
+      - name: MANIFEST.sha256 integrity
+        working-directory: /tmp/atx-conformance
+        run: |
+          rc=0
+          while read -r sha file; do
+            [ -z "$sha" ] && continue
+            got=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$got" != "$sha" ]; then
+              echo "::error::MANIFEST mismatch: $file"; rc=1
+            fi
+          done < MANIFEST.sha256
+          exit $rc
+
+      - name: Vendored Java fixtures byte-match the pinned suite
+        run: |
+          fail=0
+          for f in /tmp/atx-conformance/fixtures/*.json; do
+            b=$(basename "$f")
+            if ! cmp -s "$f" "sdk/java/src/test/resources/atx-fixtures/$b"; then
+              echo "::error::vendored fixture $b is missing or drifted from the pinned suite"
+              fail=1
+            fi
+          done
+          for f in sdk/java/src/test/resources/atx-fixtures/*.json; do
+            b=$(basename "$f")
+            if [ ! -f "/tmp/atx-conformance/fixtures/$b" ]; then
+              echo "::error::vendored fixture $b does not exist in the pinned suite"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "maven"
+
+      # Scoped to the atx package: the SDK's Live/RealWorld integration tests
+      # need a live backend and credentials that CI does not have.
+      - name: Java LocalAtxVerifier vs pinned fixtures
+        working-directory: sdk/java
+        run: mvn -B test -Dtest='org.opena2a.aim.atx.*Test'
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: apps/backend/go.sum
+
+      - name: Go issuance byte-match vs pinned fixtures
+        working-directory: apps/backend
+        env:
+          ATX_CONFORMANCE_DIR: /tmp/atx-conformance/fixtures
+        run: go test ./internal/infrastructure/registry/ -run TestATCIssuance_ConformanceByteMatch -v
+
   frontend:
     name: Frontend (Next.js)
     needs: changes
@@ -219,6 +310,7 @@ jobs:
         tenant-scoping-lint,
         changes,
         backend,
+        atx-conformance,
         frontend,
         e2e-empty-state,
       ]
@@ -231,10 +323,11 @@ jobs:
           tl='${{ needs.tenant-scoping-lint.result }}'
           ch='${{ needs.changes.result }}'
           be='${{ needs.backend.result }}'
+          ax='${{ needs.atx-conformance.result }}'
           fe='${{ needs.frontend.result }}'
           ee='${{ needs.e2e-empty-state.result }}'
           echo "secrets-lint=$sl tenant-scoping-lint=$tl changes=$ch"
-          echo "backend=$be frontend=$fe e2e-empty-state=$ee"
+          echo "backend=$be atx-conformance=$ax frontend=$fe e2e-empty-state=$ee"
           fail=0
           # Unconditional jobs must succeed outright.
           for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "changes:$ch"; do
@@ -244,7 +337,7 @@ jobs:
             fi
           done
           # Path-filtered jobs pass on success or skip; failure/cancel fails.
-          for pair in "backend:$be" "frontend:$fe" "e2e-empty-state:$ee"; do
+          for pair in "backend:$be" "atx-conformance:$ax" "frontend:$fe" "e2e-empty-state:$ee"; do
             r="${pair#*:}"
             if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
               echo "::error::${pair%%:*} failed or was cancelled ($r)."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -523,14 +523,13 @@ End-to-end UI testing:
 
 ### TypeScript/Node.js SDK
 **Priority**: High
-**Status**: Planned (Q2 2026)
+**Status**: Shipped (`sdk/typescript`; npm publish pending Trusted Publishing setup)
 
-TypeScript SDK for Node.js applications:
+TypeScript SDK for Node.js applications, implemented in `sdk/typescript`:
 - Full TypeScript support with type definitions
 - async/await API design
-- npm package distribution
-- Express/Fastify middleware integration
-- Feature parity with Python and Java SDKs
+- Local ATX credential verification (`LocalVerifier`)
+- npm package distribution (`@opena2a/aim-sdk` — first publish pending)
 
 **Use Case**: Node.js applications, serverless functions, TypeScript projects
 

--- a/apps/backend/internal/application/trust_calculator.go
+++ b/apps/backend/internal/application/trust_calculator.go
@@ -180,8 +180,17 @@ func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, er
 		{"execution_isolation", factors.ExecutionIsolation},
 	}
 
-	var weightedSum, includedWeight float64
+	var weightedSum, includedWeight, imputedSum float64
 	for _, f := range contributions {
+		w, ok := weights[f.key]
+		if !ok {
+			// A key drift between contributions and weights would silently
+			// zero a factor; fail loudly instead.
+			return nil, fmt.Errorf("trust: factor %q has no weight entry", f.key)
+		}
+		// The neutral-imputed sum uses every factor at its struct value —
+		// for excluded factors that is the neutral display placeholder.
+		imputedSum += f.value * w
 		if reason, isExcluded := excluded[f.key]; isExcluded {
 			if reason != exclReasonNoData {
 				// Un-wired repository or query failure: a deployment defect in
@@ -190,13 +199,23 @@ func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, er
 			}
 			continue
 		}
-		weightedSum += f.value * weights[f.key]
-		includedWeight += weights[f.key]
+		weightedSum += f.value * w
+		includedWeight += w
 	}
 
 	// Factors 1-4 and 6 always produce data (status-based fallbacks are part
 	// of their scoring functions), so includedWeight is at least 0.75.
 	score := weightedSum / includedWeight
+
+	// Anti-gaming ceiling: renormalization alone would hand an excluded
+	// factor the agent's own included average, so an org could RAISE a good
+	// agent's score by withholding compliance snapshots or never collecting
+	// feedback (no-data would outscore a measured 0.9). Cap the published
+	// composite at the neutral-imputed sum — a factor with no data can never
+	// help more than a neutral measurement would. Bad agents keep the honest
+	// renormalized value (exclusion no longer props them up toward neutral).
+	// With no exclusions both sums are identical and the cap is a no-op.
+	score = math.Min(score, imputedSum)
 
 	// Ensure score is within bounds [0, 1]
 	score = math.Max(0.0, math.Min(1.0, score))
@@ -207,8 +226,9 @@ func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, er
 	}
 	sort.Strings(excludedNames)
 
-	// Calculate confidence based on available data
-	confidence := c.calculateConfidence(agent, factors)
+	// Calculate confidence based on available data; excluded factors count
+	// against it (an exclusion must not be confidence-free).
+	confidence := c.calculateConfidence(agent, factors, excluded)
 
 	return &domain.TrustScore{
 		ID:              uuid.New(),
@@ -667,11 +687,26 @@ func (c *TrustCalculator) calculateExecutionIsolation(agent *domain.Agent) (floa
 	return attestation.Score, ""
 }
 
-// calculateConfidence determines confidence level based on available data
-func (c *TrustCalculator) calculateConfidence(agent *domain.Agent, factors *domain.TrustScoreFactors) float64 {
+// calculateConfidence determines confidence level based on available data.
+// excluded is the AIP §6.1 exclusion set from calculateFactorsDetailed: a
+// factor that was excluded for lack of data contributes no confidence, and a
+// measured compliance/feedback factor now does (previously neither was
+// counted at all, so exclusion was invisible to confidence).
+func (c *TrustCalculator) calculateConfidence(agent *domain.Agent, factors *domain.TrustScoreFactors, excluded map[string]string) float64 {
 	// Count available data points (each real data source adds confidence)
 	dataPoints := 0.0
 	total := 9.0 // 9 factors
+
+	if c.snapshotRepo != nil {
+		if _, isExcluded := excluded["compliance"]; !isExcluded {
+			dataPoints++ // Real compliance snapshot measured
+		}
+	}
+	if c.userFeedbackRepo != nil {
+		if _, isExcluded := excluded["user_feedback"]; !isExcluded {
+			dataPoints++ // Real user feedback measured
+		}
+	}
 
 	// Base data points from agent properties
 	if agent.Status != "" {

--- a/apps/backend/internal/application/trust_calculator.go
+++ b/apps/backend/internal/application/trust_calculator.go
@@ -3,11 +3,23 @@ package application
 import (
 	"context"
 	"fmt"
+	"log"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// Factor exclusion reasons (AIP-SPEC §6.1: "Factors with no data are excluded
+// and their weights redistributed proportionally"). A factor excluded for
+// exclReasonNotWired or a query failure is a deployment defect and is logged;
+// exclReasonNoData is a normal lifecycle state (e.g. an agent whose org has no
+// compliance snapshot yet) and is not logged.
+const (
+	exclReasonNotWired = "repository not configured"
+	exclReasonNoData   = "no data"
 )
 
 // TrustCalculator implements domain.TrustScoreCalculator
@@ -117,7 +129,7 @@ func (c *TrustCalculator) SetTMEProvider(provider NanoMindTMEProvider) {
 // Calculate calculates trust score for an agent
 // Implements the 9-factor algorithm with weighted average
 func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, error) {
-	factors, err := c.CalculateFactors(agent)
+	factors, excluded, err := c.calculateFactorsDetailed(agent)
 	if err != nil {
 		return nil, err
 	}
@@ -149,36 +161,81 @@ func (c *TrustCalculator) Calculate(agent *domain.Agent) (*domain.TrustScore, er
 		"execution_isolation": 0.10, // Factor 9 (new)
 	}
 
-	score := factors.VerificationStatus*weights["verification"] +
-		factors.Uptime*weights["uptime"] +
-		factors.SuccessRate*weights["success_rate"] +
-		factors.SecurityAlerts*weights["security_alerts"] +
-		factors.Compliance*weights["compliance"] +
-		factors.Age*weights["age"] +
-		factors.DriftDetection*weights["drift_detection"] +
-		factors.UserFeedback*weights["user_feedback"] +
-		factors.ExecutionIsolation*weights["execution_isolation"]
+	// AIP-SPEC §6.1 composition rule: factors with no data are excluded from
+	// the weighted sum and their weights redistributed proportionally across
+	// the factors that do have data. A factor whose repository is un-wired or
+	// whose query failed must not contribute a fabricated neutral value.
+	contributions := []struct {
+		key   string
+		value float64
+	}{
+		{"verification", factors.VerificationStatus},
+		{"uptime", factors.Uptime},
+		{"success_rate", factors.SuccessRate},
+		{"security_alerts", factors.SecurityAlerts},
+		{"compliance", factors.Compliance},
+		{"age", factors.Age},
+		{"drift_detection", factors.DriftDetection},
+		{"user_feedback", factors.UserFeedback},
+		{"execution_isolation", factors.ExecutionIsolation},
+	}
+
+	var weightedSum, includedWeight float64
+	for _, f := range contributions {
+		if reason, isExcluded := excluded[f.key]; isExcluded {
+			if reason != exclReasonNoData {
+				// Un-wired repository or query failure: a deployment defect in
+				// the reference implementation, not a data-lifecycle state.
+				log.Printf("WARN trust: factor %q excluded from composite for agent %s: %s", f.key, agent.ID, reason)
+			}
+			continue
+		}
+		weightedSum += f.value * weights[f.key]
+		includedWeight += weights[f.key]
+	}
+
+	// Factors 1-4 and 6 always produce data (status-based fallbacks are part
+	// of their scoring functions), so includedWeight is at least 0.75.
+	score := weightedSum / includedWeight
 
 	// Ensure score is within bounds [0, 1]
 	score = math.Max(0.0, math.Min(1.0, score))
+
+	excludedNames := make([]string, 0, len(excluded))
+	for name := range excluded {
+		excludedNames = append(excludedNames, name)
+	}
+	sort.Strings(excludedNames)
 
 	// Calculate confidence based on available data
 	confidence := c.calculateConfidence(agent, factors)
 
 	return &domain.TrustScore{
-		ID:             uuid.New(),
-		AgentID:        agent.ID,
-		Score:          score,
-		Factors:        *factors,
-		Confidence:     confidence,
-		LastCalculated: time.Now(),
-		CreatedAt:      time.Now(),
+		ID:              uuid.New(),
+		AgentID:         agent.ID,
+		Score:           score,
+		Factors:         *factors,
+		ExcludedFactors: excludedNames,
+		Confidence:      confidence,
+		LastCalculated:  time.Now(),
+		CreatedAt:       time.Now(),
 	}, nil
 }
 
 // CalculateFactors calculates individual trust factors
 func (c *TrustCalculator) CalculateFactors(agent *domain.Agent) (*domain.TrustScoreFactors, error) {
+	factors, _, err := c.calculateFactorsDetailed(agent)
+	return factors, err
+}
+
+// calculateFactorsDetailed computes the 9 factors plus the exclusion set: the
+// factors whose data source is un-wired, failed, or empty. An excluded factor
+// carries a neutral placeholder value in the returned struct (display
+// continuity for stored breakdowns) but MUST NOT contribute to the composite —
+// Calculate redistributes its weight per AIP-SPEC §6.1.
+func (c *TrustCalculator) calculateFactorsDetailed(agent *domain.Agent) (*domain.TrustScoreFactors, map[string]string, error) {
 	factors := &domain.TrustScoreFactors{}
+	excluded := make(map[string]string)
 
 	// Factor 1: Verification Status (25% weight)
 	// Ed25519 signature verification for all actions
@@ -198,7 +255,11 @@ func (c *TrustCalculator) CalculateFactors(agent *domain.Agent) (*domain.TrustSc
 
 	// Factor 5: Compliance Score (10% weight)
 	// SOC 2, HIPAA, GDPR adherence
-	factors.Compliance = c.calculateCompliance(agent)
+	var reason string
+	factors.Compliance, reason = c.calculateCompliance(agent)
+	if reason != "" {
+		excluded["compliance"] = reason
+	}
 
 	// Factor 6: Age & History (5% weight)
 	// How long agent has been operating successfully
@@ -206,15 +267,24 @@ func (c *TrustCalculator) CalculateFactors(agent *domain.Agent) (*domain.TrustSc
 
 	// Factor 7: Drift Detection (3% weight)
 	// Behavioral pattern changes
-	factors.DriftDetection = c.calculateDriftDetection(agent)
+	factors.DriftDetection, reason = c.calculateDriftDetection(agent)
+	if reason != "" {
+		excluded["drift_detection"] = reason
+	}
 
 	// Factor 8: User Feedback (2% weight)
 	// Explicit user ratings
-	factors.UserFeedback = c.calculateUserFeedback(agent)
+	factors.UserFeedback, reason = c.calculateUserFeedback(agent)
+	if reason != "" {
+		excluded["user_feedback"] = reason
+	}
 
 	// Factor 9: Execution Isolation (10% weight)
 	// Runtime isolation posture (sandbox, network, filesystem, process)
-	factors.ExecutionIsolation = c.calculateExecutionIsolation(agent)
+	factors.ExecutionIsolation, reason = c.calculateExecutionIsolation(agent)
+	if reason != "" {
+		excluded["execution_isolation"] = reason
+	}
 
 	// NanoMind TME enrichment: adjust security alerts factor based on threat model evaluation
 	if c.tmeProvider != nil {
@@ -229,7 +299,7 @@ func (c *TrustCalculator) CalculateFactors(agent *domain.Agent) (*domain.TrustSc
 		}
 	}
 
-	return factors, nil
+	return factors, excluded, nil
 }
 
 // Factor 1: Verification Status (25% weight)
@@ -404,21 +474,25 @@ func (c *TrustCalculator) calculateSecurityAlerts(agent *domain.Agent) float64 {
 // Measures adherence to compliance policies (SOC 2, HIPAA, GDPR)
 // Queries the latest compliance snapshot for the agent's organization.
 // Snapshot score is 0-100, normalized to 0.0-1.0.
-// Returns 0.5 (neutral) when no snapshot data is available.
-func (c *TrustCalculator) calculateCompliance(agent *domain.Agent) float64 {
+// With no snapshot data the factor is EXCLUDED from the composite (AIP §6.1);
+// the returned 0.5 is a display placeholder only, never a contribution.
+func (c *TrustCalculator) calculateCompliance(agent *domain.Agent) (float64, string) {
 	if c.snapshotRepo == nil {
-		return 0.5 // Neutral when snapshot repo not configured
+		return 0.5, exclReasonNotWired
 	}
 
 	// Query the latest AIM compliance snapshot for the agent's organization
 	snapshot, err := c.snapshotRepo.GetLatest(agent.OrganizationID, domain.FrameworkAIM)
-	if err != nil || snapshot == nil {
-		return 0.5 // Neutral when no compliance data exists
+	if err != nil {
+		return 0.5, "compliance snapshot query failed: " + err.Error()
+	}
+	if snapshot == nil {
+		return 0.5, exclReasonNoData
 	}
 
 	// Snapshot score is 0-100, normalize to 0.0-1.0
 	normalized := snapshot.Score / 100.0
-	return math.Max(0.0, math.Min(1.0, normalized))
+	return math.Max(0.0, math.Min(1.0, normalized)), ""
 }
 
 // Factor 6: Age & History (5% weight)
@@ -443,11 +517,15 @@ func (c *TrustCalculator) calculateAge(agent *domain.Agent) float64 {
 
 // Factor 7: Drift Detection (3% weight)
 // Measures changes in agent behavior patterns by checking for
-// configuration drift alerts. No alerts = 1.0 (perfect).
+// configuration drift alerts. No alerts = 1.0 (perfect): a wired alert
+// repository returning zero alerts is a measurement, not missing data.
 // Each drift alert reduces the score proportionally by severity.
-func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
+// With no alert repository (or a failed agent-alert query) the factor is
+// EXCLUDED from the composite (AIP §6.1); the returned 0.5 is a display
+// placeholder only.
+func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) (float64, string) {
 	if c.alertRepo == nil {
-		return 0.5 // Neutral when alert repo not available
+		return 0.5, exclReasonNotWired
 	}
 
 	// Gather drift-relevant alerts from two key spaces:
@@ -471,7 +549,7 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 
 	agentAlerts, err := c.alertRepo.GetByResourceID(agent.ID, 100, 0)
 	if err != nil {
-		return 0.5 // Neutral on error
+		return 0.5, "agent alert query failed: " + err.Error()
 	}
 	collect(agentAlerts)
 
@@ -489,7 +567,7 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 	}
 
 	if len(alerts) == 0 {
-		return 1.0 // No alerts = no drift = perfect score
+		return 1.0, "" // No alerts = no drift = perfect score
 	}
 
 	// Filter for drift-related alerts from the last 30 days
@@ -521,14 +599,16 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 		}
 	}
 
-	return math.Max(0.0, score)
+	return math.Max(0.0, score), ""
 }
 
 // Factor 8: User Feedback (2% weight)
 // Measures explicit feedback from users, scored by sentiment-bucket counts.
 //
-// Returns 0.5 (neutral) when no feedback repository is wired or no feedback
-// exists, so agents are neither penalized nor rewarded without real data.
+// With no feedback repository wired, a failed query, or zero feedback rows,
+// the factor is EXCLUDED from the composite (AIP §6.1), so agents are neither
+// penalized nor rewarded without real data; the returned 0.5 is a display
+// placeholder only.
 //
 // Scoring formula (sentiment buckets from domain.FeedbackSentiment, rating 1-5):
 //
@@ -539,46 +619,52 @@ func (c *TrustCalculator) calculateDriftDetection(agent *domain.Agent) float64 {
 //
 // Negative checks precede positive so that an agent with many positives AND
 // many negatives is not rewarded; sustained complaints dominate.
-func (c *TrustCalculator) calculateUserFeedback(agent *domain.Agent) float64 {
+func (c *TrustCalculator) calculateUserFeedback(agent *domain.Agent) (float64, string) {
 	if c.userFeedbackRepo == nil {
-		return 0.5 // Neutral when feedback collection not configured
+		return 0.5, exclReasonNotWired
 	}
 
 	stats, err := c.userFeedbackRepo.GetStats(agent.ID)
-	if err != nil || stats == nil || stats.Total == 0 {
-		return 0.5 // Neutral when no feedback data exists
+	if err != nil {
+		return 0.5, "feedback stats query failed: " + err.Error()
+	}
+	if stats == nil || stats.Total == 0 {
+		return 0.5, exclReasonNoData
 	}
 
 	if stats.NegativeCount > 5 {
-		return 0.0
+		return 0.0, ""
 	}
 	if stats.NegativeCount > 2 {
-		return 0.5
+		return 0.5, ""
 	}
 	if stats.PositiveCount > 10 {
-		return 1.0
+		return 1.0, ""
 	}
-	return 0.75
+	return 0.75, ""
 }
 
 // Factor 9: Execution Isolation (10% weight)
 // Measures the runtime isolation posture of the agent.
 // Agents self-report their isolation via SDK; the score is computed from
 // sandbox type, network isolation, filesystem isolation, and process isolation.
-// Returns 0.3 (low baseline) when no attestation exists, incentivizing agents
-// to report their isolation posture for a higher score.
-func (c *TrustCalculator) calculateExecutionIsolation(agent *domain.Agent) float64 {
+// Returns 0.3 (low baseline) when no attestation exists: unlike the no-data
+// factors this is a deliberate per-factor scoring choice (permitted by AIP
+// §6.1) that incentivizes agents to report their posture, and issuance
+// surfaces it via IsolationSelfReported. Only an un-wired repository excludes
+// the factor from the composite.
+func (c *TrustCalculator) calculateExecutionIsolation(agent *domain.Agent) (float64, string) {
 	if c.isolationRepo == nil {
-		return 0.3 // Low baseline when no isolation data available
+		return 0.3, exclReasonNotWired
 	}
 
 	attestation, err := c.isolationRepo.GetLatest(agent.ID)
 	if err != nil || attestation == nil {
-		return 0.3 // No attestation submitted yet
+		return 0.3, "" // No attestation submitted yet: scored low baseline by design
 	}
 
 	// Use the pre-computed score from the attestation
-	return attestation.Score
+	return attestation.Score, ""
 }
 
 // calculateConfidence determines confidence level based on available data

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -714,10 +714,12 @@ func TestTrustCalculator_CalculateCompliance_NoViolations(t *testing.T) {
 		ID: uuid.New(),
 	}
 
-	compliance := calculator.calculateCompliance(agent)
+	compliance, reason := calculator.calculateCompliance(agent)
 
 	// Agent with no violations should have high compliance
 	assert.True(t, compliance >= 0.0 && compliance <= 1.0, "Compliance should be valid range")
+	// Un-wired snapshot repo excludes the factor from the composite (AIP §6.1)
+	assert.Equal(t, exclReasonNotWired, reason)
 }
 
 // ===========================
@@ -731,10 +733,12 @@ func TestTrustCalculator_CalculateDriftDetection_Default(t *testing.T) {
 		ID: uuid.New(),
 	}
 
-	drift := calculator.calculateDriftDetection(agent)
+	drift, reason := calculator.calculateDriftDetection(agent)
 
 	// Without drift repo, should return baseline
 	assert.True(t, drift >= 0.0 && drift <= 1.0, "Drift detection should be valid")
+	// Un-wired alert repo excludes the factor from the composite (AIP §6.1)
+	assert.Equal(t, exclReasonNotWired, reason)
 }
 
 // ===========================
@@ -748,10 +752,12 @@ func TestTrustCalculator_CalculateUserFeedback_Baseline(t *testing.T) {
 		ID: uuid.New(),
 	}
 
-	feedback := calculator.calculateUserFeedback(agent)
+	feedback, reason := calculator.calculateUserFeedback(agent)
 
-	// Should return neutral 0.5 when no feedback repository is wired
-	assert.Equal(t, 0.5, feedback, "User feedback should return neutral 0.5 when no feedback repo is configured")
+	// Placeholder value stays neutral; the factor itself is excluded from the
+	// composite when no feedback repository is wired (AIP §6.1)
+	assert.Equal(t, 0.5, feedback, "User feedback placeholder should be neutral 0.5 when no feedback repo is configured")
+	assert.Equal(t, exclReasonNotWired, reason)
 }
 
 // MockUserFeedbackRepository mocks domain.UserFeedbackRepository for trust calculator tests
@@ -789,7 +795,7 @@ func TestTrustCalculator_CalculateUserFeedback_Formula(t *testing.T) {
 		stats *domain.UserFeedbackStats
 		want  float64
 	}{
-		{"no feedback rows -> neutral", &domain.UserFeedbackStats{Total: 0}, 0.5},
+		// The Total==0 case is covered by _NoData_Excluded below (excluded, not scored).
 		{"sustained negatives (>5) -> 0.0", &domain.UserFeedbackStats{Total: 6, NegativeCount: 6}, 0.0},
 		{"some negatives (>2) -> 0.5", &domain.UserFeedbackStats{Total: 4, NegativeCount: 3}, 0.5},
 		{"strong positives (>10) -> 1.0", &domain.UserFeedbackStats{Total: 11, PositiveCount: 11}, 1.0},
@@ -806,13 +812,30 @@ func TestTrustCalculator_CalculateUserFeedback_Formula(t *testing.T) {
 			calc := &TrustCalculator{}
 			calc.SetUserFeedbackRepo(repo)
 
-			got := calc.calculateUserFeedback(agent)
+			got, reason := calc.calculateUserFeedback(agent)
 			assert.Equal(t, tc.want, got, tc.name)
+			assert.Empty(t, reason, "scored feedback must be included in the composite")
 		})
 	}
 }
 
-func TestTrustCalculator_CalculateUserFeedback_RepoError_Neutral(t *testing.T) {
+func TestTrustCalculator_CalculateUserFeedback_NoData_Excluded(t *testing.T) {
+	agentID := uuid.New()
+	agent := &domain.Agent{ID: agentID}
+
+	repo := new(MockUserFeedbackRepository)
+	repo.On("GetStats", agentID).Return(&domain.UserFeedbackStats{Total: 0}, nil)
+
+	calc := &TrustCalculator{}
+	calc.SetUserFeedbackRepo(repo)
+
+	// Zero feedback rows = no data: excluded from the composite (AIP §6.1).
+	got, reason := calc.calculateUserFeedback(agent)
+	assert.Equal(t, 0.5, got)
+	assert.Equal(t, exclReasonNoData, reason)
+}
+
+func TestTrustCalculator_CalculateUserFeedback_RepoError_Excluded(t *testing.T) {
 	agentID := uuid.New()
 	agent := &domain.Agent{ID: agentID}
 
@@ -822,8 +845,12 @@ func TestTrustCalculator_CalculateUserFeedback_RepoError_Neutral(t *testing.T) {
 	calc := &TrustCalculator{}
 	calc.SetUserFeedbackRepo(repo)
 
-	// A failed stats query must not penalize or reward the agent.
-	assert.Equal(t, 0.5, calc.calculateUserFeedback(agent))
+	// A failed stats query must not penalize or reward the agent: the factor
+	// is excluded from the composite rather than scored a fabricated neutral.
+	got, reason := calc.calculateUserFeedback(agent)
+	assert.Equal(t, 0.5, got)
+	assert.NotEmpty(t, reason)
+	assert.NotEqual(t, exclReasonNoData, reason, "query failure is a loud exclusion, not a quiet no-data state")
 }
 
 func TestTrustCalculator_RecordUserFeedback(t *testing.T) {
@@ -1249,9 +1276,11 @@ func TestTrustCalculator_ExecutionIsolation_NoRepo(t *testing.T) {
 	calculator := &TrustCalculator{}
 
 	agent := &domain.Agent{ID: uuid.New()}
-	isolation := calculator.calculateExecutionIsolation(agent)
+	isolation, reason := calculator.calculateExecutionIsolation(agent)
 
-	assert.Equal(t, 0.3, isolation, "Without isolation repo, should return 0.3 baseline")
+	assert.Equal(t, 0.3, isolation, "Without isolation repo, should return 0.3 placeholder")
+	// Un-wired isolation repo excludes the factor from the composite (AIP §6.1)
+	assert.Equal(t, exclReasonNotWired, reason)
 }
 
 func TestTrustCalculator_ExecutionIsolation_NoAttestation(t *testing.T) {
@@ -1264,9 +1293,12 @@ func TestTrustCalculator_ExecutionIsolation_NoAttestation(t *testing.T) {
 
 	mockIsolationRepo.On("GetLatest", agentID).Return(nil, nil)
 
-	isolation := calculator.calculateExecutionIsolation(agent)
+	isolation, reason := calculator.calculateExecutionIsolation(agent)
 
 	assert.Equal(t, 0.3, isolation, "Without attestation, should return 0.3 baseline")
+	// The 0.3 no-attestation baseline is a deliberate incentive score, so the
+	// factor stays IN the composite (unlike un-wired repos).
+	assert.Empty(t, reason)
 }
 
 func TestTrustCalculator_RecordIsolationAttestation_Success(t *testing.T) {
@@ -1336,9 +1368,10 @@ func TestTrustCalculator_ExecutionIsolation_WithAttestation(t *testing.T) {
 		Score:   0.72,
 	}, nil)
 
-	isolation := calculator.calculateExecutionIsolation(agent)
+	isolation, reason := calculator.calculateExecutionIsolation(agent)
 
 	assert.Equal(t, 0.72, isolation, "Should return the pre-computed attestation score")
+	assert.Empty(t, reason)
 }
 
 // Helper function for time pointer
@@ -1415,7 +1448,8 @@ func TestCalculateDriftDetection_ConnectedServerManifestDrift_ReducesScore(t *te
 		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.InDelta(t, 0.85, score, 0.001, "a high-severity manifest drift on a connected server should subtract 0.15")
 }
 
@@ -1436,7 +1470,8 @@ func TestCalculateDriftDetection_ConnectedServerCapabilityDrift_Stacks(t *testin
 		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.InDelta(t, 0.65, score, 0.001, "critical (-0.30) + warning (-0.05) on a connected server should subtract 0.35")
 }
 
@@ -1452,7 +1487,8 @@ func TestCalculateDriftDetection_UnconnectedServerDrift_NoEffect(t *testing.T) {
 		mcpConnRepo: &mockMCPConnLister{conns: nil}, // agent connected to nothing
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.Equal(t, 1.0, score, "drift on a server the agent is not connected to must not affect its score")
 }
 
@@ -1468,7 +1504,8 @@ func TestCalculateDriftDetection_NoConnectionRepo_FallsBackToAgentKeyed(t *testi
 
 	c := &TrustCalculator{alertRepo: mockAlert} // mcpConnRepo nil
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.InDelta(t, 0.95, score, 0.001, "agent-keyed configuration drift still counts (warning -0.05)")
 }
 
@@ -1487,7 +1524,8 @@ func TestCalculateDriftDetection_ConnectionLookupError_FallsBackGracefully(t *te
 		mcpConnRepo: &mockMCPConnLister{err: assert.AnError},
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.InDelta(t, 0.95, score, 0.001, "a connection lookup error degrades to agent-keyed alerts, not the 0.5 error sentinel")
 }
 
@@ -1507,7 +1545,8 @@ func TestCalculateDriftDetection_StaleServerDrift_Ignored(t *testing.T) {
 		mcpConnRepo: &mockMCPConnLister{conns: []*domain.AgentMCPConnection{{MCPServerID: serverID}}},
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.Equal(t, 1.0, score, "drift older than 30 days is outside the window and must not reduce the score")
 }
 
@@ -1530,6 +1569,155 @@ func TestCalculateDriftDetection_DuplicateServerConnections_CountedOnce(t *testi
 		}},
 	}
 
-	score := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	score, driftReason := c.calculateDriftDetection(&domain.Agent{ID: agentID})
+	assert.Empty(t, driftReason, "a measured drift factor must be included in the composite")
 	assert.InDelta(t, 0.85, score, 0.001, "the same alert reached via two connections must subtract only once")
+}
+
+// ============================================================================
+// TEST: AIP-SPEC §6.1 composition rule — factors with no data are excluded
+// and their weights redistributed proportionally
+// ============================================================================
+
+// stubSnapshotRepo is a minimal ComplianceSnapshotRepository for composition
+// tests; only GetLatest is exercised by the trust calculator.
+type stubSnapshotRepo struct {
+	snapshot *domain.ComplianceSnapshot
+	err      error
+}
+
+func (s *stubSnapshotRepo) Create(*domain.ComplianceSnapshot) error { return nil }
+func (s *stubSnapshotRepo) GetByID(uuid.UUID) (*domain.ComplianceSnapshot, error) {
+	return nil, nil
+}
+func (s *stubSnapshotRepo) GetByOrganization(uuid.UUID, int, int) ([]*domain.ComplianceSnapshot, error) {
+	return nil, nil
+}
+func (s *stubSnapshotRepo) GetByFramework(uuid.UUID, domain.ComplianceFramework, int) ([]*domain.ComplianceSnapshot, error) {
+	return nil, nil
+}
+func (s *stubSnapshotRepo) GetTrending(uuid.UUID, domain.ComplianceFramework, time.Time, time.Time) ([]*domain.ComplianceSnapshot, error) {
+	return nil, nil
+}
+func (s *stubSnapshotRepo) GetLatest(uuid.UUID, domain.ComplianceFramework) (*domain.ComplianceSnapshot, error) {
+	return s.snapshot, s.err
+}
+func (s *stubSnapshotRepo) DeleteOlderThan(uuid.UUID, time.Time) (int, error) { return 0, nil }
+
+// compositionTestAgent returns a verified agent plus base mocks producing
+// deterministic factor values: verification 1.0, uptime 0.98, success 0.95,
+// security alerts 1.0, age 1.0 (200 days), drift 1.0 (wired repo, no alerts).
+func compositionTestAgent(t *testing.T) (*TrustCalculator, *domain.Agent) {
+	t.Helper()
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(TrustCalcMockAlertRepository)
+
+	calculator := NewTrustCalculator(
+		new(AgentServiceMockTrustScoreRepository), new(MockAPIKeyRepository),
+		new(AgentServiceMockAuditLogRepository), mockCapabilityRepo,
+		new(TrustCalcMockAgentRepository), mockAlertRepo)
+
+	agent := &domain.Agent{
+		ID:             uuid.New(),
+		OrganizationID: uuid.New(),
+		Status:         domain.AgentStatusVerified,
+		UpdatedAt:      time.Now(),
+		CreatedAt:      time.Now().Add(-200 * 24 * time.Hour),
+	}
+
+	mockCapabilityRepo.On("GetViolationsByAgentID", agent.ID, 500, 0).Return([]*domain.CapabilityViolation{}, 0, nil).Maybe()
+	mockAlertRepo.On("GetUnacknowledgedByResourceID", agent.ID).Return([]*domain.Alert{}, nil).Maybe()
+	mockAlertRepo.On("GetByResourceID", agent.ID, 100, 0).Return([]*domain.Alert{}, nil).Maybe()
+
+	return calculator, agent
+}
+
+func TestTrustCalculator_Calculate_UnwiredFactors_ExcludedAndRenormalized(t *testing.T) {
+	// Compliance, user feedback, and execution isolation repos un-wired:
+	// their 0.10+0.02+0.10 weights must be redistributed, not scored 0.5/0.3.
+	calculator, agent := compositionTestAgent(t)
+
+	score, err := calculator.Calculate(agent)
+	assert.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"compliance", "execution_isolation", "user_feedback"},
+		score.ExcludedFactors, "un-wired factors must be reported excluded (sorted)")
+
+	f := score.Factors
+	includedWeight := 0.25 + 0.15 + 0.15 + 0.15 + 0.05 + 0.03
+	expected := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+		f.SecurityAlerts*0.15 + f.Age*0.05 + f.DriftDetection*0.03) / includedWeight
+	assert.InDelta(t, expected, score.Score, 1e-9,
+		"composite must be the weighted mean over INCLUDED factors only (AIP §6.1)")
+
+	// The old fabricated-neutral behavior would have produced a strictly lower
+	// score for this all-good agent (0.5*0.12 + 0.3*0.10 dragging the sum).
+	legacy := f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+		f.SecurityAlerts*0.15 + 0.5*0.10 + f.Age*0.05 + f.DriftDetection*0.03 +
+		0.5*0.02 + 0.3*0.10
+	assert.Greater(t, score.Score, legacy,
+		"renormalization must not let fabricated neutrals drag a fully-measured good agent")
+}
+
+func TestTrustCalculator_Calculate_WiredNoData_Excluded(t *testing.T) {
+	// Repos wired but empty: compliance (no snapshot) and feedback (zero rows)
+	// are no-data exclusions; isolation with no attestation stays INCLUDED at
+	// the deliberate 0.3 incentive baseline.
+	calculator, agent := compositionTestAgent(t)
+
+	calculator.SetSnapshotRepo(&stubSnapshotRepo{snapshot: nil})
+
+	feedbackRepo := new(MockUserFeedbackRepository)
+	feedbackRepo.On("GetStats", agent.ID).Return(&domain.UserFeedbackStats{Total: 0}, nil)
+	calculator.SetUserFeedbackRepo(feedbackRepo)
+
+	isolationRepo := new(MockIsolationAttestationRepository)
+	isolationRepo.On("GetLatest", agent.ID).Return(nil, nil)
+	calculator.SetIsolationRepo(isolationRepo)
+
+	score, err := calculator.Calculate(agent)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"compliance", "user_feedback"}, score.ExcludedFactors)
+
+	f := score.Factors
+	assert.Equal(t, 0.3, f.ExecutionIsolation)
+	includedWeight := 0.25 + 0.15 + 0.15 + 0.15 + 0.05 + 0.03 + 0.10
+	expected := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+		f.SecurityAlerts*0.15 + f.Age*0.05 + f.DriftDetection*0.03 +
+		f.ExecutionIsolation*0.10) / includedWeight
+	assert.InDelta(t, expected, score.Score, 1e-9)
+}
+
+func TestTrustCalculator_Calculate_FullyWiredWithData_NoExclusions(t *testing.T) {
+	// Every factor measured: no exclusions, weights sum to 1.0, no renormalization.
+	calculator, agent := compositionTestAgent(t)
+
+	calculator.SetSnapshotRepo(&stubSnapshotRepo{snapshot: &domain.ComplianceSnapshot{Score: 80}})
+
+	feedbackRepo := new(MockUserFeedbackRepository)
+	feedbackRepo.On("GetStats", agent.ID).Return(&domain.UserFeedbackStats{Total: 12, PositiveCount: 11}, nil)
+	calculator.SetUserFeedbackRepo(feedbackRepo)
+
+	isolationRepo := new(MockIsolationAttestationRepository)
+	isolationRepo.On("GetLatest", agent.ID).Return(&domain.IsolationAttestation{
+		ID: uuid.New(), AgentID: agent.ID, Score: 0.72,
+	}, nil)
+	calculator.SetIsolationRepo(isolationRepo)
+
+	score, err := calculator.Calculate(agent)
+	assert.NoError(t, err)
+
+	assert.Empty(t, score.ExcludedFactors, "fully measured agents must have no excluded factors")
+
+	f := score.Factors
+	assert.Equal(t, 0.8, f.Compliance)
+	assert.Equal(t, 1.0, f.UserFeedback)
+	assert.Equal(t, 0.72, f.ExecutionIsolation)
+	expected := f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+		f.SecurityAlerts*0.15 + f.Compliance*0.10 + f.Age*0.05 +
+		f.DriftDetection*0.03 + f.UserFeedback*0.02 + f.ExecutionIsolation*0.10
+	assert.InDelta(t, expected, score.Score, 1e-9,
+		"with all 9 factors measured the composite is the plain weighted sum")
 }

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -922,7 +923,7 @@ func TestTrustCalculator_CalculateConfidence_FullData(t *testing.T) {
 		Uptime:             0.95,
 	}
 
-	confidence := calculator.calculateConfidence(agent, factors)
+	confidence := calculator.calculateConfidence(agent, factors, nil)
 
 	// Confidence should be in valid range
 	assert.True(t, confidence >= 0.0, "Confidence should be non-negative")
@@ -939,7 +940,7 @@ func TestTrustCalculator_CalculateConfidence_MinimalData(t *testing.T) {
 
 	factors := &domain.TrustScoreFactors{}
 
-	confidence := calculator.calculateConfidence(agent, factors)
+	confidence := calculator.calculateConfidence(agent, factors, nil)
 
 	// Agent with minimal data should have lower confidence
 	assert.True(t, confidence >= 0.0, "Confidence should be non-negative")
@@ -1625,16 +1626,22 @@ func compositionTestAgent(t *testing.T) (*TrustCalculator, *domain.Agent) {
 		CreatedAt:      time.Now().Add(-200 * 24 * time.Hour),
 	}
 
-	mockCapabilityRepo.On("GetViolationsByAgentID", agent.ID, 500, 0).Return([]*domain.CapabilityViolation{}, 0, nil).Maybe()
-	mockAlertRepo.On("GetUnacknowledgedByResourceID", agent.ID).Return([]*domain.Alert{}, nil).Maybe()
-	mockAlertRepo.On("GetByResourceID", agent.ID, 100, 0).Return([]*domain.Alert{}, nil).Maybe()
+	// Keyed on mock.Anything so a test can run the same agent through two
+	// independently-constructed calculators (measured vs withheld).
+	mockCapabilityRepo.On("GetViolationsByAgentID", mock.Anything, 500, 0).Return([]*domain.CapabilityViolation{}, 0, nil).Maybe()
+	mockAlertRepo.On("GetUnacknowledgedByResourceID", mock.Anything).Return([]*domain.Alert{}, nil).Maybe()
+	mockAlertRepo.On("GetByResourceID", mock.Anything, 100, 0).Return([]*domain.Alert{}, nil).Maybe()
 
 	return calculator, agent
 }
 
-func TestTrustCalculator_Calculate_UnwiredFactors_ExcludedAndRenormalized(t *testing.T) {
-	// Compliance, user feedback, and execution isolation repos un-wired:
-	// their 0.10+0.02+0.10 weights must be redistributed, not scored 0.5/0.3.
+func TestTrustCalculator_Calculate_UnwiredFactors_ExcludedAndCapped(t *testing.T) {
+	// Compliance, user feedback, and execution isolation repos un-wired: their
+	// 0.10+0.02+0.10 weights are redistributed (AIP §6.1) — but for a GOOD
+	// agent pure renormalization would hand each excluded factor the agent's
+	// own high average, so withholding data would RAISE the score. The
+	// anti-gaming ceiling caps the published composite at the neutral-imputed
+	// sum: missing data can never help more than a neutral measurement would.
 	calculator, agent := compositionTestAgent(t)
 
 	score, err := calculator.Calculate(agent)
@@ -1646,18 +1653,60 @@ func TestTrustCalculator_Calculate_UnwiredFactors_ExcludedAndRenormalized(t *tes
 
 	f := score.Factors
 	includedWeight := 0.25 + 0.15 + 0.15 + 0.15 + 0.05 + 0.03
-	expected := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+	renormalized := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
 		f.SecurityAlerts*0.15 + f.Age*0.05 + f.DriftDetection*0.03) / includedWeight
-	assert.InDelta(t, expected, score.Score, 1e-9,
-		"composite must be the weighted mean over INCLUDED factors only (AIP §6.1)")
-
-	// The old fabricated-neutral behavior would have produced a strictly lower
-	// score for this all-good agent (0.5*0.12 + 0.3*0.10 dragging the sum).
-	legacy := f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+	imputed := f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
 		f.SecurityAlerts*0.15 + 0.5*0.10 + f.Age*0.05 + f.DriftDetection*0.03 +
 		0.5*0.02 + 0.3*0.10
-	assert.Greater(t, score.Score, legacy,
-		"renormalization must not let fabricated neutrals drag a fully-measured good agent")
+	assert.Greater(t, renormalized, imputed,
+		"precondition: for this all-good agent renormalization exceeds the neutral-imputed sum")
+	assert.InDelta(t, imputed, score.Score, 1e-9,
+		"the ceiling must bind: published composite = neutral-imputed sum, so withholding data cannot inflate the score")
+}
+
+func TestTrustCalculator_Calculate_BadAgentExclusions_NotProppedToNeutral(t *testing.T) {
+	// For a POOR agent the renormalized composite is BELOW the neutral-imputed
+	// sum, so the honest renormalized value is published — exclusion no longer
+	// props a bad agent up toward 0.5 the way the fabricated neutrals did.
+	mockCapabilityRepo := new(MockCapabilityRepository)
+	mockAlertRepo := new(TrustCalcMockAlertRepository)
+
+	calculator := NewTrustCalculator(
+		new(AgentServiceMockTrustScoreRepository), new(MockAPIKeyRepository),
+		new(AgentServiceMockAuditLogRepository), mockCapabilityRepo,
+		new(TrustCalcMockAgentRepository), mockAlertRepo)
+
+	// Revoked, brand-new agent: verification 0.0, uptime 0.5, success 0.7,
+	// age 0.3; drift measured 1.0; alerts factor dragged by violations. Its
+	// included average sits BELOW the neutral mix, so the renormalized
+	// composite is the smaller of the two and must be the one published.
+	agent := &domain.Agent{
+		ID:             uuid.New(),
+		OrganizationID: uuid.New(),
+		Status:         domain.AgentStatusRevoked,
+		UpdatedAt:      time.Now(),
+		CreatedAt:      time.Now(),
+	}
+
+	mockCapabilityRepo.On("GetViolationsByAgentID", agent.ID, 500, 0).Return([]*domain.CapabilityViolation{
+		{Severity: domain.ViolationSeverityCritical, CreatedAt: time.Now()},
+		{Severity: domain.ViolationSeverityCritical, CreatedAt: time.Now()},
+	}, 2, nil).Maybe()
+	mockAlertRepo.On("GetUnacknowledgedByResourceID", agent.ID).Return([]*domain.Alert{}, nil).Maybe()
+	mockAlertRepo.On("GetByResourceID", agent.ID, 100, 0).Return([]*domain.Alert{}, nil).Maybe()
+
+	score, err := calculator.Calculate(agent)
+	assert.NoError(t, err)
+
+	f := score.Factors
+	includedWeight := 0.25 + 0.15 + 0.15 + 0.15 + 0.05 + 0.03
+	renormalized := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+		f.SecurityAlerts*0.15 + f.Age*0.05 + f.DriftDetection*0.03) / includedWeight
+	imputed := renormalized*includedWeight + 0.5*0.10 + 0.5*0.02 + 0.3*0.10
+	assert.Less(t, renormalized, imputed,
+		"precondition: for this poor agent the neutral-imputed sum exceeds renormalization")
+	assert.InDelta(t, renormalized, score.Score, 1e-9,
+		"the honest renormalized composite must be published — neutrals no longer prop up a bad agent")
 }
 
 func TestTrustCalculator_Calculate_WiredNoData_Excluded(t *testing.T) {
@@ -1684,10 +1733,34 @@ func TestTrustCalculator_Calculate_WiredNoData_Excluded(t *testing.T) {
 	f := score.Factors
 	assert.Equal(t, 0.3, f.ExecutionIsolation)
 	includedWeight := 0.25 + 0.15 + 0.15 + 0.15 + 0.05 + 0.03 + 0.10
-	expected := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
+	renormalized := (f.VerificationStatus*0.25 + f.Uptime*0.15 + f.SuccessRate*0.15 +
 		f.SecurityAlerts*0.15 + f.Age*0.05 + f.DriftDetection*0.03 +
 		f.ExecutionIsolation*0.10) / includedWeight
-	assert.InDelta(t, expected, score.Score, 1e-9)
+	imputed := renormalized*includedWeight + 0.5*0.10 + 0.5*0.02
+	assert.InDelta(t, math.Min(renormalized, imputed), score.Score, 1e-9,
+		"published composite is min(renormalized, neutral-imputed)")
+}
+
+func TestTrustCalculator_Calculate_WithholdingCannotBeatMeasuredGood(t *testing.T) {
+	// The gaming vector the ceiling exists for: an org that never submits a
+	// compliance snapshot must not outscore the same agent with a MEASURED
+	// good (0.9) compliance snapshot.
+	calcMeasured, agent := compositionTestAgent(t)
+	calcMeasured.SetSnapshotRepo(&stubSnapshotRepo{snapshot: &domain.ComplianceSnapshot{Score: 90}})
+
+	calcWithheld, _ := compositionTestAgent(t)
+	calcWithheld.SetSnapshotRepo(&stubSnapshotRepo{snapshot: nil})
+	// Same agent identity through both calculators.
+	measured, err := calcMeasured.Calculate(agent)
+	assert.NoError(t, err)
+	withheld, err := calcWithheld.Calculate(agent)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"execution_isolation", "user_feedback"}, measured.ExcludedFactors,
+		"compliance must be measured (included) on the snapshot-submitting side")
+	assert.Contains(t, withheld.ExcludedFactors, "compliance")
+	assert.Greater(t, measured.Score, withheld.Score,
+		"a measured 0.9 compliance must outscore withheld compliance data")
 }
 
 func TestTrustCalculator_Calculate_FullyWiredWithData_NoExclusions(t *testing.T) {

--- a/apps/backend/internal/domain/trust_score.go
+++ b/apps/backend/internal/domain/trust_score.go
@@ -39,13 +39,22 @@ type TrustScoreFactors struct {
 
 // TrustScore represents a calculated trust score for an agent
 type TrustScore struct {
-	ID             uuid.UUID         `json:"id"`
-	AgentID        uuid.UUID         `json:"agentId"`
-	Score          float64           `json:"score"` // 0-1
-	Factors        TrustScoreFactors `json:"factors"`
-	Confidence     float64           `json:"confidence"` // 0-1
-	LastCalculated time.Time         `json:"lastCalculated"`
-	CreatedAt      time.Time         `json:"createdAt"`
+	ID      uuid.UUID         `json:"id"`
+	AgentID uuid.UUID         `json:"agentId"`
+	Score   float64           `json:"score"` // 0-1
+	Factors TrustScoreFactors `json:"factors"`
+
+	// ExcludedFactors lists the factors excluded from the composite under the
+	// AIP-SPEC §6.1 composition rule (no data or un-wired source; their
+	// weights are redistributed proportionally across measured factors). The
+	// corresponding Factors fields carry neutral display placeholders, not
+	// measurements. Sorted; populated on fresh calculations only — the field
+	// is not persisted, so scores read back from storage omit it.
+	ExcludedFactors []string `json:"excludedFactors,omitempty"`
+
+	Confidence     float64   `json:"confidence"` // 0-1
+	LastCalculated time.Time `json:"lastCalculated"`
+	CreatedAt      time.Time `json:"createdAt"`
 }
 
 // TrustScoreRepository defines the interface for trust score persistence

--- a/apps/backend/internal/infrastructure/registry/atc_conformance_test.go
+++ b/apps/backend/internal/infrastructure/registry/atc_conformance_test.go
@@ -116,6 +116,12 @@ func TestATCIssuance_ConformanceByteMatch(t *testing.T) {
 				t.Fatalf("decoded capabilities diverge from pinned credential %s: got %d want %d",
 					fixture.Name, len(cred.Capabilities), len(want.Capabilities))
 			}
+			for i := range want.Capabilities {
+				if cred.Capabilities[i] != want.Capabilities[i] {
+					t.Fatalf("decoded capability %d diverges from pinned credential %s: got %q want %q",
+						i, fixture.Name, cred.Capabilities[i], want.Capabilities[i])
+				}
+			}
 		})
 	}
 }

--- a/apps/backend/internal/infrastructure/registry/atc_conformance_test.go
+++ b/apps/backend/internal/infrastructure/registry/atc_conformance_test.go
@@ -1,0 +1,121 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// conformanceFixture is the subset of an atx-conformance fixture the issuance
+// byte-match test needs: the pinned credential bytes and the expected outcome.
+type conformanceFixture struct {
+	Name     string `json:"name"`
+	Expected struct {
+		VerifyResult string `json:"verifyResult"`
+	} `json:"expected"`
+	ATX json.RawMessage `json:"atx"`
+}
+
+// TestATCIssuance_ConformanceByteMatch replays every pinned atx-conformance
+// credential as a Registry issuance response and asserts AIM's issuance path
+// is byte-preserving: the credential surfaced to callers via Raw must be the
+// Registry's exact signed bytes, or downstream local verifiers
+// (@opena2a/atx-verify, the Java LocalAtxVerifier, pkg/atcverify) would see a
+// signature over bytes the verifier can no longer reproduce.
+//
+// The suite directory is injected via ATX_CONFORMANCE_DIR (CI clones
+// opena2a-standards/atx-conformance at a pinned ref and verifies
+// MANIFEST.sha256 first); the test skips when unset so local `go test ./...`
+// does not require the suite checkout.
+func TestATCIssuance_ConformanceByteMatch(t *testing.T) {
+	dir := os.Getenv("ATX_CONFORMANCE_DIR")
+	if dir == "" {
+		t.Skip("ATX_CONFORMANCE_DIR not set; conformance byte-match runs in CI")
+	}
+
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob fixtures: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no fixtures found in %s", dir)
+	}
+
+	for _, path := range paths {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			var fixture conformanceFixture
+			if err := json.Unmarshal(raw, &fixture); err != nil {
+				t.Fatalf("decode fixture: %v", err)
+			}
+			if len(fixture.ATX) == 0 {
+				t.Fatalf("fixture %s has no atx payload", fixture.Name)
+			}
+
+			// Serve the fixture credential as the Registry's issuance response.
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != issueATCPath {
+					t.Errorf("unexpected path %s", r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(fixture.ATX)
+			}))
+			defer srv.Close()
+
+			client := NewATCClient(srv.URL, "test-token", srv.Client())
+			cred, err := client.IssueATC(context.Background(), ATCIssuanceRequest{
+				AgentID: "conformance", AgentDID: "did:aip:aim_conformance",
+			})
+
+			// The client must decode every pinned credential shape — including
+			// the REJECT fixtures, whose defects (expiry, tampered signature,
+			// untrusted issuer) are verification-time findings, not JSON
+			// malformations. malformed-schema.json is still valid JSON.
+			if err != nil {
+				t.Fatalf("IssueATC failed on pinned credential %s: %v", fixture.Name, err)
+			}
+
+			// Byte-match: Raw is the verbatim signed credential.
+			if !bytes.Equal(cred.Raw, fixture.ATX) {
+				t.Fatalf("issuance did not preserve the Registry's signed bytes for %s", fixture.Name)
+			}
+
+			// Decode fidelity: the convenience fields AIM surfaces must agree
+			// with the pinned credential, so handlers never contradict Raw.
+			var want struct {
+				ID           string   `json:"id"`
+				ATCVersion   string   `json:"atcVersion"`
+				AgentDID     string   `json:"agentDid"`
+				TrustScore   float64  `json:"trustScore"`
+				TrustLevel   int      `json:"trustLevel"`
+				Capabilities []string `json:"capabilities"`
+			}
+			if err := json.Unmarshal(fixture.ATX, &want); err != nil {
+				t.Fatalf("decode pinned credential: %v", err)
+			}
+			if cred.ID != want.ID || cred.ATCVersion != want.ATCVersion || cred.AgentDID != want.AgentDID {
+				t.Fatalf("decoded identity fields diverge from pinned credential %s: got (%s,%s,%s)",
+					fixture.Name, cred.ID, cred.ATCVersion, cred.AgentDID)
+			}
+			if cred.TrustScore != want.TrustScore || cred.TrustLevel != want.TrustLevel {
+				t.Fatalf("decoded trust fields diverge from pinned credential %s: got (%v,%d) want (%v,%d)",
+					fixture.Name, cred.TrustScore, cred.TrustLevel, want.TrustScore, want.TrustLevel)
+			}
+			if len(cred.Capabilities) != len(want.Capabilities) {
+				t.Fatalf("decoded capabilities diverge from pinned credential %s: got %d want %d",
+					fixture.Name, len(cred.Capabilities), len(want.Capabilities))
+			}
+		})
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
@@ -177,13 +177,19 @@ func (h *TrustScoreHandler) GetTrustScore(c fiber.Ctx) error {
 		})
 	}
 
-	return c.JSON(fiber.Map{
+	resp := fiber.Map{
 		"agentId":      agentID,
 		"agentName":    agent.Name,
 		"score":        score.Score,
 		"factors":      score.Factors,
 		"calculatedAt": score.LastCalculated,
-	})
+	}
+	// Present on the calculated-on-the-fly path; stored scores predate the
+	// exclusion tracking and omit it.
+	if len(score.ExcludedFactors) > 0 {
+		resp["excludedFactors"] = score.ExcludedFactors
+	}
+	return c.JSON(resp)
 }
 
 // GetTrustScoreBreakdown returns detailed trust score breakdown with weights and contributions
@@ -262,7 +268,7 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 		"executionIsolation": score.Factors.ExecutionIsolation * weights["executionIsolation"],
 	}
 
-	return c.JSON(fiber.Map{
+	resp := fiber.Map{
 		"agentId":   agentID,
 		"agentName": agent.Name,
 		"overall":   score.Score,
@@ -281,7 +287,16 @@ func (h *TrustScoreHandler) GetTrustScoreBreakdown(c fiber.Ctx) error {
 		"contributions": contributions,
 		"confidence":    score.Confidence,
 		"calculatedAt":  score.LastCalculated,
-	})
+	}
+	// Factors excluded from the composite under AIP §6.1: their entries in
+	// factors/contributions above are neutral placeholders, not measurements,
+	// and the published overall is min(renormalized, Σ contributions) — so
+	// Σ contributions can exceed overall when exclusions are present. Only
+	// available on the calculated-on-the-fly path; stored scores omit it.
+	if len(score.ExcludedFactors) > 0 {
+		resp["excludedFactors"] = score.ExcludedFactors
+	}
+	return c.JSON(resp)
 }
 
 // SubmitUserFeedback records an explicit user rating (1-5) for an agent. This is

--- a/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/trust_score_handler.go
@@ -118,12 +118,20 @@ func (h *TrustScoreHandler) CalculateTrustScore(c fiber.Ctx) error {
 		},
 	)
 
-	return c.JSON(fiber.Map{
+	resp := fiber.Map{
 		"agentId":      agentID,
 		"score":        score.Score,
 		"factors":      score.Factors,
 		"calculatedAt": score.LastCalculated,
-	})
+	}
+	// Fresh calculations know which factors had no data and were excluded
+	// from the composite under AIP §6.1 (weights redistributed). Surface
+	// them so consumers never read the placeholder factor values as
+	// measurements. Omitted entirely when every factor was measured.
+	if len(score.ExcludedFactors) > 0 {
+		resp["excludedFactors"] = score.ExcludedFactors
+	}
+	return c.JSON(resp)
 }
 
 // GetTrustScore returns current trust score for an agent

--- a/docs/API.md
+++ b/docs/API.md
@@ -546,22 +546,26 @@ Get current trust score for an agent.
 Authorization: Bearer YOUR_JWT_TOKEN
 ```
 
-**Response:**
+**Response** (factor values are 0-1 scores, not weighted contributions; factors
+with no data are excluded from the composite per AIP §6.1 — their placeholder
+values here are not measurements):
 ```json
 {
   "agentId": "550e8400-e29b-41d4-a716-446655440000",
-  "trustScore": 75.5,
+  "agentName": "my-agent",
+  "score": 0.86,
   "factors": {
-    "verificationStatus": 25.0,
-    "uptime": 12.5,
-    "actionSuccessRate": 14.0,
-    "securityAlerts": 10.5,
-    "complianceScore": 8.0,
-    "ageAndHistory": 3.5,
-    "driftDetection": 1.5,
-    "userFeedback": 0.5
+    "verificationStatus": 1.0,
+    "uptime": 0.98,
+    "successRate": 0.95,
+    "securityAlerts": 1.0,
+    "compliance": 0.8,
+    "age": 0.75,
+    "driftDetection": 1.0,
+    "userFeedback": 0.75,
+    "executionIsolation": 0.52
   },
-  "lastCalculated": "2025-10-08T00:00:00Z"
+  "calculatedAt": "2026-07-02T00:00:00Z"
 }
 ```
 

--- a/docs/sdk/trust-scoring.md
+++ b/docs/sdk/trust-scoring.md
@@ -41,26 +41,26 @@ Implemented in `apps/backend/internal/application/trust_calculator.go`.
 
 ## Liveness Status
 
-Not every factor is wired to a live signal source in current AIM. Some factors require optional repositories that may not be configured in every deployment; one factor is currently hardcoded pending a feedback collection mechanism. The honest matrix:
+Not every factor is wired to a live signal source in every AIM deployment. Per AIP-SPEC §6.1, a factor with no data is **excluded from the composite and its weight redistributed proportionally** across the measured factors — it never contributes a fabricated neutral value. The honest matrix:
 
-| # | Factor | Status today | Default when not live |
+| # | Factor | Status today | When not live |
 |---|---|---|---|
-| 1 | Verification Status | **Live** — `verificationEventRepo.GetAgentStatistics` last 30 days; falls back to `agent.Status` proxy when no events exist | Status-based 0.0-1.0 |
-| 2 | Uptime & Availability | **Live** — derived from the same verification-event success rate, with a recency boost/penalty | Status-based 0.50-0.98 |
-| 3 | Action Success Rate | **Live** — `verificationEventRepo.GetAgentStatistics` success rate | Status-based 0.70-0.95 |
+| 1 | Verification Status | **Live** — `verificationEventRepo.GetAgentStatistics` last 30 days; falls back to `agent.Status` proxy when no events exist | Status-based 0.0-1.0 (always measured) |
+| 2 | Uptime & Availability | **Live** — derived from the same verification-event success rate, with a recency boost/penalty | Status-based 0.50-0.98 (always measured) |
+| 3 | Action Success Rate | **Live** — `verificationEventRepo.GetAgentStatistics` success rate | Status-based 0.70-0.95 (always measured) |
 | 4 | Security Alerts | **Live** — `alertRepo.GetUnacknowledgedByResourceID` + `capabilityRepo.GetViolationsByAgentID` (90-day window). Optional NanoMind TME score blends in at 30% influence when wired. | 1.0 (no penalties applied) |
-| 5 | Compliance Score | **Conditional** — requires `ComplianceSnapshotRepository` to be wired AND an AIM-framework snapshot to exist for the agent's organization | 0.5 neutral |
-| 6 | Age & History | **Live** — bucketed from `agent.CreatedAt` (<7d: 0.30, <30d: 0.50, <90d: 0.75, 90+: 1.0) | N/A |
-| 7 | Drift Detection | **Conditional** — requires `alertRepo` AND drift-type alerts (`AlertTypeConfigurationDrift`, `AlertMCPCapabilityDrift`) in the last 30 days | 0.5 neutral (when `alertRepo` is nil OR query errors) |
-| 8 | User Feedback | **Not implemented** — `calculateUserFeedback` hardcoded to return `0.5` pending a `UserFeedbackRepository` and rating-collection UI. TODO at `trust_calculator.go:471-490`. | 0.5 neutral |
-| 9 | Execution Isolation | **Conditional** — requires `IsolationAttestationRepository` to be wired AND the agent to have submitted a runtime-isolation attestation via the SDK | 0.3 low baseline (incentivizes attestation submission) |
+| 5 | Compliance Score | **Conditional** — requires `ComplianceSnapshotRepository` to be wired AND an AIM-framework snapshot to exist for the agent's organization | **Excluded** from the composite (weight redistributed); reported in `excludedFactors` |
+| 6 | Age & History | **Live** — bucketed from `agent.CreatedAt` (<7d: 0.30, <30d: 0.50, <90d: 0.75, 90+: 1.0) | N/A (always measured) |
+| 7 | Drift Detection | **Conditional** — requires `alertRepo`; a wired repo with zero drift alerts scores 1.0 (measured absence of drift) | **Excluded** when `alertRepo` is nil OR the agent-alert query errors |
+| 8 | User Feedback | **Conditional** — requires `UserFeedbackRepository` (wired in production `main.go`) AND at least one feedback row (`POST /agents/:id/feedback`) | **Excluded** when un-wired, on query error, or with zero feedback rows |
+| 9 | Execution Isolation | **Conditional** — requires `IsolationAttestationRepository` to be wired; the agent submits a runtime-isolation attestation via the SDK | 0.3 low baseline when wired but no attestation (deliberate incentive, stays in the composite); **excluded** only when the repository is un-wired |
 
 Implications:
 
-- A fresh agent in a default deployment computes its score primarily off Factors 1, 2, 3, 4, and 6 (live with real signals), with Factors 5, 7, 8, 9 contributing neutral or low defaults. That accounts for roughly 75% of the weighted total being live (25 + 15 + 15 + 15 + 5 = 75%) and 25% riding on defaults until the optional repos and feedback path land.
+- The composite is always a weighted mean over **measured** factors only: `score = Σ(weight × value for included) / Σ(weight for included)`. An agent with no compliance snapshot is scored on what was actually measured, not padded with a 0.5 placeholder.
+- Fresh calculations report the excluded factor names in the `excludedFactors` field of the trust-score response; the per-factor values for excluded factors are display placeholders, not measurements.
+- Exclusions caused by an un-wired repository or a failed query are logged as warnings (they indicate a deployment defect — production `main.go` wires all repositories); exclusions from genuinely absent data (no snapshot yet, no feedback yet) are silent, normal lifecycle states.
 - Reaching the higher trust bands (>0.85) requires either real signal in the conditional factors OR strong showings across the live ones.
-- If you see a trust score that looks generous against intuition, check whether the live factors are masking neutral defaults in the optional ones. The `factors` JSONB column on `trust_scores` records each factor's contribution; the dashboard breakdown surfaces them.
-- Factor 8 (User Feedback) will always read `0.5` until the feedback collection mechanism ships. Its 2% weight bounds the impact of this gap at ±0.01 on the overall score.
 
 ### Factor 1: Verification Status (25% weight)
 

--- a/docs/sdk/trust-scoring.md
+++ b/docs/sdk/trust-scoring.md
@@ -57,10 +57,18 @@ Not every factor is wired to a live signal source in every AIM deployment. Per A
 
 Implications:
 
-- The composite is always a weighted mean over **measured** factors only: `score = Σ(weight × value for included) / Σ(weight for included)`. An agent with no compliance snapshot is scored on what was actually measured, not padded with a 0.5 placeholder.
-- Fresh calculations report the excluded factor names in the `excludedFactors` field of the trust-score response; the per-factor values for excluded factors are display placeholders, not measurements.
-- Exclusions caused by an un-wired repository or a failed query are logged as warnings (they indicate a deployment defect — production `main.go` wires all repositories); exclusions from genuinely absent data (no snapshot yet, no feedback yet) are silent, normal lifecycle states.
+- The composite is a weighted mean over **measured** factors only, with an
+  anti-gaming ceiling: `score = min( Σ(w×v included)/Σ(w included), Σ(w×v all 9) )`
+  where excluded factors enter the second sum at their neutral placeholders.
+  An agent with no compliance snapshot is scored on what was actually measured —
+  but withholding data can never RAISE a score above what a neutral measurement
+  would give (otherwise never submitting a snapshot would outscore a measured
+  0.9 compliance). Poor agents get the honest renormalized value; exclusion no
+  longer props them up toward 0.5.
+- Fresh calculations report the excluded factor names in the `excludedFactors` field of the trust-score, calculate, and breakdown responses; the per-factor values for excluded factors are display placeholders, not measurements. With exclusions present, the breakdown's Σ contributions can exceed `overall` (contributions use the placeholder values).
+- Exclusions caused by an un-wired repository or a failed query are logged as warnings (they indicate a deployment defect — production `main.go` wires all repositories); exclusions from genuinely absent data (no snapshot yet, no feedback yet) are silent, normal lifecycle states. Excluded compliance/feedback also withhold their confidence contribution.
 - Reaching the higher trust bands (>0.85) requires either real signal in the conditional factors OR strong showings across the live ones.
+- If a trust score looks generous against intuition, check `excludedFactors` first: the score may be riding on fewer measured factors than the breakdown suggests.
 
 ### Factor 1: Verification Status (25% weight)
 

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/Atx.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/Atx.java
@@ -1,6 +1,7 @@
 package org.opena2a.aim.atx;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,12 @@ public class Atx {
     public String contentHash;
     public String buildAttestation;
     public List<String> capabilities;
+    /**
+     * Declared purpose (atx-spec §1.5); null when absent. Kept as a raw tree:
+     * the v1.1 TBS passes a present, non-empty object through verbatim for JCS
+     * to re-canonicalize (§1.3a.2 rule 5).
+     */
+    public JsonNode declaredPurpose;
     /** Observed-behavior summary; null when absent. Read field-by-field in the v1.1 TBS. */
     public Map<String, Object> behavioralProfile;
     public Map<String, Object> scanSummary;

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
@@ -115,12 +115,18 @@ public final class AtxCanonicalizer {
 
     /**
      * Presence-based rule for the optional declaredPurpose member (atx-spec
-     * §1.3a.2 rule 5, mirroring the reference verifiers'
-     * projectDeclaredPurposeV11): an absent purpose — missing, null, or an
-     * empty object {} — is OMITTED from the TBS, keeping a no-purpose
-     * credential byte-identical to one issued before the field existed. A
-     * present, non-empty object passes through verbatim and JCS
-     * re-canonicalizes it.
+     * §1.3a.2 rule 5): an absent purpose — missing, null, or an empty object
+     * {} — is OMITTED from the TBS, keeping a no-purpose credential
+     * byte-identical to one issued before the field existed. A present,
+     * non-empty value passes through verbatim and JCS re-canonicalizes it.
+     *
+     * <p>Known cross-implementation edge (no pinned fixture yet): this
+     * tree-level check treats a whitespace-padded empty object like {@code
+     * "{ }"} as empty (omitted), while the Go reference verifier's raw-string
+     * check passes it through as {@code {}}; the Python reference omits any
+     * non-dict value that Go and this implementation include. Alignment and
+     * fixtures for these inputs are tracked in the atx-conformance suite —
+     * this implementation matches all 15 pinned fixtures.
      */
     private static com.fasterxml.jackson.databind.JsonNode projectDeclaredPurpose(
             com.fasterxml.jackson.databind.JsonNode dp) {

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxCanonicalizer.java
@@ -55,9 +55,10 @@ public final class AtxCanonicalizer {
 
     /**
      * Project an ATX into the v1.1 TBS and return JCS(TBS) (RFC 8785). Covers
-     * capabilities, scanSummary, issuerChain, publisher, and behavioralProfile.
-     * The projection (canonical empties, always-full scanSummary, %.6f string
-     * trustScore, root-first issuerChain) matches the reference verifiers exactly.
+     * capabilities, scanSummary, issuerChain, publisher, declaredPurpose, and
+     * behavioralProfile. The projection (canonical empties, always-full
+     * scanSummary, %.6f string trustScore, root-first issuerChain) matches the
+     * reference verifiers exactly.
      */
     public static byte[] canonicalPayloadV11(Atx atx) {
         ObjectNode tbs = MAPPER.createObjectNode();
@@ -70,6 +71,10 @@ public final class AtxCanonicalizer {
         tbs.put("contentHash", atx.contentHash);
         tbs.put("buildAttestation", ns(atx.buildAttestation));
         tbs.set("capabilities", arrayOf(atx.capabilities));
+        com.fasterxml.jackson.databind.JsonNode declaredPurpose = projectDeclaredPurpose(atx.declaredPurpose);
+        if (declaredPurpose != null) {
+            tbs.set("declaredPurpose", declaredPurpose);
+        }
         tbs.set("behavioralProfile", projectBehavioralProfile(atx.behavioralProfile));
 
         Map<String, Object> scan = atx.scanSummary != null ? atx.scanSummary : Map.of();
@@ -106,6 +111,23 @@ public final class AtxCanonicalizer {
         } catch (Exception e) {
             throw new IllegalArgumentException("invalid RFC 3339 timestamp: " + s, e);
         }
+    }
+
+    /**
+     * Presence-based rule for the optional declaredPurpose member (atx-spec
+     * §1.3a.2 rule 5, mirroring the reference verifiers'
+     * projectDeclaredPurposeV11): an absent purpose — missing, null, or an
+     * empty object {} — is OMITTED from the TBS, keeping a no-purpose
+     * credential byte-identical to one issued before the field existed. A
+     * present, non-empty object passes through verbatim and JCS
+     * re-canonicalizes it.
+     */
+    private static com.fasterxml.jackson.databind.JsonNode projectDeclaredPurpose(
+            com.fasterxml.jackson.databind.JsonNode dp) {
+        if (dp == null || dp.isNull() || (dp.isObject() && dp.isEmpty())) {
+            return null;
+        }
+        return dp;
     }
 
     /**

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
@@ -30,15 +30,21 @@ class LocalAtxVerifierConformanceTest {
 
     @ParameterizedTest(name = "{0} -> {1}{2}")
     @CsvSource({
-            "baseline-valid.json,              ACCEPT, ",
-            "baseline-valid-hybrid.json,       ACCEPT, ",
-            "threshold-2of3-cosignature.json,  ACCEPT, ",
-            "tampered-signature.json,          REJECT, SIGNATURE_INVALID",
-            "expired.json,                     REJECT, EXPIRED",
-            "revoked.json,                     REJECT, REVOKED",
-            "wrong-issuer.json,                REJECT, UNTRUSTED_ISSUER",
-            "malformed-schema.json,            REJECT, UNSUPPORTED_VERSION",
-            "cross-issuer-key.json,            REJECT, SIGNATURE_INVALID",
+            "baseline-valid.json,                  ACCEPT, ",
+            "baseline-valid-hybrid.json,           ACCEPT, ",
+            "threshold-2of3-cosignature.json,      ACCEPT, ",
+            "tampered-signature.json,              REJECT, SIGNATURE_INVALID",
+            "expired.json,                         REJECT, EXPIRED",
+            "revoked.json,                         REJECT, REVOKED",
+            "wrong-issuer.json,                    REJECT, UNTRUSTED_ISSUER",
+            "malformed-schema.json,                REJECT, UNSUPPORTED_VERSION",
+            "cross-issuer-key.json,                REJECT, SIGNATURE_INVALID",
+            "v1_1-baseline-valid.json,             ACCEPT, ",
+            "v1_1-baseline-valid-hybrid.json,      ACCEPT, ",
+            "v1_1-declared-purpose-valid.json,     ACCEPT, ",
+            "v1_1-tampered-capabilities.json,      REJECT, SIGNATURE_INVALID",
+            "v1_1-tampered-declared-purpose.json,  REJECT, SIGNATURE_INVALID",
+            "v1_1-cross-issuer-key.json,           REJECT, SIGNATURE_INVALID",
     })
     void fixture(String file, String expectedResult, String expectedRejectCategory) throws Exception {
         JsonNode fixture;

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-baseline-valid-hybrid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-baseline-valid-hybrid.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/baseline-valid-hybrid",
+  "description": "An ATX v1.1 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the SAME JCS(TBS) bytes. A spec-conformant verifier MUST verify both and ACCEPT.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-primary-pqc",
+      "path": "vectors/mldsa65-seed.json",
+      "algorithm": "ML-DSA-65",
+      "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-primary-pqc",
+        "path": "vectors/mldsa65-seed.json",
+        "algorithm": "ML-DSA-65",
+        "publicKeyHex": "48683d91978e31eb3dddb8b0473482d2b88a5f625949fd8f58a561e696bd4c27d05b38dbb2edf01e664efd81be1ea893688ce68aa2d51c5958f8bbc6eb4e89ee67d2c0320954d57212cac7229ff1d6eaf03928bd51511f8d88d847736c7de2730d5978e5410713160978867711bf5539a0bfc4c350c2be572baf0ee2e2fb16ccfea08028d99ac49aebb75937ddce111cdab62fff3cea8ba2233d1e56fbc5c5a1e726de63fadd2af016b119177fa3d971a2d9277173fce55b67745af0b7c21d597dbeb93e6a32f341c49a5a8be9e825088d1f2aa45155d6c8ae15367e4eb003b8fdf7851071949739f9fff09023eaf45104d2a84a45906eed4671a44dc28d27987bb55df69e9e8561f61a80a72699503865fed9b7ee72a8e17a19c408144f4b29afef7031c3a6d8571610b42c9f421245a88f197e16812b031159b65b9687e5b3e934c5225ae98a79ba73d2b399d73510effad19e53b8450f0ba8fce1012fd98d260a74aaaa13fae249a006b1c34f5ba0b882f26378222fb36f2283c243f0ffeb5f1bb414a0a70d55e3d40a56b6cbc88ae1f03b7b2882d98deea28e145c9dedfd8eaf1cef2ed94a8b050f8964f46d1ea0d0c2a43e0dda6182adbf4f6ed175b6742257859bf22f3a417ecf1f9d89317b5e539d587af16b9e1313e04514ffa64ba8b3ff2b8321f8811cb3fb022c8f644e70a4b80a2fbfee604abb7379091ea8e6c5c74dfc0283666b40c0793870028204a136bf5da9568eb798d349038bdb0c11e03445e7847cb5069c75cf28ac601c7799d958210ddbcb226e51afef9f1de47b073873d6d3f97456bede085082e74a298b2cd48f4b3093155f366c8fa601c6af858dfa32c08491b2a29887f90335949a5d6edaa679882a3a95d6bf6d970a221f4b9d3d8cbf384af81aac95e2b3294e04789ac83727a5dc04559f96af41d8a053516feeeebc52746eb6ab2819e09108710d835f011fa63065872ad334d5cdffb2b2310507e92fc993ae317da97f4f309cdaf0f67ed99d90215576083849f953b246d7fedb3fdb67679850a5ad404e64147fb7cf4f6aeddd05afb4b834968d1fe88014960dce5d942236526e12a478d69e5fbe6970310b308c06845018cfc7b2ab430a13a6b1ac7bb02cccbb3d911ac2f11068613fbe029bfdce02cf5cd38950ed72c83944edfbc75615af87f864c051f3c55456c5412863a40c06d1dab562bdff0571b8d3c3917bbd300880bba5e998239b95fa91b7d6416d4f398b3adbcd30983ed3592b4d9ef7d4236fd00f50d98aa53a235ac4172720f77d96172672980cfe8ff7a5a702783edc2ba31b2259015a112fc7f468a9c2f9464039002d30ef678b4cb798bc116216bf7a9a7c18ba03b7b58fd07515d3115049d3614be7a07e744300750df1d2c58753389059eafc3d785ccdd31c07648bedc03a5c3b8ad46d064d59c13d57374729fc4e295362e2a5191204530428bc1522afa28ff5fe1655e304ca5bc8c27ad0e0c6a39dd4df28956c14b38cc93682cefe402bbd5e82d29c464e44eb5d37b48fc568dfe0cc6e8e16baea05e5135590f19294e73e8367b0216dbb815030b9de55913f08039c42351c59e5515dd5af8e089a15e625e8f6dee639386c46497d7a263288774de581a7de9629b41b4424141f978fb8331208efdec3c6e0de39bc57063f3dcd6c470373c08891ea29cbc7cc6d6483b8889083ace86aa7b51b1c2cfe6e2ad18d97ce36fbc56ea42fae97e6a7ac114864478c366df1ebb1e7b11a9098504fd5975bdf1f49dc70002b63c1739a9d263fbad4073f6a9f6c2b8af4b4c332a103a0cffa5deeb2d062ca3c215fd360026be7c5164f4a4424ef74948804d66f46487732c8202c795478647b4ea71d627c086024cca354a41f0877b38f19b3774ad2095c8da53b069e21c76ae2d2007e16719ed40080d334f7da52e9f5a5990439caf083a95b833f02ad10a08c1a6d0f260c007285bd4a2f47703a5aef465287d253b18ac22514316210ff566814b10f87a293d6f199d3c3959990d0c1268b4f50d5f9fcefbbf237bd0c28b80182d6659741f14f10bfbb21bba12ab620aa2396f56c0686b4ea9017990224216b2fe8ad76c4a9148eef9a86a3635a6aa77bc1dcfb6fba59a77dfda9b7530dc0ca8648c8d973738e01bab8f08b4905e84aa4641bd602410cd97520265f2f231f2b35e15eb2fa04d2bd94d5a77abaf1e0e161010a990087f5b46ea988b2bc0512fda0fa923dadd6c45c5301d09483673265b5ab2e10f4ba520f6bbad564a5c3d5e27bdb080f7d20e13296a3181954c39c649c943ebe17df5c1f7aae0a8fe126c477585a5d4d648a0d008b6af5e8cd31be69a9296d4f3fd25ed86f221e4b93f65f5929967533624b9235750c30707550b58536d109a7131c5a5bbe4a5715567c12534aec7660761eebb9fae2891c774589b80e566ad557ddef7367196b7227ea9870ef09ddfec79d6b9319a6879b5205d76bf7aba5acf33afb59d17fc54e68383d6be5a08e9b66da53dcde008bb294b8582bd132cdcc49959fdbc21e52721880c8ad0352c79f03a43bbd84c4cdfdc6c529005e1e7cd9a349a7168a35569ba5dea818968d5a91466bd6e64e20bf62417198afc4e81c28dd77ed4028232398b52fbde86bc84f475b9016710ce2aabc11a06b4dbac901ec16cf365ca3f2d53813948a693a0f93e79c46ca5d5a6dca3d28ca50ad18bd13fca55059dd9b185f79f9c47196a4e81b2104bc460a051e02f2e8444f",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      },
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1-pqc",
+        "algorithm": "ML-DSA-65",
+        "value": "dKmrzf4H9tQfiRpzsa7fYef0vbkEUs5eYTc/y5iVlaUU5YHl4/ADb0oO0DxPsx8ZZGjSbnC2Bv2gJR4vG5/H8GhUOqQTi9+o2t5e9RUgDEiON5C/e82LRAjDAJ5RjPXYRq3hB6v2Qf0+huNAKaypD1vNChc2juYpOl0zuwo5A5DUfLwmJ2E6REj9CozFyNhYoNVBvd4kKtt/53OICdBxYRDwHuA6AgJd2wF3adfN9Z4kaYnQ3EHdtm/fPcuqMbBd0Zj/rOiUsqHe7g5B5W4PCWCS4oECmAKBIghhmBBKGed5SGcKv6Btvnsh6t3A/uAxW4ctMNzyRa35Ptr4eaUIQ4DlaqKTHT6ErBxh4J4pmZw8/QREeHg6bMaJn+SeJHPLNnsDHbrtLIZXCw7kvcgBMfLRN+2DBCy3Cdh71ZaD3E/4lsI80TU6PyJ33Fxh1cDsphNg3OEBKY3pXXh58ZMlaHTPk9GxjLZxhaC3d0QYDAYUyL0PQ9HFYIVb07w4OfuweVcfkIBmzGK9Qo7yLWj7DAj1lvpkxboiAOjS5/jQI8aPWJPiIdLHFo/kYlyHZtENmucVE2Ew0HGAP4ZfVp8DnKdscBADlrdUJEoZNLoxX0se/z8DqVdVJjXV+M9ud6ns6H6V7wNZ85nwwf8+9ebRM5+ZsbCfRQHQiCLyr4kzZ8sFhKksEOT3dfWmKviJlUjEK7Er22hEfpYJo89FbNWIN/GZI//wyEnUkx4QogvewiWpXiNSwR39fbBRVvz3WjP7Bkkr9OO+Fq7cVDKHj3WTgzS3X+Dxr8m1klIhaueLVeoMKkYAsvsoPqL/T13+/W8GvYrhEPdkoGunxoh0AuhAfIS5wW6SdAxs6h4tRTko8Vq+LdUlm28ymCxN8VquBUA7nDUzv9fGnlQdBbN7Bj40vFwNtRbCLH0eJY8I4MtcrlWIKg4GT0fjjc3sjc1McjB+aneSl2JQfQhiBvEkuWQjJBuNAiDdpX3NMxDJ0s05WtNFJKIfvCPahYSaUyWwKIi/89ce1apyC8wvyrKLuIbGgNA96WgG85T/jh6Jy9iWjd2NdILYM9Blj8TV7lBhrpCf7vE9CCq8aubfWGxjRsdxM7TZWchEE2VCMPgg1TTdwVWHTSFScMpmVGFVwGuHDXstxUNZ8/PfMXSPugN4mjOC6Zm4W/zTuXk53Gy0U2E0VX1epT/Xbeb/f91V6sTdCavRb4QEiShP/UrW46/8RntjANei96ncC1odA8IGRlLU+MUXtFc2ZtFoU/7B9n9oquMEzRysbDbP0ZtEiqQGrgvGp4L/kqff0S7HrOQgkQBpKLowRWDaoB0+V1N0/jgxKFTRB7tzoR6MQKM0BDoLSb0eEvdoLNprfmh2AtZTgPc6ogBuVU0dj2phwcKhaGr1wc1o9k322fOj+55g5Y0/Oqp8HaGMpVpeSIMf8ttpGvrUnkwOECIloWdemU3D3S1/iqCyzStUmv1TquXv03qKLsb5QZQ9CX6lYDVWabagGs7/BF0z3wzUd1E0vTFzOsbHhwDfLFb02A4GWTufyiD9qTCR8bo23KVhtcDZqvW4sLYIj8yVp/adAU8Twnv1O1KM7T6vvw9rrSbd3RvjoagLlOTWoxD3ts27L1uG235YNte+8FGcoCrfTfr9udDfB3fc9HKChg1iqbMKkSH5X2UBzt8d3ZQHVlFHNpYXrH//jly7Vad8cXg0yj9zgcEELgvyIarI/THAOAibACNjfPe4kOJtXiVIuRLxfPyYkA1nyYX1hELfwRqSAoVCBDHocsilSp303qAI1ajDwarVRGvHyUnJ95SjP4uc/++nPLAe+5nF6tiuMaT4aKZQ8ZpnZbBu3huQBn2JqTAOfoU+5EsV0TCHJnpZYHEhVsxuVxZ0dxnNaf7P6QBeRBiNN0ySZznx2lUb6gve4tP0t0hlixgEJGWRb6PAE5gh2L8T7ymQIRZfZ5SaLhBW6NJEyzJ6hMeuEuHvX8eb1ZXatfry56y2UGOx+Z2WyOXQnCNQVG199F6RbJUuEEdUHJakVYePUXtJo1qgFOF66Bh12QKefvQn2Tpv62DqZrdCAo5AnBSCea0AnkpnP7sxi2iu3Nq8LKttY0zLUIWb2Snr9gCZwZ7ggz/aLLYww5EU61MCo/41A7gixdj6Y78pL3M8exEHwRauEo9F49xLrZNoWo+a5HfN6VEqW682osFDOBSvfk48ay8KoPYyaHCSazUgam/CfSiJ0GcjR4La8ILau8YWA+ahkFr2EgDSU+7tFVugYLw8/McELqRNhu7eyhwdQ9F9l69wROxHFTpLe44JzVBA5gpcFTU9DnNXEC2ao5k+w1Q2uWvl0SW5eNNxJQGxKHfOB6l9qFGHXJuuqy4KO1eyNGCecCqLAlBU+xlsBo5eqqy0iUIlMt2MB0AwFS/y+FHYtHIQsfLR3mp9gEz0jJDNhlmxtScYpIGINNNlVdyvbIycOy30QYdsrtd3bROVVCacWhfYWEslA5W7zTDXwKmsb2ll8uVmSSv0CIbcpRNWwRPTP1oAhHF/rOIVw/x3z1rh2BSzw0KBJn81q8uBJIrS1oXa0cs3T6yquZVKRDCm+5r2n8bahcz+CkWY5BJlEcHpKXPWDZLmR59jIs0xZYXqTwgM2TWxxpY9ffNkOQ2rFqX6G8uaL9GkM987kKmJ8X0DrSX+x2U3ZLKL4ey2xSvvdEBWFEsIHI9IkbQMKfGrDq0v0RQRzLS/GPMCjIvLm6NuUKBkyt5FP6i6PyT5HWTsddTc44fKcNCyT5SCp+rDgpe5nrm4Dnra3EIev+7u4l4NQ7MNHE8X9styIvmPPdjmG5sVHXahlin/siij++Gri0dw1nODX0hWeKS2yjn+rn9CaH7dnR5t0jMV/l2M6w0yGuXjp+q2bCGJfnmq6DJ2SgUwEFszI6RU0Irg12CX1uioeJ/S1+RkAn8I4K8Eh8TMuLdnY9qycmnPe0tUlzMCZ4HYia7NGVT6zPRtP8RwyWjWfAYaj6I/ljxnBFrdGhIi58AqOFl7ewLrnbPas/0IIPK2gupoAY9/f3NTQfMj13r4bLLgSwI1SsY8FnxA+6GjNW5VGdeb/oAjXDvkeG5yT0MLeT/OfcwlO7+1K9mKA50DN2iVLgbOgPW3PT8xAuVz4W3Ku+qcISkzulZ0R5UE6RbLCPSzzLPSmyloPnFRifcjFgy8UMrLn4vr3eJRTOCvPCu+pzrl/+lWxZnYLQ5PXENSQv2LlnryKAG1eL2+D/JvYJwUZ680dHCZGSbxxoAfdFwPxIOVvoBPLk4MlmwPaXfysfU8X39INGuKxvVyWKrdQNps909fBVLveQi152rHkOBYqFQKqLb2XvlKDiMQzUsWB32T2CLCbapT5DnomuVCPGPGkU/Ohay13v99BJgWengrpX7573cnUAvdGRD+7LK6NNQc0SurxMYj55SwsfjOC4cbZd62PYFK/iPJZYzDvcc+4UI0uPUMZTRaGTYLelRnvvtCijWqnd4dbUjGqe32LPlKV6CFHnLMbvz3VIfDIEWJyn2hS7L9FCCqBXMguGO2qLMTo0wRYo2VBPnu+DotyUDUMlbZelunF38nI3LJ13sYhL3NtrI1qnsbA91nH71gslZp5/lV+5+l7zrxcyzQxmpWZ1Eelg+w1ssmT6zIXbOOpCibp1GxAOF6Dx23YfDVdY35C/g6939T9zcjVrKBN9MDGRo7gngQbd+IT37O1aBa6Z+fH9/zFaPgAGjVXIQQb8uDwy8hDai2tst6KCcRLVZMPQSD4h/krw6iCgUUx5jk6MfJp1zoH73/OTZKixYEAW62y6E1g/yvdvxRoA5CxJTbJiySdZPEnQVL9L8gh8Sjp3HsjEy5vSb+0HiOdVniOlfPU5b05lJMEFy5taMgXKll5MZGliNawA031w8+1R4L2WUjeNrlzdQWc+Gez4Eh4TqnXbPrid5tsymbievRogXfw+SY5szjbqIvmhfSMh7tH+mzILrQ7gWboZrUt6usFI2XxtzDiueMqcTA+cR5GS3kwuY/qIW7lsdhEHULCEZTTgorX1WMRkY6N7Cv0dsvf7uuYEKflOcxQdZSaZO+6pMYRw5dynJAhsDG7uxv8/FKaGQAxttD49vN7trgsDNR1wNkwljV9hz6HcobiQJKO4EfYiQoAcGQlZxBTSjxyM7QIjUN2gcUVmlrB7MeHqr7eWLdqMSSwX0Jgjdkt4mb78SyaF1kRxJF+ICwUP3Igi1kuslQVX0tfOgGOFed0GXnO0BqHn5YG/7PmTY7Iu0qTtr8QXYbT8f7zsrsHlICmhhFzpjT1OcwfyzKvxckrjutFQwIFF8BP1ujvc3g7fUYGmmEvO2FrLXu9v8CKUxfcpPxISIlQk1tqOIJMLb7AAAAAAAAAAAAAAAAAAAACQ8VHCQo"
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-baseline-valid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-baseline-valid.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/baseline-valid",
+  "description": "A baseline ATX v1.1 credential. The single Ed25519 signature covers JCS(TBS) per atx-spec core.md §1.3a.2, so capabilities, scanSummary, issuerChain, publisher, and behavioralProfile are integrity-protected. Verifier MUST ACCEPT. The canonical bytes equal the jcs-vectors baseline vector.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-cross-issuer-key.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-cross-issuer-key.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/cross-issuer-key",
+  "description": "An ATX v1.1 credential issued by the primary authority but signed by a different trusted authority's key (partner.example). The secondary authority is trusted and its key is configured, and the signature is valid over JCS(TBS), but the secondary is neither the issuer nor present in the signed issuerChain. A spec-conformant verifier binds each signature to a key controlled by the issuer (or a signed issuerChain authority) and MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    },
+    {
+      "role": "issuer-secondary",
+      "path": "vectors/issuer-secondary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+      "keyId": "did:opena2a:authority:partner.example#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:partner.example"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      },
+      {
+        "role": "issuer-secondary",
+        "path": "vectors/issuer-secondary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
+        "keyId": "did:opena2a:authority:partner.example#key-1"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "algorithm": "Ed25519",
+        "value": "VIoRLMLXWSQJosyTSMpnORfH1oMv9pfWYoehAwyASHRJ03cL7MuErJ/0vu7jziGur8meBaleSNP3D3ETLTXmBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-valid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-valid.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-valid",
+  "description": "A baseline ATX v1.1 credential carrying a populated declaredPurpose (atx-spec §1.5): vocabVersion, statement, category, taskScopes, capabilityJustification, autonomy, dataScopes, egressScopes. declaredPurpose is the one presence-based TBS member (§1.3a.2 rule 5); when present it is signed as part of JCS(TBS). Verifier MUST ACCEPT. Canonical bytes equal the jcs-vectors 08-declared-purpose vector.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "financial-operations",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-tampered-capabilities.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-tampered-capabilities.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/tampered-capabilities",
+  "description": "An ATX v1.1 credential whose capabilities were escalated to include admin:all AFTER signing. Because v1.1 signs JCS(TBS), capabilities are covered by the signature; the verifier recomputes the canonical bytes, finds they no longer match, and MUST REJECT with a signature-validation reason. This is the integrity property v1.0 lacked.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned",
+      "admin:all"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-tampered-declared-purpose.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-tampered-declared-purpose.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/tampered-declared-purpose",
+  "description": "An ATX v1.1 credential whose declaredPurpose.category was rewritten from financial-operations to agent-orchestration AFTER signing. Because v1.1 signs JCS(TBS) and declaredPurpose is part of it, the verifier recomputes the canonical bytes, finds they no longer match the signature, and MUST REJECT. This is the integrity property that makes a declared purpose binding and non-repudiable (§1.5).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "agent-orchestration",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}


### PR DESCRIPTION
## Summary

Closes the two P0 code items from the 2026-07-02 AIM spec-gap report (roadmap: aim-spec-gap-closure).

### Trust scoring — AIP-SPEC §6.1 conformance (with an anti-gaming ceiling)

The 9-factor calculator silently scored compliance/drift/user-feedback as a fabricated neutral 0.5 when their optional repositories were un-wired or empty, while keeping their full weight — violating AIP §6.1 ("Factors with no data are excluded and their weights redistributed proportionally") and presenting unmeasured values as measurements.

- Factors with no data (un-wired repo, failed query, or genuinely empty) are now **excluded** and the remaining weights renormalized.
- **Anti-gaming ceiling** (found by adversarial review of the first cut): pure renormalization hands an excluded factor the agent's own included average, so withholding compliance snapshots would have *outscored* a measured 0.9 compliance. The published composite is now `min(renormalized, neutral-imputed)` — missing data can never help more than a neutral measurement would; poor agents keep the honest renormalized value instead of being propped toward 0.5. Pinned by `TestTrustCalculator_Calculate_WithholdingCannotBeatMeasuredGood` and companions.
- Un-wired/query-failure exclusions log loudly (deployment defect; production `main.go` wires everything); no-data exclusions are silent lifecycle states. Excluded compliance/feedback no longer contribute confidence.
- `excludedFactors` surfaced on the calculate, GET, and breakdown responses (fresh-calculation path) so consumers never read placeholder factor values as measurements.
- Companion spec erratum ratifying the ceiling into AIP-SPEC §6.1 is opening in agent-identity-protocol.

### ATX conformance CI gate

`ci.yml` gains an `atx-conformance` job (wired into the fan-in CI Gate, path-filtered like backend/frontend):

1. Clones opena2a-standards/atx-conformance at a pinned ref (`b2de783`), verifies `MANIFEST.sha256`.
2. Byte-checks the vendored Java test fixtures against the pinned suite (both directions, fail-closed).
3. Runs the Java `LocalAtxVerifier` conformance tests — now against **all 15** pinned fixtures (was 9). The six new v1_1 fixtures immediately caught a real bug: the Java v1.1 TBS omitted `declaredPurpose` (atx-spec §1.5 / §1.3a.2 rule 5), false-rejecting valid declared-purpose credentials — fixed in `AtxCanonicalizer`.
4. New Go test replays every pinned credential as a Registry issuance response and asserts AIM's issuance path preserves the signed bytes verbatim (`Raw` pass-through) with element-wise decode fidelity; a grep guard keeps the step from passing on a silent skip.

### Docs

ROADMAP.md TS-SDK self-contradiction fixed; `docs/sdk/trust-scoring.md` liveness matrix rewritten for the composition rule; `docs/API.md` trust-score example matched to the real handler response.

## Testing

- Full backend `go test -race ./...` green (rebased on main).
- Java atx package 36/36 (15/15 conformance fixtures).
- Go byte-match 15/15 against the pinned suite.
- HMA `secure --ci` 100/100; 8-phase pre-push review passed (incl. adversarial self-review; its HIGH + 2 MEDIUM findings are fixed in the third commit).

## Known follow-ups (filed, not in scope)

- `trust_scores` persistence still stores only 8 factor columns (`execution_isolation` never persisted — pre-existing) and does not persist exclusions, so stored renormalized scores aren't reproducible from the row alone; needs a migration.
- Reference-verifier divergence on degenerate `declaredPurpose` inputs (whitespace-empty object, non-object values) needs fixtures + alignment in atx-conformance (issue being filed upstream).

https://claude.ai/code/session_01RJ3s1nN22u6Cg2LLEhzXdt