### PR TITLE
fix(sdk-ts): make the Fastify plugin work through fastify.register + close packaging gaps

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -57,7 +57,7 @@ console.log(`Trust score: ${result.trustScore}`);
 
 ```typescript
 import express from 'express';
-import { createAIMMiddleware, verifyAction } from '@opena2a/aim-sdk/express';
+import { createAIMMiddleware, verifyAction, aimErrorHandler } from '@opena2a/aim-sdk/express';
 
 const app = express();
 
@@ -81,6 +81,11 @@ app.get('/api/profile', (req, res) => {
   const { agentId, trustScore } = req.aim ?? {};
   res.json({ agentId, trustScore });
 });
+
+// Optional: map SDK errors thrown in later handlers to HTTP responses
+// (ActionDeniedError -> 403, AuthenticationError -> 401). aimErrorHandler IS
+// the four-argument handler — pass it to app.use, do not call it.
+app.use(aimErrorHandler);
 ```
 
 ## Fastify Integration
@@ -173,9 +178,13 @@ The SDK can correlate *why* a blocked agent action happened by joining three
 signals around one verified action: the authorization outcome (an observed
 fact), the classified intent, and the injection cause (both inferences). The
 full **correlated record** is authoritative and stays on the machine; only an
-anonymized **shared indicator** is ever uploaded.
+anonymized **shared indicator** is ever uploaded. This section covers the
+causal-denial channel only — the runtime-protection module ships a separate
+structural-signature channel that is **on by default**; see the Runtime
+Protection section for its scope and opt-out.
 
-Telemetry is **off by default** and gated by two independent opt-ins:
+The causal-denial channel is **off by default** and gated by two independent
+opt-ins:
 
 1. **Capture** (`telemetry.enabled`) — mints a correlation ID per `verifyAction`,
    assembles records, and appends them to a local log at
@@ -287,6 +296,33 @@ to "no classification" — it never fabricates a label and never blocks.
 detection outputs flow through the `telemetry.detection` seam into the
 correlated record; they never enter `verifyAction`'s allow/deny decision.
 
+**Structural signature telemetry (on by default, opt-out).** Unlike the
+opt-in causal-denial channel above, the ARP engine shares **structural attack
+signatures** by default: when a detection fires, the structural shape of the
+event sequence — technique identifier, event-type sequence, severity, and a
+one-way hash of structural tokens — is signed and reported to the OpenA2A
+registry (`https://api.oa2a.org`), so an attack shape first seen at one
+deployment can protect others. Prompts, model responses, tool arguments, file
+contents or paths, command lines, environment values, secrets, IP addresses,
+hostnames, and account, tool, agent, and model names are never shared. A
+one-time disclosure is printed before first collection, and every payload is
+appended to a local audit log (`~/.opena2a/telemetry-audit.log`, JSONL) before
+it is sent. Opt out with any one of:
+
+- `OPENA2A_TELEMETRY_OPTOUT=1` (or `ARP_TELEMETRY_DISABLED=1`) in the
+  environment,
+- `signatureTelemetry: { enabled: false }` in your ARP config, or
+- `writeOptOutMarker()` from `@opena2a/aim-sdk/arp`, which persists
+  `~/.opena2a/telemetry-optout` across processes.
+
+Any one of these is the runtime-protection module's master switch: it disables
+every telemetry channel the module can produce (structural signatures and the
+opt-in legacy GTIN runtime channel). The causal-denial channel above is
+controlled solely by its own `telemetry` client config and is off unless you
+enabled it. To also delete signatures this sensor already shared, call
+`purgeRemoteSignatures()` (right-to-delete; best-effort, never blocks the
+local opt-out).
+
 ## Configuration
 
 ### Environment Variables
@@ -360,6 +396,14 @@ try {
 }
 ```
 
+> **Class identity is per entry point.** Each entry point (`.`, `/arp`,
+> `/express`, `/fastify`) bundles its own copy of the error classes, so
+> `instanceof` only matches errors raised by the same entry point you imported
+> from. When you use an integration, import the error classes from that same
+> integration (`@opena2a/aim-sdk/express` and `/fastify` re-export the full
+> error family); for checks that must work across entry points, match on
+> `error.code` (e.g. `'ACTION_DENIED'`) instead.
+
 ## Credential Management
 
 ```typescript
@@ -395,7 +439,10 @@ client.setCredentials(saved);
 
 ### Types
 
-See [src/types/index.ts](./src/types/index.ts) for complete type definitions.
+See
+[src/types/index.ts](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/typescript/src/types/index.ts)
+for complete type definitions (source is not shipped in the npm package; the
+bundled `.d.ts` files carry the same types).
 
 ## License
 
