### PR TITLE
auth: stop OAuth service tokens from traversing human role gates

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1429,6 +1429,7 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Use(middleware.ATCAuthMiddleware(services.Secrets.ATCVerifier())) // ✅ ATC first (for DECIMA agents, Phase 7)
 	agents.Use(middleware.OptionalAPIKeyMiddleware(db))            // ✅ Try API key (for dashboard-generated keys)
 	agents.Use(middleware.PQCAgentMiddleware(services.Agent)) // ✅ Then try Ed25519/ML-DSA/hybrid (for SDK agents)
+	agents.Use(middleware.ServicePrincipalMiddleware(jwtService)) // ✅ Then OAuth (RFC 7523) service tokens; sets no role
 	agents.Use(middleware.AuthMiddleware(jwtService))             // ✅ Fallback to JWT (for web UI)
 	agents.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	agents.Use(middleware.RateLimitMiddleware())
@@ -1436,7 +1437,12 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	agents.Post("/bulk-status", h.Lifecycle.BulkStatus) // Bulk agent status lookup
 	agents.Post("/", middleware.MemberOrAPIKeyMiddleware(), h.Agent.CreateAgent) // machine API keys (org-scoped) OR member+ JWT; other routes stay MemberMiddleware (JWT-only)
 	agents.Get("/:id", h.Agent.GetAgent)
-	agents.Put("/:id", middleware.MemberMiddleware(), h.Agent.UpdateAgent)
+	// Member+ JWT, OR a service principal acting on ITSELF. The TypeScript SDK's
+	// updateAgent() calls this with its OAuth token; before the service-token fix
+	// that worked only because MemberMiddleware admitted role="service". The
+	// self-scope check keeps the SDK working while making a sibling agent
+	// unreachable by construction. See middleware/service_principal.go.
+	agents.Put("/:id", middleware.MemberOrSelfServiceMiddleware(), h.Agent.UpdateAgent)
 	agents.Delete("/:id", middleware.ManagerMiddleware(), h.Agent.DeleteAgent)
 	agents.Post("/:id/verify", middleware.ManagerMiddleware(), h.Agent.VerifyAgent)
 	// Agent lifecycle management endpoints

--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -20,6 +20,13 @@ const (
 	// IssuerSDK is the issuer for the long-lived (90-day) SDK refresh token,
 	// which is only valid at the /auth/refresh endpoint — never as a bearer.
 	IssuerSDK = "agent-identity-management-sdk"
+	// IssuerService is the issuer for tokens minted by the OAuth token endpoint
+	// (RFC 7523 jwt-bearer) to an authenticated *agent*. These are machine
+	// principals, not humans: they carry no user role and must never traverse a
+	// human role gate. SECURITY: the access-auth middleware rejects this issuer,
+	// so a service token is only usable behind ServicePrincipalMiddleware, which
+	// additionally pins the token to its own agent ID.
+	IssuerService = "agent-identity-management-service"
 )
 
 // Token types. The `typ` claim separates access tokens (valid as a bearer) from
@@ -197,6 +204,42 @@ func (s *JWTService) GenerateAccessToken(userID, orgID, email, role string) (str
 			NotBefore: jwt.NewNumericDate(now),
 			Issuer:    IssuerUser,
 			Subject:   userID,
+			ID:        uuid.New().String(),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+// GenerateServiceToken mints an access token for a machine principal — an agent
+// that authenticated at the OAuth token endpoint via RFC 7523 jwt-bearer.
+//
+// SECURITY: deliberately different from GenerateAccessToken in two ways.
+//   - Issuer is IssuerService, which AuthMiddleware rejects. A service token
+//     therefore cannot be presented on any human-authenticated route, even one
+//     that forgets to add a gate.
+//   - Role is left EMPTY. Previously this path minted role="service", a string
+//     absent from the domain.UserRole enum. MemberMiddleware rejected only
+//     "viewer", so "service" traversed it and reached 35 routes including
+//     GET /agents/:id/credentials — letting one compromised agent read every
+//     sibling agent's private key in the same organization. An empty role now
+//     fails every role gate's type assertion as well as its allow-list.
+//
+// Subject is the agent's own ID; ServicePrincipalMiddleware pins route access to
+// it so a service principal can only ever act on itself.
+func (s *JWTService) GenerateServiceToken(agentID, orgID string) (string, error) {
+	now := time.Now()
+	claims := JWTClaims{
+		UserID:         agentID,
+		OrganizationID: orgID,
+		TokenType:      TokenTypeAccess,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(s.accessExpiry)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			Issuer:    IssuerService,
+			Subject:   agentID,
 			ID:        uuid.New().String(),
 		},
 	}

--- a/apps/backend/internal/interfaces/http/handlers/oauth_token_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/oauth_token_handler.go
@@ -195,8 +195,12 @@ func (h *OAuthTokenHandler) processTokenRequest(c fiber.Ctx, grantType, clientID
 		})
 	}
 
