### PR TITLE
trust: calculate MCP trust scores instead of asserting them

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -486,6 +486,7 @@ type Repositories struct {
 	MCPCapability      *repository.MCPServerCapabilityRepository // ✅ For MCP server capabilities
 	MCPManifest        *repository.MCPManifestRepository         // ✅ For MCP manifest baseline + drift detection
 	MCPAttestation     *repository.MCPAttestationRepository      // ✅ For agent attestation of MCPs
+	MCPTrustScore      *repository.MCPTrustScoreRepository       // ✅ Source of truth for 8-factor MCP trust scores
 	AgentMCPConnection *repository.AgentMCPConnectionRepository  // ✅ For agent-MCP connections
 	Security           *repository.SecurityRepository
 	SecurityPolicy     *repository.SecurityPolicyRepository   // ✅ For configurable security policies
@@ -546,6 +547,7 @@ func initRepositories(db *sql.DB) (*Repositories, *repository.OAuthRepositoryPos
 		MCPCapability:      repository.NewMCPServerCapabilityRepository(db), // ✅ For MCP server capabilities
 		MCPManifest:        repository.NewMCPManifestRepository(db),         // ✅ For MCP manifest baseline + drift detection
 		MCPAttestation:     repository.NewMCPAttestationRepository(db),      // ✅ For agent attestation of MCPs
+		MCPTrustScore:      repository.NewMCPTrustScoreRepository(db),       // ✅ Source of truth for 8-factor MCP trust scores
 		AgentMCPConnection: repository.NewAgentMCPConnectionRepository(dbx), // ✅ For agent-MCP connections
 		Security:           repository.NewSecurityRepository(db),
 		SecurityPolicy:     repository.NewSecurityPolicyRepository(db),   // ✅ For configurable security policies
@@ -764,6 +766,18 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.MCPServer,
 	)
 
+	// ✅ 8-factor MCP trust calculator — the only writer of an MCP trust score.
+	// Scores are stored in `mcp_trust_scores` (source of truth, with the full
+	// factor breakdown and confidence); the migration 094 trigger mirrors the
+	// value into the `mcp_servers.trust_score` cache.
+	mcpTrustCalculator := application.NewMCPTrustCalculatorWithRepo(
+		repos.MCPServer,
+		repos.MCPAttestation,
+		repos.MCPCapability,
+		repos.Alert,
+		repos.MCPTrustScore,
+	)
+
 	mcpService := application.NewMCPService(
 		repos.MCPServer,
 		repos.VerificationEvent,
@@ -774,6 +788,7 @@ func initServices(db *sql.DB, repos *Repositories, cacheService *cache.RedisCach
 		repos.AgentMCPConnection, // ✅ For tracking agent-MCP connections
 		repos.Agent,              // ✅ For connected agents tracking
 		repos.Tag,                // ✅ For tagging MCP servers during registration
+		mcpTrustCalculator,       // ✅ For scoring servers at registration and verification
 	)
 
 	// ✅ Initialize MCP Attestation Service for agent attestation of MCPs

--- a/apps/backend/internal/application/mcp_policy_evaluator.go
+++ b/apps/backend/internal/application/mcp_policy_evaluator.go
@@ -178,8 +178,11 @@ func (e *MCPPolicyEvaluator) evaluateAllowlist(
 		if rules.MinTrustScore > 0 && mcpServer.TrustScore < rules.MinTrustScore {
 			result.Triggered = true
 			result.ViolatedRules = append(result.ViolatedRules, "Trust score below minimum")
+			// Both values are on the canonical [0,1] scale, so both are scaled
+			// for display. The threshold used to be printed unscaled, which
+			// rendered a 0.7 floor as "below minimum 0.7%".
 			result.Reason = fmt.Sprintf("Trust score %.1f%% is below minimum %.1f%%",
-				mcpServer.TrustScore*100, rules.MinTrustScore)
+				mcpServer.TrustScore*100, rules.MinTrustScore*100)
 			result.Recommendations = append(result.Recommendations, "Improve MCP server trust score through attestations")
 			return
 		}

--- a/apps/backend/internal/application/mcp_policy_evaluator_test.go
+++ b/apps/backend/internal/application/mcp_policy_evaluator_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
@@ -171,4 +172,115 @@ func TestNewMCPPolicyEvaluator(t *testing.T) {
 	assert.NotNil(t, evaluator)
 	assert.Nil(t, evaluator.policyRepo)
 	assert.Nil(t, evaluator.mcpRepo)
+}
+
+// TestMCPPolicy_MinTrustScoreGateRejectsLowScoringServer is the security
+// red-proof for the trust-score fabrication.
+//
+// `evaluateAllowlist` compares `mcpServer.TrustScore` against
+// `rules.MinTrustScore`, and `MinTrustScore` is on the canonical [0,1] scale.
+// While `mcp_service.go` stamped SDK-registered and verified servers with the
+// literal 75.0, that comparison could never fail: 75.0 sits above every
+// representable threshold, so an SDK-registered MCP server passed any
+// organization's trust floor unconditionally, and only a genuinely-measured
+// server could ever be rejected.
+//
+// With scores on one scale, the gate discriminates again.
+func TestMCPPolicy_MinTrustScoreGateRejectsLowScoringServer(t *testing.T) {
+	evaluator := &MCPPolicyEvaluator{}
+
+	policy := &domain.SecurityPolicy{
+		ID:         uuid.New(),
+		PolicyType: domain.PolicyTypeMCPAllowlist,
+		Rules: map[string]interface{}{
+			"allowedDomains": []string{"mcp.example.com"},
+			"minTrustScore":  0.7,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		trustScore      float64
+		expectTriggered bool
+		why             string
+	}{
+		{
+			name:            "score below the floor is rejected",
+			trustScore:      0.42,
+			expectTriggered: true,
+			why:             "0.42 is below the 0.7 floor",
+		},
+		{
+			name:            "score above the floor is allowed",
+			trustScore:      0.85,
+			expectTriggered: false,
+			why:             "0.85 clears the 0.7 floor",
+		},
+		{
+			name:            "score exactly at the floor is allowed",
+			trustScore:      0.7,
+			expectTriggered: false,
+			why:             "the comparison is strictly less-than",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &domain.MCPServer{
+				ID:         uuid.New(),
+				Name:       "example-mcp",
+				URL:        "https://mcp.example.com/sse",
+				Status:     domain.MCPServerStatusVerified,
+				IsVerified: true,
+				TrustScore: tt.trustScore,
+			}
+
+			result := &domain.MCPPolicyEvaluationResult{}
+			evaluator.evaluateAllowlist(server, policy, result)
+
+			assert.Equal(t, tt.expectTriggered, result.Triggered, tt.why)
+			if tt.expectTriggered {
+				assert.Contains(t, result.ViolatedRules, "Trust score below minimum")
+				// The threshold is rendered as a percentage alongside the
+				// score. It used to be printed unscaled, turning a 0.7 floor
+				// into "below minimum 0.7%".
+				assert.Contains(t, result.Reason, "below minimum 70.0%")
+			}
+		})
+	}
+}
+
+// TestMCPPolicy_FabricatedScoreWouldDefeatTheGate pins the failure directly:
+// the exact literal the service used to write passes a floor that no
+// calculated score could clear, because the calculator's maximum output is
+// 1.0. If this ever passes with `triggered == false` for a value above 1.0,
+// an out-of-scale writer has reappeared.
+func TestMCPPolicy_FabricatedScoreWouldDefeatTheGate(t *testing.T) {
+	evaluator := &MCPPolicyEvaluator{}
+
+	policy := &domain.SecurityPolicy{
+		ID:         uuid.New(),
+		PolicyType: domain.PolicyTypeMCPAllowlist,
+		Rules: map[string]interface{}{
+			"allowedDomains": []string{"mcp.example.com"},
+			"minTrustScore":  1.0, // the strictest representable floor
+		},
+	}
+
+	server := &domain.MCPServer{
+		ID:         uuid.New(),
+		Name:       "example-mcp",
+		URL:        "https://mcp.example.com/sse",
+		Status:     domain.MCPServerStatusVerified,
+		IsVerified: true,
+		TrustScore: 75.0, // the removed literal
+	}
+
+	result := &domain.MCPPolicyEvaluationResult{}
+	evaluator.evaluateAllowlist(server, policy, result)
+
+	assert.False(t, result.Triggered,
+		"documents the defect: 75.0 clears even a 1.0 floor. Migration 104's "+
+			"CHECK constraint is what makes this value unstorable; this test "+
+			"records why the constraint is load-bearing rather than cosmetic.")
 }

--- a/apps/backend/internal/application/mcp_policy_evaluator_test.go
+++ b/apps/backend/internal/application/mcp_policy_evaluator_test.go
@@ -284,3 +284,101 @@ func TestMCPPolicy_FabricatedScoreWouldDefeatTheGate(t *testing.T) {
 			"CHECK constraint is what makes this value unstorable; this test "+
 			"records why the constraint is load-bearing rather than cosmetic.")
 }
+
+// TestMCPPolicy_AllowlistEnforcementMatrix covers the remaining verdict
+// surface of `evaluateAllowlist`. Each case violates exactly one field and
+// asserts the verdict flips to rejected; the baseline case violates none and
+// asserts it does not.
+//
+// Before this, the only tests in this file exercised the domain-matching
+// helpers — `evaluateAllowlist` itself, which decides whether an MCP server
+// is allowed, had no test at all. Enforcement that no test can distinguish
+// from its absence is unproven.
+func TestMCPPolicy_AllowlistEnforcementMatrix(t *testing.T) {
+	evaluator := &MCPPolicyEvaluator{}
+
+	// A server that satisfies every requirement below.
+	compliant := func() *domain.MCPServer {
+		return &domain.MCPServer{
+			ID:               uuid.New(),
+			Name:             "example-mcp",
+			URL:              "https://mcp.example.com/sse",
+			Status:           domain.MCPServerStatusVerified,
+			IsVerified:       true,
+			TrustScore:       0.85,
+			ConfidenceScore:  90.0,
+			AttestationCount: 5,
+		}
+	}
+
+	rules := map[string]interface{}{
+		"allowedDomains":     []string{"mcp.example.com"},
+		"requireVerified":    true,
+		"minTrustScore":      0.7,
+		"minConfidenceScore": 80.0,
+		"minAttestations":    3,
+	}
+
+	policy := &domain.SecurityPolicy{
+		ID:         uuid.New(),
+		PolicyType: domain.PolicyTypeMCPAllowlist,
+		Rules:      rules,
+	}
+
+	tests := []struct {
+		name           string
+		violate        func(*domain.MCPServer)
+		expectViolated string // "" means the request must be allowed
+	}{
+		{
+			name:    "baseline: nothing violated",
+			violate: func(*domain.MCPServer) {},
+		},
+		{
+			name:           "domain not in allowlist",
+			violate:        func(s *domain.MCPServer) { s.URL = "https://evil.example.net/sse" },
+			expectViolated: "Not in allowlist",
+		},
+		{
+			name:           "unverified while requireVerified is set",
+			violate:        func(s *domain.MCPServer) { s.Status = domain.MCPServerStatusPending },
+			expectViolated: "MCP server not verified",
+		},
+		{
+			name:           "trust score below the floor",
+			violate:        func(s *domain.MCPServer) { s.TrustScore = 0.2 },
+			expectViolated: "Trust score below minimum",
+		},
+		{
+			name:           "confidence score below the floor",
+			violate:        func(s *domain.MCPServer) { s.ConfidenceScore = 10.0 },
+			expectViolated: "Confidence score below minimum",
+		},
+		{
+			name:           "too few attestations",
+			violate:        func(s *domain.MCPServer) { s.AttestationCount = 1 },
+			expectViolated: "Insufficient attestations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := compliant()
+			tt.violate(server)
+
+			result := &domain.MCPPolicyEvaluationResult{}
+			evaluator.evaluateAllowlist(server, policy, result)
+
+			if tt.expectViolated == "" {
+				assert.False(t, result.Triggered,
+					"a fully compliant server must be allowed; if this fails the "+
+						"other cases prove nothing, since they could be tripping "+
+						"on the baseline rather than on the field they violate")
+				return
+			}
+
+			assert.True(t, result.Triggered, "violating %q must trigger the policy", tt.name)
+			assert.Contains(t, result.ViolatedRules, tt.expectViolated)
+		})
+	}
+}