@@ -403,4 +450,6 @@ Apache-2.0
 
 ## Contributing
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See
+[CONTRIBUTING.md](https://github.com/opena2a-org/agent-identity-management/blob/main/CONTRIBUTING.md)
+for guidelines.

--- a/sdk/typescript/express/package.json
+++ b/sdk/typescript/express/package.json
@@ -1,0 +1,7 @@
+{
+  "//": "Folder stub so tooling using legacy node10 module resolution (which ignores the exports map) can resolve '@opena2a/aim-sdk/express'. Node itself resolves the subpath through the root exports map.",
+  "main": "../dist/integrations/express.js",
+  "module": "../dist/integrations/express.mjs",
+  "types": "../dist/integrations/express.d.ts",
+  "sideEffects": false
+}

--- a/sdk/typescript/fastify/package.json
+++ b/sdk/typescript/fastify/package.json
@@ -1,0 +1,7 @@
+{
+  "//": "Folder stub so tooling using legacy node10 module resolution (which ignores the exports map) can resolve '@opena2a/aim-sdk/fastify'. Node itself resolves the subpath through the root exports map.",
+  "main": "../dist/integrations/fastify.js",
+  "module": "../dist/integrations/fastify.mjs",
+  "types": "../dist/integrations/fastify.d.ts",
+  "sideEffects": false
+}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/ed25519": "^2.1.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/atx-verify": "0.2.0",
+        "fastify-plugin": "^6.0.0",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {
@@ -2599,6 +2600,22 @@
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -23,6 +23,7 @@
         "@typescript-eslint/parser": "^6.13.0",
         "eslint": "^8.55.0",
         "fastify": "^5.6.2",
+        "fastify4": "npm:fastify@^4.29.1",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0",
         "vitest": "^1.0.0"
@@ -2433,6 +2434,13 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
+      "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -2617,6 +2625,285 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fastify4": {
+      "name": "fastify",
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.29.1.tgz",
+      "integrity": "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.5.0",
+        "@fastify/error": "^3.4.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.3.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
+        "find-my-way": "^8.0.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^9.0.0",
+        "process-warning": "^3.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
+      }
+    },
+    "node_modules/fastify4/node_modules/@fastify/ajv-compiler": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
+      "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/fastify4/node_modules/@fastify/ajv-compiler/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastify4/node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+      "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/@fastify/error": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/fastify4/node_modules/@fastify/merge-json-schemas": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
+      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/fastify4/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fastify4/node_modules/avvio": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
+      "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^3.3.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/fastify4/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fastify4/node_modules/fast-json-stringify": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
+      "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.1.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^3.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "json-schema-ref-resolver": "^1.0.1",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify4/node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+      "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/find-my-way": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/fastify4/node_modules/json-schema-ref-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
+      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/fastify4/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/light-my-request": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "process-warning": "^3.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "node_modules/fastify4/node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/fastify4/node_modules/pino/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastify4/node_modules/ret": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
+      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fastify4/node_modules/safe-regex2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
+      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.4.0"
+      }
+    },
+    "node_modules/fastify4/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2718,6 +3005,16 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3760,6 +4057,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -30,6 +30,8 @@
   "files": [
     "dist",
     "arp",
+    "express",
+    "fastify",
     "README.md",
     "LICENSE"
   ],
@@ -73,6 +75,7 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/atx-verify": "0.2.0",
+    "fastify-plugin": "^6.0.0",
     "js-yaml": "^4.1.1"
   },
   "devDependencies": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -86,6 +86,7 @@
     "@typescript-eslint/parser": "^6.13.0",
     "eslint": "^8.55.0",
     "fastify": "^5.6.2",
+    "fastify4": "npm:fastify@^4.29.1",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^1.0.0"

--- a/sdk/typescript/src/integrations/fastify.test.ts
+++ b/sdk/typescript/src/integrations/fastify.test.ts
@@ -426,3 +426,62 @@ describe('Fastify exports', () => {
     expect(AIMClient).toBeDefined();
   });
 });