-	// Generate an access token for the authenticated agent
-	accessToken, err := h.jwtService.GenerateAccessToken(clientID, agent.OrganizationID.String(), clientID, "service")
+	// Generate a service token for the authenticated agent. This is a machine
+	// principal: GenerateServiceToken stamps IssuerService and leaves the role
+	// empty, so the token cannot traverse a human role gate. It previously used
+	// GenerateAccessToken with role="service", which passed the member gate and
+	// exposed sibling agents' private keys — see GenerateServiceToken's comment.
+	accessToken, err := h.jwtService.GenerateServiceToken(clientID, agent.OrganizationID.String())
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error":             "server_error",

--- a/apps/backend/internal/interfaces/http/middleware/admin.go
+++ b/apps/backend/internal/interfaces/http/middleware/admin.go
@@ -58,7 +58,18 @@ func MemberMiddleware() fiber.Handler {
 			})
 		}
 
-		if role == string(domain.RoleViewer) {
+		// SECURITY: allow-list, not deny-list. This gate previously rejected only
+		// RoleViewer and admitted every other non-empty role string. The OAuth
+		// token endpoint mints role="service" — absent from the UserRole enum — so
+		// an agent-authenticated token traversed this gate and reached all 35
+		// member routes, including GET /agents/:id/credentials, which returns a
+		// decrypted Ed25519 private key. One compromised agent could therefore
+		// read every sibling agent's key in the same organization. Enumerating
+		// what is allowed means an unrecognised role fails closed.
+		// Regression: service_token_escalation_test.go.
+		if role != string(domain.RoleAdmin) &&
+			role != string(domain.RoleManager) &&
+			role != string(domain.RoleMember) {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 				"error": "Member access required (viewers cannot perform this action)",
 			})
@@ -94,7 +105,11 @@ func MemberOrAPIKeyMiddleware() fiber.Handler {
 			})
 		}
 
-		if role == string(domain.RoleViewer) {
+		// SECURITY: allow-list, for the same reason as MemberMiddleware above —
+		// an unrecognised role must fail closed, not fall through.
+		if role != string(domain.RoleAdmin) &&
+			role != string(domain.RoleManager) &&
+			role != string(domain.RoleMember) {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 				"error": "Member access required (viewers cannot perform this action)",
 			})

--- a/apps/backend/internal/interfaces/http/middleware/auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/auth.go
@@ -26,6 +26,13 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 			return c.Next()
 		}
 
