### PR TITLE
auth: enforce agent revocation on the signature and API-key paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,11 +359,16 @@ jobs:
       # These tests call t.Skip when TEST_DATABASE_URL is unset, so a broken env
       # would leave the job green having asserted nothing — the same silent
       # no-op that let the fixtures rot. Fail loudly instead.
+      #
+      # The selector and the package list must both cover any new integration
+      # test, or the step above still runs it while this assertion silently
+      # stops applying to it. AgentRevocation + the middleware package were
+      # added for exactly that reason.
       - name: Assert integration tests were not skipped
         run: |
           set -o pipefail
-          go test -tags=integration -v -run 'Trigger|Backfill|OutOfScale' \
-            ./internal/application/... 2>&1 | tee /tmp/integration.log
+          go test -tags=integration -v -run 'Trigger|Backfill|OutOfScale|AgentRevocation' \
+            ./internal/application/... ./internal/interfaces/http/middleware/... 2>&1 | tee /tmp/integration.log
           if grep -q '^--- SKIP' /tmp/integration.log; then
             echo "::error::Integration tests were SKIPPED — TEST_DATABASE_URL is not reaching them."
             grep '^--- SKIP' /tmp/integration.log

--- a/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
@@ -1,0 +1,356 @@
+//go:build integration
+
+package middleware
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
+)
+
+// Revocation enforcement on the agent auth middlewares.
+//
+// Before this suite existed, `AgentService.RevokeAgent` and `EnforceKeyExpiry`
+// expressed denial ONLY as a write to `agents.status`, and three of the six auth
+// middlewares never read that column. A revoked or suspended agent that still held
+// its key material authenticated successfully — on `secrets resolve` among other
+// routes in the public backend, and on every SDK route in aim-cloud, which mounts
+// Ed25519AgentMiddleware where the public backend mounts the PQC one.
+//
+// These tests drive the REAL repository against a real Postgres and the REAL fiber
+// middleware, with real Ed25519 signatures over the exact message the middleware
+// reconstructs. There is no injectable seam on `*application.AgentService`, and a
+// faked one would not have caught the defect anyway: the bug was that the status
+// column was never read, which only a real row can demonstrate.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL with the AIM
+// schema applied (run migrations first).
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestAgentRevocation ./internal/interfaces/http/middleware/...
+
+// The statuses under test, and what each must do.
+//
+// Written as literals, not derived from the domain constants, so this table states
+// the contract independently of the code it checks. "deactivated" is not a status
+// the system has — it stands for any value a future migration or a hand-run UPDATE
+// could put in the column, which `agents.status` permits because it carries no
+// CHECK constraint. A deny-list implementation authenticates it; an allow-list
+// denies it.
+var revocationCases = []struct {
+	status     string
+	shouldAuth bool
+	why        string
+}{
+	{"verified", true, "the ordinary case — also proves the request is otherwise well-formed"},
+	{"pending", true, "registration default; denying it would break enrollment"},
+	{"revoked", false, "RevokeAgent writes this and nothing else denied the request"},
+	{"suspended", false, "SuspendAgent and EnforceKeyExpiry write this"},
+	{"deactivated", false, "unrecognised value must fail closed, not fall through"},
+}
+
+func revocationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping revocation enforcement test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// seedAgentWithStatus creates the organization, user and agent rows an auth request
+// needs, with the agent in `status` and holding `publicKeyB64`.
+//
+// This mirrors the shape of `seedOrgAndUser` in internal/application rather than
+// reusing it: that helper is unexported in a different package. The NOT NULL and FK
+// requirements it documents are honoured here, and the same rule applies — a future
+// column requirement gets fixed in this one helper, not per test.
+func seedAgentWithStatus(t *testing.T, db *sql.DB, ctx context.Context, status, publicKeyB64 string) uuid.UUID {
+	t.Helper()
+
+	orgID, userID, agentID := uuid.New(), uuid.New(), uuid.New()
+	suffix := agentID.String()[:8]
+
+	// Child-first, so the foreign keys hold on the way out.
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM api_keys WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "revocation-org-"+suffix, "revocation-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, password_hash, role,
+		                    provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, "revocation-"+suffix+"@example.com", "revocation-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	// `description` is nullable with no default, but AgentRepository.GetByID scans it
+	// into a plain string — a NULL there fails the whole lookup, and the middleware
+	// reports it as "Agent not found", which reads exactly like a revocation denial.
+	// Set it explicitly so a green run means the status check ran, not that the row
+	// was unreadable.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
+		                     status, public_key, trust_score, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, 'ai_agent', $6, $7, 0.5, $8, NOW(), NOW())`,
+		agentID, orgID, "revocation-agent-"+suffix, "Revocation Agent",
+		"seeded by the revocation enforcement suite", status, publicKeyB64, userID)
+	require.NoError(t, err,
+		"seeding status %q failed — agents.status carries no CHECK constraint, so "+
+			"even a value outside the domain constants must insert", status)
+
+	return agentID
+}
+
+// signedGet runs one real Ed25519-signed GET through `app` and returns the status
+// code and body. The message is the exact one both signature middlewares
+// reconstruct: METHOD\nOriginalURL\ntimestamp, with no body.
+func signedGet(t *testing.T, app *fiber.App, agentID uuid.UUID, pub ed25519.PublicKey, priv ed25519.PrivateKey) (int, string) {
+	t.Helper()
+
+	const path = "/protected"
+	timestampStr := strconv.FormatInt(time.Now().Unix(), 10)
+	message := fmt.Sprintf("GET\n%s\n%s", path, timestampStr)
+
+	req := httptest.NewRequest("GET", path, nil)
+	req.Header.Set("X-Agent-ID", agentID.String())
+	req.Header.Set("X-Signature", base64.StdEncoding.EncodeToString(ed25519.Sign(priv, []byte(message))))
+	req.Header.Set("X-Timestamp", timestampStr)
+	req.Header.Set("X-Public-Key", base64.StdEncoding.EncodeToString(pub))
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(body)
+}
+
+// newSignatureApp mounts one of the two signature middlewares over a real
+// DB-backed AgentService. Only agentRepo is exercised — GetAgent delegates
+// straight to it — so the remaining dependencies are nil by design.
+func newSignatureApp(db *sql.DB, mount func(*application.AgentService) fiber.Handler) *fiber.App {
+	svc := application.NewAgentService(
+		repository.NewAgentRepository(db),
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	app := fiber.New()
+	app.Use(mount(svc))
+	app.Get("/protected", func(c fiber.Ctx) error {
+		return c.JSON(fiber.Map{"reached": true})
+	})
+	return app
+}
+
+// assertSignatureMiddlewareEnforcesStatus is the shared body for both signature
+// middlewares. Both directions are asserted for every status: a denial is only
+// counted when the body names the status, because a 401 for some unrelated reason
+// (bad signature, clock skew, missing key) would otherwise read as enforcement
+// that is not there.
+func assertSignatureMiddlewareEnforcesStatus(t *testing.T, mount func(*application.AgentService) fiber.Handler) {
+	db := revocationTestDB(t)
+	ctx := context.Background()
+
+	for _, tc := range revocationCases {
+		t.Run(tc.status, func(t *testing.T) {
+			pub, priv, err := ed25519.GenerateKey(nil)
+			require.NoError(t, err)
+			pubB64 := base64.StdEncoding.EncodeToString(pub)
+
+			agentID := seedAgentWithStatus(t, db, ctx, tc.status, pubB64)
+			app := newSignatureApp(db, mount)
+
+			code, body := signedGet(t, app, agentID, pub, priv)
+
+			if tc.shouldAuth {
+				assert.Equal(t, fiber.StatusOK, code,
+					"status %q must authenticate (%s); body: %s", tc.status, tc.why, body)
+				assert.Contains(t, body, "reached",
+					"the handler must actually run for status %q", tc.status)
+				return
+			}
+
+			assert.Equal(t, fiber.StatusUnauthorized, code,
+				"status %q must be denied (%s); body: %s", tc.status, tc.why, body)
+			assert.NotContains(t, body, "reached",
+				"the handler ran for status %q — the request was authenticated", tc.status)
+			assert.Contains(t, body, tc.status,
+				"status %q was denied, but not for being %q — the 401 came from some "+
+					"other check, so this asserts nothing about revocation. Body: %s",
+				tc.status, tc.status, body)
+		})
+	}
+}
+
+// aim-cloud mounts this one on every SDK route, so it is live in the deployed SaaS
+// even though the public backend has no non-test call site for it.
+func TestAgentRevocation_Ed25519Middleware(t *testing.T) {
+	assertSignatureMiddlewareEnforcesStatus(t, Ed25519AgentMiddleware)
+}
+
+// The public backend mounts this one, including on secrets resolve.
+func TestAgentRevocation_PQCMiddleware(t *testing.T) {
+	assertSignatureMiddlewareEnforcesStatus(t, PQCAgentMiddleware)
+}
+
+// seedAPIKey inserts a real api_keys row for `agentID` and returns the plaintext
+// key. The hash is computed the way the middleware computes it, so the row is
+// reachable by an actual request rather than by a value the test asserts about
+// itself.
+func seedAPIKey(t *testing.T, db *sql.DB, ctx context.Context, agentID, orgID, userID uuid.UUID) string {
+	t.Helper()
+
+	plaintext := "aim_live_revocation_" + uuid.New().String()
+	sum := sha256.Sum256([]byte(plaintext))
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO api_keys (id, organization_id, agent_id, name, key_hash, prefix,
+		                       is_active, created_at, created_by)
+		 VALUES ($1, $2, $3, $4, $5, $6, TRUE, NOW(), $7)`,
+		uuid.New(), orgID, agentID, "revocation-key",
+		base64.StdEncoding.EncodeToString(sum[:]), plaintext[:8], userID)
+	require.NoError(t, err)
+
+	return plaintext
+}
+
+// agentOwners reads back the org and creator of a seeded agent, so the API key row
+// can satisfy its own foreign keys without seedAgentWithStatus having to return
+// four values for the callers that do not need them.
+func agentOwners(t *testing.T, db *sql.DB, ctx context.Context, agentID uuid.UUID) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	var orgID, userID uuid.UUID
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT organization_id, created_by FROM agents WHERE id = $1`, agentID).
+		Scan(&orgID, &userID))
+	return orgID, userID
+}
+
+// APIKeyMiddleware: an API key is bound to exactly one agent by a NOT NULL FK, and
+// `is_active` revokes the KEY, not the agent. RevokeAgent never touches the agent's
+// keys, so before the join every key issued before a revocation kept working.
+func TestAgentRevocation_APIKeyMiddleware(t *testing.T) {
+	db := revocationTestDB(t)
+	ctx := context.Background()
+
+	for _, tc := range revocationCases {
+		t.Run(tc.status, func(t *testing.T) {
+			agentID := seedAgentWithStatus(t, db, ctx, tc.status, "")
+			orgID, userID := agentOwners(t, db, ctx, agentID)
+			key := seedAPIKey(t, db, ctx, agentID, orgID, userID)
+
+			app := fiber.New()
+			app.Use(APIKeyMiddleware(db))
+			app.Get("/protected", func(c fiber.Ctx) error {
+				return c.JSON(fiber.Map{"reached": true})
+			})
+
+			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Header.Set("X-API-Key", key)
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			if tc.shouldAuth {
+				assert.Equal(t, fiber.StatusOK, resp.StatusCode,
+					"status %q must authenticate (%s); body: %s", tc.status, tc.why, body)
+				assert.Contains(t, string(body), "reached")
+				return
+			}
+
+			assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode,
+				"status %q must be denied (%s); body: %s", tc.status, tc.why, body)
+			assert.NotContains(t, string(body), "reached",
+				"the handler ran with a key belonging to a %q agent", tc.status)
+			assert.Contains(t, string(body), tc.status,
+				"denied, but not for being %q — the 401 came from some other check "+
+					"(the key is active and unexpired, so it should not have). Body: %s",
+				tc.status, body)
+		})
+	}
+}
+
+// OptionalAPIKeyMiddleware is optional-auth: a denied agent must continue WITHOUT
+// auth context rather than 401, matching how it already handles an inactive key.
+// The assertion is on the context it sets, not on the status code — a 200 here
+// means nothing on its own, since the middleware always calls Next().
+func TestAgentRevocation_OptionalAPIKeyMiddleware(t *testing.T) {
+	db := revocationTestDB(t)
+	ctx := context.Background()
+
+	for _, tc := range revocationCases {
+		t.Run(tc.status, func(t *testing.T) {
+			agentID := seedAgentWithStatus(t, db, ctx, tc.status, "")
+			orgID, userID := agentOwners(t, db, ctx, agentID)
+			key := seedAPIKey(t, db, ctx, agentID, orgID, userID)
+
+			var sawAuthMethod string
+			var sawAgentID any
+
+			app := fiber.New()
+			app.Use(OptionalAPIKeyMiddleware(db))
+			app.Get("/protected", func(c fiber.Ctx) error {
+				sawAuthMethod, _ = c.Locals("auth_method").(string)
+				sawAgentID = c.Locals("agent_id")
+				return c.JSON(fiber.Map{"reached": true})
+			})
+
+			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Header.Set("X-API-Key", key)
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, fiber.StatusOK, resp.StatusCode,
+				"optional auth always reaches the handler")
+
+			if tc.shouldAuth {
+				assert.Equal(t, "api_key", sawAuthMethod,
+					"status %q must still receive auth context (%s)", tc.status, tc.why)
+				assert.Equal(t, agentID, sawAgentID)
+				return
+			}
+
+			assert.Empty(t, sawAuthMethod,
+				"status %q was given auth context — downstream handlers will treat the "+
+					"request as an authenticated %q agent (%s)", tc.status, tc.status, tc.why)
+			assert.Nil(t, sawAgentID,
+				"agent_id was set for a %q agent", tc.status)
+		})
+	}
+}

--- a/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
@@ -305,6 +305,77 @@ func TestAgentRevocation_APIKeyMiddleware(t *testing.T) {
 	}
 }
 
+// The other two fields APIKeyMiddleware is responsible for. `is_active` had only a
+// sqlmock-backed negative test and `expires_at` had none at all, so the enforcement
+// matrix for this middleware was one-third proven. Asserted here against real rows,
+// alongside a positive control, so a middleware that dropped either check would fail.
+func TestAgentRevocation_APIKeyMiddlewareEnforcesKeyFields(t *testing.T) {
+	db := revocationTestDB(t)
+	ctx := context.Background()
+
+	// .UTC() is load-bearing, and its absence found a real defect worth naming here.
+	// `api_keys.expires_at` is TIMESTAMP, not TIMESTAMPTZ. lib/pq sends a local-zone
+	// time.Time as its wall clock, Postgres drops the offset, and the value reads back
+	// labelled UTC — so a time written from a UTC-6 process comes back six hours early,
+	// and one written from UTC+2 comes back two hours LATE, i.e. the key outlives its
+	// stated expiry. `time.Now().Add(time.Hour)` here failed the positive control for
+	// exactly that reason. Writing UTC sidesteps it; the column is still wrong, and
+	// api_key_service.CreateAPIKey writes a local time. Tracked separately — fixing it
+	// is a migration on a production table, not part of a revocation change.
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	future := time.Now().UTC().Add(1 * time.Hour)
+
+	for _, tc := range []struct {
+		name       string
+		active     bool
+		expiresAt  *time.Time
+		wantStatus int
+		wantErr    string
+	}{
+		{"control-active-unexpired", true, nil, fiber.StatusOK, ""},
+		{"control-active-future-expiry", true, &future, fiber.StatusOK, ""},
+		{"inactive", false, nil, fiber.StatusUnauthorized, "inactive"},
+		{"expired", true, &past, fiber.StatusUnauthorized, "expired"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID := seedAgentWithStatus(t, db, ctx, "verified", "")
+			orgID, userID := agentOwners(t, db, ctx, agentID)
+			key := seedAPIKey(t, db, ctx, agentID, orgID, userID)
+
+			_, err := db.ExecContext(ctx,
+				`UPDATE api_keys SET is_active = $1, expires_at = $2 WHERE agent_id = $3`,
+				tc.active, tc.expiresAt, agentID)
+			require.NoError(t, err)
+
+			app := fiber.New()
+			app.Use(APIKeyMiddleware(db))
+			app.Get("/protected", func(c fiber.Ctx) error {
+				return c.JSON(fiber.Map{"reached": true})
+			})
+
+			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Header.Set("X-API-Key", key)
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantStatus, resp.StatusCode, "body: %s", body)
+			if tc.wantErr == "" {
+				assert.Contains(t, string(body), "reached")
+				return
+			}
+			assert.NotContains(t, string(body), "reached")
+			// The reason is asserted, not just the code: the agent here is
+			// `verified`, so a 401 naming a status would mean the wrong check fired.
+			assert.Contains(t, string(body), tc.wantErr,
+				"denied, but not for being %s", tc.wantErr)
+		})
+	}
+}
+
 // OptionalAPIKeyMiddleware is optional-auth: a denied agent must continue WITHOUT
 // auth context rather than 401, matching how it already handles an inactive key.
 // The assertion is on the context it sets, not on the status code — a 200 here

--- a/apps/backend/internal/interfaces/http/middleware/agent_status.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_status.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// agentStatusPermitsAuth reports whether an agent in this status may authenticate.
+//
+// SECURITY: allow-list, for the same reason as MemberOrAPIKeyMiddleware's role check —
+// an unrecognised status must fail closed, not fall through. `agents.status` is a plain
+// VARCHAR(50) with no CHECK constraint (migration 001), so a value outside the four
+// domain constants is storable. A deny-list on {revoked, suspended} would authenticate
+// every such value.
+//
+// `pending` PASSES deliberately. AgentService.RegisterAgent sets it at registration
+// ("agents start as pending, verification is earned"), so it is the default state of an
+// honestly registered agent, not an earned one. Denying it would break enrollment for
+// every new agent while blocking nothing an attacker holds.
+//
+// Denial states are the ones a human or EnforceKeyExpiry assigns on purpose:
+// `revoked` (AgentService.RevokeAgent) and `suspended` (SuspendAgent, EnforceKeyExpiry).
+// Before this check existed, both wrote a status that no signature or API-key path read,
+// so revoking an agent did not stop it authenticating with key material it already held.
+func agentStatusPermitsAuth(status domain.AgentStatus) bool {
+	switch status {
+	case domain.AgentStatusVerified, domain.AgentStatusPending:
+		return true
+	default:
+		return false
+	}
+}
+
+// agentStatusDeniedMessage is the 401 body for a status-denied request. It names the
+// status so an operator whose agent stopped working can see why without opening a
+// support ticket; atc_auth.go already discloses revocation the same way ("ATC has been
+// revoked"), and the request is only reached by a caller holding valid key material for
+// that specific agent.
+func agentStatusDeniedMessage(status domain.AgentStatus) string {
+	return "Agent is not permitted to authenticate (status: " + string(status) + ")"
+}

--- a/apps/backend/internal/interfaces/http/middleware/agent_status_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_status_test.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// The permitted set is written out as literals rather than referencing the
+// implementation's switch, so a change to the allow-list has to be made twice —
+// once in the rule, once here — instead of the test silently tracking it.
+func TestAgentStatusPermitsAuth_PermitsVerifiedAndPending(t *testing.T) {
+	assert.True(t, agentStatusPermitsAuth(domain.AgentStatus("verified")),
+		"a verified agent must be able to authenticate")
+	assert.True(t, agentStatusPermitsAuth(domain.AgentStatus("pending")),
+		"pending is the registration default (AgentService sets it on register); "+
+			"denying it would break enrollment for every new agent")
+}
+
+func TestAgentStatusPermitsAuth_DeniesRevokedAndSuspended(t *testing.T) {
+	assert.False(t, agentStatusPermitsAuth(domain.AgentStatus("revoked")),
+		"RevokeAgent writes this status and nothing else denies the request")
+	assert.False(t, agentStatusPermitsAuth(domain.AgentStatus("suspended")),
+		"SuspendAgent and EnforceKeyExpiry write this status")
+}
+
+// agents.status is VARCHAR(50) with no CHECK constraint (migration 001), so a
+// value outside the four domain constants is storable — by a future migration,
+// a hand-run UPDATE, or a bug. The rule must be an allow-list: anything it does
+// not recognise has to fail closed. A deny-list on {revoked, suspended} passes
+// every one of these.
+func TestAgentStatusPermitsAuth_DeniesUnrecognisedStatus(t *testing.T) {
+	for _, status := range []string{
+		"",                 // NOT NULL, but an empty string satisfies that
+		"deactivated",      // a plausible fifth status added without updating this rule
+		"Verified",         // case variant — Postgres comparison is case-sensitive
+		"verified ",        // trailing space
+		"pending\x00",      // NUL-suffixed
+		"revoked'--",       // injection-shaped
+		"active",           // the status this system does NOT have, despite api_keys.is_active
+		"verified,revoked", // comma-joined, in case a caller ever concatenates
+	} {
+		assert.False(t, agentStatusPermitsAuth(domain.AgentStatus(status)),
+			"unrecognised status %q must fail closed", status)
+	}
+}
+
+// Every status the domain declares must be decided one way or the other. This
+// fails if a fifth constant is added and nobody revisits the allow-list — the
+// point being that the new status lands on the deny branch by default, which is
+// the safe direction, but the author is told rather than left to find out in
+// production.
+func TestAgentStatusPermitsAuth_CoversEveryDeclaredStatus(t *testing.T) {
+	declared := map[domain.AgentStatus]bool{
+		domain.AgentStatusVerified:  true,
+		domain.AgentStatusPending:   true,
+		domain.AgentStatusSuspended: false,
+		domain.AgentStatusRevoked:   false,
+	}
+
+	for status, wantPermitted := range declared {
+		assert.Equal(t, wantPermitted, agentStatusPermitsAuth(status),
+			"status %q", status)
+	}
+
+	assert.Len(t, declared, 4,
+		"domain declares a status this rule has not been asked about — add it to "+
+			"this map and decide explicitly whether it may authenticate")
+}
+
+func TestAgentStatusDeniedMessage_NamesTheStatus(t *testing.T) {
+	msg := agentStatusDeniedMessage(domain.AgentStatusRevoked)
+	assert.Contains(t, msg, "revoked",
+		"an operator whose agent stopped working must be able to see why")
+	assert.NotContains(t, msg, "%!",
+		"format verb left unsubstituted")
+}

--- a/apps/backend/internal/interfaces/http/middleware/api_key.go
+++ b/apps/backend/internal/interfaces/http/middleware/api_key.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
 // APIKeyMiddleware validates API keys from Authorization header or X-API-Key header
@@ -59,11 +61,23 @@ func APIKeyMiddleware(db *sql.DB) fiber.Handler {
 		Name           string     `db:"name"`
 		IsActive       bool       `db:"is_active"`
 		ExpiresAt      *time.Time `db:"expires_at"`
+		AgentStatus    string     `db:"agent_status"`
 	}
 
+	// SECURITY: joins `agents` so agent revocation is enforced on this path too.
+	// `is_active` revokes the KEY (APIKeyRepository.Revoke sets it); it says nothing
+	// about the AGENT the key authenticates as, and RevokeAgent does not touch the
+	// agent's keys. Without this join a revoked agent kept working through any API key
+	// issued before the revocation.
+	//
+	// INNER JOIN is deliberate and fail-closed: `api_keys.agent_id` is
+	// NOT NULL REFERENCES agents(id), so a row always exists for a legitimate key. If
+	// it somehow does not, the query returns no row and lands on the "Invalid API key"
+	// 401 below rather than authenticating without a status to check.
 	query := `