+
+// Regression tests for the encapsulation defect: the mocked-instance tests
+// above invoke the plugin function directly, which cannot catch decorations
+// being trapped in the plugin's own child context. These register the plugin
+// through a REAL Fastify instance and exercise routes defined on the root
+// instance — the way the README tells users to wire it.
+describe('aimPlugin through fastify.register (real instance)', () => {
+  it('populates request.aim on routes registered outside the plugin', async () => {
+    const { default: Fastify } = await import('fastify');
+    const app = Fastify();
+    await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
+    app.get('/whoami', async (request) => ({
+      hasClient: Boolean(request.aim?.client),
+      verified: request.aim?.verified ?? null,
+    }));
+
+    const res = await app.inject({ method: 'GET', url: '/whoami' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ hasClient: true, verified: false });
+    await app.close();
+  });
+
+  it('verifyAction preHandler works on a root-instance route (was 500 "AIM plugin not initialized")', async () => {
+    const { default: Fastify } = await import('fastify');
+    const app = Fastify();
+    await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
+    app.post(
+      '/api/data',
+      { preHandler: verifyAction('data:write') },
+      async () => ({ success: true })
+    );
+
+    const res = await app.inject({ method: 'POST', url: '/api/data' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true });
+    await app.close();
+  });
+
+  it('maps ActionDeniedError thrown by a root-instance handler to 403', async () => {
+    const { default: Fastify } = await import('fastify');
+    const app = Fastify();
+    await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
+    app.get('/deny', async () => {
+      throw new ActionDeniedError('file:delete', 'trust score below threshold', 0.2);
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/deny' });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toMatchObject({
+      error: 'Action denied',
+      action: 'file:delete',
+      reason: 'trust score below threshold',
+    });
+    await app.close();
+  });
+});

