### PR TITLE
sdk-ts: bump @opena2a/atx-verify to 0.3.0 (1.0.1 -> 1.0.2)

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opena2a/aim-sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
         "@noble/post-quantum": "^0.2.1",
-        "@opena2a/atx-verify": "0.2.0",
+        "@opena2a/atx-verify": "0.3.0",
         "fastify-plugin": "^6.0.0",
         "js-yaml": "^4.1.1"
       },
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@opena2a/atx-verify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.2.0.tgz",
-      "integrity": "sha512-tq1mZTgDLhEm0Gyhh0jqtcon1iBQbwYNxGPly3uT/SQoRVHXMRNCx8b9zmBFKgSwe8Q7NBrLjOHySGuKCX/ucg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.3.0.tgz",
+      "integrity": "sha512-2kRybBSfQv128jhcmfgZSpG0y9uK989pdgL86dCIiqEnj5/YXLpoYjrF0ijHgtpfJdhPekwaprnUbDXi1htqhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Agent Identity Management SDK for TypeScript/Node.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -76,7 +76,7 @@
   "dependencies": {
     "@noble/ed25519": "^2.1.0",
     "@noble/post-quantum": "^0.2.1",
-    "@opena2a/atx-verify": "0.2.0",
+    "@opena2a/atx-verify": "0.3.0",
     "fastify-plugin": "^6.0.0",
     "js-yaml": "^4.1.1"
   },


### PR DESCRIPTION
Propagation of @opena2a/atx-verify 0.3.0 (opena2a-org/opena2a#230, published today with SLSA v1 provenance).

**Why this matters for the SDK:** 0.2.0's v1.1 TBS projection omitted `declaredPurpose` (atx-spec §1.3a.2 rule 5), so `LocalVerifier`/`AIMClient.verifyActionLocally` accepted unsigned purpose content appended to a signed credential and falsely rejected honestly-signed purposes. The pin bump alone closes that — the fix is in `canonicalPayloadV11`, on the parsed-object `verify(atx)` path the SDK already uses.

**Not in this PR:** 0.3.0's raw strict-parse entry point (`LocalAtxVerifier.verifyCredential(string | Uint8Array)`, duplicate-member smuggle rejection). The SDK's credential path only ever sees pre-parsed `Atx` objects — AAP resolution (the only step holding raw bytes) happens outside the SDK — so adopting it means designing a new raw-accepting public entry point (and resolving the nominal name collision with `LocalVerifier.verifyCredential(atx)`). Tracked as a 1.1.0 design item.

989 tests + CJS/ESM `smoke:local` consumer checks green. Publish via `sdk-ts-v1.0.2` tag after merge (Trusted Publishing).