### PR TITLE
harden delegation chains: enforce child expiry <= parent expiry

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `@opena2a/aim-sdk` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-16
+
+### Security
+
+- **Delegation chains now enforce temporal narrowing: a child may not outlive its
+  parent.** `verifyDelegationChain` rejects any chain in which a child's
+  `expiresAt` is later than its parent's, evaluated independently of the current
+  time (the per-hop expiry check added in 1.0.3 already fails the chain once a
+  parent has actually expired; this closes the window before that and covers
+  partial / as-of verification). This completes the delegation-expiry hardening
+  from 1.0.3.
+
+### Added
+
+- `createDelegation` accepts an optional `parentExpiresAt`. When creating a
+  sub-delegation, pass the parent's `expiresAt`: the child's default expiry is
+  capped at the parent's, and an explicit `expiresAt` beyond the parent's is
+  rejected (fails closed on an unparseable value). This prevents the default
+  seven-day expiry from silently producing a child that outlives its parent.
+
+### Note
+
+- Stricter verification: a chain whose child outlives its parent — previously
+  accepted — is now rejected. Chains built with `createDelegation` (using
+  `parentExpiresAt` for sub-delegations) are unaffected. Cross-engine parity for
+  this rule (Go / Java verifiers, kanoniv interop spec) is tracked as a follow-up;
+  the TypeScript verifier being stricter is fail-closed-safe in the interim.
+
 ## [1.0.3] - 2026-07-15
 
 ### Security

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -207,6 +207,7 @@ const d2 = await createDelegation({
   delegatePublicKey: worker.publicKey,
   scopes: ['search', 'memory.read'], // must be a subset of the parent's scopes
   parentDelegation: 'd1',
+  parentExpiresAt: d1.expiresAt,     // a child must not outlive its parent
 });
 
 const { valid, results } = await verifyDelegationChain([d1, d2]);