+		// Check if already authenticated by the service-principal middleware
+		if authMethod == "service" {
+			// Already authenticated as a machine principal - skip JWT validation.
+			// No "role" was set, so human role gates still fail closed.
+			return c.Next()
+		}
+
 		// Check if already authenticated by ATC middleware
 		if authMethod == "atc" {
 			// Already authenticated via ATC - skip JWT validation
@@ -72,6 +79,17 @@ func AuthMiddleware(jwtService *auth.JWTService) fiber.Handler {
 		if claims.Issuer == auth.IssuerSDK {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 				"error": "SDK tokens cannot be used for API access; exchange it at /auth/refresh",
+			})
+		}
+
+		// SECURITY: service tokens (OAuth RFC 7523 jwt-bearer, minted to an agent)
+		// are machine principals, not users. They must never traverse a human
+		// auth path — this middleware populates "role", which the role gates read.
+		// Service principals are authenticated by ServicePrincipalMiddleware
+		// instead, which pins them to their own agent ID.
+		if claims.Issuer == auth.IssuerService {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Service tokens cannot be used on user-authenticated routes",
 			})
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/service_principal.go
+++ b/apps/backend/internal/interfaces/http/middleware/service_principal.go
@@ -1,0 +1,152 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
+)
+
+// ServicePrincipalMiddleware authenticates a machine principal — an agent that
+// obtained a token from the OAuth token endpoint (RFC 7523 jwt-bearer).
+//
+// It is an OPTIONAL authenticator, in the same shape as OptionalAPIKeyMiddleware:
+// a request without a service token passes straight through so the remaining
+// middleware (PQC agent auth, then JWT) can handle it. Only a token minted with
+// auth.IssuerService is claimed here.
+//
+// SECURITY: this deliberately does NOT set "role". A service principal is not a
+// human and must not satisfy a human role gate. It sets "agent_id" so route gates
+// can pin access to the caller's own agent — see MemberOrSelfServiceMiddleware.
+//
+// Must be registered BEFORE AuthMiddleware, which skips when auth_method is
+// already "service".
+func ServicePrincipalMiddleware(jwtService *auth.JWTService) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		// Leave already-authenticated requests alone.
+		if c.Locals("auth_method") != nil || c.Locals("authenticated_via") != nil {
+			return c.Next()
+		}
+
+		authHeader := c.Get("Authorization")
+		if authHeader == "" {
+			return c.Next()
+		}
+		parts := strings.Split(authHeader, " ")
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			return c.Next() // let AuthMiddleware produce the format error
+		}
+
+		claims, err := jwtService.ValidateToken(parts[1])
+		if err != nil {
+			return c.Next() // not ours to reject; AuthMiddleware reports invalid tokens
+		}
+
+		// Only claim service-issuer tokens. Anything else belongs downstream.
+		if claims.Issuer != auth.IssuerService {
+			return c.Next()
+		}
+
+		// From here the token IS a service token, so failures are terminal —
+		// falling through would hand it to AuthMiddleware, which rejects the
+		// issuer outright and would mask the real reason.
+		if claims.TokenType != auth.TokenTypeAccess {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "This token cannot be used for API access",
+			})
+		}
+
+		if jwtService.IsRevoked(c.Context(), claims.ID) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Token has been revoked",
+			})
+		}
+
+		agentID, err := uuid.Parse(claims.Subject)
+		if err != nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Invalid agent ID in token",
+			})
+		}
+
+		orgID, err := uuid.Parse(claims.OrganizationID)
+		if err != nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Invalid organization ID in token",
+			})
+		}
+
+		c.Locals("auth_method", "service")
+		c.Locals("agent_id", agentID)
+		c.Locals("organization_id", orgID)
+		// Intentionally no "role" and no "user_id": a service principal is not a
+		// user. Handlers calling RequireOrgAndUserID will fail closed, which is
+		// correct — those handlers serve human flows.
+
+		return c.Next()
+	}
+}
+
+// MemberOrSelfServiceMiddleware allows a route to be reached EITHER by a human
+// with at least member role (the JWT path) OR by a service principal acting on
+// ITSELF — the ":id" path parameter must equal the agent ID the token was minted
+// for.
+//
+// Shaped after MemberOrAPIKeyMiddleware and deliberately just as narrow. The
+// self-scope check is what makes this safe to apply: a service principal cannot
+// reach a sibling agent's resource through it by construction, so the route does
+// not depend on an allowlist being kept up to date.
+//
+// Apply ONLY to routes an SDK legitimately calls on its own agent record.
+//
+// MUST be registered as a route handler — agents.Put("/:id", gate, handler) — not
+// via .Use(). It reads c.Params("id"), which Fiber only populates after route
+// matching; mounted with .Use() the param is empty and every service request 400s.
+// That direction is fail-closed, but the route would be unusable.
+func MemberOrSelfServiceMiddleware() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		if method, _ := c.Locals("auth_method").(string); method == "service" {
+			callerAgentID, ok := c.Locals("agent_id").(uuid.UUID)
+			if !ok {
+				return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+					"error": "Authentication required",
+				})
+			}
+
+			targetID, err := uuid.Parse(c.Params("id"))
+			if err != nil {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+					"error": "Invalid agent ID",
+				})
+			}
+
+			if targetID != callerAgentID {
+				return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+					"error": "Service principals may only act on their own agent",
+				})
+			}
+
+			return c.Next()
+		}
+
+		// Human path — identical allow-list to MemberMiddleware.
+		role, ok := c.Locals("role").(string)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Authentication required",
+			})
+		}
+
+		if role != string(domain.RoleAdmin) &&
+			role != string(domain.RoleManager) &&
+			role != string(domain.RoleMember) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "Member access required (viewers cannot perform this action)",
+			})
+		}
+
+		return c.Next()
+	}
+}

