### PR TITLE
test: repair the integration fixtures against the current schema

### DIFF
--- a/apps/backend/internal/application/a2a_consent_backfill_integration_test.go
+++ b/apps/backend/internal/application/a2a_consent_backfill_integration_test.go
@@ -35,9 +35,13 @@ func TestA2AConsentBackfill_ConstraintEnforced(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	grantorID := uuid.New()
 	recipientID := uuid.New()
+
+	// Seeded before the cleanup below is registered, so that cleanup (agents,
+	// consent records) runs first under t.Cleanup's LIFO order and the org/user
+	// rows it depends on are removed last.
+	orgID, userID := seedOrgAndUser(t, db, ctx, "consent-backfill")
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx,
@@ -45,20 +49,14 @@ func TestA2AConsentBackfill_ConstraintEnforced(t *testing.T) {
 			grantorID, recipientID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2)`,
 			grantorID, recipientID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "consent-backfill-test-org-"+grantorID.String()[:8])
-	require.NoError(t, err)
 
 	for _, id := range []uuid.UUID{grantorID, recipientID} {
 		_, err = db.ExecContext(ctx,
-			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
-			id, orgID, "consent-backfill-agent-"+id.String()[:8])
+			`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.5, $5, NOW(), NOW())`,
+			id, orgID, "consent-backfill-agent-"+id.String()[:8],
+			"Consent Backfill Agent", userID)
 		require.NoError(t, err)
 	}
 
@@ -104,28 +102,24 @@ func TestA2AConsentBackfill_OrgIDDerivesFromGrantor(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	grantorID := uuid.New()
 	recipientID := uuid.New()
 	consentID := uuid.New()
+
+	orgID, userID := seedOrgAndUser(t, db, ctx, "consent-derive")
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_consent_records WHERE id = $1`, consentID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2)`,
 			grantorID, recipientID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
 
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "consent-derive-test-org-"+grantorID.String()[:8])
-	require.NoError(t, err)
 	for _, id := range []uuid.UUID{grantorID, recipientID} {
 		_, err = db.ExecContext(ctx,
-			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
-			id, orgID, "consent-derive-agent-"+id.String()[:8])
+			`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.5, $5, NOW(), NOW())`,
+			id, orgID, "consent-derive-agent-"+id.String()[:8],
+			"Consent Derive Agent", userID)
 		require.NoError(t, err)
 	}
 

--- a/apps/backend/internal/application/a2a_peer_trust_aggregates_trigger_integration_test.go
+++ b/apps/backend/internal/application/a2a_peer_trust_aggregates_trigger_integration_test.go
@@ -35,11 +35,12 @@ func TestA2APeerTrustAggregatesTrigger_RecomputesOnInsert(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	agentID := uuid.New()
 	peerA := uuid.New()
 	peerB := uuid.New()
 	peerC := uuid.New()
+
+	orgID, userID := seedOrgAndUser(t, db, ctx, "a2a-aggr")
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_peer_trust WHERE agent_id = $1 OR peer_agent_id IN ($2, $3, $4)`,
@@ -47,19 +48,13 @@ func TestA2APeerTrustAggregatesTrigger_RecomputesOnInsert(t *testing.T) {
 		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_trust_scores WHERE agent_id = $1`, agentID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2, $3, $4)`,
 			agentID, peerA, peerB, peerC)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "a2a-aggr-test-org-"+agentID.String()[:8])
-	require.NoError(t, err)
 
 	for _, id := range []uuid.UUID{agentID, peerA, peerB, peerC} {
 		_, err = db.ExecContext(ctx,
-			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
-			id, orgID, "a2a-aggr-agent-"+id.String()[:8])
+			`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.5, $5, NOW(), NOW())`,
+			id, orgID, "a2a-aggr-agent-"+id.String()[:8], "A2A Aggr Agent", userID)
 		require.NoError(t, err)
 	}
 