@@ -215,10 +216,14 @@ const { valid, results } = await verifyDelegationChain([d1, d2]);
 ```
 
 `verifyDelegation` and `verifyDelegationChain` enforce the delegation's signed
-`createdAt`/`expiresAt` window. An expired delegation — or a child that outlives an
-expired parent — is rejected, and verification fails closed on a missing,
-unparseable, or inverted (`createdAt` after `expiresAt`) timestamp. A chain is
-evaluated against a single instant so every hop is judged by the same clock.
+`createdAt`/`expiresAt` window. An expired delegation is rejected, and verification
+fails closed on a missing, unparseable, or inverted (`createdAt` after `expiresAt`)
+timestamp. A chain is evaluated against a single instant so every hop is judged by
+the same clock, and a child that outlives its parent is rejected even while the
+parent is still live (a delegate cannot hold authority in time beyond its
+delegator). When creating a sub-delegation, pass `parentExpiresAt` so the child's
+default expiry is capped at the parent's and an over-long child expiry is refused
+at creation.
 
 Pass an explicit evaluation time for deterministic tests or offline / as-of
 verification:

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Agent Identity Management SDK for TypeScript/Node.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/typescript/src/crypto/delegation.test.ts
+++ b/sdk/typescript/src/crypto/delegation.test.ts
@@ -260,6 +260,7 @@ describe('Delegation chain verification', () => {
       delegatePublicKey: researcher.publicKey,
       scopes: ['search', 'memory.read'],
       parentDelegation: 'del-1',
+      parentExpiresAt: d1.expiresAt,
     });
 
     const result = await verifyDelegationChain([d1, d2]);
@@ -287,6 +288,7 @@ describe('Delegation chain verification', () => {
       delegatorKeyPair: unrelated,
       delegatePublicKey: researcher.publicKey,
       scopes: ['search'],
+      parentExpiresAt: d1.expiresAt,
     });
 
     const result = await verifyDelegationChain([d1, d2]);
@@ -309,6 +311,7 @@ describe('Delegation chain verification', () => {
       delegatorKeyPair: coordinator,
       delegatePublicKey: researcher.publicKey,
       scopes: ['search', 'memory.write'],
+      parentExpiresAt: d1.expiresAt,
     });
 
     const result = await verifyDelegationChain([d1, d2]);
@@ -438,7 +441,10 @@ describe('Temporal validity (expiry enforcement)', () => {
     const result = await verifyDelegationChain([parent, child], { verifyAt: '2026-08-01T00:00:00.000Z' });
     expect(result.valid).toBe(false);
     expect(result.results[0].temporalValid).toBe(false); // parent expired
-    expect(result.results[1].temporalValid).toBe(true); // child still live, but chain fails on parent
+    // The child is within its own 2026-2036 window, but it outlives its parent,
+    // so temporal narrowing rejects it too (independent of the parent's expiry).
+    expect(result.results[1].temporalValid).toBe(false);
+    expect(result.results[1].error).toMatch(/narrowing/i);
   });
 
   it('verifyDelegationChain accepts the same chain while the parent is still live', async () => {
@@ -506,6 +512,117 @@ describe('Temporal validity (expiry enforcement)', () => {
     });
     expect(await verifyDelegation(d)).toBe(true);
     expect((await verifyDelegationChain([d])).valid).toBe(true);
+  });
+});
+
+describe('Temporal narrowing (child must not outlive parent)', () => {
+  it('rejects a child that outlives a still-live parent', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+    });
+    // Child expires AFTER the parent, though both are live at the eval time.
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2026-09-01T00:00:00.000Z',
+    });
+
+    const result = await verifyDelegationChain([parent, child], { verifyAt: '2026-03-01T00:00:00.000Z' });
+    expect(result.valid).toBe(false);
+    expect(result.results[0].temporalValid).toBe(true); // parent is fine
+    expect(result.results[1].temporalValid).toBe(false); // child outlives parent
+    expect(result.results[1].error).toMatch(/narrowing/i);
+  });
+
+  it('accepts a child whose expiry equals its parent', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z', // exactly equal is allowed
+    });
+
+    const result = await verifyDelegationChain([parent, child], { verifyAt: '2026-03-01T00:00:00.000Z' });
+    expect(result.valid).toBe(true);
+    expect(result.results.every((r) => r.temporalValid)).toBe(true);
+  });
+
+  it('createDelegation caps a default child expiry at the parent', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      expiresAt: '2026-01-02T00:00:00.000Z', // parent expires very soon
+    });
+    // Child uses the default 7-day expiry, but is capped at the parent's.
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      parentExpiresAt: parent.expiresAt,
+    });
+    expect(child.expiresAt).toBe(parent.expiresAt);
+  });
+
+  it('createDelegation rejects an explicit child expiry beyond the parent', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      expiresAt: '2026-06-01T00:00:00.000Z',
+    });
+    await expect(
+      createDelegation({
+        delegatorKeyPair: agent,
+        delegatePublicKey: leaf.publicKey,
+        scopes: ['search'],
+        expiresAt: '2027-01-01T00:00:00.000Z', // beyond the parent
+        parentExpiresAt: parent.expiresAt,
+      }),
+    ).rejects.toThrow(/outlive its delegator/i);
+  });
+
+  it('createDelegation fails closed on an unparseable parentExpiresAt', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    await expect(
+      createDelegation({
+        delegatorKeyPair: root,
+        delegatePublicKey: agent.publicKey,
+        scopes: ['search'],
+        parentExpiresAt: 'not-a-date',
+      }),
+    ).rejects.toThrow(/parentExpiresAt/i);
   });
 });
 
@@ -652,6 +769,7 @@ describe('Trust attenuation through delegation hops', () => {
       delegatorKeyPair: coordinator,
       delegatePublicKey: researcher.publicKey,
       scopes: ['search'],
+      parentExpiresAt: d1.expiresAt,
     });
 
     const result = await verifyDelegationChain([d1, d2], { rootTrustScore: 1.0 });
@@ -679,6 +797,7 @@ describe('Trust attenuation through delegation hops', () => {
       delegatorKeyPair: b,
       delegatePublicKey: c.publicKey,
       scopes: ['search', 'read'],
+      parentExpiresAt: d1.expiresAt,
     });
     d2.trustAttenuation = 0.5;
     d2.minDelegatedTrust = 0.3;
@@ -687,6 +806,7 @@ describe('Trust attenuation through delegation hops', () => {
       delegatorKeyPair: c,
       delegatePublicKey: d.publicKey,
       scopes: ['search'],
+      parentExpiresAt: d2.expiresAt,
     });
 
     // Trust: 1.0 -> 0.5 -> 0.25 (below 0.3 minimum)

--- a/sdk/typescript/src/crypto/delegation.ts
+++ b/sdk/typescript/src/crypto/delegation.ts
@@ -209,16 +209,47 @@ export async function createDelegation(params: {
   createdAt?: string;
   expiresAt?: string;
   parentDelegation?: string;
+  /**
+   * The parent delegation's `expiresAt`, supplied when creating a
+   * sub-delegation. A child must not outlive its delegator: when this is set,
+   * the default child expiry is capped at the parent's, and an explicit
+   * `expiresAt` beyond the parent's is rejected. Enforced symmetrically by
+   * {@link verifyDelegationChain}.
+   */
+  parentExpiresAt?: string;
 }): Promise<Delegation> {
   const now = new Date();
   const oneWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  // A child must not outlive its parent. When the parent's expiry is known,
+  // cap the default and reject an explicit expiry that exceeds it.
+  let expiresAt = params.expiresAt ?? oneWeek.toISOString();
+  if (params.parentExpiresAt !== undefined) {
+    const parentMs = Date.parse(params.parentExpiresAt);
+    if (Number.isNaN(parentMs)) {
+      throw new Error('createDelegation: parentExpiresAt is not a valid timestamp');
+    }
+    const childMs = Date.parse(expiresAt);
+    if (Number.isNaN(childMs)) {
+      throw new Error('createDelegation: expiresAt is not a valid timestamp');
+    }
+    if (params.expiresAt === undefined) {
+      // Default path: cap the child at the parent's expiry.
+      if (parentMs < childMs) expiresAt = params.parentExpiresAt;
+    } else if (childMs > parentMs) {
+      // Explicit path: a child cannot be asked to outlive its parent.
+      throw new Error(
+        'createDelegation: expiresAt exceeds parentExpiresAt (a delegation cannot outlive its delegator)',
+      );
+    }
+  }
 
   const delegation: Omit<Delegation, 'signature' | 'publicKey'> & { publicKey?: string; signature?: string } = {
     delegator: publicKeyToDidKey(params.delegatorKeyPair.publicKey),
     delegate: publicKeyToDidKey(params.delegatePublicKey),
     scopes: params.scopes,
     createdAt: params.createdAt ?? now.toISOString(),
-    expiresAt: params.expiresAt ?? oneWeek.toISOString(),
+    expiresAt,
   };
 
   if (params.parentDelegation) {
@@ -376,7 +407,9 @@ export interface DelegationChainResult {
  * 3. Each sub-delegation's delegator matches the parent's delegate
  * 4. Scope narrowing is enforced
  * 5. Temporal validity: every hop must be within its signed createdAt/expiresAt
- *    window, evaluated against one shared instant for the whole chain
+ *    window, evaluated against one shared instant for the whole chain, AND each
+ *    child's expiresAt must not exceed its parent's (a child cannot outlive its
+ *    delegator, even before the parent expires)
  * 6. Trust attenuation: effective trust decays per hop and must stay above minimum
  */
 export async function verifyDelegationChain(
@@ -407,7 +440,24 @@ export async function verifyDelegationChain(
     const signatureValid = await verifyDelegationSignature(delegation);
     const identityValid = verifyDelegatorIdentity(delegation);
     const temporal = temporalAtMs(delegation, evalAtMs);
-    const temporalValid = temporal.valid;
+    let temporalValid = temporal.valid;
+    let temporalError = temporal.error;
+
+    // Temporal narrowing: a child must not outlive its parent. Enforced even
+    // while the parent is still live, so a child cannot claim authority in time
+    // beyond its delegator's. (The per-hop expiry check above already fails the
+    // chain once the parent has actually expired; this closes the window before
+    // that.) The own-window error, if any, takes precedence in the message.
+    if (i > 0) {
+      const parentExpMs = Date.parse(chain[i - 1].expiresAt);
+      const childExpMs = Date.parse(delegation.expiresAt);
+      if (!Number.isNaN(parentExpMs) && !Number.isNaN(childExpMs) && childExpMs > parentExpMs) {
+        temporalValid = false;
+        if (temporalError === undefined) {
+          temporalError = 'Temporal narrowing violated: expiresAt exceeds parent expiresAt';
+        }
+      }
+    }
 
     let scopeValid = true;
     if (i > 0) {
@@ -439,8 +489,8 @@ export async function verifyDelegationChain(
       }
     }
 
-    // Surface an expiry/window failure as the hop error when nothing worse fired.
-    const error = temporalValid ? undefined : temporal.error;
+    // Surface an expiry/window/narrowing failure as the hop error when nothing worse fired.
+    const error = temporalValid ? undefined : temporalError;
     results.push({ index: i, label, signatureValid, identityValid, scopeValid, temporalValid, effectiveTrust, error });
   }
 

--- a/sdk/typescript/src/crypto/signed-field-enforcement.test.ts
+++ b/sdk/typescript/src/crypto/signed-field-enforcement.test.ts
@@ -185,6 +185,34 @@ describe('Signed-field enforcement — delegation chain', () => {
     // After the parent expires, the chain must fail even though the child is live.
     expect((await verifyDelegationChain([parent, child], { verifyAt: '2026-05-01T00:00:00.000Z' })).valid).toBe(false);
   });
+
+  it('rejects a child that outlives its parent even while the parent is still live (temporal narrowing)', async () => {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    const leaf = await generateKeyPair();
+
+    const parent = await createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+    });
+    const child = await createDelegation({
+      delegatorKeyPair: agent,
+      delegatePublicKey: leaf.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2036-01-01T00:00:00.000Z', // outlives the parent
+      parentDelegation: 'del-root',
+    });
+
+    // Both are live at NOW (2026-03-01), but the child claims authority in time
+    // beyond its delegator — the invariant a child must not outlive its parent.
+    const result = await verifyDelegationChain([parent, child], { verifyAt: NOW });
+    expect(result.valid).toBe(false);
+    expect(result.results[1].temporalValid).toBe(false);
+  });
 });
 
 describe('Signed-field enforcement — fail-closed on malformed input', () => {

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -6,4 +6,4 @@
  * the same commit). It is a standalone leaf module so any part of the SDK can
  * import it without a circular dependency on the barrel `index.ts`.
  */
-export const SDK_VERSION = '1.0.3';
+export const SDK_VERSION = '1.1.0';


### PR DESCRIPTION
## Summary

Completes the delegation-expiry hardening from 1.0.3. `verifyDelegationChain` now rejects any chain where a child's `expiresAt` is later than its parent's, evaluated independently of the current time. The 1.0.3 per-hop check already fails a chain once the parent has actually expired; this closes the window before that and covers partial / as-of verification.

## Changes

- `verifyDelegationChain`: enforce `child.expiresAt <= parent.expiresAt` per hop (a delegate cannot hold authority in time beyond its delegator).
- `createDelegation`: new optional `parentExpiresAt` — caps a child's default expiry at the parent's and rejects an explicit expiry beyond it; fails closed on an unparseable value.
- Chain test fixtures pinned with `parentExpiresAt` so default-created siblings don't drift a few ms past the parent (would otherwise be flaky under the new rule). Verified deterministic across repeated runs.
- New tests + an enforcement-harness narrowing case; README + CHANGELOG updated.

## Release

1.1.0. Full suite green (1026 passed). Release-tested against the packed tarball as an external consumer (ESM + CJS), no P1/P2/P3.

Note: cross-engine parity for this rule (Go/Java verifiers, kanoniv interop spec) is a tracked follow-up; the TypeScript verifier being stricter is fail-closed-safe in the interim.