### PR TITLE
chore: point published contact email to info@opena2a.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Full index: [docs/USE-CASES.md](docs/USE-CASES.md).
 
 Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, test conventions, and pre-push review gates.
 
-Security issues: `security@opena2a.org` (coordinated disclosure, response within 24 hours).
+Security issues: `info@opena2a.org` (coordinated disclosure, response within 24 hours).
 
 ## Links
 

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -659,7 +659,7 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 // Platform admins are AIM Cloud operators (e.g., the OpenA2A team), distinct from
 // customer org admins. The allowlist is a comma-separated env var, e.g.:
 //
-//	AIM_PLATFORM_ADMINS=info@opena2a.org,ops@opena2a.org
+//	AIM_PLATFORM_ADMINS=info@opena2a.org,abdel@opena2a.org
 //
 // Email comparison is case-insensitive and trims whitespace. Empty env var means
 // no platform admins exist (safe default — only approved-by-existing-admin users

--- a/docs/api/direct-api-usage.md
+++ b/docs/api/direct-api-usage.md
@@ -751,7 +751,7 @@ curl -H "Authorization: Bearer YOUR_API_KEY" \
 ## Need Help?
 
 - 💬 **Discord**: https://discord.gg/uRZa3KXgEn
-- 📧 **Email**: support@opena2a.org
+- 📧 **Email**: info@opena2a.org
 - 🐛 **GitHub Issues**: https://github.com/opena2a-org/agent-identity-management/issues
 - 📚 **API Docs**: https://docs.opena2a.org/api
 


### PR DESCRIPTION
Points published contact/security emails to `info@opena2a.org`, the real monitored business inbox.

The previously listed addresses (`security@`, `support@`, etc.) are not provisioned and receive no mail.

Part of an org-wide contact-email sweep. Only the email strings changed; no logic. The Go change is a doc-comment example (`AIM_PLATFORM_ADMINS=info@,abdel@`), not runtime behavior.