-		SELECT ak.id, ak.organization_id, ak.agent_id, ak.created_by as user_id, ak.name, ak.is_active, ak.expires_at
+		SELECT ak.id, ak.organization_id, ak.agent_id, ak.created_by as user_id, ak.name, ak.is_active, ak.expires_at, a.status
 		FROM api_keys ak
+		JOIN agents a ON a.id = ak.agent_id
 		WHERE ak.key_hash = $1
 		LIMIT 1
 	`
@@ -76,6 +90,7 @@ func APIKeyMiddleware(db *sql.DB) fiber.Handler {
 		&keyData.Name,
 		&keyData.IsActive,
 		&keyData.ExpiresAt,
+		&keyData.AgentStatus,
 	)
 
 		if err != nil {
@@ -95,6 +110,13 @@ func APIKeyMiddleware(db *sql.DB) fiber.Handler {
 		if keyData.ExpiresAt != nil && keyData.ExpiresAt.Before(time.Now()) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 				"error": "API key has expired",
+			})
+		}
+
+		// Check that the agent this key authenticates as may still authenticate
+		if agentStatus := domain.AgentStatus(keyData.AgentStatus); !agentStatusPermitsAuth(agentStatus) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": agentStatusDeniedMessage(agentStatus),
 			})
 		}
 
@@ -151,11 +173,14 @@ func OptionalAPIKeyMiddleware(db *sql.DB) fiber.Handler {
 		Name           string     `db:"name"`
 		IsActive       bool       `db:"is_active"`
 		ExpiresAt      *time.Time `db:"expires_at"`
+		AgentStatus    string     `db:"agent_status"`
 	}
 
+	// SECURITY: same agent-status join as APIKeyMiddleware — see the comment there.
 	query := `
