### PR TITLE
sdk-ts: 1.0.1 deferred-findings batch + ARP live-fire harnesses

### DIFF
--- a/sdk/typescript/.eslintrc.cjs
+++ b/sdk/typescript/.eslintrc.cjs
@@ -1,0 +1,75 @@
+/**
+ * ESLint config for @opena2a/aim-sdk (TypeScript).
+ *
+ * Uses the eslintrc format because the pinned toolchain is ESLint 8 +
+ * @typescript-eslint 6 (flat config is the ESLint 9 default). A future bump to
+ * ESLint 9 / typescript-eslint 8 should migrate this to `eslint.config.mjs` and
+ * also clears the ESLint-8-chain npm audit advisories.
+ *
+ * This is a lint-only dev tool; it is not part of the published artifact and is
+ * not run in CI today. Keep it green so `npm run lint` stays usable.
+ */
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+  env: {
+    node: true,
+    es2022: true,
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: [
+    'dist/**',
+    'node_modules/**',
+    'coverage/**',
+    '*.config.ts',
+    '*.config.mjs',
+    '*.config.cjs',
+  ],
+  rules: {
+    // Type-safety escape hatches are used deliberately at adapter/JS boundaries
+    // (untyped daemon bags, dynamic requires); keep them visible but non-fatal.
+    '@typescript-eslint/no-explicit-any': 'warn',
+    // Adopting lint on a previously-unlinted tree: surface existing unused
+    // symbols as warnings (green baseline) so `npm run lint` is usable, while
+    // NEW unused symbols still stand out for cleanup. `_`-prefixed are ignored.
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrors: 'none' },
+    ],
+    // Empty catch blocks are the intentional "errors here must not block the
+    // pipeline" pattern throughout the engine; other empty blocks still error.
+    'no-empty': ['error', { allowEmptyCatch: true }],
+    // `const self = this` appears in a few closures; low-value to forbid.
+    '@typescript-eslint/no-this-alias': 'off',
+    // Pre-existing regex escapes flagged as redundant — surface, don't block;
+    // "fixing" a regex escape blindly can change semantics.
+    'no-useless-escape': 'warn',
+    // require(...) is used intentionally for lazy/optional loads in dual-format
+    // code paths; the surrounding code documents each one.
+    '@typescript-eslint/no-var-requires': 'off',
+    // Keep the default type bans ({}, Object, String, ...) but allow `Function`:
+    // it is used deliberately for `Record<string, Function>` fs-module patching
+    // and `as Function` casts around Node crypto overloads.
+    '@typescript-eslint/ban-types': [
+      'error',
+      { types: { Function: false }, extendDefaults: true },
+    ],
+  },
+  overrides: [
+    {
+      files: ['**/*.test.ts', 'tests/**/*.ts'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+      },
+    },
+  ],
+};

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -139,6 +139,8 @@ const client = new AIMClient({
 });
 
 // Resolve the agent's ATX once (the AAP broker / network step), then cache it.
