### PR TITLE
harden delegation verification: enforce signed temporal window

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to `@opena2a/aim-sdk` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Security
+
+- **Delegation verification now enforces temporal validity.** `verifyDelegation`
+  and `verifyDelegationChain` previously checked signature, delegator identity and
+  scope narrowing but never evaluated the signed `createdAt`/`expiresAt` window, so
+  an expired delegation — and a child that outlived its parent — still verified as
+  valid. Verification now rejects delegations that are expired, have an unparseable
+  or missing timestamp, or have an inverted window (`createdAt` after `expiresAt`),
+  and fails closed in every one of those cases. `verifyDelegationChain` evaluates
+  every hop against a single shared instant.
+
+### Added
+
+- `verifyDelegation(delegation, { verifyAt })` and
+  `verifyDelegationChain(chain, { verifyAt })` accept an explicit evaluation time
+  (a `Date` or ISO-8601 string) for deterministic tests and offline / as-of
+  verification. Defaults to the current time.
+- `checkDelegationTemporalValidity(delegation, verifyAt?)` — the standalone
+  temporal check, exported for callers that want the reason a delegation is
+  temporally invalid.
+- `verifyDelegationSignature(delegation)` — the raw Ed25519 signature check with
+  no temporal evaluation, for archival/audit inspection where authenticity matters
+  independent of time. `verifyDelegation` now composes signature + temporal checks.
+- `DelegationChainResult` gains a `temporalValid` field.
+
+### Notes
+
+- The production ATX/ATC credential verifiers (Go backend, `LocalVerifier`, the
+  Java SDK) already enforce credential expiry and are unaffected. This change
+  concerns the cross-engine delegation-chain primitive in this package.
+- Reported privately by Tymofii Pidlisnyi (Agent Passport System,
+  agent-passport.org).

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@opena2a/aim-sdk` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.0.3] - 2026-07-15
 
 ### Security
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Agent Identity Management SDK for TypeScript/Node.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -34,6 +34,7 @@
     "express",
     "fastify",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "scripts": {

--- a/sdk/typescript/src/crypto/delegation.test.ts
+++ b/sdk/typescript/src/crypto/delegation.test.ts
@@ -6,9 +6,11 @@ import {
   canonicalJSONDeep,
   createDelegation,
   verifyDelegation,
+  verifyDelegationSignature,
   verifyDelegatorIdentity,
   verifyScopeNarrowing,
   verifyDelegationChain,
+  checkDelegationTemporalValidity,
   exportDelegationChain,
   delegationSignablePayload,
   toBase64url,
@@ -312,6 +314,198 @@ describe('Delegation chain verification', () => {
     const result = await verifyDelegationChain([d1, d2]);
     expect(result.valid).toBe(false);
     expect(result.results[1].scopeValid).toBe(false);
+  });
+});
+
+describe('Temporal validity (expiry enforcement)', () => {
+  // A delegation whose window is entirely in the past.
+  async function makeExpired() {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    return createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-08T00:00:00.000Z',
+    });
+  }
+
+  it('checkDelegationTemporalValidity rejects an expired delegation', async () => {
+    const d = await makeExpired();
+    const res = checkDelegationTemporalValidity(d, '2026-02-01T00:00:00.000Z');
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/expired/i);
+  });
+
+  it('checkDelegationTemporalValidity accepts a delegation live at the eval time', async () => {
+    const d = await makeExpired();
+    expect(checkDelegationTemporalValidity(d, '2026-01-05T00:00:00.000Z').valid).toBe(true);
+  });
+
+  it('checkDelegationTemporalValidity fails closed on unparseable timestamps', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: 'not-a-date',
+      expiresAt: 'also-not-a-date',
+    });
+    expect(checkDelegationTemporalValidity(d).valid).toBe(false);
+  });
+
+  it('checkDelegationTemporalValidity rejects createdAt after expiresAt', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2030-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-01T00:00:00.000Z',
+    });
+    const res = checkDelegationTemporalValidity(d, '2027-01-01T00:00:00.000Z');
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/createdAt/i);
+  });
+
+  it('checkDelegationTemporalValidity fails closed when verifyAt itself is unparseable', async () => {
+    const d = await makeExpired();
+    expect(checkDelegationTemporalValidity(d, 'garbage-time').valid).toBe(false);
+  });
+
+  it('verifyDelegation rejects an expired delegation (default: now)', async () => {
+    const d = await makeExpired();
+    expect(await verifyDelegation(d)).toBe(false);
+  });
+
+  it('verifyDelegation accepts an expired delegation when verifyAt is pinned inside its window', async () => {
+    const d = await makeExpired();
+    expect(await verifyDelegation(d, { verifyAt: '2026-01-05T00:00:00.000Z' })).toBe(true);
+  });
+
+  it('verifyDelegation still rejects a tampered-but-in-window delegation', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+    });
+    d.scopes = ['search', 'admin'];
+    expect(await verifyDelegation(d, { verifyAt: '2027-01-01T00:00:00.000Z' })).toBe(false);
+  });
+
+  it('verifyDelegationSignature ignores expiry (pure crypto check)', async () => {
+    const d = await makeExpired();
+    // Signature is authentic even though the delegation is expired.
+    expect(await verifyDelegationSignature(d)).toBe(true);
+    expect(await verifyDelegation(d)).toBe(false);
+  });
+
+  it('verifyDelegationChain rejects a chain whose sole delegation is expired', async () => {
+    const d = await makeExpired();
+    const result = await verifyDelegationChain([d]);
+    expect(result.valid).toBe(false);
+    expect(result.results[0].temporalValid).toBe(false);
+  });
+
+  it('verifyDelegationChain rejects a child that outlives an expired parent (reporter case 2)', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search', 'memory.read'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-07-15T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2036-01-01T00:00:00.000Z',
+    });
+
+    // Evaluate after the parent has expired.
+    const result = await verifyDelegationChain([parent, child], { verifyAt: '2026-08-01T00:00:00.000Z' });
+    expect(result.valid).toBe(false);
+    expect(result.results[0].temporalValid).toBe(false); // parent expired
+    expect(result.results[1].temporalValid).toBe(true); // child still live, but chain fails on parent
+  });
+
+  it('verifyDelegationChain accepts the same chain while the parent is still live', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search', 'memory.read'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-07-15T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      parentDelegation: 'del-1',
+    });
+
+    const result = await verifyDelegationChain([parent, child], { verifyAt: '2026-05-01T00:00:00.000Z' });
+    expect(result.valid).toBe(true);
+    expect(result.results.every((r) => r.temporalValid)).toBe(true);
+  });
+
+  it('verifyDelegationChain uses a single evaluation time across all hops', async () => {
+    // Both delegations expire at the same instant; evaluating exactly after it
+    // must fail every hop, not race between per-hop clock reads.
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-02-01T00:00:00.000Z',
+    });
+    const atExpiry = await verifyDelegationChain([d], { verifyAt: '2026-02-01T00:00:00.000Z' });
+    expect(atExpiry.valid).toBe(false); // expiry is exclusive: valid strictly before expiresAt
+  });
+
+  it('verifyDelegationChain fails closed when verifyAt is unparseable', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+    });
+    const result = await verifyDelegationChain([d], { verifyAt: 'not-a-time' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('freshly created delegations still verify (no regression)', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const d = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+    });
+    expect(await verifyDelegation(d)).toBe(true);
+    expect((await verifyDelegationChain([d])).valid).toBe(true);
   });
 });
 

--- a/sdk/typescript/src/crypto/delegation.ts
+++ b/sdk/typescript/src/crypto/delegation.ts
@@ -236,9 +236,16 @@ export async function createDelegation(params: {
 }
 
 /**
- * Verify a single delegation's Ed25519 signature.
+ * Verify a single delegation's Ed25519 signature only.
+ *
+ * This is the raw cryptographic check: it proves the delegation was signed by
+ * the holder of `publicKey` and has not been tampered with. It deliberately
+ * ignores temporal validity — an authentic but expired delegation returns true.
+ * Prefer {@link verifyDelegation}, which also enforces the signed `expiresAt`
+ * window. Use this only when you need signature authenticity independent of
+ * time (e.g. archival/audit inspection).
  */
-export async function verifyDelegation(delegation: Delegation): Promise<boolean> {
+export async function verifyDelegationSignature(delegation: Delegation): Promise<boolean> {
   try {
     const publicKeyBytes = fromBase64url(delegation.publicKey);
     const signatureBytes = fromBase64url(delegation.signature);
@@ -247,6 +254,83 @@ export async function verifyDelegation(delegation: Delegation): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+/**
+ * Options controlling temporal (expiry) evaluation.
+ */
+export interface DelegationTemporalOptions {
+  /**
+   * The instant to evaluate temporal validity against. Accepts a Date or an
+   * ISO-8601 string; defaults to the current time. Supply it to keep tests
+   * deterministic and to support offline / as-of verification. If provided but
+   * unparseable, verification fails closed.
+   */
+  verifyAt?: Date | string;
+}
+
+export interface DelegationTemporalResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Resolve a verifyAt option to epoch milliseconds. Returns NaN when the caller
+ * supplied a value that cannot be parsed, so callers can fail closed.
+ */
+function resolveVerifyAtMs(verifyAt?: Date | string): number {
+  if (verifyAt === undefined) return Date.now();
+  if (verifyAt instanceof Date) return verifyAt.getTime();
+  return Date.parse(verifyAt);
+}
+
+/**
+ * Evaluate a delegation's signed temporal window (`createdAt`/`expiresAt`)
+ * against an evaluation time. Fails closed: a missing or unparseable timestamp,
+ * an inverted window (createdAt after expiresAt), or an unparseable evaluation
+ * time all return `{ valid: false }`. The expiry bound is exclusive — a
+ * delegation is valid strictly before `expiresAt`.
+ */
+export function checkDelegationTemporalValidity(
+  delegation: Pick<Delegation, 'createdAt' | 'expiresAt'>,
+  verifyAt?: Date | string,
+): DelegationTemporalResult {
+  const atMs = resolveVerifyAtMs(verifyAt);
+  if (Number.isNaN(atMs)) return { valid: false, error: 'Unparseable verifyAt evaluation time' };
+  return temporalAtMs(delegation, atMs);
+}
+
+/**
+ * Core temporal check against a resolved epoch-ms evaluation time. Kept private
+ * so a chain can evaluate every hop against one shared instant.
+ */
+function temporalAtMs(
+  delegation: Pick<Delegation, 'createdAt' | 'expiresAt'>,
+  atMs: number,
+): DelegationTemporalResult {
+  const createdMs = delegation.createdAt === undefined ? NaN : Date.parse(delegation.createdAt);
+  const expiresMs = delegation.expiresAt === undefined ? NaN : Date.parse(delegation.expiresAt);
+  if (Number.isNaN(createdMs)) return { valid: false, error: 'Missing or unparseable createdAt timestamp' };
+  if (Number.isNaN(expiresMs)) return { valid: false, error: 'Missing or unparseable expiresAt timestamp' };
+  if (createdMs > expiresMs) return { valid: false, error: 'Invalid window: createdAt is after expiresAt' };
+  if (atMs >= expiresMs) return { valid: false, error: 'Delegation has expired' };
+  return { valid: true };
+}
+
+/**
+ * Verify a single delegation: Ed25519 signature AND temporal validity.
+ *
+ * Returns true only when the signature is authentic and the delegation is
+ * within its signed `createdAt`/`expiresAt` window at the evaluation time
+ * (default: now). Expired, not-yet-parseable, or malformed-window delegations
+ * return false. Pass `options.verifyAt` for deterministic or offline checks.
+ */
+export async function verifyDelegation(
+  delegation: Delegation,
+  options?: DelegationTemporalOptions,
+): Promise<boolean> {
+  if (!(await verifyDelegationSignature(delegation))) return false;
+  return checkDelegationTemporalValidity(delegation, options?.verifyAt).valid;
 }
 
 /**
@@ -269,7 +353,7 @@ export function verifyScopeNarrowing(parent: Delegation, child: Delegation): boo
   return child.scopes.every((scope) => parent.scopes.includes(scope));
 }
 
-export interface DelegationChainVerificationOptions {
+export interface DelegationChainVerificationOptions extends DelegationTemporalOptions {
   rootTrustScore?: number; // Trust score of the root delegator (default 1.0)
 }
 
@@ -279,6 +363,7 @@ export interface DelegationChainResult {
   signatureValid: boolean;
   identityValid: boolean;
   scopeValid: boolean;
+  temporalValid: boolean;
   effectiveTrust: number;
   error?: string;
 }
@@ -290,7 +375,9 @@ export interface DelegationChainResult {
  * 2. Each delegator's publicKey matches their DID
  * 3. Each sub-delegation's delegator matches the parent's delegate
  * 4. Scope narrowing is enforced
- * 5. Trust attenuation: effective trust decays per hop and must stay above minimum
+ * 5. Temporal validity: every hop must be within its signed createdAt/expiresAt
+ *    window, evaluated against one shared instant for the whole chain
+ * 6. Trust attenuation: effective trust decays per hop and must stay above minimum
  */
 export async function verifyDelegationChain(
   chain: Delegation[],
@@ -300,7 +387,14 @@ export async function verifyDelegationChain(
   results: DelegationChainResult[];
 }> {
   if (chain.length === 0) {
-    return { valid: false, results: [{ index: 0, label: 'root', signatureValid: false, identityValid: false, scopeValid: false, effectiveTrust: 0, error: 'Empty delegation chain' }] };
+    return { valid: false, results: [{ index: 0, label: 'root', signatureValid: false, identityValid: false, scopeValid: false, temporalValid: false, effectiveTrust: 0, error: 'Empty delegation chain' }] };
+  }
+
+  // Capture ONE evaluation instant for the whole chain so every hop is judged
+  // against the same clock. Fail closed if a supplied verifyAt is unparseable.
+  const evalAtMs = resolveVerifyAtMs(options?.verifyAt);
+  if (Number.isNaN(evalAtMs)) {
+    return { valid: false, results: [{ index: 0, label: 'root', signatureValid: false, identityValid: false, scopeValid: false, temporalValid: false, effectiveTrust: 0, error: 'Unparseable verifyAt evaluation time' }] };
   }
 
   const results: DelegationChainResult[] = [];
@@ -310,15 +404,17 @@ export async function verifyDelegationChain(
     const delegation = chain[i];
     const label = i === 0 ? 'root' : `subdelegation-${i}`;
 
-    const signatureValid = await verifyDelegation(delegation);
+    const signatureValid = await verifyDelegationSignature(delegation);
     const identityValid = verifyDelegatorIdentity(delegation);
+    const temporal = temporalAtMs(delegation, evalAtMs);
+    const temporalValid = temporal.valid;
 
     let scopeValid = true;
     if (i > 0) {
       scopeValid = verifyScopeNarrowing(chain[i - 1], delegation);
       // Also verify chain linkage: this delegator should be the parent's delegate
       if (delegation.delegator !== chain[i - 1].delegate) {
-        results.push({ index: i, label, signatureValid, identityValid, scopeValid: false, effectiveTrust, error: 'Chain broken: delegator does not match parent delegate' });
+        results.push({ index: i, label, signatureValid, identityValid, scopeValid: false, temporalValid, effectiveTrust, error: 'Chain broken: delegator does not match parent delegate' });
         continue;
       }
 
@@ -335,6 +431,7 @@ export async function verifyDelegationChain(
           signatureValid,
           identityValid,
           scopeValid,
+          temporalValid,
           effectiveTrust,
           error: `Effective trust ${effectiveTrust.toFixed(4)} is below minimum threshold ${minTrust}`,
         });
@@ -342,11 +439,13 @@ export async function verifyDelegationChain(
       }
     }
 
-    results.push({ index: i, label, signatureValid, identityValid, scopeValid, effectiveTrust });
+    // Surface an expiry/window failure as the hop error when nothing worse fired.
+    const error = temporalValid ? undefined : temporal.error;
+    results.push({ index: i, label, signatureValid, identityValid, scopeValid, temporalValid, effectiveTrust, error });
   }
 
   return {
-    valid: results.every((r) => r.signatureValid && r.identityValid && r.scopeValid && !r.error),
+    valid: results.every((r) => r.signatureValid && r.identityValid && r.scopeValid && r.temporalValid && !r.error),
     results,
   };
 }

--- a/sdk/typescript/src/crypto/signed-field-enforcement.test.ts
+++ b/sdk/typescript/src/crypto/signed-field-enforcement.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Signed-field enforcement harness.
+ *
+ * A verifier's most dangerous bug is a MISSING check: a field that is signed
+ * into the payload but never evaluated at verification time, so the verdict
+ * silently ignores it. `@opena2a/aim-sdk` 1.0.2 signed `expiresAt` into every
+ * delegation but never enforced it — expired delegations verified as valid.
+ *
+ * This harness makes that bug class fail CI by construction. It derives the set
+ * of fields that go INTO the signed bytes directly from the signable payload,
+ * then asserts that for every one of those fields there is a violation which
+ * flips `verifyDelegation` / `verifyDelegationChain` to reject. A newly added
+ * signed field with no registered violation fails the coverage assertion, so the
+ * enforcement gap cannot merge unnoticed.
+ *
+ * See the pre-push-review "Signed-Field Enforcement Matrix" phase.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeyPair, type KeyPair } from './ed25519';
+import {
+  createDelegation,
+  verifyDelegation,
+  verifyDelegationChain,
+  delegationSignablePayload,
+  publicKeyToDidKey,
+  toBase64url,
+  type Delegation,
+} from './delegation';
+
+// A fixed evaluation time inside the fixtures' validity window, so "valid"
+// fixtures are unambiguously live and only the injected violation causes a
+// rejection.
+const NOW = '2026-03-01T00:00:00.000Z';
+
+async function baseDelegation(delegator: KeyPair, delegatePub: Uint8Array): Promise<Delegation> {
+  return createDelegation({
+    delegatorKeyPair: delegator,
+    delegatePublicKey: delegatePub,
+    scopes: ['search', 'memory.read'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2026-12-31T00:00:00.000Z',
+  });
+}
+
+/**
+ * For each field that appears in the signed payload, a mutation that violates
+ * it. Every signed field MUST have an entry here (enforced by the coverage
+ * test below); each mutation MUST make verification reject.
+ */
+type Violation = {
+  reason: string;
+  mutate: (d: Delegation) => Delegation;
+};
+
+const VIOLATIONS: Record<string, Violation> = {
+  delegator: {
+    reason: 'delegator DID no longer matches the signing key',
+    mutate: (d) => ({ ...d, delegator: 'did:key:zInvalidDelegatorDid' }),
+  },
+  delegate: {
+    reason: 'delegate DID swapped after signing',
+    mutate: (d) => ({ ...d, delegate: 'did:key:zAttackerControlledDelegate' }),
+  },
+  scopes: {
+    reason: 'scopes widened after signing',
+    mutate: (d) => ({ ...d, scopes: [...d.scopes, 'admin'] }),
+  },
+  created_at: {
+    reason: 'createdAt after expiresAt (inverted window)',
+    mutate: (d) => ({ ...d, createdAt: '2030-01-01T00:00:00.000Z' }),
+  },
+  expires_at: {
+    reason: 'delegation is expired at the evaluation time',
+    mutate: (d) => ({ ...d, expiresAt: '2026-02-01T00:00:00.000Z' }),
+  },
+  parent_delegation: {
+    reason: 'parentDelegation reference altered after signing',
+    mutate: (d) => ({ ...d, parentDelegation: 'del-tampered' }),
+  },
+};
+
+describe('Signed-field enforcement coverage', () => {
+  it('every field in the signed payload has a registered violation', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const withParent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-12-31T00:00:00.000Z',
+      parentDelegation: 'del-root',
+    });
+
+    const signedFields = Object.keys(
+      JSON.parse(new TextDecoder().decode(delegationSignablePayload(withParent))),
+    );
+
+    const uncovered = signedFields.filter((f) => !(f in VIOLATIONS));
+    // If this fails, a new field was added to the signed payload without a
+    // corresponding negative test. Enforcement is unproven — add a violation
+    // (and the verifier check it exercises) before shipping.
+    expect(uncovered, `signed fields with no enforcement violation: ${uncovered.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('Signed-field enforcement — single delegation', () => {
+  for (const [field, violation] of Object.entries(VIOLATIONS)) {
+    // parent_delegation is only present on sub-delegations; covered in the chain block.
+    if (field === 'parent_delegation') continue;
+
+    it(`rejects when ${field} is violated (${violation.reason})`, async () => {
+      const root = await generateKeyPair();
+      const agent = await generateKeyPair();
+      const good = await baseDelegation(root, agent.publicKey);
+
+      // Sanity: the untouched fixture verifies at NOW.
+      expect(await verifyDelegation(good, { verifyAt: NOW })).toBe(true);
+
+      // The violated fixture must be rejected.
+      const bad = violation.mutate(structuredClone(good));
+      expect(await verifyDelegation(bad, { verifyAt: NOW })).toBe(false);
+    });
+  }
+});
+
+describe('Signed-field enforcement — delegation chain', () => {
+  async function goodChain(): Promise<{ chain: Delegation[]; agent: KeyPair; leaf: KeyPair; root: KeyPair }> {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search', 'memory.read'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-12-31T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2026-12-31T00:00:00.000Z',
+      parentDelegation: 'del-root',
+    });
+    return { chain: [parent, child], agent, leaf, root };
+  }
+
+  it('accepts an untampered chain at the evaluation time', async () => {
+    const { chain } = await goodChain();
+    expect((await verifyDelegationChain(chain, { verifyAt: NOW })).valid).toBe(true);
+  });
+
+  for (const [field, violation] of Object.entries(VIOLATIONS)) {
+    it(`rejects the chain when the child's ${field} is violated (${violation.reason})`, async () => {
+      const { chain } = await goodChain();
+      const tampered = [chain[0], violation.mutate(structuredClone(chain[1]))];
+      expect((await verifyDelegationChain(tampered, { verifyAt: NOW })).valid).toBe(false);
+    });
+  }
+
+  it('rejects a child that outlives its parent once the parent has expired', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-04-01T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2036-01-01T00:00:00.000Z',
+      parentDelegation: 'del-root',
+    });
+
+    // After the parent expires, the chain must fail even though the child is live.
+    expect((await verifyDelegationChain([parent, child], { verifyAt: '2026-05-01T00:00:00.000Z' })).valid).toBe(false);
+  });
+});
+
+describe('Signed-field enforcement — fail-closed on malformed input', () => {
+  it('rejects a delegation with a non-signature string in the signature field', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const good = await baseDelegation(root, agent.publicKey);
+    const bad = { ...good, signature: 'verified' }; // descriptor-vs-value: a word is not a signature
+    expect(await verifyDelegation(bad, { verifyAt: NOW })).toBe(false);
+  });
+
+  it('rejects a delegation whose public key does not match the delegator DID', async () => {
+    const root = await generateKeyPair();
+    const other = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const good = await baseDelegation(root, agent.publicKey);
+    const bad = { ...good, publicKey: toBase64url(other.publicKey), delegator: publicKeyToDidKey(other.publicKey) };
+    // Re-pointed identity: signature no longer matches the payload → reject.
+    expect(await verifyDelegation(bad, { verifyAt: NOW })).toBe(false);
+  });
+});

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -129,14 +129,20 @@ export {
   canonicalJSONDeep,
   createDelegation,
   verifyDelegation,
+  verifyDelegationSignature,
   verifyDelegatorIdentity,
   verifyScopeNarrowing,
   verifyDelegationChain,
+  checkDelegationTemporalValidity,
   exportDelegationChain,
   delegationSignablePayload,
   type Delegation,
   type DelegationChainEntry,
   type DelegationChainExport,
+  type DelegationTemporalOptions,
+  type DelegationTemporalResult,
+  type DelegationChainResult,
+  type DelegationChainVerificationOptions,
 } from './crypto/delegation';
 
 // A2A Protocol

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -6,4 +6,4 @@
  * the same commit). It is a standalone leaf module so any part of the SDK can
  * import it without a circular dependency on the barrel `index.ts`.
  */
-export const SDK_VERSION = '1.0.1';
+export const SDK_VERSION = '1.0.3';


### PR DESCRIPTION
## Summary

`verifyDelegation` and `verifyDelegationChain` verified signature, delegator identity, and scope narrowing, but did not evaluate the delegation's signed `createdAt`/`expiresAt` window. This change enforces temporal validity at verification time.

## Changes

- Reject delegations that are expired, carry a missing/unparseable timestamp, or have an inverted window (`createdAt` after `expiresAt`); fail closed in all cases.
- `verifyDelegationChain` evaluates every hop against a single shared instant.
- New `verifyAt` option (Date or ISO-8601 string) for deterministic and offline verification.
- New `verifyDelegationSignature` (signature-only) and `checkDelegationTemporalValidity` (standalone temporal check) exports; `DelegationChainResult` gains `temporalValid`.
- Adds a data-driven signed-field enforcement harness and 14 temporal tests.
- Bumps to 1.0.3 and corrects `src/version.ts` (had drifted to 1.0.1).

## Testing

Full suite green (1020 passed). Typecheck, lint, build clean. Verified against the packed tarball as an external consumer (ESM + CJS).