### PR TITLE
Persist execution_isolation and excluded_factors on trust scores

### DIFF
--- a/apps/backend/internal/application/trust_score_mirror_trigger_integration_test.go
+++ b/apps/backend/internal/application/trust_score_mirror_trigger_integration_test.go
@@ -42,27 +42,35 @@ func TestTrustScoreMirrorTrigger_InsertSyncsAgentCache(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "trust-score-mirror-test-org-"+agentID.String()[:8])
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "trust-score-mirror-test-org-"+agentID.String()[:8],
+		"trust-score-mirror-test-"+agentID.String()[:8]+".test")
+	require.NoError(t, err)
+	userID := uuid.New()
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID) })
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'trust-score-mirror-test-user', 'test', $4, NOW(), NOW())`,
+		userID, orgID, "trust-score-mirror-test-"+agentID.String()[:8]+"@test.invalid",
+		"trust-score-mirror-test-"+userID.String()[:8])
 	require.NoError(t, err)
 
 	// Agent starts with a stale cache value of 0.500.
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.500, NOW(), NOW())`,
-		agentID, orgID, "trust-score-mirror-test-agent-"+agentID.String()[:8])
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $3, 'ai_agent', 'verified', 0.500, $4, NOW(), NOW())`,
+		agentID, orgID, "trust-score-mirror-test-agent-"+agentID.String()[:8], userID)
 	require.NoError(t, err)
 
 	// INSERT a new score row. The trigger must mirror to agents.trust_score.
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO trust_scores
 		   (id, agent_id, score,
-		    verification_status, certificate_validity, repository_quality,
-		    documentation_score, community_trust, security_audit,
-		    update_frequency, age_score, confidence,
-		    last_calculated, created_at)
-		 VALUES (gen_random_uuid(), $1, 0.823,
+		    verification_status, uptime, success_rate, security_alerts,
+		    compliance, age, drift_detection, user_feedback,
+		    confidence, last_calculated, created_at)
+		 VALUES (gen_random_uuid(), $1, 0.820,
 		         0.9, 0.8, 0.7, 0.6, 0.85, 0.9, 0.7, 0.8, 0.95,
 		         NOW(), NOW())`,
 		agentID)
@@ -73,7 +81,9 @@ func TestTrustScoreMirrorTrigger_InsertSyncsAgentCache(t *testing.T) {
 		`SELECT trust_score FROM agents WHERE id = $1`, agentID,
 	).Scan(&agentScore)
 	require.NoError(t, err)
-	require.InDelta(t, 0.823, agentScore, 0.001,
+	// agents.trust_score carries two fractional digits; keep the fixture
+	// representable so the mirrored value compares exactly.
+	require.InDelta(t, 0.820, agentScore, 0.001,
 		"trigger must mirror trust_scores.score onto agents.trust_score on INSERT")
 }
 
@@ -101,14 +111,23 @@ func TestTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "trust-score-update-test-org-"+agentID.String()[:8])
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "trust-score-update-test-org-"+agentID.String()[:8],
+		"trust-score-update-test-"+agentID.String()[:8]+".test")
+	require.NoError(t, err)
+	userID := uuid.New()
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID) })
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'trust-score-update-test-user', 'test', $4, NOW(), NOW())`,
+		userID, orgID, "trust-score-update-test-"+agentID.String()[:8]+"@test.invalid",
+		"trust-score-update-test-"+userID.String()[:8])
 	require.NoError(t, err)
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.500, NOW(), NOW())`,
-		agentID, orgID, "trust-score-update-test-agent-"+agentID.String()[:8])
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $3, 'ai_agent', 'verified', 0.500, $4, NOW(), NOW())`,
+		agentID, orgID, "trust-score-update-test-agent-"+agentID.String()[:8], userID)
 	require.NoError(t, err)
 
 	// Seed two trust_scores rows: an older one and a newer one.
@@ -117,8 +136,8 @@ func TestTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
 	olderCreatedAt := time.Now().UTC().Add(-1 * time.Hour)
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO trust_scores
-		   (id, agent_id, score, verification_status, certificate_validity, repository_quality,
-		    documentation_score, community_trust, security_audit, update_frequency, age_score,
+		   (id, agent_id, score, verification_status, uptime, success_rate,
+		    security_alerts, compliance, age, drift_detection, user_feedback,
 		    confidence, last_calculated, created_at)
 		 VALUES ($1, $2, 0.600, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.9, $3, $3)`,
 		olderID, agentID, olderCreatedAt)