+// `resolvedAtx` is the signed ATX credential returned by that broker/network step.
+const resolvedAtx = await fetchAtxForAgent(); // your resolution step
 client.setLocalCredential(resolvedAtx);
 
 // Per action: verified offline, sub-millisecond, no network.

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -919,9 +919,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -933,9 +933,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -947,9 +947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -961,9 +961,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +975,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -989,9 +989,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1003,13 +1003,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,13 +1020,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1031,13 +1037,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,13 +1054,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,13 +1071,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,13 +1105,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1087,13 +1139,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1101,13 +1156,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1115,13 +1173,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1129,13 +1190,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,9 +1207,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1153,13 +1234,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1171,9 +1252,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1185,9 +1266,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1199,9 +1280,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -1213,9 +1294,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -1255,9 +1336,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1725,9 +1806,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1760,9 +1841,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1871,9 +1952,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2313,9 +2394,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2324,9 +2405,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2518,9 +2599,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2559,9 +2640,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -2576,9 +2657,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.6.2.tgz",
-      "integrity": "sha512-dPugdGnsvYkBlENLhCgX8yhyGCsCPrpA8lFWbTNU428l+YOnLgYHR69hzV8HWPC79n536EqzqQtvhtdaCE0dKg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
       "dev": true,
       "funding": [
         {
@@ -2592,16 +2673,16 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@fastify/ajv-compiler": "^4.0.0",
+        "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
         "@fastify/fast-json-stringify-compiler": "^5.0.0",
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
-        "pino": "^10.1.0",
+        "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
@@ -2623,6 +2704,55 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.0.tgz",
+      "integrity": "sha512-YV53BAbR3Qwq37wfD1oZ97YJ0nYj6CwfzKXQ38ock9XxI2EnLOdl5psKms6Evook6ACckytZJOaKY0ThmIi1uw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastify4": {
@@ -2941,9 +3071,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
-      "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3000,9 +3130,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3097,9 +3227,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3108,9 +3238,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3331,9 +3461,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3629,9 +3769,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -3857,9 +3997,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3932,9 +4072,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -3952,7 +4092,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4217,13 +4357,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4233,28 +4373,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -4283,9 +4426,9 @@
       }
     },
     "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "dev": true,
       "funding": [
         {
@@ -4300,6 +4443,9 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safe-stable-stringify": {
@@ -4634,9 +4780,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opena2a/aim-sdk",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Agent Identity Management SDK for TypeScript/Node.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -25,7 +25,8 @@
       "types": "./dist/integrations/fastify.d.ts",
       "import": "./dist/integrations/fastify.mjs",
       "require": "./dist/integrations/fastify.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -39,6 +40,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
+    "test:harness": "vitest run --config vitest.harness.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src --ext .ts",

--- a/sdk/typescript/src/arp/engine/event-engine.ts
+++ b/sdk/typescript/src/arp/engine/event-engine.ts
@@ -48,6 +48,22 @@ export class EventEngine {
 
   /** Emit an event from a monitor — evaluates rules and triggers actions */
   async emit(event: Omit<ARPEvent, 'id' | 'timestamp' | 'classifiedBy'>): Promise<ARPEvent> {
+    // Shallow validation for untyped (JS) callers. Without this, an event that
+    // omits `data` crashes deep in the pipeline with an opaque
+    // "Cannot read properties of undefined (reading 'correlationKey')".
+    if (event === null || typeof event !== 'object') {
+      throw new TypeError(
+        'EventEngine.emit(event): event must be an object with { source, category, severity, description, data }',
+      );
+    }
+    if (event.data === null || typeof event.data !== 'object') {
+      throw new TypeError(
+        `EventEngine.emit(event): event.data must be an object (received ${
+          event.data === undefined ? 'undefined' : typeof event.data
+        })`,
+      );
+    }
+
     const fullEvent: ARPEvent = {
       ...event,
       id: crypto.randomUUID(),

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -1,3 +1,9 @@
+/**
+ * ARP engine version. This tracks the ARP protocol/engine lineage and is
+ * INTENTIONALLY independent of the `@opena2a/aim-sdk` package version (the
+ * package may be 1.x while the engine is 0.2.x). Read the package version from
+ * `require('@opena2a/aim-sdk/package.json').version` if you need that instead.
+ */
 export const VERSION = '0.2.0';
 
 // Re-export types

--- a/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
@@ -5,7 +5,7 @@
  * at first run, exactly what is shared, why, and how to turn it off. This text is
  * intentionally plain and non-marketing (CPO/legal voice). It is shown once (a
  * marker is written after the first show) and is always available on demand via
- * `arp telemetry disclosure`.
+ * `disclosureText()` (or `arp telemetry disclosure` for hackmyagent CLI users).
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
@@ -40,13 +40,13 @@ export function disclosureText(config?: SignatureTelemetryConfig): string {
     'verify exactly what left your machine.',
     '',
     `Audit log:  ${auditLogPath()}`,
-    'Review it:  arp telemetry log',
-    'Status:     arp telemetry status',
+    'Review it:  read the audit log file above. If you installed the hackmyagent',
+    '            CLI you can also run `arp telemetry log` / `arp telemetry status`.',
     '',
     'How to turn it off (any one):',
-    '  - arp telemetry opt-out',
-    '  - set OPENA2A_TELEMETRY_OPTOUT=1',
+    '  - set OPENA2A_TELEMETRY_OPTOUT=1 (or ARP_TELEMETRY_DISABLED=1)',
     '  - signatureTelemetry.enabled: false in your ARP config',
+    '  - run `arp telemetry opt-out` (hackmyagent CLI)',
     'Opting out disables ALL OpenA2A telemetry and purges shared signatures',
     'on the registry (right-to-delete).',
   ].join('\n');

--- a/sdk/typescript/src/auth/oauth.test.ts
+++ b/sdk/typescript/src/auth/oauth.test.ts
@@ -283,6 +283,35 @@ describe('Credential file operations', () => {
       const { loadCredentialsFromFile } = await import('./oauth');
       expect(typeof loadCredentialsFromFile).toBe('function');
     });
+
+    it('throws a typed ConfigurationError (not raw ENOENT) for a missing file', async () => {
+      const { loadCredentialsFromFile } = await import('./oauth');
+      const { ConfigurationError } = await import('../exceptions');
+      const missing = '/nonexistent/does-not-exist-aim-creds.json';
+      await expect(loadCredentialsFromFile(missing)).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(loadCredentialsFromFile(missing)).rejects.toMatchObject({
+        code: 'CONFIGURATION_ERROR',
+        message: expect.stringContaining('not found'),
+      });
+    });
+
+    it('throws a typed ConfigurationError for a file that is not valid JSON', async () => {
+      const fs = await import('fs/promises');
+      const os = await import('os');
+      const path = await import('path');
+      const { loadCredentialsFromFile } = await import('./oauth');
+      const { ConfigurationError } = await import('../exceptions');
+      const tmp = path.join(os.tmpdir(), `aim-creds-bad-${process.pid}-${Date.now()}.json`);
+      await fs.writeFile(tmp, 'not-json{');
+      try {
+        await expect(loadCredentialsFromFile(tmp)).rejects.toBeInstanceOf(ConfigurationError);
+        await expect(loadCredentialsFromFile(tmp)).rejects.toMatchObject({
+          message: expect.stringContaining('not valid JSON'),
+        });
+      } finally {
+        await fs.rm(tmp, { force: true });
+      }
+    });
   });
 
   describe('saveCredentialsToFile', () => {

--- a/sdk/typescript/src/auth/oauth.ts
+++ b/sdk/typescript/src/auth/oauth.ts
@@ -4,6 +4,7 @@
 
 import type { TokenResponse, AgentCredentials } from '../types';
 import { createRequestSignature, toBase64, fromBase64 } from '../crypto/ed25519';
+import { ConfigurationError } from '../exceptions';
 
 /**
  * Token cache entry
@@ -157,8 +158,29 @@ export function loadCredentialsFromEnv(): AgentCredentials | null {
  */
 export async function loadCredentialsFromFile(filePath: string): Promise<AgentCredentials> {
   const fs = await import('fs/promises');
-  const content = await fs.readFile(filePath, 'utf-8');
-  return JSON.parse(content) as AgentCredentials;
+
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') {
+      throw new ConfigurationError(`Credential file not found: ${filePath}`, { filePath, cause: code });
+    }
+    throw new ConfigurationError(
+      `Could not read credential file ${filePath}: ${(err as Error)?.message ?? 'unknown error'}`,
+      { filePath, cause: code },
+    );
+  }
+
+  try {
+    return JSON.parse(content) as AgentCredentials;
+  } catch (err) {
+    throw new ConfigurationError(
+      `Credential file ${filePath} is not valid JSON: ${(err as Error)?.message ?? 'parse error'}`,
+      { filePath },
+    );
+  }
 }
 
 /**

--- a/sdk/typescript/src/client/AIMClient.test.ts
+++ b/sdk/typescript/src/client/AIMClient.test.ts
@@ -65,6 +65,22 @@ describe('AIMClient', () => {
       expect(client).toBeInstanceOf(AIMClient);
     });
 
+    it('adds a localhost-default hint to the network error when baseUrl was not set', async () => {
+      vi.stubGlobal('fetch', mockFetch);
+      mockFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      const client = new AIMClient();
+      await expect(client.registerAgent({ name: 'a' })).rejects.toThrow(NetworkError);
+      await expect(client.registerAgent({ name: 'a' })).rejects.toThrow(/baseUrl defaulted to http:\/\/localhost:8080/);
+    });
+
+    it('does NOT add the localhost-default hint when baseUrl is explicit', async () => {
+      vi.stubGlobal('fetch', mockFetch);
+      mockFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      const client = new AIMClient({ baseUrl: 'https://custom.aim.example.com' });
+      await expect(client.registerAgent({ name: 'a' })).rejects.toThrow(/Network error/);
+      await expect(client.registerAgent({ name: 'a' })).rejects.not.toThrow(/baseUrl defaulted/);
+    });
+
     it('should use environment variables when no config provided', () => {
       process.env.AIM_BASE_URL = 'https://env.aim.example.com';
       process.env.AIM_ORGANIZATION_ID = 'env-org-123';

--- a/sdk/typescript/src/client/AIMClient.test.ts
+++ b/sdk/typescript/src/client/AIMClient.test.ts
@@ -81,6 +81,23 @@ describe('AIMClient', () => {
       await expect(client.registerAgent({ name: 'a' })).rejects.not.toThrow(/baseUrl defaulted/);
     });
 
+    it('treats an empty/whitespace AIM_BASE_URL as unset (defaults to localhost, hint accurate)', async () => {
+      // Regression: an empty env var used to resolve to a relative URL ('' is
+      // not nullish) that failed to parse, while the hint claimed localhost —
+      // both halves wrong. It must now default to localhost with an honest hint.
+      process.env.AIM_BASE_URL = '   ';
+      vi.stubGlobal('fetch', mockFetch);
+      mockFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      const client = new AIMClient();
+      // The request URL must be the localhost default, not a relative path.
+      await expect(client.registerAgent({ name: 'a' })).rejects.toThrow(/baseUrl defaulted to http:\/\/localhost:8080/);
+      await client.registerAgent({ name: 'a' }).catch(() => {});
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/^http:\/\/localhost:8080\/api\/v1\/agents$/),
+        expect.any(Object),
+      );
+    });
+
     it('should use environment variables when no config provided', () => {
       process.env.AIM_BASE_URL = 'https://env.aim.example.com';
       process.env.AIM_ORGANIZATION_ID = 'env-org-123';

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -11,6 +11,7 @@ import type {
   VerifyActionOptions,
 } from '../types';
 import { RiskLevel } from '../types';
+import { SDK_VERSION } from '../version';
 import { OAuthTokenManager, loadCredentialsFromEnv } from '../auth/oauth';
 import { generateKeyPair, toBase64, createRequestSignature, fromBase64 } from '../crypto/ed25519';
 import {
@@ -98,8 +99,14 @@ export class AIMClient {
   // Single resolved telemetry dir shared by the auto-joiner sink and the relay,
   // so the relay always reads exactly where the joiner writes.
   private readonly telemetryDir: string;
+  // True when baseUrl fell through to the localhost default (neither the
+  // `baseUrl` option nor AIM_BASE_URL was set). Used to add an actionable hint
+  // to the first connection failure instead of a bare ECONNREFUSED.
+  private readonly usedDefaultBaseUrl: boolean;
 
   constructor(config: AIMClientConfig = {}) {
+    this.usedDefaultBaseUrl =
+      config.baseUrl === undefined && (process.env.AIM_BASE_URL ?? '') === '';
     this.config = {
       baseUrl: config.baseUrl ?? process.env.AIM_BASE_URL ?? DEFAULT_BASE_URL,
       organizationId: config.organizationId ?? process.env.AIM_ORGANIZATION_ID ?? '',
@@ -173,7 +180,7 @@ export class AIMClient {
     const url = `${this.config.baseUrl}${path}`;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      'User-Agent': 'AIM-SDK-TypeScript/1.0.0',
+      'User-Agent': `AIM-SDK-TypeScript/${SDK_VERSION}`,
       ...this.config.headers,
       // Best-effort, non-auth extras (e.g. the correlation ID). Listed before
       // auth/signature headers below so they can never override them.
@@ -242,7 +249,10 @@ export class AIMClient {
         if (error.name === 'AbortError') {
           throw new NetworkError('Request timed out', error);
         }
-        throw new NetworkError(`Network error: ${error.message}`, error);
+        const hint = this.usedDefaultBaseUrl
+          ? ` (baseUrl defaulted to ${DEFAULT_BASE_URL} — no baseUrl option or AIM_BASE_URL env var was set)`
+          : '';
+        throw new NetworkError(`Network error: ${error.message}${hint}`, error);
       }
 
       throw new NetworkError('Unknown network error');

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -100,15 +100,19 @@ export class AIMClient {
   // so the relay always reads exactly where the joiner writes.
   private readonly telemetryDir: string;
   // True when baseUrl fell through to the localhost default (neither the
-  // `baseUrl` option nor AIM_BASE_URL was set). Used to add an actionable hint
-  // to the first connection failure instead of a bare ECONNREFUSED.
+  // `baseUrl` option nor a usable AIM_BASE_URL was provided). Used to add an
+  // actionable hint to connection failures instead of a bare ECONNREFUSED.
   private readonly usedDefaultBaseUrl: boolean;
 
   constructor(config: AIMClientConfig = {}) {
-    this.usedDefaultBaseUrl =
-      config.baseUrl === undefined && (process.env.AIM_BASE_URL ?? '') === '';
+    // Treat an empty/whitespace AIM_BASE_URL as unset so the flag and the
+    // resolved baseUrl below agree: an empty env var must fall through to the
+    // localhost default (not become a relative URL that fails to parse), and
+    // the hint must reflect that.
+    const envBaseUrl = process.env.AIM_BASE_URL?.trim() || undefined;
+    this.usedDefaultBaseUrl = config.baseUrl == null && envBaseUrl === undefined;
     this.config = {
-      baseUrl: config.baseUrl ?? process.env.AIM_BASE_URL ?? DEFAULT_BASE_URL,
+      baseUrl: config.baseUrl ?? envBaseUrl ?? DEFAULT_BASE_URL,
       organizationId: config.organizationId ?? process.env.AIM_ORGANIZATION_ID ?? '',
       apiKey: config.apiKey ?? process.env.AIM_API_KEY ?? '',
       autoRegister: config.autoRegister ?? true,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -291,5 +291,5 @@ export {
   type FlushResult,
 } from './telemetry';
 
-// Version
-export const VERSION = '1.0.0';
+// Version (single source of truth: src/version.ts)
+export { SDK_VERSION as VERSION } from './version';

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Single source of truth for the @opena2a/aim-sdk package version.
+ *
+ * Keep this in sync with `version` in package.json on every release
+ * (`npm version <patch|minor|major>` updates package.json; update this file in
+ * the same commit). It is a standalone leaf module so any part of the SDK can
+ * import it without a circular dependency on the barrel `index.ts`.
+ */
+export const SDK_VERSION = '1.0.0';

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -6,4 +6,4 @@
  * the same commit). It is a standalone leaf module so any part of the SDK can
  * import it without a circular dependency on the barrel `index.ts`.
  */
-export const SDK_VERSION = '1.0.0';
+export const SDK_VERSION = '1.0.1';

--- a/sdk/typescript/tests/arp/engine/event-engine.test.ts
+++ b/sdk/typescript/tests/arp/engine/event-engine.test.ts
@@ -102,6 +102,17 @@ describe('EventEngine', () => {
     expect(processOnly.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('rejects a malformed event (missing data) with a clear TypeError', async () => {
+    const engine = new EventEngine(makeConfig());
+    // JS callers can omit `data`; without validation this crashed deep in the
+    // pipeline with "Cannot read properties of undefined (reading 'correlationKey')".
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(engine.emit({ source: 'process', category: 'normal', severity: 'info', description: 'no data' } as any))
+      .rejects.toThrow(/event\.data must be an object/);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(engine.emit(null as any)).rejects.toThrow(/event must be an object/);
+  });
+
   it('reclassifies events', async () => {
     const engine = new EventEngine(makeConfig());
 

--- a/sdk/typescript/tests/arp/harness/dvaa-integration.ts
+++ b/sdk/typescript/tests/arp/harness/dvaa-integration.ts
@@ -58,7 +58,7 @@ function hasDetection(patternId: string): boolean {
 }
 
 describe('HMA Attack Coverage Matrix', () => {
-  describe('Prompt Injection -> LegacyBot :3003', () => {
+  describe('Prompt Injection -> LegacyBot :7003', () => {
     it('PI-001: instruction override', () => {
       clearDetections();
       promptInterceptor.scanInput(
@@ -84,7 +84,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('Jailbreak -> CodeBot :3004', () => {
+  describe('Jailbreak -> CodeBot :7004', () => {
     it('JB-001: DAN mode', () => {
       clearDetections();
       promptInterceptor.scanInput(
@@ -102,7 +102,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('System Prompt Extraction -> LegacyBot :3003', () => {
+  describe('System Prompt Extraction -> LegacyBot :7003', () => {
     it('DE-001: system prompt extraction attempt', () => {
       clearDetections();
       promptInterceptor.scanInput(
@@ -120,7 +120,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('Credential Leak -> LegacyBot :3003', () => {
+  describe('Credential Leak -> LegacyBot :7003', () => {
     it('DE-002: credential extraction attempt', () => {
       clearDetections();
       promptInterceptor.scanInput(
@@ -138,7 +138,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('MCP Path Traversal -> ToolBot :3010', () => {
+  describe('MCP Path Traversal -> ToolBot :7010', () => {
     it('MCP-001: path traversal', () => {
       clearDetections();
       mcpInterceptor.scanToolCall('readFile', {
@@ -148,7 +148,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('MCP Command Injection -> ToolBot :3010', () => {
+  describe('MCP Command Injection -> ToolBot :7010', () => {
     it('MCP-002: command injection via tool parameter', () => {
       clearDetections();
       mcpInterceptor.scanToolCall('execute', {
@@ -166,7 +166,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('MCP SSRF -> ToolBot :3010', () => {
+  describe('MCP SSRF -> ToolBot :7010', () => {
     it('MCP-003: SSRF to cloud metadata', () => {
       clearDetections();
       mcpInterceptor.scanToolCall('fetch', {
@@ -184,7 +184,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('A2A Identity Spoofing -> Orchestrator :3020', () => {
+  describe('A2A Identity Spoofing -> Orchestrator :7020', () => {
     it('A2A-001: identity spoofing', () => {
       clearDetections();
       a2aInterceptor.scanMessage(
@@ -196,7 +196,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('A2A Delegation Abuse -> Worker :3021', () => {
+  describe('A2A Delegation Abuse -> Worker :7021', () => {
     it('A2A-002: delegation abuse', () => {
       clearDetections();
       a2aInterceptor.scanMessage(
@@ -208,7 +208,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('Context Manipulation -> HelperBot :3002', () => {
+  describe('Context Manipulation -> HelperBot :7002', () => {
     it('CM-001: false memory injection', () => {
       clearDetections();
       promptInterceptor.scanInput(
@@ -226,7 +226,7 @@ describe('HMA Attack Coverage Matrix', () => {
     });
   });
 
-  describe('RAG Poisoning -> RAGBot :3005', () => {
+  describe('RAG Poisoning -> RAGBot :7005', () => {
     it('PI-001: injection via retrieval content', () => {
       clearDetections();
       // RAG poisoning works by embedding injection in retrieved documents

--- a/sdk/typescript/tests/arp/harness/live-dvaa.ts
+++ b/sdk/typescript/tests/arp/harness/live-dvaa.ts
@@ -6,10 +6,10 @@
  * Validates that every HMA attack category produces at least one ARP detection.
  *
  * Prerequisites:
- *   DVAA running: docker run -p 3000-3006:3000-3006 -p 3010-3011:3010-3011 \
- *                   -p 3020-3021:3020-3021 -p 9000:9000 opena2a/dvaa:0.4.0
+ *   DVAA running: docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.2
  *
- * Run: npx vitest run test/harness/live-dvaa.ts
+ * Run: npm run test:harness (or npx vitest run --config vitest.harness.config.ts
+ *      tests/arp/harness/live-dvaa.ts)
  *
  * This test is skipped by default if DVAA is not reachable.
  */
@@ -23,11 +23,11 @@ import { A2AProtocolInterceptor } from '../../../src/arp/interceptors/a2a-protoc
 import { ARPProxy } from '../../../src/arp/proxy/server';
 import type { ARPEvent } from '../../../src/arp/types';
 
-// DVAA ports
-const DVAA_API = 'http://localhost:3003';   // LegacyBot (CRITICAL)
-const DVAA_MCP = 'http://localhost:3010';   // ToolBot (VULNERABLE)
-const DVAA_A2A_ORCH = 'http://localhost:3020'; // Orchestrator
-const DVAA_A2A_WORKER = 'http://localhost:3021'; // Worker
+// DVAA ports (v0.8.0+ moved agents from 3000-base to 7000-base)
+const DVAA_API = 'http://localhost:7003';   // LegacyBot (CRITICAL)
+const DVAA_MCP = 'http://localhost:7010';   // ToolBot (VULNERABLE)
+const DVAA_A2A_ORCH = 'http://localhost:7020'; // Orchestrator
+const DVAA_A2A_WORKER = 'http://localhost:7021'; // Worker
 
 // ARP proxy
 let proxy: ARPProxy;
@@ -37,7 +37,6 @@ let promptInterceptor: PromptInterceptor;
 let mcpInterceptor: MCPProtocolInterceptor;
 let a2aInterceptor: A2AProtocolInterceptor;
 const detections: ARPEvent[] = [];
-let dvaaAvailable = false;
 
 // Check if DVAA is running
 async function checkDVAA(): Promise<boolean> {
@@ -49,6 +48,12 @@ async function checkDVAA(): Promise<boolean> {
     req.on('timeout', () => { req.destroy(); resolve(false); });
   });
 }
+
+// Probe DVAA at module load. `it.skipIf(...)` is evaluated at collection time,
+// so this MUST resolve before the describe() blocks below define their tests --
+// a beforeAll() probe would run too late and every test would skip even when
+// DVAA is up. Top-level await is supported in vitest test modules.
+const dvaaAvailable = await checkDVAA();
 
 // Send HTTP request through proxy
 function sendRequest(
@@ -100,7 +105,6 @@ function detectionIds(): string[] {
 }
 
 beforeAll(async () => {
-  dvaaAvailable = await checkDVAA();
   if (!dvaaAvailable) return;
 
   engine = new EventEngine({ agentName: 'live-dvaa-test' });
@@ -150,11 +154,11 @@ describe('Live ARP + DVAA Integration', () => {
   beforeAll(() => {
     if (!dvaaAvailable) {
       console.log('DVAA not available -- skipping live integration tests.');
-      console.log('Start DVAA with: docker run -p 3000-3006:3000-3006 -p 3010-3011:3010-3011 -p 3020-3021:3020-3021 -p 9000:9000 opena2a/dvaa:0.4.0');
+      console.log('Start DVAA with: docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.2');
     }
   });
 
-  describe('OpenAI API Protocol (LegacyBot :3003)', () => {
+  describe('OpenAI API Protocol (LegacyBot :7003)', () => {
     it.skipIf(!dvaaAvailable)('detects prompt injection (PI-001)', async () => {
       clearDetections();
       const res = await sendRequest('/api/v1/chat/completions', {
@@ -240,7 +244,7 @@ describe('Live ARP + DVAA Integration', () => {
     });
   });
 
-  describe('MCP JSON-RPC Protocol (ToolBot :3010)', () => {
+  describe('MCP JSON-RPC Protocol (ToolBot :7010)', () => {
     it.skipIf(!dvaaAvailable)('detects path traversal (MCP-001)', async () => {
       clearDetections();
       const res = await sendRequest('/mcp/', {

--- a/sdk/typescript/tsup.config.ts
+++ b/sdk/typescript/tsup.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   minify: false,
+  // Preserve class/function names in the CJS output so error-class
+  // `constructor.name` matches the ESM build (esbuild otherwise drops the
+  // inferred name of a class assigned into the CJS exports object).
+  keepNames: true,
   // @opena2a/atx-verify is ESM-only; keep it external and load it via a dynamic
   // import() at runtime so both the CJS and ESM builds resolve it natively on
   // every supported Node (a static require of an ESM package would throw).

--- a/sdk/typescript/vitest.harness.config.ts
+++ b/sdk/typescript/vitest.harness.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Manual ARP live-fire harnesses (tests/arp/harness/*.ts).
+ *
+ * These are NOT part of the default `npm test` suite: they are named `*.ts`
+ * (not `*.test.ts`) so the main vitest `include` glob skips them, and several
+ * require an external target (a running DVAA fleet). Run them explicitly with
+ * `npm run test:harness` when validating the engine against a live target.
+ *
+ * Prerequisites for the live-DVAA harness (live-dvaa.ts):
+ *   docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.2
+ * The self-contained harnesses (dvaa-integration.ts, proxy-e2e.ts,
+ * benchmark.ts) need no external services.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/arp/harness/**/*.ts'],
+    // Harnesses drive a real proxy / live target — keep them serial and give
+    // the live-DVAA round-trips room over the default 5s timeout.
+    fileParallelism: false,
+    testTimeout: 20000,
+    hookTimeout: 20000,
+  },
+});


### PR DESCRIPTION
Published as @opena2a/aim-sdk **1.0.1** (tag `sdk-ts-v1.0.1`, first OIDC-attested SDK release; SLSA v1 provenance). This PR carries the same commits onto main.

## What
Batches 9 of the 10 deferred 1.0.0 release-test findings (#334) plus ARP live-fire enablement.

- Typed `ConfigurationError` from `loadCredentialsFromFile` (missing file + bad JSON), was raw ENOENT
- `EventEngine.emit()` input validation — clear `TypeError` for JS callers omitting `data`
- `./package.json` export; tsup `keepNames` (CJS `constructor.name` now matches ESM)
- `AIMClient` localhost-default network hint (incl. empty/whitespace `AIM_BASE_URL`, caught in pre-push adversarial review)
- `/arp` VERSION documented as engine version; package version centralized in `src/version.ts` (used by User-Agent)
- Telemetry disclosure text leads with env/config opt-outs
- Working ESLint config (lint was crashing with no config); in-range js-yaml 4.1.1→4.3.0

ARP live-fire:
- `npm run test:harness` (`vitest.harness.config.ts`) — the moved harnesses were `*.ts` not `*.test.ts`, so the default suite skipped them
- `live-dvaa.ts`: DVAA ports 3000→7000-base (v0.9.2) + fixed a latent bug where `it.skipIf` evaluated at collection time so the live tests never actually ran. All 4 harnesses green (14 patterns, all 6 categories, real HTTP through ARPProxy → live DVAA).

## Verification
988→990 unit tests, 53 harness tests, CJS+ESM consumer smoke, lint green, prod audit clean, typecheck clean, fresh-user release-test 8/8 on the packed tarball, pre-push adversarial review (1 MEDIUM found + fixed), post-publish smoke on the real 1.0.1.

Deferred: #334 item 1 (per-entry-point `instanceof` identity — structural; `error.code` workaround documented).

Refs #334.