### PR TITLE
ATX: strict-parse the credential in the Java SDK; bump conformance ref to 20 fixtures (#335)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       # Pinned suite ref. Bump deliberately when the suite grows; the vendored
       # Java fixture copies must be refreshed in the same PR or the drift gate
       # below fails.
-      ATX_CONFORMANCE_REF: 00b28797cbd44ce1552f9a44d484bbb548044a97
+      ATX_CONFORMANCE_REF: f4d40a4e33ac15946e90683ad1f1c59122559407
     steps:
       - uses: actions/checkout@v4
 

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/AtxStrictParse.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/AtxStrictParse.java
@@ -1,0 +1,129 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Strict pre-parse for ATX credentials: rejects a credential that carries a
+ * duplicate object member at ANY depth, where "duplicate" is judged under the
+ * field folding a lenient consumer's JSON parser would apply.
+ *
+ * <p>Every ATX field feeds a signed canonical form (the v1.1 JCS(TBS)
+ * projection, the v1.0 pipe fields), so there is no layer with sanctioned
+ * RFC 7519 last-wins semantics — a duplicate member anywhere in the credential
+ * is the RFC 8259 §4 first-wins/last-wins parser-divergence smuggling split and
+ * MUST be rejected before any field is interpreted. This mirrors the strict
+ * parse in the reference verifiers (atx-conformance {@code verifiers/go},
+ * {@code verifiers/python}) and {@code opena2a-registry/pkg/atcverify}.
+ *
+ * <p>Folding matters because a lenient struct/case-insensitive parser collapses
+ * a case-variant pair like {@code {"trustLevel":9,"TRUSTLEVEL":1}} to one field
+ * last-wins. Jackson's own {@code STRICT_DUPLICATE_DETECTION} is case-SENSITIVE
+ * and would miss that collapse, so this scan folds member names (matching the Go
+ * reference verifier's {@code foldKey}) and catches both exact duplicates and
+ * fold-colliding case variants in a single pass.
+ *
+ * <p>Depth is bounded by Jackson's own {@code StreamReadConstraints}
+ * (default max nesting 1000): a credential nested deeper makes {@link JsonParser}
+ * throw before this scan can recurse unbounded, so no manual depth guard is
+ * needed here (unlike Go's {@code encoding/json.Decoder.Token}, which has no
+ * limit and forced an explicit bound in the reference verifier).
+ */
+public final class AtxStrictParse {
+
+    private static final JsonFactory JSON = new JsonFactory();
+
+    private AtxStrictParse() {
+    }
+
+    /**
+     * Scans raw ATX credential JSON for a member name that collides — under field
+     * folding — with an earlier member of the same object, at any depth, and
+     * returns the first such name. Returns {@code null} when the credential has no
+     * duplicate members.
+     *
+     * @throws IOException if the bytes are not well-formed JSON (or exceed
+     *     Jackson's nesting limit); the caller surfaces that as a rejection.
+     */
+    public static String firstDuplicateMember(byte[] credentialJson) throws IOException {
+        try (JsonParser p = JSON.createParser(credentialJson)) {
+            JsonToken first = p.nextToken();
+            if (first == null) {
+                throw new IOException("empty credential");
+            }
+            return scanValue(p, first);
+        }
+    }
+
+    /**
+     * Consumes exactly one JSON value from {@code p} (whose current token is
+     * {@code t}, the value's first token) and returns the first fold-duplicate
+     * member found within it, or {@code null}. On return the parser's current
+     * token is the last token of that value (its scalar, or its matching
+     * END_OBJECT / END_ARRAY), so the caller advances past it with one
+     * {@code nextToken()}.
+     */
+    private static String scanValue(JsonParser p, JsonToken t) throws IOException {
+        if (t == JsonToken.START_OBJECT) {
+            Map<String, String> seen = new HashMap<>(); // foldKey -> first raw name
+            JsonToken ft;
+            while ((ft = p.nextToken()) != JsonToken.END_OBJECT) {
+                // ft is FIELD_NAME here.
+                String name = p.currentName();
+                String fk = foldKey(name);
+                if (seen.containsKey(fk)) {
+                    return name;
+                }
+                seen.put(fk, name);
+                String dup = scanValue(p, p.nextToken());
+                if (dup != null) {
+                    return dup;
+                }
+            }
+        } else if (t == JsonToken.START_ARRAY) {
+            JsonToken et;
+            while ((et = p.nextToken()) != JsonToken.END_ARRAY) {
+                String dup = scanValue(p, et);
+                if (dup != null) {
+                    return dup;
+                }
+            }
+        }
+        // Scalar: nothing to consume; the token itself is the whole value.
+        return null;
+    }
+
+    /**
+     * Folds a JSON member name the way a lenient JSON-to-struct parser folds field
+     * names: ASCII letters lowercased, plus the two non-ASCII letters that fold
+     * onto ASCII (Kelvin sign U+212A -&gt; k, long s U+017F -&gt; s); any other code
+     * point via {@link Character#toLowerCase(int)} (simple 1:1 case mapping, matching
+     * Go's {@code unicode.ToLower} used by the reference verifier's {@code foldKey}).
+     * Two names with the same fold key are the same field to such a parser, so
+     * treating them as a duplicate here catches the case-variant collapse. Real ATX
+     * member names are ASCII, so the fold is exact on every honest credential.
+     */
+    static String foldKey(String s) {
+        StringBuilder b = new StringBuilder(s.length());
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            i += Character.charCount(cp);
+            if (cp >= 'A' && cp <= 'Z') {
+                b.appendCodePoint(cp + ('a' - 'A'));
+            } else if (cp == 0x212A) { // Kelvin sign -> k
+                b.append('k');
+            } else if (cp == 0x017F) { // latin small letter long s -> s
+                b.append('s');
+            } else {
+                b.appendCodePoint(Character.toLowerCase(cp));
+            }
+        }
+        return b.toString();
+    }
+}

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
@@ -1,5 +1,11 @@
 package org.opena2a.aim.atx;
 
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -30,10 +36,68 @@ public final class LocalAtxVerifier {
     private static final String SUPPORTED_V11 = "1.1";
     private static final byte[] ED25519_SPKI_PREFIX = hexToBytes("302a300506032b6570032100");
 
+    /**
+     * Credential deserializer with strict duplicate detection enabled as
+     * defense-in-depth. {@link AtxStrictParse#firstDuplicateMember} already
+     * rejects exact AND fold-colliding duplicates ahead of this parse; this
+     * feature additionally fails an exact-name duplicate at the databind layer,
+     * so a bug in the pre-scan could not let one through.
+     */
+    private static final ObjectMapper CREDENTIAL_MAPPER = JsonMapper.builder()
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .build();
+
     private final AtxTrustAnchors anchors;
 
     public LocalAtxVerifier(AtxTrustAnchors anchors) {
         this.anchors = anchors;
+    }
+
+    /**
+     * Verifies a credential from its raw JSON bytes, applying the strict parse
+     * (reject a duplicate object member at any depth, folded — see
+     * {@link AtxStrictParse}) before interpreting any field, then delegating to
+     * {@link #verify(Atx)}. This is the entry point wire consumers should use:
+     * the object-taking overload cannot see duplicate members a lenient
+     * databind parse has already collapsed. A duplicate or otherwise unparseable
+     * credential rejects as {@link RejectCategory#MALFORMED} (the SDK's
+     * structural-parse category; the reference verifiers call it PARSE_ERROR),
+     * with a reason naming the duplicate member.
+     */
+    public AtxVerificationResult verify(byte[] credentialJson) {
+        if (credentialJson == null) {
+            return AtxVerificationResult.reject(RejectCategory.MALFORMED, "credential is null");
+        }
+        Atx atx;
+        try {
+            String dup = AtxStrictParse.firstDuplicateMember(credentialJson);
+            if (dup != null) {
+                return AtxVerificationResult.reject(
+                        RejectCategory.MALFORMED,
+                        "credential contains duplicate member \"" + dup
+                                + "\" (strict parse: the ATX credential is a signed body; "
+                                + "RFC 8259 §4 duplicate names are parser-divergent)");
+            }
+            atx = CREDENTIAL_MAPPER.readValue(credentialJson, Atx.class);
+        } catch (IOException e) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.MALFORMED, "credential is not valid ATX JSON: " + e.getMessage());
+        }
+        // A bare JSON `null` (or any document Jackson maps to a null Atx) is not a
+        // credential — reject rather than NPE in verify(Atx).
+        if (atx == null) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.MALFORMED, "credential is not valid ATX JSON: document is JSON null");
+        }
+        return verify(atx);
+    }
+
+    /** Verifies a credential from its raw JSON string. See {@link #verify(byte[])}. */
+    public AtxVerificationResult verify(String credentialJson) {
+        if (credentialJson == null) {
+            return AtxVerificationResult.reject(RejectCategory.MALFORMED, "credential is null");
+        }
+        return verify(credentialJson.getBytes(StandardCharsets.UTF_8));
     }
 
     public AtxVerificationResult verify(Atx atx) {

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/AtxStrictParseTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/AtxStrictParseTest.java
@@ -1,0 +1,66 @@
+package org.opena2a.aim.atx;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit coverage for the fold-aware strict parse (AtxStrictParse). */
+class AtxStrictParseTest {
+
+    @Test
+    void foldKeyMatchesReferenceFold() {
+        assertEquals("trustlevel", AtxStrictParse.foldKey("trustLevel"));
+        assertEquals("trustlevel", AtxStrictParse.foldKey("TRUSTLEVEL"));
+        assertEquals("trustlevel", AtxStrictParse.foldKey("TrustLevel"));
+        assertEquals("category", AtxStrictParse.foldKey("Category"));
+        assertEquals("agentid", AtxStrictParse.foldKey("agentId"));
+        // The two non-ASCII runes that fold onto ASCII.
+        assertEquals("k", AtxStrictParse.foldKey("K")); // Kelvin sign -> k
+        assertEquals("s", AtxStrictParse.foldKey("ſ")); // long s -> s
+        // Case variants and their fold targets collide; distinct names do not.
+        assertEquals(AtxStrictParse.foldKey("trustLevel"), AtxStrictParse.foldKey("TRUSTLEVEL"));
+        assertEquals(AtxStrictParse.foldKey("K"), AtxStrictParse.foldKey("K"));
+    }
+
+    @Test
+    void detectsSameNameAndFoldDuplicatesAtAnyDepth() throws IOException {
+        assertEquals("trustLevel", firstDup("{\"trustLevel\":4,\"trustLevel\":9}"));
+        assertEquals("trustLevel", firstDup("{\"TRUSTLEVEL\":9,\"trustLevel\":4}"));
+        assertEquals("category", firstDup("{\"a\":{\"Category\":\"x\",\"category\":\"y\"}}"));
+        assertEquals("k", firstDup("{\"a\":[{\"K\":1,\"k\":2}]}")); // Kelvin/k fold in an array element
+    }
+
+    @Test
+    void passesDuplicateFreeCredentials() throws IOException {
+        assertNull(firstDup("{\"trustLevel\":4,\"trustScore\":9.5}"));
+        assertNull(firstDup("{\"a\":{\"x\":1},\"b\":{\"x\":2}}"));
+        assertNull(firstDup("{}"));
+        assertNull(firstDup("{\"caps\":[\"read\",\"read\"]}")); // duplicate VALUES are fine, not member names
+    }
+
+    @Test
+    void rejectsPathologicallyDeepNesting() {
+        // Jackson's StreamReadConstraints caps nesting (default 1000); a deeper
+        // credential makes the parser throw before the scan can recurse unbounded,
+        // so verify(byte[]) surfaces it as MALFORMED rather than overflowing.
+        StringBuilder deep = new StringBuilder();
+        int depth = 5000;
+        for (int i = 0; i < depth; i++) {
+            deep.append("{\"a\":");
+        }
+        deep.append("1");
+        for (int i = 0; i < depth; i++) {
+            deep.append("}");
+        }
+        assertThrows(IOException.class, () -> firstDup(deep.toString()));
+    }
+
+    private static String firstDup(String json) throws IOException {
+        return AtxStrictParse.firstDuplicateMember(json.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
@@ -1,15 +1,21 @@
 package org.opena2a.aim.atx;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * accepts/rejects exactly the credentials the Go and Python reference verifiers do.
  *
  * <p>We assert the machine contract (verifyResult + rejectCategory), NOT the
- * fixtures' reasonContains — that is the reference verifiers' own wording.
+ * fixtures' reasonContains — that is the reference verifiers' own wording. Where
+ * the reference verifiers report {@code PARSE_ERROR} (strict-parse rejections),
+ * this SDK reports {@link RejectCategory#MALFORMED} — the SDK RejectCategory
+ * union (shared with {@code @opena2a/atx-verify}) has no PARSE_ERROR, and
+ * MALFORMED is its structural-parse category — so those fixtures are pinned to
+ * MALFORMED here.
  */
 class LocalAtxVerifierConformanceTest {
 
@@ -48,18 +59,28 @@ class LocalAtxVerifierConformanceTest {
             "v1_1-declared-purpose-empty-whitespace.json, ACCEPT, ",
             "v1_1-declared-purpose-array-injected.json,   REJECT, SIGNATURE_INVALID",
             "v1_1-declared-purpose-string-injected.json,  REJECT, SIGNATURE_INVALID",
+            // Strict-parse rejections. The suite pins these PARSE_ERROR; this SDK
+            // has no such category and reports MALFORMED (see class javadoc).
+            "v1_1-duplicate-purpose-member.json,          REJECT, MALFORMED",
+            "v1_1-case-variant-member.json,               REJECT, MALFORMED",
     })
     void fixture(String file, String expectedResult, String expectedRejectCategory) throws Exception {
-        JsonNode fixture;
+        byte[] fixtureBytes;
         try (InputStream in = getClass().getResourceAsStream("/atx-fixtures/" + file.trim())) {
             assertNotNull(in, "fixture not found: " + file);
-            fixture = MAPPER.readTree(in);
+            fixtureBytes = in.readAllBytes();
         }
 
+        JsonNode fixture = MAPPER.readTree(fixtureBytes);
         JsonNode vs = fixture.get("verifierState");
-        Atx atx = MAPPER.treeToValue(fixture.get("atx"), Atx.class);
 
-        AtxVerificationResult result = new LocalAtxVerifier(anchorsFrom(vs)).verify(atx);
+        // Verify from the RAW credential bytes so the strict parse (duplicate /
+        // fold-colliding members at any depth) runs before any field is
+        // interpreted — the object-taking verify(Atx) overload cannot see members
+        // a lenient databind parse has already collapsed. The fixture wrapper
+        // itself stays lenient; only the atx credential is strict-parsed.
+        byte[] atxBytes = rawAtxBytes(fixtureBytes);
+        AtxVerificationResult result = new LocalAtxVerifier(anchorsFrom(vs)).verify(atxBytes);
 
         if ("ACCEPT".equals(expectedResult)) {
             assertEquals(true, result.valid(), "expected ACCEPT, got: " + result.reason());
@@ -69,6 +90,25 @@ class LocalAtxVerifierConformanceTest {
                 assertEquals(RejectCategory.valueOf(expectedRejectCategory.trim()), result.rejectCategory());
             }
         }
+    }
+
+    /**
+     * The raw-bytes entry point must reject every non-credential document as
+     * MALFORMED — never throw. Covers the JSON literal {@code null} (Jackson maps
+     * it to a Java null), bare scalars, a top-level array, empty/whitespace input,
+     * and null arguments.
+     */
+    @Test
+    void degenerateCredentialsRejectMalformed() {
+        LocalAtxVerifier v = new LocalAtxVerifier(
+                new AtxTrustAnchors(List.of(), List.of(), null, Clock.systemUTC()));
+        for (String bad : new String[] {"null", "5", "\"x\"", "true", "[]", "", "   "}) {
+            AtxVerificationResult r = v.verify(bad);
+            assertEquals(false, r.valid(), "expected reject for: [" + bad + "]");
+            assertEquals(RejectCategory.MALFORMED, r.rejectCategory(), "expected MALFORMED for: [" + bad + "]");
+        }
+        assertEquals(RejectCategory.MALFORMED, v.verify((String) null).rejectCategory());
+        assertEquals(RejectCategory.MALFORMED, v.verify((byte[]) null).rejectCategory());
     }
 
     private static AtxTrustAnchors anchorsFrom(JsonNode vs) {
@@ -98,5 +138,35 @@ class LocalAtxVerifierConformanceTest {
         }
 
         return new AtxTrustAnchors(trustedIssuers, publicKeys, crl, clock);
+    }
+
+    /**
+     * Extracts the verbatim bytes of the fixture's {@code atx} credential value,
+     * preserving any duplicate / case-variant members that a tree parse would
+     * collapse. Uses the streaming parser's byte offsets: the slice runs from the
+     * credential's opening brace to just past its matching close.
+     */
+    private static final JsonFactory JSON = new JsonFactory();
+
+    private static byte[] rawAtxBytes(byte[] fixtureBytes) throws IOException {
+        try (JsonParser p = JSON.createParser(fixtureBytes)) {
+            if (p.nextToken() != JsonToken.START_OBJECT) {
+                throw new IOException("fixture is not a JSON object");
+            }
+            while (p.nextToken() != JsonToken.END_OBJECT) {
+                String field = p.currentName();
+                JsonToken valueStart = p.nextToken();
+                if ("atx".equals(field)) {
+                    long start = p.currentTokenLocation().getByteOffset();
+                    p.skipChildren();
+                    long end = p.currentLocation().getByteOffset();
+                    return Arrays.copyOfRange(fixtureBytes, (int) start, (int) end);
+                }
+                if (valueStart == JsonToken.START_OBJECT || valueStart == JsonToken.START_ARRAY) {
+                    p.skipChildren();
+                }
+            }
+        }
+        throw new IOException("fixture has no atx member");
     }
 }

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-case-variant-member.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-case-variant-member.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/case-variant-member",
+  "description": "An ATX v1.1 credential carrying a decoy top-level TRUSTLEVEL member (value 9) injected before the signed trustLevel member (value 4) — two names that fold to the same field. Go's encoding/json resolves struct fields case-insensitively last-wins, so it collapses the pair to the signed trustLevel=4: a lenient Go verifier ACCEPTs, silently carrying a stray fold-colliding TRUSTLEVEL member. The same bytes read differently under other conforming parsers: a case-insensitive first-wins parser reads 9, and a case-sensitive parser (this suite's Python json.loads) keeps both as distinct members, reading trustLevel=4 alongside a separate TRUSTLEVEL=9. A case-SENSITIVE duplicate check flags neither. Because encoding/json's field folding makes the credential mean different things to different conforming parsers — the RFC 8259 §4 first-wins/last-wins parser divergence the strict parse exists to close — verifiers MUST fold member names and REJECT fold-colliding members with PARSE_ERROR before interpreting any field. Reference: foldKey in verifiers/go and verifiers/python (atx-conformance#16).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "PARSE_ERROR",
+    "reasonContains": "duplicate"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "TRUSTLEVEL": 9,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "yzWTRo2drtwsfSdx0RkabNQsRMXFR/KaJPA6lN95CcKbRuNVUN4QEmb/k/A3MGDn7IcSptJJv28KNHaMoL9wBw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-duplicate-purpose-member.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-duplicate-purpose-member.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
+  "name": "atx-v1_1/duplicate-purpose-member",
+  "description": "An ATX v1.1 credential whose declaredPurpose bytes contain the category member twice: a decoy (customer-support) followed by the signed value (financial-operations). The Ed25519 signature is REAL and covers the last-wins interpretation, so a lenient last-wins parser sees a verifying credential while a first-wins parser sees different content — the classic RFC 8259 §4 duplicate-member smuggling split. Because the entire ATX credential feeds the signed canonical form (JCS(TBS), §1.3a.2), verifiers MUST strict-parse the credential object and REJECT duplicate members at any depth with PARSE_ERROR, before interpreting any field. A verifier that parses last-wins without a duplicate check wrongly ACCEPTs; a first-wins verifier rejects with the wrong category (SIGNATURE_INVALID).",
+  "spec": [
+    {
+      "id": "ATX",
+      "ref": "https://github.com/opena2a-org/atx-spec/blob/main/core.md",
+      "section": "§1.1 Credential schema and §6 Threshold cosignature"
+    },
+    {
+      "id": "AIP",
+      "ref": "https://github.com/opena2a-org/agent-identity-protocol/blob/main/AIP-SPEC.md",
+      "section": "§3 Hybrid Ed25519 + ML-DSA-65 signing, §6.1 9-factor trust scoring"
+    },
+    {
+      "id": "RFC 8032",
+      "ref": "https://datatracker.ietf.org/doc/html/rfc8032",
+      "section": "§7.1 Test 1 (Ed25519 keypair source for issuer-primary)"
+    },
+    {
+      "id": "FIPS 204",
+      "ref": "https://csrc.nist.gov/pubs/fips/204/final",
+      "section": "ML-DSA-65 (Module-Lattice-Based DSA)"
+    }
+  ],
+  "keypairRefs": [
+    {
+      "role": "issuer-primary",
+      "path": "vectors/issuer-primary.json",
+      "algorithm": "Ed25519",
+      "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "keyId": "did:opena2a:authority:opena2a.org#key-1"
+    }
+  ],
+  "verifierState": {
+    "clockRfc3339": "2026-05-24T00:00:00Z",
+    "trustedIssuers": [
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "publicKeys": [
+      {
+        "role": "issuer-primary",
+        "path": "vectors/issuer-primary.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "keyId": "did:opena2a:authority:opena2a.org#key-1"
+      },
+      {
+        "role": "issuer-cosigner-1",
+        "path": "vectors/issuer-cosigner-1.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "keyId": "did:opena2a:authority:opena2a.org#key-2"
+      },
+      {
+        "role": "issuer-cosigner-2",
+        "path": "vectors/issuer-cosigner-2.json",
+        "algorithm": "Ed25519",
+        "publicKeyHex": "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "keyId": "did:opena2a:authority:opena2a.org#key-3"
+      }
+    ]
+  },
+  "expected": {
+    "verifyResult": "REJECT",
+    "rejectCategory": "PARSE_ERROR",
+    "reasonContains": "duplicate"
+  },
+  "atx": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "atcVersion": "1.1",
+    "agentId": "agent_conformance_test_001",
+    "agentDid": "did:opena2a:agent:agent_conformance_test_001",
+    "publisher": "opena2a-conformance",
+    "publisherDid": "did:opena2a:publisher:opena2a-conformance",
+    "version": "1.0.0",
+    "contentHash": "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    "buildAttestation": "https://slsa.dev/provenance/v1#opena2a-conformance",
+    "transparencyLogIndex": 42,
+    "capabilities": [
+      "read:public",
+      "write:owned"
+    ],
+    "declaredPurpose": {
+      "vocabVersion": "1",
+      "statement": "Processes customer billing inquiries and issues refunds up to a supervisor-set limit. 北京",
+      "category": "customer-support",
+      "category": "financial-operations",
+      "taskScopes": [
+        "billing:inquiry",
+        "billing:refund"
+      ],
+      "capabilityJustification": {
+        "read:public": [
+          "billing:inquiry"
+        ],
+        "write:owned": [
+          "billing:refund"
+        ]
+      },
+      "autonomy": "supervised",
+      "dataScopes": [
+        "customer.billing",
+        "customer.contact"
+      ],
+      "egressScopes": [
+        "api.stripe.com",
+        "hooks.internal.acme.com"
+      ]
+    },
+    "behavioralProfile": {
+      "checksum": "sha256:ghi789",
+      "generatedAt": "2026-05-19T00:00:00Z",
+      "observationDays": 14
+    },
+    "scanSummary": {
+      "hma": "passed",
+      "criticalFindings": 0,
+      "highFindings": 0,
+      "secretless": "clean",
+      "cryptoServe": "no-weak-crypto",
+      "oasbLevel": "L1"
+    },
+    "trustScore": 87.5,
+    "trustLevel": 4,
+    "issuedAt": "2026-05-23T00:00:00Z",
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "issuerDid": "did:opena2a:authority:opena2a.org",
+    "issuerChain": [
+      "did:opena2a:authority:opena2a.org-root",
+      "did:opena2a:authority:opena2a.org"
+    ],
+    "signatures": [
+      {
+        "keyId": "did:opena2a:authority:opena2a.org#key-1",
+        "algorithm": "Ed25519",
+        "value": "sfxSAtxm3TwrzodrXyjph5dEBGePWAot8lz96WdlCrCDYGlHvuAYhgWF/GCzwsFDxjWXUFYTUX0DN+0ofCvRAw=="
+      }
+    ],
+    "revoked": false,
+    "createdAt": "2026-05-23T00:00:00Z"
+  }
+}


### PR DESCRIPTION
Closes #335.

Bumps `ATX_CONFORMANCE_REF` to `f4d40a4` (opena2a-standards/atx-conformance suite 18 → 20 vendored fixtures) and teaches the Java `LocalAtxVerifier` the strict-parse rule the suite now pins.

## The rule

A duplicate object member at any depth of the credential — exact-name (`v1_1-duplicate-purpose-member`) **or** a case-variant a lenient parser folds together (`v1_1-case-variant-member`: `TRUSTLEVEL`/`trustLevel`) — is a signed-body smuggling split (RFC 8259 §4 first-wins/last-wins parser divergence) and must reject before any field is interpreted. Every ATX field feeds a signed canonical form, so there is no layer with sanctioned last-wins semantics.

Jackson's default is last-wins and its `@JsonIgnoreProperties(ignoreUnknown=true)` + case-sensitive matching means both smuggles would otherwise sail through to ACCEPT.

## Changes

- **`AtxStrictParse`** — a streaming Jackson fold-scan. `foldKey` mirrors the Go/Python reference verifiers (ASCII case + Kelvin `U+212A` + long-s `U+017F`). Catches exact **and** fold-colliding duplicates at any depth in one pass. Jackson's own `StreamReadConstraints` caps nesting, so a pathologically deep credential throws rather than overflowing (no manual depth guard needed, unlike Go).
- **`LocalAtxVerifier.verify(byte[])` / `verify(String)`** — the entry point wire consumers should use: `verify(Atx)` cannot see members a lenient databind parse already collapsed. A duplicate, unparseable, or JSON-`null` credential rejects `MALFORMED`. `STRICT_DUPLICATE_DETECTION` is enabled on the deserializer as defense-in-depth.
- **Category mapping** — the SDK `RejectCategory` union (shared with `@opena2a/atx-verify`) has no `PARSE_ERROR`; `MALFORMED` is its structural-parse category, so the two `PARSE_ERROR` fixtures are pinned to `MALFORMED` in the conformance test. (The TS SDK has the same missing-strict-parse gap — worth a follow-up.)
- **Fixtures vendored** (byte-match gated) and the conformance test routes every fixture through the raw-bytes strict path.

## Verification

- Java atx suite: **46/46** (conformance 21 incl. the two new REJECT fixtures + a degenerate-input reject test; `AtxStrictParse` unit tests).
- Go issuance byte-match: **20/20** — the two new REJECT fixtures pass through unmodified (their defects are verification-time, not JSON malformations; the client still preserves bytes).
- Vendored-fixture drift gate: byte-match, 20/20.
- Adversarial review of the verifier logic: fold false-negatives, token-stream sync, byte-offset extraction (incl. multibyte UTF-8), depth handling, and cross-language fold parity all verified; one NPE-on-JSON-`null` defect found and fixed with a regression test.