-		SELECT ak.id, ak.organization_id, ak.agent_id, ak.created_by as user_id, ak.name, ak.is_active, ak.expires_at
+		SELECT ak.id, ak.organization_id, ak.agent_id, ak.created_by as user_id, ak.name, ak.is_active, ak.expires_at, a.status
 		FROM api_keys ak
+		JOIN agents a ON a.id = ak.agent_id
 		WHERE ak.key_hash = $1
 		LIMIT 1
 	`
@@ -168,6 +193,7 @@ func OptionalAPIKeyMiddleware(db *sql.DB) fiber.Handler {
 		&keyData.Name,
 		&keyData.IsActive,
 		&keyData.ExpiresAt,
+		&keyData.AgentStatus,
 	)
 
 		// If key not found or invalid, continue without auth
@@ -177,6 +203,14 @@ func OptionalAPIKeyMiddleware(db *sql.DB) fiber.Handler {
 
 		// Check if key is active and not expired
 		if !keyData.IsActive || (keyData.ExpiresAt != nil && keyData.ExpiresAt.Before(time.Now())) {
+			return c.Next()
+		}
+
+		// Check that the agent this key authenticates as may still authenticate.
+		// This middleware is optional-auth, so a denied agent continues WITHOUT auth
+		// context rather than 401ing — the same shape as the inactive-key branch above.
+		// Downstream handlers see no organization_id / agent_id and reject on their own.
+		if !agentStatusPermitsAuth(domain.AgentStatus(keyData.AgentStatus)) {
 			return c.Next()
 		}
 

--- a/apps/backend/internal/interfaces/http/middleware/credential_routes_gate_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/credential_routes_gate_test.go
@@ -18,12 +18,19 @@ import (
 // agent-anchored key (the shape of the Cartographer's machine key). active controls
 // whether the key is usable — an inactive key must NOT authenticate, which is how the
 // control below is kept honest.
+//
+// The trailing agent_status column mirrors the JOIN on `agents` that the api-key
+// middlewares perform to enforce agent revocation. It is "verified" here because this
+// test is about the credential-routes gate, not revocation: the key must be a fully
+// valid principal so a 401 on a gated route can only be the gate. Revocation itself is
+// covered against a real database in agent_revocation_integration_test.go — a sqlmock
+// cannot prove a JOIN reads the column it claims to.
 func newAPIKeyDB(t *testing.T, active bool) *sql.DB {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	rows := sqlmock.NewRows([]string{"id", "organization_id", "agent_id", "user_id", "name", "is_active", "expires_at"}).
-		AddRow(uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString(), "honeymap-cartographer-machine-key", active, nil)
+	rows := sqlmock.NewRows([]string{"id", "organization_id", "agent_id", "user_id", "name", "is_active", "expires_at", "agent_status"}).
+		AddRow(uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString(), "honeymap-cartographer-machine-key", active, nil, "verified")
 	mock.ExpectQuery("api_keys").WithArgs(sqlmock.AnyArg()).WillReturnRows(rows)
 	// The UPDATE last_used_at only runs when the key is active (middleware returns early otherwise).
 	if active {

--- a/apps/backend/internal/interfaces/http/middleware/ed25519_agent_auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/ed25519_agent_auth.go
@@ -132,6 +132,16 @@ func Ed25519AgentMiddleware(agentService *application.AgentService) fiber.Handle
 			})
 		}
 
+		// SECURITY: Revocation is enforced HERE, on the read path, not only at the write
+		// that sets the status. RevokeAgent and EnforceKeyExpiry both express denial purely
+		// as `agents.status`, so an agent that keeps its key material after being revoked
+		// or suspended authenticated successfully until this check existed.
+		if !agentStatusPermitsAuth(agent.Status) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": agentStatusDeniedMessage(agent.Status),
+			})
+		}
+
 		// SECURITY: Agent MUST have a registered public key
 		// Reject requests from agents without registered keys to prevent TOFU bypass attacks
 		// where an attacker supplies their own key via X-Public-Key header.

--- a/apps/backend/internal/interfaces/http/middleware/pqc_agent_auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/pqc_agent_auth.go
@@ -97,6 +97,17 @@ func PQCAgentMiddleware(agentService *application.AgentService) fiber.Handler {
 			})
 		}
 
+		// SECURITY: Revocation is enforced HERE, on the read path, not only at the write
+		// that sets the status. RevokeAgent and EnforceKeyExpiry both express denial purely
+		// as `agents.status`, so an agent that keeps its key material after being revoked
+		// or suspended authenticated successfully until this check existed. Checked before
+		// any signature work so a denied agent costs no ML-DSA verification.
+		if !agentStatusPermitsAuth(agent.Status) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": agentStatusDeniedMessage(agent.Status),
+			})
+		}
+
 		// Check if hybrid mode is required but agent doesn't support it
 		if pqc.IsHybridAlgorithm(alg) && !agent.HybridModeEnabled {
 			// Check if agent has PQC key registered

--- a/docs/troubleshooting/authentication.md
+++ b/docs/troubleshooting/authentication.md
@@ -356,6 +356,71 @@ else:
 
 ---
 
+### Error 5: "Agent is not permitted to authenticate" (Status: 401)
+
+**Full Error**:
+```
+❌ Authentication Failed: Agent is not permitted to authenticate (status: revoked)
+```
+
+**Root Cause**: The signature or API key is valid, but the agent itself is no
+longer allowed to authenticate. Only agents in `pending` or `verified` status may
+authenticate; `suspended` and `revoked` are refused, as is any other status value.
+
+This applies to every agent auth path — Ed25519, ML-DSA, hybrid, and API keys.
+Rotating the key or re-signing the request will not help, because the key is not
+what was rejected.
+
+**Possible Causes**:
+
+#### 1. The agent was revoked
+
+Someone called `DELETE /api/v1/agents/{id}`, or revoked it from the dashboard.
+
+```bash
+# Check the agent's current status
+curl -s http://localhost:8080/api/v1/agents/YOUR_AGENT_ID \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" | jq '.status'
+```
+
+Revoked agents are retained for 30 days before cleanup and can be reinstated in
+that window. Reinstating is a privileged action — ask an organization admin.
+
+#### 2. The agent was suspended by key expiry
+
+Agents whose signing key passed its expiry and its rotation grace period are
+suspended automatically. This is the common cause when nobody remembers revoking
+anything.
+
+```bash
+# Was it a key-expiry suspension? A keyExpiresAt in the past alongside
+# status "suspended" is the signature of this case.
+curl -s http://localhost:8080/api/v1/agents/YOUR_AGENT_ID \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  | jq '{status, keyExpiresAt, keyCreatedAt, rotationCount}'
+```
+
+**Fix**: rotate the signing key, then have an admin reinstate the agent. Rotating
+on a schedule ahead of `keyExpiresAt` avoids the suspension entirely.
+
+#### 3. An API key still works but its agent does not
+
+An API key carries its own `is_active` flag, but it authenticates *as an agent*.
+If that agent is revoked or suspended, the key is refused even while it is active
+and unexpired — the key is not the thing being denied.
+
+```bash
+# The key's own state and its agent's state are two different questions
+curl -s http://localhost:8080/api/v1/api-keys \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  | jq '.apiKeys[] | {name, isActive, expiresAt, agentId, agentName}'
+```
+
+Then check that `agentId` against Cause 1. A key showing `isActive: true` with a
+future `expiresAt` still fails if its agent is suspended or revoked.
+
+---
+
 ## Advanced Diagnostics
 
 ### Check Token Status in Database


### PR DESCRIPTION
## The defect

`AgentService.RevokeAgent` and `EnforceKeyExpiry` express denial **only** as a write to
`agents.status`. Three of the six auth middlewares never read that column, so a revoked or
suspended agent that still held its key material authenticated successfully.

| Middleware | Revocation check before |
|---|---|
| `AuthMiddleware` / `OptionalAuthMiddleware` | yes |
| `ATCAuthMiddleware` | yes |
| `ServicePrincipalMiddleware` | yes |
| `Ed25519AgentMiddleware` | **no** |
| `PQCAgentMiddleware` | **no** |
| `APIKeyMiddleware` / `OptionalAPIKeyMiddleware` | **no** — `is_active` + `expires_at` only |

Reachable, not theoretical: `PQCAgentMiddleware` guards sdkAPI, detection, agents,
**secrets resolve**, the MCP server agent-auth group, and a2a.

## The fix

One shared allow-list in `middleware/agent_status.go`, applied to all four unguarded handlers.

**Allow-list, not deny-list.** `agents.status` is `VARCHAR(50)` with no CHECK constraint, so a
value outside the four domain constants is storable and a deny-list on `{revoked, suspended}`
would authenticate it. `MemberOrAPIKeyMiddleware` already made this call for roles.

**`pending` passes.** It is the state every agent is registered in ("verification is earned"), so
denying it would break enrollment while blocking nothing an attacker holds.

**No new column.** `api_keys.agent_id` is `NOT NULL REFERENCES agents(id)`, so the status is read
by joining `agents`. `is_active` revokes the *key*; whether the *agent* may authenticate is a
different fact with an authoritative home already.

Denials keep the existing fail-closed shape — the strict paths 401, and optional auth continues
without auth context exactly as it already does for an inactive key.

## Evidence

A build-tagged integration suite drives all four middlewares against a real database with real
Ed25519 signatures. Both directions are asserted for every status, and a denial only counts when
the body names the status — a 401 from an unrelated check cannot read as enforcement.

Confirmed to fail against four mutants: permit-everything, deny-list (killed by the
unrecognised-status case alone), drop-`is_active`, and drop-`expires_at`.

Verified end to end on a running backend: a signed request from a `verified` agent returned 200;
the identical request after `status='revoked'` returned 401 naming the status; reinstating
restored 200.

## Also here

- `is_active` had only a mock-backed negative test and `expires_at` had none. Both are now proven
  against real rows with positive controls.
- The CI not-skipped assertion gains both the test name and the package. Widening only the
  selector would have left the new test running outside the assertion.
- Documents the new 401 for SDK users, including the confusing case: an API key that is active and
  unexpired but whose agent is not. Every command in that section was run against a live backend.

## Known issue found, not fixed here

`api_keys.expires_at` is `TIMESTAMP`, not `TIMESTAMPTZ`. lib/pq writes a local-zone time as its
wall clock, Postgres drops the offset, and it reads back labelled UTC — so a key written from a
process east of UTC outlives its stated expiry by that offset. `agents.pqc_key_expires_at` and
`agent_capabilities.revoked_at` share the column type. Fixing it is a migration on a production
table and is tracked separately; the new test writes UTC to sidestep it and says why.