@@ -102,28 +97,24 @@ func TestA2APeerTrustAggregatesTrigger_DeleteShrinksAggregates(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	agentID := uuid.New()
 	peerA := uuid.New()
 	peerB := uuid.New()
+
+	orgID, userID := seedOrgAndUser(t, db, ctx, "a2a-del")
 
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_peer_trust WHERE agent_id = $1 OR peer_agent_id IN ($2, $3)`,
 			agentID, peerA, peerB)
 		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_trust_scores WHERE agent_id = $1`, agentID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id IN ($1, $2, $3)`, agentID, peerA, peerB)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
 
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "a2a-del-test-org-"+agentID.String()[:8])
-	require.NoError(t, err)
 	for _, id := range []uuid.UUID{agentID, peerA, peerB} {
 		_, err = db.ExecContext(ctx,
-			`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score, created_at, updated_at)
-			 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, NOW(), NOW())`,
-			id, orgID, "a2a-del-agent-"+id.String()[:8])
+			`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score, created_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.5, $5, NOW(), NOW())`,
+			id, orgID, "a2a-del-agent-"+id.String()[:8], "A2A Del Agent", userID)
 		require.NoError(t, err)
 	}
 

--- a/apps/backend/internal/application/capability_violation_trigger_integration_test.go
+++ b/apps/backend/internal/application/capability_violation_trigger_integration_test.go
@@ -43,28 +43,21 @@ func TestCapabilityViolationTrigger_BumpsCounter(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Setup: create a throwaway organization + agent so the test does
+	// Setup: create a throwaway organization + user + agent so the test does
 	// not depend on any seeded row and cleans up after itself.
-	orgID := uuid.New()
 	agentID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "capviolation-trigger")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM capability_violations WHERE agent_id = $1`, agentID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
 
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "trigger-test-org-"+agentID.String()[:8],
-	)
-	require.NoError(t, err)
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
-		                     capability_violation_count, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.9, 0, NOW(), NOW())`,
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score,
+		                     capability_violation_count, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.9, 0, $5, NOW(), NOW())`,
 		agentID, orgID, "trigger-test-agent-"+agentID.String()[:8],
+		"Trigger Test Agent", userID,
 	)
 	require.NoError(t, err)
 
@@ -124,27 +117,22 @@ func TestCapabilityViolationTrigger_BackfillReconcilesDrift(t *testing.T) {
 
 	ctx := context.Background()
 
-	orgID := uuid.New()
 	agentID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "capviolation-backfill")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM capability_violations WHERE agent_id = $1`, agentID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "backfill-test-org-"+agentID.String()[:8])
-	require.NoError(t, err)
 
 	// Seed an agent whose counter is INTENTIONALLY drifted: 7 actual
 	// rows, but the counter says 2 (simulating pre-trigger state where
 	// 5 violations were inserted without an accompanying increment).
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
-		                     capability_violation_count, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.5, 2, NOW(), NOW())`,
-		agentID, orgID, "backfill-test-agent-"+agentID.String()[:8])
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score,
+		                     capability_violation_count, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.5, 2, $5, NOW(), NOW())`,
+		agentID, orgID, "backfill-test-agent-"+agentID.String()[:8],
+		"Backfill Test Agent", userID)
 	require.NoError(t, err)
 
 	// Disable the trigger for the next inserts to simulate pre-091

--- a/apps/backend/internal/application/integration_seed_test.go
+++ b/apps/backend/internal/application/integration_seed_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared seeding for the integration tests in this package.
+//
+// These helpers exist because the same NOT NULL / foreign-key columns kept
+// being omitted independently in each test file, and nothing caught it: the
+// integration suite is excluded from `go test ./...` by its build tag, and CI
+// had no database, so every one of these tests failed the moment it was
+// actually run. Seeding through one path means a future column requirement is
+// fixed once rather than in eleven places.
+//
+// The requirements as of migration 104:
+//   - organizations.domain  VARCHAR(255) UNIQUE NOT NULL
+//   - users.*               organization_id, email, name, password_hash, role,
+//                           provider, provider_id
+//   - agents.display_name   NOT NULL
+//   - agents.created_by     NOT NULL, FK -> users(id)
+//   - mcp_servers.created_by NOT NULL, FK -> users(id)
+
+// seedOrgAndUser creates the organization and user rows that `agents` and
+// `mcp_servers` require via NOT NULL / foreign key. Returns both IDs and
+// registers cleanup.
+//
+// The domain is derived from the generated org UUID rather than from the
+// caller's prefix, because the column is UNIQUE and prefixes repeat across
+// tests in the same run.
+func seedOrgAndUser(t *testing.T, db *sql.DB, ctx context.Context, prefix string) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	orgID := uuid.New()
+	userID := uuid.New()
+	suffix := orgID.String()[:8]
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, prefix+"-org-"+suffix, prefix+"-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users
+		   (id, organization_id, email, name, password_hash, role, provider,
+		    provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, prefix+"-"+suffix+"@example.com", prefix+"-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	return orgID, userID
+}

--- a/apps/backend/internal/application/mcp_capabilities_cache_trigger_integration_test.go
+++ b/apps/backend/internal/application/mcp_capabilities_cache_trigger_integration_test.go
@@ -42,29 +42,23 @@ func TestMCPCapabilitiesCacheTrigger_DerivesFromDetailTable(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	serverID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-caps")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_server_capabilities WHERE mcp_server_id = $1`, serverID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "mcp-caps-test-org-"+serverID.String()[:8])
-	require.NoError(t, err)
 
 	// Seed MCP server with the registering agent's claim of all
 	// three capability types.
 	claimed := `["resources", "prompts", "tools"]`
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, $6, NOW(), NOW())`,
 		serverID, orgID,
 		"mcp-caps-test-server-"+serverID.String()[:8],
 		"https://mcp-caps-test-"+serverID.String()[:8]+".example.com",
-		claimed)
+		claimed, userID)
 	require.NoError(t, err)
 
 	// Insert detail rows of TWO types only ('tool' and 'resource').
@@ -106,27 +100,21 @@ func TestMCPCapabilitiesCacheTrigger_PreservesClaimWhenDetailEmpty(t *testing.T)
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	serverID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-caps-preserve")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_server_capabilities WHERE mcp_server_id = $1`, serverID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "mcp-caps-preserve-test-org-"+serverID.String()[:8])
-	require.NoError(t, err)
 
 	claimed := `["tools", "prompts"]`
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, $6, NOW(), NOW())`,
 		serverID, orgID,
 		"mcp-caps-preserve-test-server-"+serverID.String()[:8],
 		"https://mcp-caps-preserve-test-"+serverID.String()[:8]+".example.com",
-		claimed)
+		claimed, userID)
 	require.NoError(t, err)
 
 	// Insert a row then delete it. After DELETE the detail table
@@ -172,26 +160,20 @@ func TestMCPCapabilitiesCacheTrigger_PreservesClaimOnFreshServer(t *testing.T) {
 	require.NoError(t, db.Ping())
 
 	ctx := context.Background()
-	orgID := uuid.New()
 	serverID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "mcp-caps-fresh")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "mcp-caps-fresh-test-org-"+serverID.String()[:8])
-	require.NoError(t, err)
 
 	claimed := `["tools", "resources"]`
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, NOW(), NOW())`,
+		`INSERT INTO mcp_servers (id, organization_id, name, url, version, capabilities, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, '1.0.0', $5::jsonb, $6, NOW(), NOW())`,
 		serverID, orgID,
 		"mcp-caps-fresh-test-server-"+serverID.String()[:8],
 		"https://mcp-caps-fresh-test-"+serverID.String()[:8]+".example.com",
