### PR TITLE
auth: gate agent credential + SDK download routes to member (JWT) access

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1453,10 +1453,13 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	// Agent Trust Credential issuance - computes the behavioral score and delegates
 	// signing + transparency-log recording to the Registry (Certificate Authority)
 	agents.Post("/:id/atc", middleware.ManagerMiddleware(), h.ATCIssuance.IssueATC)
-	// SDK download endpoint - Download Python/Node.js/Go SDK with embedded credentials
-	agents.Get("/:id/sdk", h.Agent.DownloadSDK)
-	// Credentials endpoint - Get raw Ed25519 public/private keys for manual integration
-	agents.Get("/:id/credentials", h.Agent.GetCredentials)
+	// SDK download endpoint - Download Python/Node.js/Go SDK with embedded credentials.
+	// Returns agent private key material, so it is member+ (JWT) only — consistent with
+	// rotate-credentials / keys / pqc-key. MemberMiddleware rejects bare API keys (no role).
+	agents.Get("/:id/sdk", middleware.MemberMiddleware(), h.Agent.DownloadSDK)
+	// Credentials endpoint - Get raw Ed25519 public/private keys for manual integration.
+	// Returns the decrypted private key, so it is member+ (JWT) only — same rationale as above.
+	agents.Get("/:id/credentials", middleware.MemberMiddleware(), h.Agent.GetCredentials)
 	// MCP Server relationship management - "talks_to" endpoints
 	agents.Get("/:id/mcp-servers", h.Agent.GetAgentMCPServers)                                                  // ✅ Dashboard: Get MCP servers from talks_to field
 	agents.Put("/:id/mcp-servers", middleware.MemberMiddleware(), h.Agent.AddMCPServersToAgent)                // Add MCP servers (bulk)