--- a/apps/backend/internal/application/mcp_service.go
+++ b/apps/backend/internal/application/mcp_service.go
@@ -30,10 +30,12 @@ type MCPService struct {
 	httpClient            *http.Client           // ✅ For real MCP server communication
 	agentRepo             *repository.AgentRepository // ✅ For querying connected agents
 	tagRepo               *repository.TagRepository   // ✅ For tagging MCP servers during registration
-	// trustCalculator is the ONLY writer of a trust score for an MCP server.
-	// Required, not optional: a nil calculator would leave every server at the
-	// DB default of 0.0, which reads as "measured and maximally untrusted"
-	// rather than "not scored". See the [CHIEF-CDS] decision of 2026-08-04.
+	// trustCalculator is the only source of an MCP server's trust score. This
+	// service assigns no score of its own; it asks the calculator and stores
+	// what it returns. Required, not optional: a nil calculator leaves every
+	// server at the DB default of 0.0, which reads as "measured and maximally
+	// untrusted" rather than "not scored", and fails every MinTrustScore
+	// policy gate. See the [CHIEF-CDS] decision of 2026-08-04.
 	trustCalculator *MCPTrustCalculator
 	// In-memory challenge storage (in production, use Redis)
 	challenges map[string]ChallengeData

--- a/apps/backend/internal/application/mcp_service.go
+++ b/apps/backend/internal/application/mcp_service.go
@@ -30,6 +30,11 @@ type MCPService struct {
 	httpClient            *http.Client           // ✅ For real MCP server communication
 	agentRepo             *repository.AgentRepository // ✅ For querying connected agents
 	tagRepo               *repository.TagRepository   // ✅ For tagging MCP servers during registration
+	// trustCalculator is the ONLY writer of a trust score for an MCP server.
+	// Required, not optional: a nil calculator would leave every server at the
+	// DB default of 0.0, which reads as "measured and maximally untrusted"
+	// rather than "not scored". See the [CHIEF-CDS] decision of 2026-08-04.
+	trustCalculator *MCPTrustCalculator
 	// In-memory challenge storage (in production, use Redis)
 	challenges map[string]ChallengeData
 }
@@ -42,7 +47,7 @@ type ChallengeData struct {
 	ExpiresAt time.Time
 }
 
-func NewMCPService(mcpRepo *repository.MCPServerRepository, verificationEventRepo domain.VerificationEventRepository, userRepo *repository.UserRepository, keyVault *crypto.KeyVault, capabilityService *MCPCapabilityService, capabilityRepo *repository.MCPServerCapabilityRepository, connectionRepo *repository.AgentMCPConnectionRepository, agentRepo *repository.AgentRepository, tagRepo *repository.TagRepository) *MCPService {
+func NewMCPService(mcpRepo *repository.MCPServerRepository, verificationEventRepo domain.VerificationEventRepository, userRepo *repository.UserRepository, keyVault *crypto.KeyVault, capabilityService *MCPCapabilityService, capabilityRepo *repository.MCPServerCapabilityRepository, connectionRepo *repository.AgentMCPConnectionRepository, agentRepo *repository.AgentRepository, tagRepo *repository.TagRepository, trustCalculator *MCPTrustCalculator) *MCPService {
 	return &MCPService{
 		mcpRepo:               mcpRepo,
 		verificationEventRepo: verificationEventRepo,
@@ -55,10 +60,42 @@ func NewMCPService(mcpRepo *repository.MCPServerRepository, verificationEventRep
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second, // 30 second timeout for MCP server communication
 		},
-		challenges: make(map[string]ChallengeData),
-		agentRepo:  agentRepo,
-		tagRepo:    tagRepo,
+		challenges:      make(map[string]ChallengeData),
+		agentRepo:       agentRepo,
+		tagRepo:         tagRepo,
+		trustCalculator: trustCalculator,
 	}
+}
+
+// scoreServer runs the 8-factor trust calculation for a persisted MCP server
+// and stores the result. `mcp_trust_scores` is the source of truth; the
+// migration 094 trigger mirrors the score into `mcp_servers.trust_score`.
+//
+// The server row must already exist — the calculator re-reads it so that
+// database-supplied columns (notably `created_at`, which Factor 6 buckets by
+// age) hold their real values rather than Go zero values. A zero `time.Time`
+// would score as "90+ days old" and hand a brand-new server the maximum age
+// factor.
+//
+// The in-memory server is updated with the stored score, so the value this
+// service returns to its caller is the value that was persisted rather than
+// the zero the struct was constructed with.
+//
+// Scoring failure never fails the caller's operation: registration and
+// verification are the user's action, the score is a derived value, and a
+// server with no score yet is a state the system already represents. It is
+// logged rather than swallowed so an unscored server is traceable.
+func (s *MCPService) scoreServer(ctx context.Context, server *domain.MCPServer, occasion string) {
+	if s.trustCalculator == nil {
+		fmt.Printf("⚠️  No trust calculator configured; MCP server %s left unscored after %s\n", server.ID, occasion)
+		return
+	}
+	score, err := s.trustCalculator.CalculateTrustScore(ctx, server.ID)
+	if err != nil {
+		fmt.Printf("⚠️  Failed to calculate trust score for MCP server %s after %s: %v\n", server.ID, occasion, err)
+		return
+	}
+	server.TrustScore = score.Score
 }
 
 // CreateMCPServerRequest represents the request to create an MCP server
@@ -206,7 +243,6 @@ func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRe
 	isSDKRegistration := agentID != nil
 	var status domain.MCPServerStatus
 	var isVerified bool
-	var trustScore float64
 	var verificationMethod string
 	var lastVerifiedAt *time.Time
 
@@ -214,7 +250,6 @@ func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRe
 		// SDK registration: auto-verify since agent is authenticated
 		status = domain.MCPServerStatusVerified
 		isVerified = true
-		trustScore = 75.0 // Initial trust score for SDK-verified servers
 		verificationMethod = "sdk_registration"
 		now := time.Now()
 		lastVerifiedAt = &now
@@ -223,9 +258,16 @@ func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRe
 		// Manual registration: requires admin verification
 		status = domain.MCPServerStatusPending
 		isVerified = false
-		trustScore = 0.0
 		verificationMethod = "manual"
 	}
+
+	// The trust score is NOT set here. It is calculated from the server's real
+	// inputs by the 8-factor calculator once the row exists (see scoreServer
+	// below). Assigning a literal here — this line used to read
+	// `trustScore = 75.0` for SDK registrations — published a number that
+	// implied measurement without measuring anything, and, being on a 0-100
+	// scale, sat above every [0,1] `MinTrustScore` policy threshold, so an
+	// SDK-registered server passed any organization trust floor unconditionally.
 
 	server := &domain.MCPServer{
 		ID:                  uuid.New(),
@@ -240,7 +282,6 @@ func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRe
 		LastVerifiedAt:      lastVerifiedAt,
 		VerificationURL:     strings.TrimSpace(req.VerificationURL), // ✅ Trim spaces
 		Capabilities:        req.Capabilities,
-		TrustScore:          trustScore,
 		VerificationMethod:  verificationMethod,
 		RegisteredByAgent:   agentID,         // ✅ Track which agent registered this MCP (for SDK registrations)
 		CreatedBy:           userID,
@@ -350,6 +391,16 @@ func (s *MCPService) CreateMCPServer(ctx context.Context, req *CreateMCPServerRe
 			}
 		}
 	}