--- a/sdk/typescript/src/integrations/fastify.test.ts
+++ b/sdk/typescript/src/integrations/fastify.test.ts
@@ -432,9 +432,23 @@ describe('Fastify exports', () => {
 // being trapped in the plugin's own child context. These register the plugin
 // through a REAL Fastify instance and exercise routes defined on the root
 // instance — the way the README tells users to wire it.
-describe('aimPlugin through fastify.register (real instance)', () => {
+//
+// Both peer majors are exercised: 'fastify' resolves the v5 devDependency,
+// 'fastify4' is an npm alias for fastify@^4. fastify-plugin@6 declares no
+// peerDependencies — the '4.x || 5.x' range passed to fp() is validated by
+// fastify itself at register time, so this matrix is what actually proves
+// the peer range in package.json.
+describe.each([
+  ['fastify 5', 'fastify'],
+  ['fastify 4', 'fastify4'],
+])('aimPlugin through %s register (real instance)', (_label, fastifyModule) => {
+  // Non-literal specifier: resolved at runtime (both aliases are installed),
+  // and TypeScript does not demand declarations for the alias.
+  const loadFastify = async () =>
+    ((await import(fastifyModule)) as { default: typeof import('fastify').default }).default;
+
   it('populates request.aim on routes registered outside the plugin', async () => {
-    const { default: Fastify } = await import('fastify');
+    const Fastify = await loadFastify();
     const app = Fastify();
     await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
     app.get('/whoami', async (request) => ({
@@ -450,7 +464,7 @@ describe('aimPlugin through fastify.register (real instance)', () => {
   });
 
   it('verifyAction preHandler works on a root-instance route (was 500 "AIM plugin not initialized")', async () => {
-    const { default: Fastify } = await import('fastify');
+    const Fastify = await loadFastify();
     const app = Fastify();
     await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
     app.post(
@@ -467,7 +481,7 @@ describe('aimPlugin through fastify.register (real instance)', () => {
   });
 
   it('maps ActionDeniedError thrown by a root-instance handler to 403', async () => {
-    const { default: Fastify } = await import('fastify');
+    const Fastify = await loadFastify();
     const app = Fastify();
     await app.register(aimPlugin, { baseUrl: 'http://localhost:9' });
     app.get('/deny', async () => {

--- a/sdk/typescript/src/integrations/fastify.ts
+++ b/sdk/typescript/src/integrations/fastify.ts
@@ -118,6 +118,11 @@ const aimPluginCallback: FastifyPluginCallback<AIMPluginOptions> = (
  * ```
  */
 export const aimPlugin = fp(aimPluginCallback, {
+  // This range is metadata that fastify itself validates against its own
+  // version at register time; it is NOT a fastify-plugin version constraint.
+  // fastify-plugin@6 is dependency-free and declares no peerDependencies, so
+  // it imposes nothing on which fastify major the consumer runs. Both peer
+  // majors are covered by the register-matrix tests in fastify.test.ts.
   fastify: '4.x || 5.x',
   name: '@opena2a/aim-sdk',
 });

--- a/sdk/typescript/src/integrations/fastify.ts
+++ b/sdk/typescript/src/integrations/fastify.ts
@@ -9,6 +9,7 @@ import type {
   FastifyPluginCallback,
   preHandlerAsyncHookHandler,
 } from 'fastify';
+import fp from 'fastify-plugin';
 import { AIMClient } from '../client/AIMClient';
 import type { AIMClientConfig, VerifyActionOptions } from '../types';
 import { ActionDeniedError, AuthenticationError } from '../exceptions';
@@ -35,23 +36,7 @@ export interface AIMPluginOptions extends AIMClientConfig {
   skipPaths?: string[];
 }
 
-/**
- * AIM Fastify Plugin
- *
- * @example
- * ```typescript
- * import Fastify from 'fastify';
- * import { aimPlugin } from '@opena2a/aim-sdk/fastify';
- *
- * const fastify = Fastify();
- *
- * await fastify.register(aimPlugin, {
- *   baseUrl: 'https://aim.example.com',
- *   apiKey: 'your-api-key',
- * });
- * ```
- */
-export const aimPlugin: FastifyPluginCallback<AIMPluginOptions> = (
+const aimPluginCallback: FastifyPluginCallback<AIMPluginOptions> = (
   fastify: FastifyInstance,
   options: AIMPluginOptions,
   done: (err?: Error) => void
@@ -109,6 +94,33 @@ export const aimPlugin: FastifyPluginCallback<AIMPluginOptions> = (
 
   done();
 };
+
+/**
+ * AIM Fastify Plugin
+ *
+ * Wrapped with fastify-plugin: without the skip-override wrap, everything the
+ * plugin registers (decorateRequest, the onRequest hook, the error handler)
+ * stays inside the plugin's own encapsulation context and never applies to
+ * routes the user defines — verifyAction then fails every request with
+ * "AIM plugin not initialized".
+ *
+ * @example
+ * ```typescript
+ * import Fastify from 'fastify';
+ * import { aimPlugin } from '@opena2a/aim-sdk/fastify';
+ *
+ * const fastify = Fastify();
+ *
+ * await fastify.register(aimPlugin, {
+ *   baseUrl: 'https://aim.example.com',
+ *   apiKey: 'your-api-key',
+ * });
+ * ```
+ */
+export const aimPlugin = fp(aimPluginCallback, {
+  fastify: '4.x || 5.x',
+  name: '@opena2a/aim-sdk',
+});
 
 /**
  * Create a preHandler hook for action verification


### PR DESCRIPTION
## Summary

Pre-publish release testing of `@opena2a/aim-sdk` 1.0.0 (zero-context walkthrough against the packed tarball) found two release blockers and a documentation honesty gap. All are fixed here; the first publish tag waits on this PR.

### Fastify integration was unusable as documented (release blocker)

`aimPlugin` was a bare plugin callback, so `fastify.register` trapped its request decoration, `onRequest` hook, and error handler inside the plugin's own encapsulation context. No user-registered route ever saw `request.aim`, and `verifyAction` failed every request with `500 {"error":"AIM plugin not initialized"}`.

Fix: wrap the plugin with `fastify-plugin` (new runtime dependency; fastify core team, dependency-free), declared range `4.x || 5.x` to match the peer range. Verified end-to-end against the packed tarball on fastify 5.6.2 and 4.29.1: root-instance route with `verifyAction` preHandler now returns `401 {"error":"Authentication required","message":"No credentials available. Register an agent first."}` — same behavior as the Express integration.

The existing tests invoked the plugin function directly against a mocked instance, which cannot catch encapsulation defects. New regression tests register through a real Fastify instance and exercise root-instance routes; all three fail without the wrap (verified by stashing the fix).

### node10 type resolution missing for the integrations (release blocker)

Legacy `moduleResolution: node10` resolved `.` and `./arp` (which has a folder stub) but not `./express` / `./fastify`. Shipped matching folder stubs and added them to `files`. Verified all four subpaths compile under node10 from the tarball.

### README corrections (honesty + dead ends)

- The telemetry section read as if all telemetry were opt-in ("Telemetry is off by default"). The ARP structural-signature channel is **on by default** (ratified opt-out posture). The README now documents that channel: scope (what is and is never shared), the one-time disclosure, the local audit log, all three master opt-out mechanisms, and `purgeRemoteSignatures()` for right-to-delete. The off-by-default claim is now correctly scoped to the causal-denial channel.
- Documented `aimErrorHandler` (it is the four-argument handler, not a factory — passing `aimErrorHandler()` crashes at startup in plain JS).
- Documented that error-class identity is per entry point (each bundle carries its own class copies; `instanceof` does not match across entry points — use `error.code`).
- Pointed the types and CONTRIBUTING links at URLs that resolve from the npm package (previous relative links were dead for npm consumers).

## Testing

- `npm test`: 980 passed, 36 skipped (977 before + 3 new regression tests).
- Regression tests confirmed to fail without the fastify-plugin wrap.
- Packed-tarball verification: fastify e2e on v5.6.2 and v4.29.1; node10/node16/bundler TS resolution across all four subpaths.
- README claims re-verified against the code (audit-log path, opt-out sources, purge export, master-switch scope).