--- a/apps/backend/cmd/server/routes_gate_test.go
+++ b/apps/backend/cmd/server/routes_gate_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSensitiveAgentRoutesAreMemberGated is a source-wiring guard.
+//
+// GET /agents/:id/credentials and GET /agents/:id/sdk return agent private key
+// material (the decrypted Ed25519 private key / an SDK zip with the key embedded).
+// The /agents group applies OptionalAPIKeyMiddleware, so without a per-route role
+// gate a bare org-scoped API key is admitted straight to the private-key retrieval
+// path. These routes — like rotate-credentials and key replacement — MUST carry
+// middleware.MemberMiddleware() (JWT role-gated; API keys carry no role → 401).
+//
+// setupRoutes() cannot be exercised in isolation (it needs a live DB + full service
+// wiring), so this guard reads main.go directly. It FAILS if any listed route loses
+// its MemberMiddleware() gate — e.g. reverted to no gate, or widened to
+// MemberOrAPIKeyMiddleware() (which "MemberMiddleware()" is deliberately not a
+// substring of).
+func TestSensitiveAgentRoutesAreMemberGated(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate main.go")
+	}
+	mainPath := filepath.Join(filepath.Dir(thisFile), "main.go")
+	src, err := os.ReadFile(mainPath) //nolint:gosec // G304: path derived from runtime.Caller, not user input
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	lines := strings.Split(string(src), "\n")
+
+	// route-registration substring -> must appear on the SAME line as the gate.
+	sensitive := []string{
+		`agents.Get("/:id/credentials"`,
+		`agents.Get("/:id/sdk"`,
+		`agents.Post("/:id/rotate-credentials"`,
+		`agents.Put("/:id/keys"`,
+	}
+
+	for _, route := range sensitive {
+		var found bool
+		for _, line := range lines {
+			if strings.Contains(line, route) {
+				found = true
+				if !strings.Contains(line, "middleware.MemberMiddleware()") {
+					t.Errorf("route %s must be gated by middleware.MemberMiddleware() "+
+						"(returns/derives private key material); got:\n  %s",
+						route, strings.TrimSpace(line))
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("route registration %s not found in main.go — did it move or get renamed? "+
+				"Update this guard so private-key routes stay covered.", route)
+		}
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/agent_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/agent_handler.go
@@ -969,7 +969,9 @@ func (h *AgentHandler) DownloadSDK(c fiber.Ctx) error {
 	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	c.Set("Content-Length", fmt.Sprintf("%d", len(sdkBytes)))
 
-	// Log audit (userID is optional for SDK download - could be API key auth)
+	// Log audit. This route is MemberMiddleware()-gated (member+ JWT only; see the
+	// agents route table), so userID is always present here; the optional read stays
+	// defensive. Bare API keys can no longer reach this handler.
 	userID, _ := GetUserID(c)
 	h.auditService.LogAction(
 		c.Context(),

--- a/apps/backend/internal/interfaces/http/middleware/credential_routes_gate_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/credential_routes_gate_test.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"database/sql"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAPIKeyDB returns a *sql.DB whose api_keys lookup resolves to an org-scoped,
+// agent-anchored key (the shape of the Cartographer's machine key). active controls
+// whether the key is usable — an inactive key must NOT authenticate, which is how the
+// control below is kept honest.
+func newAPIKeyDB(t *testing.T, active bool) *sql.DB {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	rows := sqlmock.NewRows([]string{"id", "organization_id", "agent_id", "user_id", "name", "is_active", "expires_at"}).
+		AddRow(uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString(), "honeymap-cartographer-machine-key", active, nil)
+	mock.ExpectQuery("api_keys").WithArgs(sqlmock.AnyArg()).WillReturnRows(rows)
+	// The UPDATE last_used_at only runs when the key is active (middleware returns early otherwise).
+	if active {
+		mock.ExpectExec("UPDATE api_keys").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// registerGated wires the real OptionalAPIKeyMiddleware, then (optionally) the
+// MemberMiddleware gate, then a sentinel that echoes the resolved auth principal.
+// The sentinel returns c.Locals("auth_method") as the body so a 200 response is only
+// meaningful if the key actually authenticated (empty body => no principal). This is
+// what keeps the control below from being a tautology.
+func registerGated(app *fiber.App, method, pattern string, gate bool, db *sql.DB) {
+	app.Use(OptionalAPIKeyMiddleware(db))
+	if gate {
+		app.Use(MemberMiddleware())
+	}
+	reached := func(c fiber.Ctx) error {
+		am, _ := c.Locals("auth_method").(string)
+		return c.Status(fiber.StatusOK).SendString(am)
+	}
+	switch method {
+	case "GET":
+		app.Get(pattern, reached)
+	case "POST":
+		app.Post(pattern, reached)
+	case "PUT":
+		app.Put(pattern, reached)
+	}
+}
+
+func concretePath(pattern string) string {
+	return strings.Replace(pattern, ":id", "00000000-0000-0000-0000-000000000000", 1)
+}
+
+func callBearer(t *testing.T, method, pattern string, gate, activeKey bool) (int, string) {
+	t.Helper()
+	app := fiber.New()
+	registerGated(app, method, pattern, gate, newAPIKeyDB(t, activeKey))
+	req := httptest.NewRequest(method, concretePath(pattern), nil)
+	req.Header.Set("Authorization", "Bearer aim_live_test_machine_key")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// TestPrivateKeyRoutes_BareAPIKeyBlocked proves, through the REAL api-key auth path,
+// that a bare org-scoped API key cannot reach the agent routes that return or derive
+// private key material once they are MemberMiddleware()-gated:
+//
+//	GET  /agents/:id/credentials        -> decrypted Ed25519 private key
+//	GET  /agents/:id/sdk                -> SDK zip with the private key embedded
+//	POST /agents/:id/rotate-credentials -> returns a fresh private key (LOW-2)
+//	PUT  /agents/:id/keys               -> replaces the signing key
+//
+// The control asserts the SAME key on the UNgated route both reaches the handler (200)
+// AND was recognized as an api_key principal (body == "api_key"). That second assertion
+// is load-bearing: without it a 401 on the gated route could be a false pass caused by an
+// unrecognized key (no principal -> no role -> 401 anyway). Remove the gate and the gated
+// route returns 200/"api_key"; break api-key auth and the control's body assertion fails.
+func TestPrivateKeyRoutes_BareAPIKeyBlocked(t *testing.T) {
+	cases := []struct{ name, method, pattern string }{
+		{"credentials", "GET", "/api/v1/agents/:id/credentials"},
+		{"sdk", "GET", "/api/v1/agents/:id/sdk"},
+		{"rotate-credentials", "POST", "/api/v1/agents/:id/rotate-credentials"},
+		{"keys", "PUT", "/api/v1/agents/:id/keys"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Control: the active api key authenticates (auth_method=api_key) and, ungated,
+			// reaches the handler. Proves the key is a real recognized principal.
+			code, body := callBearer(t, tc.method, tc.pattern, false, true)
+			assert.Equal(t, fiber.StatusOK, code, "control: an active api key must reach the ungated handler")
+			assert.Equal(t, "api_key", body, "control: the REAL OptionalAPIKeyMiddleware must recognize the key as an api_key principal")
+
+			// Gated: MemberMiddleware() rejects the api_key principal (no role) with 401.
+			gcode, _ := callBearer(t, tc.method, tc.pattern, true, true)
+			assert.Equal(t, fiber.StatusUnauthorized, gcode,
+				"a bare org-scoped API key must NOT reach %s (returns/derives private key material)", tc.pattern)
+		})
+	}
+}
+
+// TestControlHasTeeth guards the control assertion itself: an INACTIVE key must not
+// authenticate, so even on the UNgated route the sentinel echoes no principal. If this
+// ever returns "api_key", the api-key auth mock has drifted and the control above would
+// be a tautology again (the exact defect the adversarial review caught).
+func TestControlHasTeeth(t *testing.T) {
+	code, body := callBearer(t, "GET", "/api/v1/agents/:id/credentials", false, false)
+	assert.Equal(t, fiber.StatusOK, code, "sentinel always returns 200; the signal is the body")
+	assert.NotEqual(t, "api_key", body, "an inactive key must NOT be recognized as an api_key principal")
+}


### PR DESCRIPTION
## What

`GET /agents/:id/credentials` and `GET /agents/:id/sdk` return agent private key material (the decrypted Ed25519 private key, or an SDK zip with the key embedded). The `/agents` group applies `OptionalAPIKeyMiddleware`, so without a per-route role gate these two routes were reachable by a bare org-scoped API key. This PR gates both behind `MemberMiddleware()` (JWT role-gated; API keys carry no role), making them consistent with `rotate-credentials`, `keys`, and `pqc-key`, which are already member-gated.

## Why it is safe for consumers

No known consumer uses these routes with an API key. The web dashboard calls them with a session JWT, and the SDKs read a local credentials file rather than the server route. `DownloadSDK` previously tolerated API-key auth by design, but that path handed private key material to any org-scoped key. Viewer-role JWT users are now also blocked (403), consistent with the other credential routes.

## Tests

- `credential_routes_gate_test.go` drives the real `OptionalAPIKeyMiddleware` (sqlmock) and asserts a bare API key gets 401 on credentials / sdk / rotate-credentials / keys. The control asserts the ungated route both reaches the handler and recognizes the API-key principal, so a 401 cannot be a false pass from an unrecognized key. `TestControlHasTeeth` locks that.
- `routes_gate_test.go` is a source-wiring guard asserting these routes keep the `MemberMiddleware()` gate in `main.go`.