-		claimed)
+		claimed, userID)
 	require.NoError(t, err)
 
 	// No detail rows ever inserted. The cache should still be the

--- a/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
+++ b/apps/backend/internal/application/mcp_trust_score_mirror_trigger_integration_test.go
@@ -14,34 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// seedOrgAndUser creates the organization and user rows that `mcp_servers`
-// requires via NOT NULL / foreign key. Returns both IDs and registers cleanup.
-func seedOrgAndUser(t *testing.T, db *sql.DB, ctx context.Context, prefix string) (uuid.UUID, uuid.UUID) {
-	t.Helper()
-	orgID := uuid.New()
-	userID := uuid.New()
-	suffix := orgID.String()[:8]
-
-	t.Cleanup(func() {
-		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
-	})
-
-	_, err := db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
-		 VALUES ($1, $2, $3, NOW(), NOW())`,
-		orgID, prefix+"-org-"+suffix, prefix+"-"+suffix+".example.com")
-	require.NoError(t, err)
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO users
-		   (id, organization_id, email, name, password_hash, role, provider,
-		    provider_id, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
-		userID, orgID, prefix+"-"+suffix+"@example.com", prefix+"-user", "local-"+suffix)
-	require.NoError(t, err)
-
-	return orgID, userID
-}
+// seedOrgAndUser now lives in integration_seed_test.go, shared with the other
+// integration tests in this package.
 
 // TestMCPTrustScoreMirrorTrigger_InsertSyncsServerCache is the
 // regression test for issue #170. Migration 094 installs an

--- a/apps/backend/internal/application/verified_at_trigger_integration_test.go
+++ b/apps/backend/internal/application/verified_at_trigger_integration_test.go
@@ -42,26 +42,20 @@ func TestVerifiedAtTrigger_SetsOnStatusTransition(t *testing.T) {
 
 	ctx := context.Background()
 
-	orgID := uuid.New()
 	agentID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "verified-at-trigger")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "verified-at-trigger-test-org-"+agentID.String()[:8])
-	require.NoError(t, err)
 
 	// Seed an agent in 'pending' state with NULL verified_at — the
 	// pre-flip state.
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
-		                     verified_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'pending', 0.5, NULL, NOW(), NOW())`,
-		agentID, orgID, "verified-at-trigger-test-agent-"+agentID.String()[:8])
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score,
+		                     verified_at, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'ai_agent', 'pending', 0.5, NULL, $5, NOW(), NOW())`,
+		agentID, orgID, "verified-at-trigger-test-agent-"+agentID.String()[:8],
+		"Verified At Trigger Agent", userID)
 	require.NoError(t, err)
 
 	// Direct-SQL status flip: this is the path the audit observed
@@ -102,28 +96,21 @@ func TestVerifiedAtTrigger_DoesNotOverwriteExisting(t *testing.T) {
 
 	ctx := context.Background()
 
-	orgID := uuid.New()
 	agentID := uuid.New()
+	orgID, userID := seedOrgAndUser(t, db, ctx, "verified-at-noclobber")
 	t.Cleanup(func() {
 		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
 	})
-
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO organizations (id, name, created_at, updated_at)
-		 VALUES ($1, $2, NOW(), NOW())`,
-		orgID, "verified-at-noclobber-test-org-"+agentID.String()[:8])
-	require.NoError(t, err)
 
 	// Seed an agent already in 'verified' state with a known
 	// verified_at three days ago.
 	originalVerifiedAt := time.Now().UTC().Add(-72 * time.Hour).Truncate(time.Second)
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, organization_id, name, agent_type, status, trust_score,
-		                     verified_at, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'ai_agent', 'verified', 0.8, $4, NOW(), NOW())`,
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, status, trust_score,
+		                     verified_at, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'ai_agent', 'verified', 0.8, $5, $6, NOW(), NOW())`,
 		agentID, orgID, "verified-at-noclobber-test-agent-"+agentID.String()[:8],
