### PR TITLE
auth: allow machine API keys to register agents via a narrow gate

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1434,7 +1434,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Use(middleware.RateLimitMiddleware())
 	agents.Get("/", h.Agent.ListAgents)
 	agents.Post("/bulk-status", h.Lifecycle.BulkStatus) // Bulk agent status lookup
-	agents.Post("/", middleware.MemberMiddleware(), h.Agent.CreateAgent)
+	agents.Post("/", middleware.MemberOrAPIKeyMiddleware(), h.Agent.CreateAgent) // machine API keys (org-scoped) OR member+ JWT; other routes stay MemberMiddleware (JWT-only)
 	agents.Get("/:id", h.Agent.GetAgent)
 	agents.Put("/:id", middleware.MemberMiddleware(), h.Agent.UpdateAgent)
 	agents.Delete("/:id", middleware.ManagerMiddleware(), h.Agent.DeleteAgent)

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -311,8 +311,17 @@ func (h *AgentHandler) CreateAgent(c fiber.Ctx) error {
 	// Check if this is an SDK registration (set by SDKTokenTrackingMiddleware)
 	isSDKRegistration, _ := c.Locals("is_sdk_registration").(bool)
 
-	if !isSDKRegistration && sdkTokenID == nil {
-		// Non-SDK registration: auto-create API key for convenience
+	// A machine API-key caller already holds a durable credential. Do NOT auto-mint
+	// another long-lived (1-year) key for it: that would turn every registration into
+	// a persistence vector where a short-lived key bootstraps a long-lived one. Such
+	// callers can mint keys explicitly via the JWT-gated /api-keys route if needed.
+	isAPIKeyAuth := false
+	if m, _ := c.Locals("auth_method").(string); m == "api_key" {
+		isAPIKeyAuth = true
+	}
+
+	if !isSDKRegistration && sdkTokenID == nil && !isAPIKeyAuth {
+		// Non-SDK, non-machine-key registration: auto-create API key for convenience
 		apiKeyName := fmt.Sprintf("%s-default-key", agent.Name)
 		fullAPIKey, apiKeyRecord, apiKeyErr = h.apiKeyService.GenerateAPIKey(
 			c.Context(),

--- a/apps/backend/internal/interfaces/http/middleware/admin.go
+++ b/apps/backend/internal/interfaces/http/middleware/admin.go
@@ -67,3 +67,39 @@ func MemberMiddleware() fiber.Handler {
 		return c.Next()
 	}
 }
+
+// MemberOrAPIKeyMiddleware allows a request authenticated EITHER by a valid API
+// key (a machine principal, org derived from the key) OR by a human with at
+// least member role (the JWT path). Must be used AFTER the auth middlewares that
+// set "auth_method" / "role" (OptionalAPIKeyMiddleware + AuthMiddleware).
+//
+// It exists so machine API keys can register agents (POST /agents/) WITHOUT the
+// blanket member surface that setting a role on the API-key path would grant.
+// Deliberately narrow: it is applied ONLY to agent registration. Every other
+// role-gated route keeps MemberMiddleware / ManagerMiddleware / AdminMiddleware,
+// which require a JWT role — so key-material routes (credential rotation, agent
+// key replacement, PQC key registration) stay unreachable by a bearer API key.
+// Agent-signature auth (ed25519/mldsa/hybrid/atc) sets no role and is not
+// "api_key", so an already-registered agent still cannot register other agents.
+func MemberOrAPIKeyMiddleware() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		if method, _ := c.Locals("auth_method").(string); method == "api_key" {
+			return c.Next()
+		}
+
+		role, ok := c.Locals("role").(string)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Authentication required",
+			})
+		}
+
+		if role == string(domain.RoleViewer) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "Member access required (viewers cannot perform this action)",
+			})
+		}
+
+		return c.Next()
+	}
+}

--- a/apps/backend/internal/interfaces/http/middleware/admin_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/admin_test.go
@@ -243,3 +243,112 @@ func TestMemberMiddleware_IsMember(t *testing.T) {
 		})
 	}
 }
