### PR TITLE
Bump pinned atx-conformance ref to the 18-fixture suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       # Pinned suite ref. Bump deliberately when the suite grows; the vendored
       # Java fixture copies must be refreshed in the same PR or the drift gate
       # below fails.
-      ATX_CONFORMANCE_REF: b2de78387e5b9e70af5efbef28f46e7732016c82
+      ATX_CONFORMANCE_REF: 00b28797cbd44ce1552f9a44d484bbb548044a97
     steps:
       - uses: actions/checkout@v4
 

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
@@ -45,6 +45,9 @@ class LocalAtxVerifierConformanceTest {
             "v1_1-tampered-capabilities.json,      REJECT, SIGNATURE_INVALID",
             "v1_1-tampered-declared-purpose.json,  REJECT, SIGNATURE_INVALID",
             "v1_1-cross-issuer-key.json,           REJECT, SIGNATURE_INVALID",
+            "v1_1-declared-purpose-empty-whitespace.json, ACCEPT, ",
+            "v1_1-declared-purpose-array-injected.json,   REJECT, SIGNATURE_INVALID",
+            "v1_1-declared-purpose-string-injected.json,  REJECT, SIGNATURE_INVALID",
     })
     void fixture(String file, String expectedResult, String expectedRejectCategory) throws Exception {
         JsonNode fixture;

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-array-injected.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-array-injected.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-array-injected",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying an attacker-appended ARRAY declaredPurpose value. Non-object values are included in the TBS verbatim (atx-spec §1.3a.2 rule 5), so the recomputed canonical bytes no longer match the signature and the verifier MUST REJECT with a signature-validation reason. A verifier that normalizes non-object values away would accept unsigned purpose content riding a valid signature.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": [
+      "billing:inquiry",
+      "act-autonomously"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-empty-whitespace.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-empty-whitespace.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-empty-whitespace",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying a whitespace-empty declaredPurpose object ({ }) appended after signing. Emptiness is a JSON-parse-level property (atx-spec §1.3a.2 rule 5): any serialization of the empty object is the empty object, treated as absent and omitted from the TBS, so the signature still verifies. Verifier MUST ACCEPT. A verifier that compares the raw byte string against \"{}\" instead of parsing wrongly includes the value and REJECTs.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "ACCEPT"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": { },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-string-injected.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-declared-purpose-string-injected.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/declared-purpose-string-injected",
+  "description": "An ATX v1.1 credential signed with no declaredPurpose, carrying an attacker-appended STRING declaredPurpose value. Non-object values are included in the TBS verbatim (atx-spec §1.3a.2 rule 5), so the recomputed canonical bytes no longer match the signature and the verifier MUST REJECT with a signature-validation reason.",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "SIGNATURE_INVALID",
+    "reasonContains": "signature"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": "customer-support",
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}


### PR DESCRIPTION
Downstream half of atx-conformance#14 / atx-spec#8 (closes the AIM leg of atx-conformance#11):

- `ATX_CONFORMANCE_REF` `b2de783` → `00b2879` — the suite now pins degenerate `declaredPurpose` handling (parse-level emptiness incl. whitespace-empty objects; verbatim inclusion of non-object values so unsigned injection breaks the signature).
- Vendors the three new fixtures for the both-directions byte-drift gate; Java conformance test extended to 18 rows.
- **No production change needed**: `LocalAtxVerifier`'s `AtxCanonicalizer` (JsonNode passthrough, absent/null/{} omitted) already implements the pinned rule — verified locally, 18/18 pass.

https://claude.ai/code/session_01RJ3s1nN22u6Cg2LLEhzXdt