-		originalVerifiedAt)
+		"Verified At Noclobber Agent", originalVerifiedAt, userID)
 	require.NoError(t, err)
 
 	// UPDATE that does NOT touch status. The trigger fires (BEFORE


### PR DESCRIPTION
Every test in `internal/application` behind `//go:build integration` fails against a correctly
migrated database, and has for as long as the columns below have existed.

This was found while adding an integration-test job to the private deployed fork, where the same
files are byte-identical and fail identically. It is not a fork-specific problem —
`001_initial_schema.sql` is the same file in both trees.

## Why nobody noticed

`go test ./...` excludes these by build tag, and no CI job sets `TEST_DATABASE_URL`. So the suite
has never run: not in CI, and not locally for anyone who ran the default test command. A developer
who did run it would see 11 failures and could reasonably assume their environment was wrong.

## What broke

The tests insert directly into `organizations`, `agents` and `mcp_servers`, and the schema grew
NOT NULL columns underneath them.

| Column | Requirement | Tests affected |
|---|---|---|
| `organizations.domain` | `VARCHAR(255) UNIQUE NOT NULL` | 11 |
| `agents.display_name` | `NOT NULL` | 8 |
| `agents.created_by` | `NOT NULL`, FK → `users(id)` | 8 |
| `mcp_servers.created_by` | `NOT NULL`, FK → `users(id)` | 3 |

The two foreign keys are why this is more than adding columns to an INSERT: these tests never
created a `users` row at all, so there was nothing for `created_by` to reference.

## Changes

- **`integration_seed_test.go`** — `seedOrgAndUser` moved here out of
  `mcp_trust_score_mirror_trigger_integration_test.go`, which happened to define it. Seeding
  through one path means the next NOT NULL column is a one-line fix instead of eleven. The domain
  is derived from the generated org UUID because the column is UNIQUE and the test prefixes repeat
  within a single run.
- **The eleven tests** seed org + user through that helper and pass the required columns.
  Assertions are untouched — only fixtures changed.

## Verification

Against a freshly migrated Postgres 16, `go test -tags=integration -race ./...` goes from **11
failures to 0**.

## Not fixed here

No CI job runs these, so they can rot again exactly the same way. `e2e-empty-state` applies
migrations — which is why schema changes themselves have been caught — but nothing ever compiles
the Go integration tests with their build tag.

Worth adding a job that runs them, and that **fails if any test reports SKIP rather than PASS**:
these skip themselves when `TEST_DATABASE_URL` is unset, so without that assertion a misconfigured
environment is indistinguishable from a green run, which is the same silent-no-op that hid this for
so long.