+
+// ===========================================================================
+// MemberOrAPIKeyMiddleware — the narrow agent-registration gate.
+// A machine API key (auth_method=api_key) may register agents; a member+ JWT
+// may too; viewers and unauthenticated are rejected; agent-signature auth
+// (ed25519/atc, no role) cannot register agents. The final test locks the
+// invariant that a machine key must STILL be blocked by plain MemberMiddleware,
+// so no other role-gated route (credential rotation, key replacement, pqc-key)
+// opens to bearer API keys.
+// ===========================================================================
+
+// withLocals sets arbitrary Fiber locals before the middleware under test.
+func withLocals(kv map[string]string) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		for k, v := range kv {
+			c.Locals(k, v)
+		}
+		return c.Next()
+	}
+}
+
+func TestMemberOrAPIKey_APIKeyPasses(t *testing.T) {
+	app := fiber.New()
+	app.Use(withLocals(map[string]string{"auth_method": "api_key"})) // no role, like OptionalAPIKeyMiddleware
+	app.Use(MemberOrAPIKeyMiddleware())
+	app.Post("/agents", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+	req := httptest.NewRequest("POST", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode, "a valid API key must be allowed to register agents")
+}
+
+func TestMemberOrAPIKey_MemberJWTPasses(t *testing.T) {
+	app := fiber.New()
+	app.Use(withLocals(map[string]string{"role": string(domain.RoleMember)}))
+	app.Use(MemberOrAPIKeyMiddleware())
+	app.Post("/agents", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+	req := httptest.NewRequest("POST", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusCreated, resp.StatusCode)
+}
+
+func TestMemberOrAPIKey_ViewerBlocked(t *testing.T) {
+	app := fiber.New()
+	app.Use(withLocals(map[string]string{"role": string(domain.RoleViewer)}))
+	app.Use(MemberOrAPIKeyMiddleware())
+	app.Post("/agents", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+	req := httptest.NewRequest("POST", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
+func TestMemberOrAPIKey_UnauthenticatedBlocked(t *testing.T) {
+	app := fiber.New()
+	app.Use(MemberOrAPIKeyMiddleware()) // nothing set
+	app.Post("/agents", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+	req := httptest.NewRequest("POST", "/agents", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+// Agent-signature auth (ed25519/mldsa/hybrid/atc) sets auth_method but no role
+// and is not "api_key" — an already-registered agent must not be able to register
+// agents. All such auth methods must be rejected by the gate.
+func TestMemberOrAPIKey_AgentSignatureBlocked(t *testing.T) {
+	for _, method := range []string{"ed25519", "mldsa", "hybrid", "atc"} {
+		t.Run(method, func(t *testing.T) {
+			app := fiber.New()
+			app.Use(withLocals(map[string]string{"auth_method": method}))
+			app.Use(MemberOrAPIKeyMiddleware())
+			app.Post("/agents", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusCreated) })
+
+			req := httptest.NewRequest("POST", "/agents", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode, "agent-signature auth must not register agents")
+		})
+	}
+}
+
+// INVARIANT LOCK: a machine API key (auth_method=api_key, no role) must STILL be
+// rejected by plain MemberMiddleware. This proves the fix opens ONLY the
+// agent-registration route and no other role-gated route (rotate-credentials,
+// key replacement, pqc-key) becomes reachable by a bearer API key.
+func TestMemberMiddleware_StillBlocksAPIKey(t *testing.T) {
+	app := fiber.New()
+	app.Use(withLocals(map[string]string{"auth_method": "api_key"})) // key authed, but no role
+	app.Use(MemberMiddleware())
+	app.Post("/agents/x/rotate-credentials", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	req := httptest.NewRequest("POST", "/agents/x/rotate-credentials", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode,
+		"API keys must NOT pass plain MemberMiddleware — key-material routes stay JWT-only")
+}


### PR DESCRIPTION
## Problem

A machine API key authenticates an org-scoped principal (organization + creating user), but the API-key auth path never sets a `role`. `MemberMiddleware` is role-gated, so a valid API key could **read** agents but was rejected (401) when trying to **register** one via `POST /api/v1/agents/`. That blocks any headless/service integration from enrolling an agent with a key.

## Approach — a narrow gate, not a blanket role

The tempting fix is to give API keys a `member` role in the auth middleware. That was rejected: it would open **every** `MemberMiddleware`-gated route to a bearer credential — including credential rotation (returns a fresh private key) and agent key replacement — which is exactly what a bearer token should not reach.

Instead this adds `MemberOrAPIKeyMiddleware` and applies it to **only** `POST /agents/`:

- Passes an authenticated API key (`auth_method=api_key`, org derived from the key) **or** a member+ JWT.
- Rejects viewers, unauthenticated requests, and agent-signature auth (ed25519/mldsa/hybrid/atc) — an already-registered agent cannot register other agents.
- Every other role-gated route keeps `MemberMiddleware` / `ManagerMiddleware` / `AdminMiddleware`, so key-material routes (rotate-credentials, `PUT /:id/keys`, pqc-key) stay unreachable by a bearer key. An invariant-lock test asserts a bare API key is still rejected by plain `MemberMiddleware`.

Also suppresses the per-agent auto-mint of a 1-year API key when the caller authenticated with an API key — otherwise every registration would let a short-lived key bootstrap a long-lived one (a persistence vector). Such callers can mint keys explicitly via the JWT-gated `/api-keys` route.

## Tests

`MemberOrAPIKeyMiddleware` gate (api-key pass, member pass, viewer 403, unauth 401, agent-sig blocked across ed25519/mldsa/hybrid/atc) plus the invariant lock. Teeth verified by mutation (removing the api-key bypass fails the pass test; making `MemberMiddleware` accept api-key fails the lock). `go build`, `go test -race`, `go vet` green.