--- a/apps/backend/internal/interfaces/http/middleware/service_token_escalation_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/service_token_escalation_test.go
@@ -1,11 +1,14 @@
 package middleware
 
 import (
+	"context"
 	"io"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -190,6 +193,107 @@ func TestServiceTokenIsRefusedOnRoutesWithoutTheServiceGate(t *testing.T) {
 	status, body := callMemberGated(t, svc, token)
 	require.Equal(t, fiber.StatusUnauthorized, status,
 		"service token was not refused by AuthMiddleware on an un-opted-in route (body: %q)", body)
+}
+
+// --- Enforcement matrix for the service-token verifier -----------------------
+//
+// ServicePrincipalMiddleware reads five fields off a service token. Signature,
+// expiry and malformed-token handling are enforced inside ValidateToken and are
+// already proven there (auth/jwt_test.go: WrongSecret, Expired, Malformed). The
+// three below are enforced in THIS middleware, so they need rejection cases here
+// or the enforcement is unproven.
+//
+// | Field                | Enforced at            | Negative test                            |
+// |----------------------|------------------------|------------------------------------------|
+// | signature / alg      | ValidateToken          | auth/jwt_test.go WrongSecret             |
+// | exp                  | ValidateToken          | auth/jwt_test.go Expired                 |
+// | issuer == service    | ServicePrincipal       | TestServiceTokenIsRefusedOnRoutes...      |
+// | typ == access        | ServicePrincipal       | TestServiceTokenWithNonAccessTypeIsRejected |
+// | revocation (jti)     | ServicePrincipal       | TestRevokedServiceTokenIsRejected        |
+// | sub parses as UUID   | ServicePrincipal       | TestServiceTokenWithMalformedSubjectIsRejected |
+// | :id == sub           | MemberOrSelfService    | TestServicePrincipalIsPinnedToItsOwnAgent |
+
+const testJWTSecret = "test-secret-at-least-32-characters-long!"
+
+// craftServiceToken signs an arbitrary claim set with the test secret, so a case
+// GenerateServiceToken would never produce (wrong typ, unparseable subject) can
+// still be presented to the middleware.
+func craftServiceToken(t *testing.T, claims auth.JWTClaims) string {
+	t.Helper()
+	if claims.RegisteredClaims.ExpiresAt == nil {
+		claims.RegisteredClaims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour))
+	}
+	claims.RegisteredClaims.IssuedAt = jwt.NewNumericDate(time.Now())
+	claims.RegisteredClaims.Issuer = auth.IssuerService
+	if claims.RegisteredClaims.ID == "" {
+		claims.RegisteredClaims.ID = uuid.NewString()
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(testJWTSecret))
+	require.NoError(t, err)
+	return signed
+}
+
+// A service token whose typ is not "access" must be refused. Without the typ
+// check the token would proceed to the handler, so this fails on a verifier that
+// skips it.
+func TestServiceTokenWithNonAccessTypeIsRejected(t *testing.T) {
+	t.Setenv("JWT_SECRET", testJWTSecret)
+	svc := auth.NewJWTService()
+
+	agentID := uuid.NewString()
+	token := craftServiceToken(t, auth.JWTClaims{
+		UserID:           agentID,
+		OrganizationID:   uuid.NewString(),
+		TokenType:        auth.TokenTypeRefresh,
+		RegisteredClaims: jwt.RegisteredClaims{Subject: agentID},
+	})
+
+	status, body := callSelfScoped(t, svc, token, agentID)
+	require.Equal(t, fiber.StatusUnauthorized, status,
+		"a refresh-typed service token reached the handler (body: %q)", body)
+}
+
+// A revoked service token must be refused. IsRevoked is called but nothing
+// exercised it before this test.
+func TestRevokedServiceTokenIsRejected(t *testing.T) {
+	t.Setenv("JWT_SECRET", testJWTSecret)
+	svc := auth.NewJWTService()
+	svc.SetRevoker(auth.NewTokenRevoker(&inMemRevocationStore{m: map[string]bool{}}, false))
+
+	agentID := uuid.NewString()
+	token, err := svc.GenerateServiceToken(agentID, uuid.NewString())
+	require.NoError(t, err)
+
+	// CONTROL: it works before revocation, so the assertion below is about
+	// revocation and not about some unrelated rejection.
+	status, _ := callSelfScoped(t, svc, token, agentID)
+	require.Equal(t, fiber.StatusOK, status, "service token must work before it is revoked")
+
+	require.NoError(t, svc.RevokeToken(context.Background(), token))
+
+	status, body := callSelfScoped(t, svc, token, agentID)
+	require.Equal(t, fiber.StatusUnauthorized, status,
+		"revoked service token still reached the handler (body: %q)", body)
+}
+
+// An unparseable subject must be refused by THIS middleware, not merely bounced
+// later. Asserting the specific error body is what gives this teeth: a fall-
+// through would also produce 401, from AuthMiddleware's issuer check.
+func TestServiceTokenWithMalformedSubjectIsRejected(t *testing.T) {
+	t.Setenv("JWT_SECRET", testJWTSecret)
+	svc := auth.NewJWTService()
+
+	token := craftServiceToken(t, auth.JWTClaims{
+		UserID:           "not-a-uuid",
+		OrganizationID:   uuid.NewString(),
+		TokenType:        auth.TokenTypeAccess,
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "not-a-uuid"},
+	})
+
+	status, body := callSelfScoped(t, svc, token, uuid.NewString())
+	require.Equal(t, fiber.StatusUnauthorized, status)
+	require.Contains(t, body, "Invalid agent ID in token",
+		"expected the service-principal middleware to reject the subject itself, got %q", body)
 }
 
 // Unknown role strings must fail closed. This is the class fix, not the instance:

--- a/apps/backend/internal/interfaces/http/middleware/service_token_escalation_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/service_token_escalation_test.go
@@ -1,0 +1,210 @@
+package middleware
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
+)
+
+// The OAuth token endpoint (RFC 7523 jwt-bearer) mints an access token for an
+// authenticated *agent* with role="service" — see oauth_token_handler.go:
+//
+//	GenerateAccessToken(clientID, agent.OrganizationID.String(), clientID, "service")
+//
+// "service" is not a member of domain.UserRole (admin|manager|member|viewer).
+// MemberMiddleware rejects only RoleViewer, so every other non-empty role string
+// — including "service" — reaches the handler. That puts an agent-authenticated
+// token on all 35 MemberMiddleware-gated routes, among them
+// GET /agents/:id/credentials, which returns a decrypted Ed25519 private key.
+//
+// Net effect: one compromised agent can read every sibling agent's private key in
+// the same organization. These tests pin that shut.
+
+// newServiceToken mints a token exactly the way the OAuth token endpoint does.
+// Kept byte-identical to the production call so this test tracks the real mint
+// site rather than a paraphrase of it.
+func newServiceToken(t *testing.T, svc *auth.JWTService, agentID, orgID string) string {
+	t.Helper()
+	tok, err := svc.GenerateAccessToken(agentID, orgID, agentID, "service")
+	require.NoError(t, err)
+	return tok
+}
+
+func newRoleToken(t *testing.T, svc *auth.JWTService, orgID, role string) string {
+	t.Helper()
+	tok, err := svc.GenerateAccessToken(uuid.NewString(), orgID, "user@example.com", role)
+	require.NoError(t, err)
+	return tok
+}
+
+// callMemberGated wires the real AuthMiddleware + MemberMiddleware in front of a
+// sentinel that echoes the resolved role. A 200 with an empty body would mean the
+// request arrived with no principal, so asserting on the body — not just the status
+// — is what keeps the positive control from being a tautology.
+func callMemberGated(t *testing.T, svc *auth.JWTService, token string) (int, string) {
+	t.Helper()
+	app := fiber.New()
+	app.Use(AuthMiddleware(svc))
+	app.Use(MemberMiddleware())
+	app.Get("/agents/:id/credentials", func(c fiber.Ctx) error {
+		role, _ := c.Locals("role").(string)
+		return c.Status(fiber.StatusOK).SendString(role)
+	})
+
+	req := httptest.NewRequest("GET", "/agents/"+uuid.NewString()+"/credentials", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+func TestServiceTokenCannotReachMemberGatedCredentialRoute(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-at-least-32-characters-long!")
+	svc := auth.NewJWTService()
+
+	orgID := uuid.NewString()
+	victimOrgID := orgID // same tenant: this is sibling-agent access, not cross-tenant
+
+	t.Run("service token is refused", func(t *testing.T) {
+		attackerAgentID := uuid.NewString()
+		status, body := callMemberGated(t, svc, newServiceToken(t, svc, attackerAgentID, victimOrgID))
+
+		// An agent-authenticated token must never traverse a human role gate.
+		// Either layer may reject it (AuthMiddleware on issuer/type, or the role
+		// gate on an unknown role) — what must not happen is reaching the handler.
+		assert.NotEqual(t, fiber.StatusOK, status,
+			"service token reached GET /agents/:id/credentials — an agent can read a sibling agent's private key (role echoed: %q)", body)
+		assert.Contains(t, []int{fiber.StatusUnauthorized, fiber.StatusForbidden}, status,
+			"expected 401 or 403 for a service token on a member-gated route, got %d", status)
+	})
+
+	// POSITIVE CONTROL — proves the harness can deliver a 200 at all. Without this,
+	// the assertion above would also pass if every request 401'd for an unrelated
+	// reason (bad secret, malformed token, middleware wiring error).
+	t.Run("member token still reaches the handler", func(t *testing.T) {
+		status, body := callMemberGated(t, svc, newRoleToken(t, svc, orgID, "member"))
+		require.Equal(t, fiber.StatusOK, status, "member token must still reach the handler; harness is broken otherwise")
+		require.Equal(t, "member", body, "handler reached but no role resolved — sentinel proves nothing")
+	})
+
+	// NEGATIVE CONTROL — proves MemberMiddleware is actually mounted and rejecting.
+	// If this passed while the service-token case failed, the gate would be absent
+	// rather than merely permissive.
+	t.Run("viewer token is refused", func(t *testing.T) {
+		status, _ := callMemberGated(t, svc, newRoleToken(t, svc, orgID, "viewer"))
+		require.Equal(t, fiber.StatusForbidden, status, "viewer must be rejected by MemberMiddleware")
+	})
+}
+
+// callSelfScoped wires the real service-principal authenticator + the
+// MemberOrSelfService gate in front of a sentinel that echoes the resolved auth
+// method, then addresses targetAgentID. This is the route shape of
+// PUT /agents/:id, which the TypeScript SDK's updateAgent() calls.
+func callSelfScoped(t *testing.T, svc *auth.JWTService, token, targetAgentID string) (int, string) {
+	t.Helper()
+	app := fiber.New()
+	app.Use(ServicePrincipalMiddleware(svc))
+	app.Use(AuthMiddleware(svc))
+	// Registered as a ROUTE handler, not via app.Use — matching main.go. The gate
+	// reads c.Params("id"), which is only populated after route matching, so
+	// mounting it with .Use() would leave the param empty (it fails closed with a
+	// 400, but the route would be unusable). Keep this mirroring production.
+	app.Put("/agents/:id", MemberOrSelfServiceMiddleware(), func(c fiber.Ctx) error {
+		am, _ := c.Locals("auth_method").(string)
+		if am == "" {
+			am, _ = c.Locals("role").(string)
+		}
+		return c.Status(fiber.StatusOK).SendString(am)
+	})
+
+	req := httptest.NewRequest("PUT", "/agents/"+targetAgentID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+// The self-scope check is the security property that lets a service principal keep
+// using PUT /agents/:id (the SDK needs it) without being able to reach a sibling.
+// An allowlist alone would not give this — it has to be pinned to the token subject.
+func TestServicePrincipalIsPinnedToItsOwnAgent(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-at-least-32-characters-long!")
+	svc := auth.NewJWTService()
+
+	orgID := uuid.NewString()
+	callerAgentID := uuid.NewString()
+	siblingAgentID := uuid.NewString()
+	token, err := svc.GenerateServiceToken(callerAgentID, orgID)
+	require.NoError(t, err)
+
+	// POSITIVE CONTROL — without this, the sibling assertion below would also pass
+	// if service tokens were rejected outright, which would silently break the SDK.
+	t.Run("service principal may update its OWN agent", func(t *testing.T) {
+		status, body := callSelfScoped(t, svc, token, callerAgentID)
+		require.Equal(t, fiber.StatusOK, status, "SDK updateAgent() on its own record must keep working")
+		require.Equal(t, "service", body, "reached the handler without resolving a service principal")
+	})
+
+	t.Run("service principal may NOT update a sibling agent", func(t *testing.T) {
+		status, body := callSelfScoped(t, svc, token, siblingAgentID)
+		assert.Equal(t, fiber.StatusForbidden, status,
+			"service principal reached a sibling agent's record (auth echoed: %q)", body)
+	})
+
+	t.Run("member may still update any agent in the org", func(t *testing.T) {
+		status, body := callSelfScoped(t, svc, newRoleToken(t, svc, orgID, "member"), siblingAgentID)
+		require.Equal(t, fiber.StatusOK, status, "human member path must be unaffected")
+		require.Equal(t, "member", body)
+	})
+
+	t.Run("viewer is still rejected", func(t *testing.T) {
+		status, _ := callSelfScoped(t, svc, newRoleToken(t, svc, orgID, "viewer"), siblingAgentID)
+		require.Equal(t, fiber.StatusForbidden, status)
+	})
+}
+
+// A service token presented on a route that has NOT opted into service principals
+// must be refused by AuthMiddleware on the issuer alone — defence in depth, so a
+// route that forgets its gate still fails closed.
+func TestServiceTokenIsRefusedOnRoutesWithoutTheServiceGate(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-at-least-32-characters-long!")
+	svc := auth.NewJWTService()
+
+	token, err := svc.GenerateServiceToken(uuid.NewString(), uuid.NewString())
+	require.NoError(t, err)
+
+	// No ServicePrincipalMiddleware in this chain, mirroring the other 34 routes.
+	status, body := callMemberGated(t, svc, token)
+	require.Equal(t, fiber.StatusUnauthorized, status,
+		"service token was not refused by AuthMiddleware on an un-opted-in route (body: %q)", body)
+}
+
+// Unknown role strings must fail closed. This is the class fix, not the instance:
+// "service" is today's escaping value, but any future non-enum role string would
+// traverse a deny-list gate the same way.
+func TestMemberGateFailsClosedOnUnknownRoles(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-at-least-32-characters-long!")
+	svc := auth.NewJWTService()
+	orgID := uuid.NewString()
+
+	for _, role := range []string{"service", "root", "superuser", "system", "bot", "unknown"} {
+		t.Run(role, func(t *testing.T) {
+			status, body := callMemberGated(t, svc, newRoleToken(t, svc, orgID, role))
+			assert.NotEqual(t, fiber.StatusOK, status,
+				"unknown role %q traversed MemberMiddleware (role echoed: %q) — the gate is a deny-list, not an allow-list", role, body)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The OAuth token endpoint (RFC 7523 `jwt-bearer`) minted an access token with `role="service"` — a value absent from the `domain.UserRole` enum. `MemberMiddleware` was a deny-list that rejected only `RoleViewer` and admitted every other non-empty role string, so an agent-authenticated service token traversed it and reached all 35 member-gated routes, including `GET /agents/:id/credentials`, which returns a decrypted Ed25519 private key.

**Impact:** one compromised agent could read every sibling agent's private key in the same organization. (Precondition: the attacker must already control one agent's key to sign the client assertion — this is post-compromise lateral movement, but blast-radius containment is the product's core promise.)

## Fix

Addressed at the token-type layer, not just the middleware symptom:

- **`IssuerService` + `GenerateServiceToken`** — service tokens now carry a distinct issuer and an **empty role**, so they fail every role gate's type assertion and allow-list.
- **`AuthMiddleware` rejects `IssuerService`** — a service token cannot ride a user-authenticated route even if that route omits its gate.
- **`MemberMiddleware` / `MemberOrAPIKeyMiddleware` → allow-lists** — an unrecognised role now fails closed instead of falling through (defense in depth).
- **`ServicePrincipalMiddleware` + `MemberOrSelfServiceMiddleware`** — a service principal is validated (signature, expiry, token type, revocation, UUID subject/org) and **pinned to its own agent ID**, so a sibling agent is unreachable by construction rather than by a maintained allowlist.
- **`PUT /agents/:id`** accepts member+ JWT *or* a self-scoped service principal — the TypeScript SDK's `updateAgent()` calls it with an OAuth token and previously worked only because the member gate admitted `role="service"`. SDK compatibility is preserved.

## Testing

`service_token_escalation_test.go` fails on the prior code: the service token reaches the credentials route, and `root`/`superuser`/`system`/`bot` traverse the gate identically. Positive and negative controls in the same test keep the assertions from passing vacuously; each service-token field check is mutation-verified (disabling the check flips its test to FAIL). `go vet` clean, all backend packages green.

A dynamic pentest against a local instance found **no findings against these changes**.