+
+	// Score the server from its real inputs. This runs last, after the
+	// capability rows and the agent-MCP connection have been written, because
+	// Factor 3 (capability stability) reads `mcp_server_capabilities` and
+	// Factor 7 (usage patterns) reads the connection count. Scoring before
+	// those writes would measure a server that looks emptier than it is.
+	//
+	// A freshly registered server legitimately scores low — no attestations,
+	// age bucket under 7 days — and that is the honest value, not a defect.
+	s.scoreServer(ctx, server, "registration")
 
 	return server, nil
 }
@@ -522,11 +573,18 @@ func (s *MCPService) VerifyMCPServer(ctx context.Context, id uuid.UUID, userID u
 		server.IsVerified = true
 		server.Status = domain.MCPServerStatusVerified
 		server.LastVerifiedAt = &now
-		server.TrustScore = 75.0 // Initial trust score for verified servers
 
 		if err := s.mcpRepo.Update(server); err != nil {
 			return err
 		}
+
+		// Recalculate from real inputs now that the server is verified.
+		// Verification genuinely moves two factors — Security Posture credits
+		// `IsVerified`, and Attestation Consensus stops applying the 0.5
+		// pending-status multiplier — so the score rises on its own. It used
+		// to be pinned here to the literal 75.0 regardless of what the server
+		// actually looked like.
+		s.scoreServer(ctx, server, "verification")
 
 		// ✅ AUTOMATIC CAPABILITY DETECTION
 		// After successful verification, automatically detect MCP server capabilities

--- a/apps/backend/internal/application/mcp_service_test.go
+++ b/apps/backend/internal/application/mcp_service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -363,7 +364,7 @@ func TestSanitizeTalksToEntries_MultipleCommas(t *testing.T) {
 
 func TestNewMCPService_NilDependencies(t *testing.T) {
 	// Test that constructor handles nil dependencies gracefully
-	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.NotNil(t, service)
 	assert.Nil(t, service.mcpRepo)
@@ -375,13 +376,14 @@ func TestNewMCPService_NilDependencies(t *testing.T) {
 	assert.Nil(t, service.connectionRepo)
 	assert.Nil(t, service.agentRepo)
 	assert.Nil(t, service.tagRepo)
+	assert.Nil(t, service.trustCalculator)
 	assert.NotNil(t, service.cryptoService)
 	assert.NotNil(t, service.httpClient)
 	assert.NotNil(t, service.challenges)
 }
 
 func TestNewMCPService_HttpClientTimeout(t *testing.T) {
-	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Verify HTTP client has 30 second timeout
 	assert.NotNil(t, service.httpClient)
@@ -389,7 +391,7 @@ func TestNewMCPService_HttpClientTimeout(t *testing.T) {
 }
 
 func TestNewMCPService_ChallengesMapInitialized(t *testing.T) {
-	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	service := NewMCPService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// Verify challenges map is initialized
 	assert.NotNil(t, service.challenges)
@@ -415,37 +417,136 @@ func TestMCPService_ChallengeExpirationDuration(t *testing.T) {
 // Trust Score Logic Tests
 // ========================================
 
-func TestMCPService_TrustScoreValues(t *testing.T) {
-	// Document expected trust score values
-	tests := []struct {
-		name     string
-		score    float64
-		scenario string
-	}{
-		{
-			name:     "SDK registration",
-			score:    75.0,
-			scenario: "Initial trust score for SDK-verified servers",
+// The test this replaces declared three literal scores (75.0 / 0.0 / 75.0) and
+// then asserted only that each was between 0 and 100. It passed for any value
+// in that range, including the fabricated 75.0 it existed to document, and it
+// would have passed unchanged after the literal was removed. It measured
+// nothing.
+//
+// What follows pins the actual invariant: an MCP trust score is produced by
+// the 8-factor calculator, on the canonical [0,1] scale, and no code path
+// assigns a literal.
+
+// TestMCPTrustScore_CalculatorOutputIsCanonicalScale pins the range contract
+// that `mcp_servers_trust_score_range_check` (migration 104) enforces in the
+// database. A score outside [0,1] is unstorable; if the calculator could
+// produce one, registration would fail at the constraint.
+func TestMCPTrustScore_CalculatorOutputIsCanonicalScale(t *testing.T) {
+	calculator := &MCPTrustCalculator{}
+
+	servers := map[string]*domain.MCPServer{
+		"freshly registered, no signal": {
+			ID:        uuid.New(),
+			URL:       "https://mcp.example.com",
+			Status:    domain.MCPServerStatusPending,
+			CreatedAt: time.Now(),
 		},
-		{
-			name:     "Manual pending",
-			score:    0.0,
-			scenario: "Unverified servers have zero trust",
+		"verified, well established": {
+			ID:                   uuid.New(),
+			URL:                  "https://mcp.example.com",
+			PublicKey:            "dGVzdC1wdWJsaWMta2V5",
+			Description:          "an established server",
+			Status:               domain.MCPServerStatusVerified,
+			IsVerified:           true,
+			CreatedBy:            uuid.New(),
+			CreatedAt:            time.Now().Add(-365 * 24 * time.Hour),
+			AttestationCount:     12,
+			ConfidenceScore:      95.0,
+			ConnectedAgentsCount: 9,
+			Capabilities:         []string{"read_file", "write_file", "list_directory"},
 		},
-		{
-			name:     "Verified server",
-			score:    75.0,
-			scenario: "Verified servers start at 75.0",
+		"revoked": {
+			ID:         uuid.New(),
+			URL:        "http://mcp.example.com",
+			Status:     domain.MCPServerStatusRevoked,
+			IsVerified: false,
+			CreatedAt:  time.Now().Add(-90 * 24 * time.Hour),
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Document expected values
-			assert.True(t, tt.score >= 0.0)
-			assert.True(t, tt.score <= 100.0)
+	for name, server := range servers {
+		t.Run(name, func(t *testing.T) {
+			score, err := calculator.Calculate(server)
+			require.NoError(t, err)
+			require.NotNil(t, score)
+
+			assert.GreaterOrEqual(t, score.Score, 0.0,
+				"score must be within the [0,1] range the DB constraint allows")
+			assert.LessOrEqual(t, score.Score, 1.0,
+				"score must be within the [0,1] range the DB constraint allows")
+
+			// The specific value the service used to hardcode. On the
+			// canonical scale it is not merely wrong, it is unrepresentable.
+			assert.NotEqual(t, 75.0, score.Score,
+				"75.0 was the fabricated literal; it cannot be a calculated score")
 		})
 	}
+}
+
+// TestMCPTrustScore_CalculatedScoresDiscriminate is the red-proof for the
+// fabrication itself. Under the old code every SDK-registered and every
+// verified server carried the same 75.0 regardless of its inputs, so the
+// number could not distinguish a brand-new server from an established one.
+// A calculated score must.
+func TestMCPTrustScore_CalculatedScoresDiscriminate(t *testing.T) {
+	calculator := &MCPTrustCalculator{}
+
+	fresh := &domain.MCPServer{
+		ID:         uuid.New(),
+		URL:        "https://mcp.example.com",
+		PublicKey:  "dGVzdC1wdWJsaWMta2V5",
+		Status:     domain.MCPServerStatusVerified,
+		IsVerified: true,
+		CreatedBy:  uuid.New(),
+		CreatedAt:  time.Now(),
+	}
+
+	established := &domain.MCPServer{
+		ID:                   uuid.New(),
+		URL:                  "https://mcp.example.com",
+		PublicKey:            "dGVzdC1wdWJsaWMta2V5",
+		Description:          "an established server",
+		Status:               domain.MCPServerStatusVerified,
+		IsVerified:           true,
+		CreatedBy:            uuid.New(),
+		CreatedAt:            time.Now().Add(-365 * 24 * time.Hour),
+		AttestationCount:     12,
+		ConfidenceScore:      95.0,
+		ConnectedAgentsCount: 9,
+		Capabilities:         []string{"read_file", "write_file", "list_directory"},
+	}
+
+	freshScore, err := calculator.Calculate(fresh)
+	require.NoError(t, err)
+	establishedScore, err := calculator.Calculate(established)
+	require.NoError(t, err)
+
+	assert.Greater(t, establishedScore.Score, freshScore.Score,
+		"a server with attestations, connections and a year of history must "+
+			"outscore one registered seconds ago; a constant cannot do this")
+
+	// Both were "verified", which is exactly the pair the 75.0 literal
+	// collapsed into one value.
+	assert.NotEqual(t, freshScore.Score, establishedScore.Score)
+}
+
+// TestMCPTrustScore_AgeFactorRequiresRealCreatedAt guards the failure mode
+// named in the decision's pre-mortem. `Calculate` buckets by
+// `time.Since(server.CreatedAt)`, so a zero `time.Time` — which is what an
+// in-memory struct carries before the database supplies the column — reads as
+// "90+ days old" and awards the maximum age factor to a server that does not
+// exist yet. This is why scoring happens after the row is persisted.
+func TestMCPTrustScore_AgeFactorRequiresRealCreatedAt(t *testing.T) {
+	calculator := &MCPTrustCalculator{}
+
+	unset := &domain.MCPServer{ID: uuid.New(), URL: "https://mcp.example.com"}
+	justCreated := &domain.MCPServer{ID: uuid.New(), URL: "https://mcp.example.com", CreatedAt: time.Now()}
+
+	assert.Equal(t, 1.0, calculator.calculateAge(unset),
+		"a zero CreatedAt scores as maximally aged — the reason scoring must "+
+			"run against the persisted row, not the in-memory struct")
+	assert.Equal(t, 0.30, calculator.calculateAge(justCreated),
+		"a server created now belongs in the under-7-days bucket")
 }
 
 // ========================================

--- a/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
+++ b/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
@@ -14,6 +14,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// seedOrgAndUser creates the organization and user rows that `mcp_servers`
+// requires via NOT NULL / foreign key. Returns both IDs and registers cleanup.
+func seedOrgAndUser(t *testing.T, db *sql.DB, ctx context.Context, prefix string) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	orgID := uuid.New()
+	userID := uuid.New()
+	suffix := orgID.String()[:8]
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, prefix+"-org-"+suffix, prefix+"-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users
+		   (id, organization_id, email, name, password_hash, role, provider,
+		    provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, prefix+"-"+suffix+"@example.com", prefix+"-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	return orgID, userID
+}
+
 // TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache is the
 // regression test for issue #170. Migration 094 installs an
 // AFTER INSERT OR UPDATE trigger on mcp_trust_scores that mirrors
@@ -34,28 +63,23 @@ func TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	serverID := uuid.New()
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_scores WHERE mcp_server_id = $1`, serverID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
 
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "mcp-mirror-test-org-"+serverID.String()[:8])
-	require.NoError(t, err)
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-mirror")
 
 	// Seed MCP server with a stale cache value.
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO mcp_servers
-		   (id, organization_id, name, url, version, trust_score, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, '1.0.0', 0.50, NOW(), NOW())`,
+		   (id, organization_id, name, url, version, public_key, trust_score,
+		    created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', 'test-key', 0.50, $5, NOW(), NOW())`,
 		serverID, orgID,
 		"mcp-mirror-test-server-"+serverID.String()[:8],
-		"https://mcp-mirror-test-"+serverID.String()[:8]+".example.com")
+		"https://mcp-mirror-test-"+serverID.String()[:8]+".example.com", userID)
 	require.NoError(t, err)
 
 	// INSERT a new score row. Trigger must mirror to mcp_servers.trust_score.
@@ -71,11 +95,71 @@ func TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache(t *testing.T) {
 		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID,
 	).Scan(&cached)
 	require.NoError(t, err)
-	// mcp_servers.trust_score is DECIMAL(5,2); mcp_trust_scores.score is
-	// DECIMAL(5,4). The mirrored value gets rounded to 2 decimals on
-	// storage, so 0.8234 -> 0.82. Tolerance reflects that.
-	require.InDelta(t, 0.82, cached, 0.01,
-		"trigger must mirror mcp_trust_scores.score onto mcp_servers.trust_score on INSERT")
+	// Both columns are DECIMAL(5,4) since migration 104, so the cache holds
+	// the source value exactly. This assertion previously tolerated 0.8234
+	// arriving as 0.82, because `mcp_servers.trust_score` was DECIMAL(5,2)
+	// and silently rounded every mirrored write — a cache that disagreed
+	// with its source on every score, which is the #170 defect this trigger
+	// exists to prevent.
+	require.InDelta(t, 0.8234, cached, 0.00001,
+		"trigger must mirror mcp_trust_scores.score onto mcp_servers.trust_score exactly")
+}
+
+// TestMCPServerTrustScore_RejectsOutOfScaleValue is the structural guard for
+// the [CHIEF-CDS] decision of 2026-08-04: an MCP trust score is a [0,1] value
+// produced by the 8-factor calculator, and the schema — not reviewer
+// attention — is what keeps a literal on some other scale out of the column.
+//
+// Before migration 104 `mcp_servers.trust_score` was DECIMAL(5,2) with no
+// CHECK constraint, so the application's hardcoded 75.0 stored cleanly and
+// then sat above every [0,1] `MinTrustScore` policy threshold.
+func TestMCPServerTrustScore_RejectsOutOfScaleValue(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping constraint regression test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	serverID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+	})
+
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-scale")
+
+	insert := func(score string) error {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO mcp_servers
+			   (id, organization_id, name, url, version, public_key, trust_score,
+			    created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, '1.0.0', 'test-key', `+score+`, $5, NOW(), NOW())`,
+			serverID, orgID,
+			"mcp-scale-test-server-"+serverID.String()[:8],
+			"https://mcp-scale-test-"+serverID.String()[:8]+".example.com", userID)
+		return err
+	}
+
+	// The exact literal the application used to write.
+	require.Error(t, insert("75.0"),
+		"75.0 must be rejected: it is the fabricated 0-100 literal")
+	require.Error(t, insert("1.5"),
+		"any value above 1.0 must be rejected")
+	require.Error(t, insert("-0.1"),
+		"any value below 0.0 must be rejected")
+
+	// A legitimate calculated score must still store, at full precision.
+	require.NoError(t, insert("0.8234"),
+		"a calculated [0,1] score must be storable")
+
+	var stored float64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID).Scan(&stored))
+	require.InDelta(t, 0.8234, stored, 0.00001,
+		"the column must retain 4 decimal places to match mcp_trust_scores.score")
 }
 
 // TestMCPTrustScoreMirrorTrigger_UpdateSyncsLatestOnly asserts the
@@ -92,26 +176,21 @@ func TestMCPTrustScoreMirrorTrigger_UpdateSyncsLatestOnly(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	serverID := uuid.New()
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_scores WHERE mcp_server_id = $1`, serverID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
 
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "mcp-update-test-org-"+serverID.String()[:8])
-	require.NoError(t, err)
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-update")
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO mcp_servers
-		   (id, organization_id, name, url, version, trust_score, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, '1.0.0', 0.50, NOW(), NOW())`,
+		   (id, organization_id, name, url, version, public_key, trust_score,
+		    created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', 'test-key', 0.50, $5, NOW(), NOW())`,
 		serverID, orgID,
 		"mcp-update-test-server-"+serverID.String()[:8],
-		"https://mcp-update-test-"+serverID.String()[:8]+".example.com")
+		"https://mcp-update-test-"+serverID.String()[:8]+".example.com", userID)
 	require.NoError(t, err)
 
 	olderID := uuid.New()

--- a/apps/backend/internal/application/tag_service.go
+++ b/apps/backend/internal/application/tag_service.go
@@ -428,14 +428,23 @@ func (s *TagService) suggestTagsForCapabilities(capabilities []string) []*domain
 	return suggestions
 }
 
-// suggestTagsForTrustScore suggests tags based on trust score level
+// suggestTagsForTrustScore suggests tags based on trust score level.
+//
+// Trust scores are on the canonical [0,1] scale — `agents.trust_score`
+// (CHECK 0..1, migration 031) and `mcp_servers.trust_score` (CHECK 0..1,
+// migration 104). The thresholds below used to be 8.0 and 5.0, a 0-10 scale
+// that exists nowhere else in the system. The effect was that this function
+// never suggested anything but "low"/"development" for agents, whose scores
+// cannot exceed 1.0, while MCP servers carrying the old hardcoded 75.0
+// literal always took the top branch and were tagged
+// `trust-level=high` + `environment=production` on registration.
 func (s *TagService) suggestTagsForTrustScore(trustScore float64) []*domain.Tag {
 	suggestions := make([]*domain.Tag, 0)
 
-	if trustScore >= 8.0 {
+	if trustScore >= 0.8 {
 		suggestions = append(suggestions, &domain.Tag{Key: "trust-level", Value: "high", Category: domain.TagCategoryDataClassification})
 		suggestions = append(suggestions, &domain.Tag{Key: "environment", Value: "production", Category: domain.TagCategoryEnvironment})
-	} else if trustScore >= 5.0 {
+	} else if trustScore >= 0.5 {
 		suggestions = append(suggestions, &domain.Tag{Key: "trust-level", Value: "medium", Category: domain.TagCategoryDataClassification})
 		suggestions = append(suggestions, &domain.Tag{Key: "environment", Value: "staging", Category: domain.TagCategoryEnvironment})
 	} else {

--- a/apps/backend/internal/application/tag_service_test.go
+++ b/apps/backend/internal/application/tag_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockTagRepository for tag service tests
@@ -1052,16 +1053,21 @@ func TestTagService_suggestTagsForTrustScore(t *testing.T) {
 
 	service := NewTagService(mockTagRepo, mockAgentRepo, mockMCPRepo)
 
+	// These scores were 9.0 / 8.0 / 6.0 / 5.0 / 3.0 / 0.0 — a 0-10 scale
+	// copied from the implementation's thresholds rather than derived from
+	// the domain contract, which is why the test passed while the function
+	// was unreachable for every real agent. Trust scores are [0,1]; a score
+	// of 9.0 cannot occur.
 	tests := []struct {
-		score            float64
-		expectedTrust    string
-		expectedEnv      string
+		score         float64
+		expectedTrust string
+		expectedEnv   string
 	}{
-		{9.0, "high", "production"},
-		{8.0, "high", "production"},
-		{6.0, "medium", "staging"},
-		{5.0, "medium", "staging"},
-		{3.0, "low", "development"},
+		{0.9, "high", "production"},
+		{0.8, "high", "production"},
+		{0.6, "medium", "staging"},
+		{0.5, "medium", "staging"},
+		{0.3, "low", "development"},
 		{0.0, "low", "development"},
 	}
 
@@ -1609,10 +1615,10 @@ func TestTagService_suggestTagsForMCPConnections(t *testing.T) {
 	service := NewTagService(mockTagRepo, mockAgentRepo, mockMCPRepo)
 
 	tests := []struct {
-		name          string
-		talksTo       []string
-		expectedKeys  []string
-		expectedVals  []string
+		name         string
+		talksTo      []string
+		expectedKeys []string
+		expectedVals []string
 	}{
 		{
 			name:         "github connection",
@@ -1838,12 +1844,12 @@ func TestTagService_suggestTagsForMCPStatus(t *testing.T) {
 	service := NewTagService(mockTagRepo, mockAgentRepo, mockMCPRepo)
 
 	tests := []struct {
-		name            string
-		status          domain.MCPServerStatus
-		isVerified      bool
-		expectedStatus  string
-		expectedAvail   string
-		hasAlert        bool
+		name           string
+		status         domain.MCPServerStatus
+		isVerified     bool
+		expectedStatus string
+		expectedAvail  string
+		hasAlert       bool
 	}{
 		{
 			name:           "verified and active",
@@ -2235,4 +2241,95 @@ func (m *MockTagRepoForTags) GetMCPServerTagsByServerIDs(ctx context.Context, mc
 		}
 	}
 	return result, nil
+}
+
+// TestSuggestTagsForTrustScore_UsesCanonicalScale is the red-proof for the
+// third trust-score scale found in the 2026-08-04 audit.
+//
+// The thresholds here were 8.0 and 5.0 — a 0-10 scale that exists nowhere
+// else in the system. Agent trust scores are [0,1] (`agents.trust_score`
+// CHECK 0..1, migration 031), so no agent could ever reach 8.0 or 5.0 and
+// this function returned "low"/"development" for every agent regardless of
+// how trusted it was. MCP servers, carrying the hardcoded 75.0 literal, took
+// the top branch every time and were tagged `trust-level=high` +
+// `environment=production` on registration.
+func TestSuggestTagsForTrustScore_UsesCanonicalScale(t *testing.T) {
+	service := &TagService{}
+
+	tagValue := func(tags []*domain.Tag, key string) string {
+		for _, tag := range tags {
+			if tag.Key == key {
+				return tag.Value
+			}
+		}
+		return ""
+	}
+
+	tests := []struct {
+		name        string
+		trustScore  float64
+		trustLevel  string
+		environment string
+	}{
+		{"top of the range", 1.0, "high", "production"},
+		{"high band", 0.85, "high", "production"},
+		{"high band lower bound", 0.8, "high", "production"},
+		{"medium band upper", 0.79, "medium", "staging"},
+		{"medium band", 0.6, "medium", "staging"},
+		{"medium band lower bound", 0.5, "medium", "staging"},
+		{"low band upper", 0.49, "low", "development"},
+		{"bottom of the range", 0.0, "low", "development"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tags := service.suggestTagsForTrustScore(tt.trustScore)
+
+			assert.Equal(t, tt.trustLevel, tagValue(tags, "trust-level"))
+			assert.Equal(t, tt.environment, tagValue(tags, "environment"))
+		})
+	}
+}
+
+// TestSuggestTagsForTrustScore_HighBandIsReachable guards the class rather
+// than the constants. A threshold above the maximum a trust score can take
+// makes a branch unreachable — silently, since nothing fails. Pinning the
+// relationship between the calculator's output range and these thresholds
+// means the next person to change either one has to change both.
+func TestSuggestTagsForTrustScore_HighBandIsReachable(t *testing.T) {
+	service := &TagService{}
+	calculator := &MCPTrustCalculator{}
+
+	// The most trustworthy server the calculator can describe.
+	best := &domain.MCPServer{
+		ID:                   uuid.New(),
+		URL:                  "https://mcp.example.com",
+		PublicKey:            "dGVzdC1wdWJsaWMta2V5",
+		Description:          "a maximally established server",
+		Status:               domain.MCPServerStatusVerified,
+		IsVerified:           true,
+		CreatedBy:            uuid.New(),
+		CreatedAt:            time.Now().Add(-3 * 365 * 24 * time.Hour),
+		AttestationCount:     50,
+		ConfidenceScore:      100.0,
+		ConnectedAgentsCount: 25,
+		Capabilities:         []string{"a", "b", "c", "d", "e"},
+	}
+
+	score, err := calculator.Calculate(best)
+	require.NoError(t, err)
+
+	tags := service.suggestTagsForTrustScore(score.Score)
+
+	var trustLevel string
+	for _, tag := range tags {
+		if tag.Key == "trust-level" {
+			trustLevel = tag.Value
+		}
+	}
+
+	assert.Equal(t, "high", trustLevel,
+		"the best score the calculator can produce (%.4f) must reach the "+
+			"high band; if it cannot, the thresholds are on a different "+
+			"scale than the scores they judge", score.Score)
 }

--- a/apps/backend/internal/domain/security_policy.go
+++ b/apps/backend/internal/domain/security_policy.go
@@ -105,7 +105,10 @@ type MCPAllowlistRules struct {
 	// RequireVerified requires MCP servers to be verified before use
 	RequireVerified bool `json:"requireVerified"`
 
-	// MinTrustScore is the minimum trust score required (0-100)
+	// MinTrustScore is the minimum trust score required, on the canonical
+	// [0,1] trust scale (e.g. 0.7, not 70). This comment previously said
+	// 0-100, which disagreed with every value actually assigned to the field
+	// and with `mcp_servers.trust_score` (CHECK 0..1, migration 104).
 	MinTrustScore float64 `json:"minTrustScore"`
 
 	// MinConfidenceScore is the minimum confidence score required (0-100)

--- a/apps/backend/migrations/104_normalize_mcp_trust_score_scale.sql
+++ b/apps/backend/migrations/104_normalize_mcp_trust_score_scale.sql
@@ -123,5 +123,8 @@ CHECK (previous_score IS NULL OR (previous_score >= 0.0 AND previous_score <= 1.
 --    does not have to reconstruct it from three disagreeing call sites.
 COMMENT ON COLUMN mcp_servers.trust_score IS
     'Denormalized cache of the latest mcp_trust_scores.score. Scale [0,1], '
-    'enforced by mcp_servers_trust_score_range_check. Written only by the '
-    '8-factor calculator via the mig 094 mirror trigger — never by a literal.';
+    'enforced by mcp_servers_trust_score_range_check. Every value originates '
+    'from MCPTrustCalculator, which clamps to [0,1]; it reaches this column '
+    'both via the migration 094 mirror trigger and via the calculator''s own '
+    'UPDATE. Other writers (MCPServerRepository Create/Update) only carry a '
+    'value already set from that source. Never assign a literal here.';

--- a/apps/backend/migrations/104_normalize_mcp_trust_score_scale.sql
+++ b/apps/backend/migrations/104_normalize_mcp_trust_score_scale.sql
@@ -1,0 +1,127 @@
+-- Migration 104: make [0,1] the single canonical scale for MCP trust scores,
+-- and enforce it in the schema.
+--
+-- `mcp_servers.trust_score` (mig 004) is DECIMAL(5,2) with no CHECK
+-- constraint, so it has been accepting three mutually incompatible scales:
+--
+--   [0,1]   the 8-factor calculator clamps its output to [0,1]
+--           (`mcp_trust_calculator.go`), and `mcp_trust_scores.score` is
+--           DECIMAL(5,4) CHECK (score >= 0 AND score <= 1) (mig 051).
+--   [0,100] mig 061 declared this column a 0-100 field, and
+--           `mcp_service.go` wrote the literal 75.0 into it.
+--   [0,10]  `tag_service.suggestTagsForTrustScore` branches on >= 8.0 / >= 5.0.
+--
+-- Migration 094 made `mcp_trust_scores` the source of truth and mirrors it
+-- with `SET trust_score = NEW.score` — unscaled. So the cache column must
+-- carry the SAME scale as its source, not a transform of it; a transformed
+-- copy is the defect class 094 was written to close (#170).
+--
+-- [0,1] is also the scale every other trust value in this schema already
+-- uses: `agents.trust_score` (CHECK 0..1, mig 031), `trust_scores.score`,
+-- and the `MinTrustScore` policy thresholds the evaluator compares against.
+--
+-- Per the [CHIEF-CDS] decision + [CHIEF-CA] second opinion of 2026-08-04 in
+-- `todo/COUNCIL_LEDGER.md`.
+
+-- Audit trail: report what is about to be rewritten.
+DO $$
+DECLARE
+    server_count INTEGER;
+    server_max   NUMERIC;
+    history_count INTEGER;
+BEGIN
+    SELECT COUNT(*), MAX(trust_score) INTO server_count, server_max
+    FROM mcp_servers WHERE trust_score > 1.0;
+
+    SELECT COUNT(*) INTO history_count
+    FROM mcp_trust_score_history WHERE trust_score > 1.0;
+
+    RAISE NOTICE 'mcp_servers: % rows above 1.0 (max %), normalizing to [0,1]',
+        server_count, server_max;
+    RAISE NOTICE 'mcp_trust_score_history: % rows above 1.0, normalizing to [0,1]',
+        history_count;
+END $$;
+
+-- 1. Drop the audit trigger BEFORE touching any value.
+--
+--    `mcp_trust_score_change_trigger` (mig 051) records every change to
+--    `mcp_servers.trust_score` into `mcp_trust_score_history`. A rescaling is
+--    not a change in trust, but the trigger cannot tell the difference: left
+--    installed, it writes an audit row claiming each server's score fell from
+--    75.00 to 0.75. That is a fabricated security event, and in an audit
+--    trail it is worse than the defect being fixed.
+--
+--    Postgres also refuses to alter the type of a column named in a trigger's
+--    AFTER UPDATE OF list, so the trigger has to come off for step 3 anyway.
+DROP TRIGGER IF EXISTS mcp_trust_score_change_trigger ON mcp_servers;
+
+-- 2. Normalize existing out-of-scale values BEFORE narrowing the column type.
+--    Anything above 1.0 was written on the 0-100 scale (in practice: the
+--    hardcoded 75.0). Narrowing first would raise numeric_value_out_of_range.
+UPDATE mcp_servers
+SET trust_score = trust_score / 100.0
+WHERE trust_score > 1.0;
+
+-- 3. Widen the fractional precision to match the source of truth.
+--    At DECIMAL(5,2) the mig 094 mirror trigger silently rounds a calculated
+--    0.8234 down to 0.82, so the cache disagrees with `mcp_trust_scores.score`
+--    on every write — #170 reopened by rounding.
+ALTER TABLE mcp_servers
+ALTER COLUMN trust_score TYPE DECIMAL(5,4);
+
+-- 4. Restore the audit trigger, unchanged.
+CREATE TRIGGER mcp_trust_score_change_trigger
+    AFTER UPDATE OF trust_score ON mcp_servers
+    FOR EACH ROW
+    EXECUTE FUNCTION record_mcp_trust_score_change();
+
+-- 5. Enforce the scale so an out-of-range literal can never be stored again.
+ALTER TABLE mcp_servers
+DROP CONSTRAINT IF EXISTS mcp_servers_trust_score_range_check;
+
+ALTER TABLE mcp_servers
+ADD CONSTRAINT mcp_servers_trust_score_range_check
+CHECK (trust_score >= 0.0 AND trust_score <= 1.0);
+
+-- 6. Return `mcp_trust_score_history` to [0,1], undoing mig 061.
+--    Mig 061 moved this table to 0-100 to accommodate the 75.0 literal that
+--    this migration removes. The table is populated by
+--    `record_mcp_trust_score_change` (mig 051), which copies
+--    `mcp_servers.trust_score` on every change — so leaving it on the old
+--    scale would mean the audit trail of a score disagreed with the score.
+--    No Go code writes it directly; the repository only SELECTs from it at
+--    `mcp_trust_score_repository.go:150`.
+UPDATE mcp_trust_score_history
+SET trust_score = trust_score / 100.0
+WHERE trust_score > 1.0;
+
+UPDATE mcp_trust_score_history
+SET previous_score = previous_score / 100.0
+WHERE previous_score IS NOT NULL AND previous_score > 1.0;
+
+ALTER TABLE mcp_trust_score_history
+DROP CONSTRAINT IF EXISTS mcp_trust_score_history_trust_score_check;
+
+ALTER TABLE mcp_trust_score_history
+DROP CONSTRAINT IF EXISTS mcp_trust_score_history_previous_score_check;
+
+ALTER TABLE mcp_trust_score_history
+ALTER COLUMN trust_score TYPE DECIMAL(5,4);
+
+ALTER TABLE mcp_trust_score_history
+ALTER COLUMN previous_score TYPE DECIMAL(5,4);
+
+ALTER TABLE mcp_trust_score_history
+ADD CONSTRAINT mcp_trust_score_history_trust_score_check
+CHECK (trust_score >= 0.0 AND trust_score <= 1.0);
+
+ALTER TABLE mcp_trust_score_history
+ADD CONSTRAINT mcp_trust_score_history_previous_score_check
+CHECK (previous_score IS NULL OR (previous_score >= 0.0 AND previous_score <= 1.0));
+
+-- 7. Document the canonical scale on the column itself, so the next reader
+--    does not have to reconstruct it from three disagreeing call sites.
+COMMENT ON COLUMN mcp_servers.trust_score IS
+    'Denormalized cache of the latest mcp_trust_scores.score. Scale [0,1], '
+    'enforced by mcp_servers_trust_score_range_check. Written only by the '
+    '8-factor calculator via the mig 094 mirror trigger — never by a literal.';

--- a/apps/web/app/dashboard/mcp/[id]/page.tsx
+++ b/apps/web/app/dashboard/mcp/[id]/page.tsx
@@ -115,11 +115,12 @@ export default function MCPServerDetailsPage({
 }) {
   const router = useRouter();
 
-  // Helper to normalize trust score (handles both 0-1 and 0-100 formats)
-  const normalizeTrustScore = (score: number | undefined): number => {
-    const s = score ?? 0;
-    return s <= 1 ? s * 100 : s;
-  };
+  // MCP trust scores are on the canonical [0,1] scale, enforced by the
+  // mcp_servers_trust_score_range_check constraint (migration 104). This used
+  // to guess the scale with `s <= 1 ? s * 100 : s` to tolerate the 0-100
+  // literals the backend wrote; the guess is what let three incompatible
+  // scales coexist unnoticed, so it is deliberately not kept as a fallback.
+  const trustScorePercent = (score: number | undefined): number => (score ?? 0) * 100;
 
   const [serverId, setServerId] = useState<string | null>(null);
   const [server, setServer] = useState<MCPServer | null>(null);
@@ -449,12 +450,12 @@ export default function MCPServerDetailsPage({
                     className={
                       server.verificationMethod === "agent_attestation"
                         ? getConfidenceColor(server.confidenceScore ?? 0)
-                        : getTrustColor(normalizeTrustScore(server.trustScore))
+                        : getTrustColor(trustScorePercent(server.trustScore))
                     }
                   >
                     {server.verificationMethod === "agent_attestation"
                       ? `Confidence: ${(server.confidenceScore ?? 0).toFixed(1)}%`
-                      : `Trust: ${normalizeTrustScore(server.trustScore).toFixed(1)}%`}
+                      : `Trust: ${trustScorePercent(server.trustScore).toFixed(1)}%`}
                   </Badge>
                 </div>
               </div>
@@ -600,15 +601,15 @@ export default function MCPServerDetailsPage({
                 <div className="text-right">
                   <div
                     className={`text-4xl font-bold ${
-                      getTrustColor(normalizeTrustScore(server.trustScore)).split(" ")[0]
+                      getTrustColor(trustScorePercent(server.trustScore)).split(" ")[0]
                     }`}
                   >
-                    {normalizeTrustScore(server.trustScore).toFixed(1)}%
+                    {trustScorePercent(server.trustScore).toFixed(1)}%
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {normalizeTrustScore(server.trustScore) >= 80
+                    {trustScorePercent(server.trustScore) >= 80
                       ? "High trust"
-                      : normalizeTrustScore(server.trustScore) >= 60
+                      : trustScorePercent(server.trustScore) >= 60
                         ? "Medium trust"
                         : "Low trust"}
                   </p>
@@ -1381,12 +1382,12 @@ export default function MCPServerDetailsPage({
                         className={
                           server.verificationMethod === "agent_attestation"
                             ? getConfidenceColor(server.confidenceScore ?? 0)
-                            : getTrustColor(normalizeTrustScore(server.trustScore))
+                            : getTrustColor(trustScorePercent(server.trustScore))
                         }
                       >
                         {server.verificationMethod === "agent_attestation"
                           ? (server.confidenceScore ?? 0).toFixed(1)
-                          : normalizeTrustScore(server.trustScore).toFixed(1)}%
+                          : trustScorePercent(server.trustScore).toFixed(1)}%
                       </Badge>
                     </span>
                   </div>

--- a/apps/web/app/dashboard/mcp/page.tsx
+++ b/apps/web/app/dashboard/mcp/page.tsx
@@ -396,9 +396,13 @@ export default function MCPServersPage() {
     },
     {
       name: "Avg Trust Score",
-      value: stats.avgTrustScore.toFixed(1),
-      // change: stats.avgTrustScore >= 75 ? "+5.2%" : "-2.1%",
-      // changeType: stats.avgTrustScore >= 75 ? "positive" : "negative",
+      // Trust scores are on the canonical [0,1] scale, so the average is
+      // rendered as a percentage. It used to print the raw value, which read
+      // as "75.0" only because the backend was writing the literal 75.0 into
+      // a field the calculator defines on [0,1].
+      value: mcpServers.length > 0
+        ? `${(stats.avgTrustScore * 100).toFixed(1)}%`
+        : "—",
       icon: Shield,
     },
     {

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Content-Type: application/json
   "publicKey": "base64-encoded-ed25519-public-key",
   "version": "1.0.0",
   "status": "pending_verification",
-  "trustScore": 50.0,
+  "trustScore": 0.50,
   "createdAt": "2025-10-08T00:00:00Z",
   "updatedAt": "2025-10-08T00:00:00Z"
 }
@@ -235,7 +235,7 @@ Authorization: Bearer YOUR_JWT_TOKEN
       "displayName": "My Awesome Agent",
       "agentType": "ai_agent",
       "status": "verified",
-      "trustScore": 75.5,
+      "trustScore": 0.755,
       "capabilities": ["file:read"],
       "tags": [],
       "createdAt": "2025-10-07T00:00:00Z"
@@ -270,7 +270,7 @@ Authorization: Bearer YOUR_JWT_TOKEN
   "publicKey": "base64-encoded-ed25519-public-key",
   "version": "1.0.0",
   "status": "active",
-  "trustScore": 75.5,
+  "trustScore": 0.755,
   "capabilities": ["read_database", "modify_user"],
   "metadata": {
     "totalActions": 1234,
@@ -322,7 +322,7 @@ POST /api/v1/agents/{id}/verify/response
 {
   "verified": true,
   "verificationId": "770e8400-e29b-41d4-a716-446655440000",
-  "trustScore": 75.5,
+  "trustScore": 0.755,
   "verifiedAt": "2025-10-08T00:00:00Z"
 }
 ```
@@ -416,7 +416,7 @@ Content-Type: application/json
   "displayName": "My MCP Server",
   "endpoint": "https://mcp.example.com",
   "status": "pending_verification",
-  "trustScore": 50.0,
+  "trustScore": 0.50,
   "createdAt": "2025-10-08T00:00:00Z"
 }
 ```
@@ -442,7 +442,7 @@ Authorization: Bearer YOUR_JWT_TOKEN
       "displayName": "My MCP Server",
       "endpoint": "https://mcp.example.com",
       "status": "active",
-      "trustScore": 85.0,
+      "trustScore": 0.85,
       "lastVerifiedAt": "2025-10-08T00:00:00Z"
     }
   ]
@@ -591,11 +591,11 @@ Authorization: Bearer YOUR_JWT_TOKEN
   "agentId": "550e8400-e29b-41d4-a716-446655440000",
   "history": [
     {
-      "trustScore": 75.5,
+      "trustScore": 0.755,
       "timestamp": "2025-10-08T00:00:00Z"
     },
     {
-      "trustScore": 74.2,
+      "trustScore": 0.742,
       "timestamp": "2025-10-07T00:00:00Z"
     }
   ]
@@ -876,7 +876,7 @@ Create a webhook.
   "timestamp": "2025-10-08T00:00:00Z",
   "data": {
     "agentId": "550e8400-e29b-41d4-a716-446655440000",
-    "trustScore": 75.5,
+    "trustScore": 0.755,
     "verifiedAt": "2025-10-08T00:00:00Z"
   }
 }


### PR DESCRIPTION
## What was wrong

`mcp_servers.trust_score` never held a measured value. The 8-factor MCP trust calculator was never constructed outside `_test.go`, so every server carried either the literal `75.0` (SDK-registered or verified) or `0.0` (manual registration) — while the weight table in `mcp_trust_calculator.go` and migration 051's table comment both described a measurement that nothing performed.

Three incompatible scales shared the one column, which is why it went unnoticed:

| Scale | Where |
|---|---|
| `[0,1]` | calculator clamp, `mcp_trust_scores.score` (CHECK 0..1), `mcp_policy_evaluator` rendering, `DefaultMinTrustScoreForRiskLevel` |
| `[0,100]` | migration 061's header, the `75.0` literal in `mcp_service.go` |
| `[0,10]` | `tag_service.suggestTagsForTrustScore` (`>= 8.0` / `>= 5.0`) |

`mcp_servers.trust_score` was `DECIMAL(5,2)` with no CHECK constraint, so it accepted all three.

### Two consequences beyond the misleading number

1. **The minimum-trust policy gate could not fail.** `evaluateAllowlist` compares `mcpServer.TrustScore` against `rules.MinTrustScore`, which is `[0,1]`. A server carrying `75.0` cleared every representable floor, so an SDK-registered MCP server passed any organization's trust policy unconditionally — and only a genuinely measured server could ever be rejected.
2. **Every SDK-registered server was auto-tagged** `trust-level=high` + `environment=production`, because `75.0` tripped the tag suggester's top branch. The same function was inert for agents, whose `[0,1]` scores never reach `5.0`.

## The fix

`[0,1]` becomes the single canonical scale. It matches the source of truth that migration 094's mirror trigger copies from unscaled, and it matches `agents.trust_score` (CHECK 0..1, migration 031).

- **Migration 104** normalizes existing rows, widens `DECIMAL(5,2)` → `(5,4)` so the cache stops rounding its source, and adds a CHECK constraint so an out-of-scale literal is unstorable. The migration 051 audit trigger is dropped around the rescale — left installed, it records a fabricated *"trust fell from 75.00 to 0.75"* event for every server, which in an audit trail is worse than the defect being fixed.
- **`MCPService`** takes the calculator and scores each server from its real inputs, after registration (once capability rows and the agent connection exist, which two factors read) and after verification.
- Tag thresholds move to `0.8`/`0.5`; the `MinTrustScore` doc comment and the evaluator's violation message are corrected to the same scale (a `0.7` floor used to render as *"below minimum 0.7%"*).
- The frontend drops its `s <= 1 ? s * 100 : s` scale guess. A helper that infers which scale a number is on is what let the mismatch survive.
- `docs/API.md` published trust scores of `75.5`, `85.0`, `74.2`, `50.0` across nine agent examples. `agents.trust_score` has had a CHECK 0..1 constraint since migration 031, so the API could never have returned them. Rescaled.

## Behaviour change worth knowing

A freshly registered server now scores around **0.485** rather than `0.75`. That is the honest value for a server with no attestations, no connected agents, and no history. **Organizations running a `MinTrustScore` floor above it will begin seeing new servers held for review — that is the bypass closing, not a regression.** If it lands badly the mitigation is a documented grace window on new servers, not a floor on the score.

## Verification

End-to-end against a running instance, registering through the real API:

```
"trustScore": 0.485
```

and the stored factor breakdown recomputes to exactly that:

```
0.6(.15) + 0.6(.15) + 0.75(.15) + 1.0(.10) + 0.3(.10) + 0.5(.05) + 0.75(.05) = 0.485
```

`mcp_trust_scores` and `mcp_servers.trust_score` agree to four decimal places. The published weight table now produces the published number.

- Migration applied on throwaway Postgres from **both** a clean schema and a seeded pre-104 database holding `75.0` rows; confirmed no spurious audit row is written.
- Regression tests confirmed **red** against the previous code; the constraint test confirmed **red** against the pre-104 schema.
- `evaluateAllowlist` had no test at all before this. Added a rejection case per enforced field plus a baseline case that violates nothing — each of the five guards was mutated to a no-op and confirmed to fail only its own case.

## Follow-up (not in this PR)

`NewMCPService` gained a parameter and `aim-cloud/apps/backend/cmd/server/main.go` is sync-protected, so the wiring will not propagate automatically. aim-cloud needs the constructor call and migration 104 ported by hand.