@@ -127,8 +146,8 @@ func TestTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
 	// Newer row inserts; trigger fires; cache moves to 0.900.
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO trust_scores
-		   (id, agent_id, score, verification_status, certificate_validity, repository_quality,
-		    documentation_score, community_trust, security_audit, update_frequency, age_score,
+		   (id, agent_id, score, verification_status, uptime, success_rate,
+		    security_alerts, compliance, age, drift_detection, user_feedback,
 		    confidence, last_calculated, created_at)
 		 VALUES ($1, $2, 0.900, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.95, NOW(), NOW())`,
 		newerID, agentID)

--- a/apps/backend/internal/domain/trust_score.go
+++ b/apps/backend/internal/domain/trust_score.go
@@ -48,8 +48,10 @@ type TrustScore struct {
 	// AIP-SPEC §6.1 composition rule (no data or un-wired source; their
 	// weights are redistributed proportionally across measured factors). The
 	// corresponding Factors fields carry neutral display placeholders, not
-	// measurements. Sorted; populated on fresh calculations only — the field
-	// is not persisted, so scores read back from storage omit it.
+	// measurements. Sorted. Persisted in trust_scores.excluded_factors
+	// (migration 103) so a stored capped or renormalized composite is
+	// reproducible from its row; rows predating the migration read back as
+	// empty (all factors treated as measured).
 	ExcludedFactors []string `json:"excludedFactors,omitempty"`
 
 	Confidence     float64   `json:"confidence"` // 0-1

--- a/apps/backend/internal/infrastructure/repository/trust_score_repository.go
+++ b/apps/backend/internal/infrastructure/repository/trust_score_repository.go
@@ -2,9 +2,11 @@ package repository
 
 import (
 	"database/sql"
-	"github.com/google/uuid"
-	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
 type TrustScoreRepository struct {
@@ -16,15 +18,17 @@ func NewTrustScoreRepository(db *sql.DB) *TrustScoreRepository {
 }
 
 func (r *TrustScoreRepository) Create(score *domain.TrustScore) error {
-	// 8-factor trust scoring system
+	// 9-factor trust scoring system (execution_isolation column: migration 090;
+	// excluded_factors column: migration 103)
 	query := `
 		INSERT INTO trust_scores (
 			id, agent_id, score,
 			verification_status, uptime, success_rate, security_alerts,
 			compliance, age, drift_detection, user_feedback,
+			execution_isolation, excluded_factors,
 			confidence, last_calculated, created_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 	`
 
 	if score.ID == uuid.Nil {
@@ -49,6 +53,8 @@ func (r *TrustScoreRepository) Create(score *domain.TrustScore) error {
 		score.Factors.Age,
 		score.Factors.DriftDetection,
 		score.Factors.UserFeedback,
+		score.Factors.ExecutionIsolation,
+		pq.Array(excludedOrEmpty(score.ExcludedFactors)),
 		score.Confidence,
 		score.LastCalculated,
 		score.CreatedAt,
@@ -56,17 +62,27 @@ func (r *TrustScoreRepository) Create(score *domain.TrustScore) error {
 	return err
 }
 
+// excludedOrEmpty keeps the NOT NULL excluded_factors column honest: a nil
+// slice means "all nine factors measured" and is stored as the empty array.
+func excludedOrEmpty(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
+}
+
 func (r *TrustScoreRepository) GetByAgent(agentID uuid.UUID) (*domain.TrustScore, error) {
 	return r.GetLatest(agentID)
 }
 
 func (r *TrustScoreRepository) GetLatest(agentID uuid.UUID) (*domain.TrustScore, error) {
-	// 8-factor trust scoring system
+	// 9-factor trust scoring system
 	query := `
 		SELECT
 			id, agent_id, score,
 			verification_status, uptime, success_rate, security_alerts,
 			compliance, age, drift_detection, user_feedback,
+			execution_isolation, excluded_factors,
 			confidence, last_calculated, created_at
 		FROM trust_scores
 		WHERE agent_id = $1
@@ -87,6 +103,8 @@ func (r *TrustScoreRepository) GetLatest(agentID uuid.UUID) (*domain.TrustScore,
 		&score.Factors.Age,
 		&score.Factors.DriftDetection,
 		&score.Factors.UserFeedback,
+		&score.Factors.ExecutionIsolation,
+		pq.Array(&score.ExcludedFactors),
 		&score.Confidence,
 		&score.LastCalculated,
 		&score.CreatedAt,
@@ -99,12 +117,13 @@ func (r *TrustScoreRepository) GetLatest(agentID uuid.UUID) (*domain.TrustScore,
 }
 
 func (r *TrustScoreRepository) GetHistory(agentID uuid.UUID, limit int) ([]*domain.TrustScore, error) {
-	// 8-factor trust scoring system
+	// 9-factor trust scoring system
 	query := `
 		SELECT
 			id, agent_id, score,
 			verification_status, uptime, success_rate, security_alerts,
 			compliance, age, drift_detection, user_feedback,
+			execution_isolation, excluded_factors,
 			confidence, last_calculated, created_at
 		FROM trust_scores
 		WHERE agent_id = $1
@@ -133,6 +152,8 @@ func (r *TrustScoreRepository) GetHistory(agentID uuid.UUID, limit int) ([]*doma
 			&score.Factors.Age,
 			&score.Factors.DriftDetection,
 			&score.Factors.UserFeedback,
+			&score.Factors.ExecutionIsolation,
+			pq.Array(&score.ExcludedFactors),
 			&score.Confidence,
 			&score.LastCalculated,
 			&score.CreatedAt,

--- a/apps/backend/internal/infrastructure/repository/trust_score_repository_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/trust_score_repository_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// TestTrustScoreRepository_RoundTripNineFactorsAndExclusions pins the
+// persistence contract that was silently broken until migration 103's
+// companion repository change: factor 9 (execution_isolation, 10% weight)
+// was absent from the INSERT/SELECT column lists, so it was dropped on
+// write and read back as 0; ExcludedFactors was API-response-only, so a
+// stored AIP-SPEC 6.1 capped/renormalized composite was not reproducible
+// from its row.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL with
+// migrations through 103 applied.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestTrustScoreRepository_RoundTrip ./internal/infrastructure/repository/...
+func TestTrustScoreRepository_RoundTripNineFactorsAndExclusions(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping repository round-trip test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	userID := uuid.New()
+	agentID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM trust_scores WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "trust-persistence-test-org-"+agentID.String()[:8],
+		"trust-persistence-"+agentID.String()[:8]+".test")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'trust-persistence-test-user', 'test', $4, NOW(), NOW())`,
+		userID, orgID, "trust-persistence-"+agentID.String()[:8]+"@test.invalid",
+		"trust-persistence-test-"+userID.String()[:8])
+	require.NoError(t, err)
+
+	agentName := "trust-persistence-test-agent-" + agentID.String()[:8]
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $3, 'ai_agent', 'verified', 0.500, $4, NOW(), NOW())`,
+		agentID, orgID, agentName, userID)
+	require.NoError(t, err)
+
+	repo := NewTrustScoreRepository(db)
+
+	written := &domain.TrustScore{
+		AgentID: agentID,
+		// trust_scores.score is DECIMAL with 3 fractional digits; keep the
+		// fixture representable so the round-trip assertion is exact.
+		Score: 0.813,
+		Factors: domain.TrustScoreFactors{
+			VerificationStatus: 1.0,
+			Uptime:             0.95,
+			SuccessRate:        0.9,
+			SecurityAlerts:     1.0,
+			Compliance:         0.5, // neutral placeholder for an excluded factor
+			Age:                0.4,
+			DriftDetection:     1.0,
+			UserFeedback:       0.5, // neutral placeholder for an excluded factor
+			ExecutionIsolation: 0.75,
+		},
+		ExcludedFactors: []string{"compliance", "user_feedback"},
+		Confidence:      0.77,
+		LastCalculated:  time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, repo.Create(written))
+
+	read, err := repo.GetLatest(agentID)
+	require.NoError(t, err)
+	require.NotNil(t, read)
+
+	// The regression this test exists for: factor 9 survives the round trip.
+	require.Equal(t, written.Factors.ExecutionIsolation, read.Factors.ExecutionIsolation,
+		"execution_isolation (factor 9) must be persisted, not dropped on write")
+	require.Equal(t, written.ExcludedFactors, read.ExcludedFactors,
+		"excluded_factors must make the stored composite reproducible from its row")
+	require.Equal(t, written.Factors, read.Factors)
+	require.InDelta(t, written.Score, read.Score, 1e-9)
+
+	// GetHistory takes the same column list.
+	history, err := repo.GetHistory(agentID, 5)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, written.Factors.ExecutionIsolation, history[0].Factors.ExecutionIsolation)
+	require.Equal(t, written.ExcludedFactors, history[0].ExcludedFactors)
+
+	// Nothing-excluded scores round-trip as empty (rows predating migration
+	// 103 read the same way via the column default).
+	clean := &domain.TrustScore{
+		AgentID:        agentID,
+		Score:          0.9,
+		Factors:        written.Factors,
+		Confidence:     0.9,
+		LastCalculated: time.Now().UTC(),
+	}
+	require.NoError(t, repo.Create(clean))
+	latest, err := repo.GetLatest(agentID)
+	require.NoError(t, err)
+	require.Empty(t, latest.ExcludedFactors)
+}

--- a/apps/backend/migrations/103_persist_excluded_factors.sql
+++ b/apps/backend/migrations/103_persist_excluded_factors.sql
@@ -1,0 +1,18 @@
+-- Migration 103: Persist excluded factors on trust_scores
+--
+-- AIP-SPEC section 6.1 composition (exclude-and-redistribute with the
+-- anti-gaming cap) makes the set of excluded factors part of what a stored
+-- composite means: a capped or renormalized score is not reproducible from
+-- the row without knowing which factors were excluded. Until now
+-- TrustScore.ExcludedFactors was API-response-only, so stored rows held
+-- placeholder factor values with no record of the exclusion set (audit gap).
+--
+-- Companion repository change also starts writing/reading the
+-- execution_isolation factor column (added in migration 090 but never
+-- referenced by the Go repository, silently dropping factor 9 on write).
+
+ALTER TABLE trust_scores
+    ADD COLUMN IF NOT EXISTS excluded_factors TEXT[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN trust_scores.excluded_factors IS
+    'Factor keys excluded from the composite under AIP-SPEC 6.1 (no data or un-wired source; weights redistributed with the anti-gaming cap). Empty array = all nine factors measured. Rows predating migration 103 read as empty.';


### PR DESCRIPTION
Closes the two persistence gaps found during the WS1 spec-gap adversarial review (todo/2026-07-02-standards-hardening-followups.md, AIM section; referenced from AIP GAP-ANALYSIS via agent-identity-protocol#10).

**P1 — factor 9 silently dropped on write.** `trust_score_repository.go`'s INSERT/SELECT column lists carried only 8 factor columns; `execution_isolation` (10% weight, column added by migration 090) was never written and read back as 0 in stored breakdowns. The repository now writes and reads it in `Create`/`GetLatest`/`GetHistory`.

**P2 — exclusions not persisted (audit gap).** `TrustScore.ExcludedFactors` (AIP-SPEC §6.1 exclude-and-redistribute, #330) was API-response-only, so a stored capped or renormalized composite was not reproducible from its row. Migration 103 adds `trust_scores.excluded_factors TEXT[] NOT NULL DEFAULT '{}'`; the repository persists and returns it. Pre-103 rows read back as empty (all factors treated as measured); migrations run automatically at server startup, so deploy ordering is safe.

**Verification.** New `TestTrustScoreRepository_RoundTripNineFactorsAndExclusions` (integration-tagged) pins both regressions; executed against a throwaway Postgres 16 with all 103 migrations applied — PASS. Full backend suite `go test -race ./...`: 25 packages ok. HMA `secure --ci`: 100/100.

**Drive-by repair.** The pre-existing `trust_score_mirror_trigger_integration_test.go` could not run against the migrated schema at all: fixtures omitted `organizations.domain` / `agents.display_name` / `agents.created_by` (NOT NULL), its `trust_scores` INSERTs still used the pre-migration-019 legacy column set (`certificate_validity` et al.), and its mirrored-value fixture was not representable in `agents.trust_score`'s two fractional digits. Both subtests now pass against the migrated schema.

https://claude.ai/code/session_01RJ3s1nN22u6Cg2LLEhzXdt