### PR TITLE
mcp: stop the repository Update from writing the trust-score cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,12 +363,16 @@ jobs:
       # The selector and the package list must both cover any new integration
       # test, or the step above still runs it while this assertion silently
       # stops applying to it. AgentRevocation + the middleware package were
-      # added for exactly that reason.
+      # added for exactly that reason; UpdateDoesNotWriteTrustScore + RoundTrip
+      # and the repository package were added for the same reason after the MCP
+      # trust-score write-path fix.
       - name: Assert integration tests were not skipped
         run: |
           set -o pipefail
-          go test -tags=integration -v -run 'Trigger|Backfill|OutOfScale|AgentRevocation' \
-            ./internal/application/... ./internal/interfaces/http/middleware/... 2>&1 | tee /tmp/integration.log
+          go test -tags=integration -v \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip' \
+            ./internal/application/... ./internal/interfaces/http/middleware/... \
+            ./internal/infrastructure/repository/... 2>&1 | tee /tmp/integration.log
           if grep -q '^--- SKIP' /tmp/integration.log; then
             echo "::error::Integration tests were SKIPPED — TEST_DATABASE_URL is not reaching them."
             grep '^--- SKIP' /tmp/integration.log

--- a/apps/backend/internal/application/mcp_trust_calculator.go
+++ b/apps/backend/internal/application/mcp_trust_calculator.go
@@ -482,17 +482,28 @@ func (c *MCPTrustCalculator) CalculateTrustScore(ctx context.Context, mcpServerI
 		return nil, fmt.Errorf("failed to calculate trust score: %w", err)
 	}
 
-	// Store the score if repository is available
+	// Store the score if repository is available.
+	//
+	// This insert is also what updates the `mcp_servers.trust_score` cache: the
+	// migration 094 trigger `mirror_mcp_trust_score_to_server` fires AFTER INSERT
+	// on `mcp_trust_scores` and mirrors NEW.score onto the server row, in the same
+	// transaction. There is deliberately no second write here.
+	//
+	// There used to be one — `server.TrustScore = score.Score` followed by
+	// `mcpServerRepo.Update(server)`. It was redundant once 094 landed, and it was
+	// the reason `Update` carried `trust_score` in its SET list at all, which made
+	// every unrelated caller of `Update` a silent writer of the cache. See
+	// `MCPServerRepository.Update` for why that column is now absent there.
+	//
+	// When `mcpTrustScoreRepo` is nil this function calculates without persisting
+	// anything, which is what "optionally stores" means: no score row, and
+	// therefore no cache update. Production always wires the repository
+	// (`NewMCPTrustCalculatorWithRepo` in `cmd/server/main.go`); the nil-repo
+	// constructor has no non-test callers.
 	if c.mcpTrustScoreRepo != nil {
 		if err := c.mcpTrustScoreRepo.Create(score); err != nil {
 			return nil, fmt.Errorf("failed to store trust score: %w", err)
 		}
-	}
-
-	// Update the server's trust_score field
-	server.TrustScore = score.Score
-	if err := c.mcpServerRepo.Update(server); err != nil {
-		return nil, fmt.Errorf("failed to update MCP server trust score: %w", err)
 	}
 
 	return score, nil

--- a/apps/backend/internal/infrastructure/repository/mcp_repository.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_repository.go
@@ -406,6 +406,24 @@ func (r *MCPServerRepository) GetByName(orgID uuid.UUID, name string) (*domain.M
 	return server, nil
 }
 
+// Update writes the caller-editable fields of an MCP server.
+//
+// `trust_score` is deliberately NOT in the SET list, and must not be added back.
+// It is a denormalized cache of `mcp_trust_scores.score`. `Create` seeds it once
+// at row creation; from then on the only thing that CHANGES it is the migration
+// 094 trigger `mirror_mcp_trust_score_to_server`, which fires when the 8-factor
+// calculator inserts a new score row. Callers of Update patch an
+// unrelated field (a description, a version, a capability list) from an in-memory
+// snapshot they fetched earlier; including `trust_score` here made every one of
+// them write back whatever value that snapshot happened to hold. When the snapshot
+// was stale, that reverted the calculated cache AND fired
+// `mcp_trust_score_change_trigger` (migration 051), inserting a
+// `mcp_trust_score_history` row labelled `automated_recalculation` — an audit
+// record of a security event that never happened. Migration 104's own header names
+// that fabrication as worse than the defect it was fixing.
+//
+// A server's score is changed by calculating one, never by saving a row.
+// Regression test: `mcp_update_trust_score_integration_test.go`.
 func (r *MCPServerRepository) Update(server *domain.MCPServer) error {
 	query := `
 		UPDATE mcp_servers
@@ -420,9 +438,8 @@ func (r *MCPServerRepository) Update(server *domain.MCPServer) error {
 			last_verified_at = $8,
 			verification_url = $9,
 			capabilities = $10,
-			trust_score = $11,
-			updated_at = $12
-		WHERE id = $13
+			updated_at = $11
+		WHERE id = $12
 		RETURNING updated_at
 	`
 
@@ -444,7 +461,6 @@ func (r *MCPServerRepository) Update(server *domain.MCPServer) error {
 		server.LastVerifiedAt,
 		server.VerificationURL,
 		capabilitiesJSON, // Use JSON bytes
-		server.TrustScore,
 		time.Now().UTC(),
 		server.ID,
 	).Scan(&server.UpdatedAt)

--- a/apps/backend/internal/infrastructure/repository/mcp_update_trust_score_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/mcp_update_trust_score_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPServerRepository_UpdateDoesNotWriteTrustScore is the regression test for
+// `MCPServerRepository.Update` writing `mcp_servers.trust_score` unconditionally.
+//
+// `trust_score` is a denormalized cache of `mcp_trust_scores.score`, maintained by
+// the migration 094 trigger. While `Update` carried it in its SET list, every
+// caller that patched an unrelated field wrote back whatever `TrustScore` its
+// in-memory snapshot happened to hold. When that snapshot was stale the write did
+// two things:
+//
+//  1. reverted the calculated cache to an old value, and
+//  2. fired `mcp_trust_score_change_trigger` (migration 051), inserting a
+//     `mcp_trust_score_history` row with `change_reason = 'automated_recalculation'`
+//     describing a recalculation that never ran.
+//
+// (2) is the reason this is filed as a data-integrity defect rather than a cache
+// bug: it fabricates a security event inside an audit trail. Migration 104's header
+// names exactly that fabrication as worse than the defect it was fixing.
+//
+// The staleness has to be real for this test to mean anything. `UpdateMCPServer`
+// calls `GetByID` immediately before `Update`, so its snapshot is fresh, the
+// trigger's `IF OLD.trust_score IS DISTINCT FROM NEW.trust_score` guard suppresses
+// the insert, and a test written that way passes on the unfixed code. So the
+// sequence below deliberately opens the window: take a snapshot, move the cache
+// underneath it through the source of truth, and only then save the snapshot.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL with
+// migrations through 104 applied.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestMCPServerRepository_UpdateDoesNotWriteTrustScore \
+//	  ./internal/infrastructure/repository/...
+func TestMCPServerRepository_UpdateDoesNotWriteTrustScore(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping MCP update write-path test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	userID := uuid.New()
+	serverID := uuid.New()
+	suffix := serverID.String()[:8]
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_score_history WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_trust_scores WHERE mcp_server_id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM mcp_servers WHERE id = $1`, serverID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "mcp-update-writepath-org-"+suffix, "mcp-update-writepath-"+suffix+".test")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'mcp-update-writepath-user', 'test', $4, NOW(), NOW())`,
+		userID, orgID, "mcp-update-writepath-"+suffix+"@test.invalid",
+		"mcp-update-writepath-"+suffix)
+	require.NoError(t, err)
+
+	// `verification_method` is scanned into a plain string by GetByID, so seed it
+	// explicitly rather than relying on a column default.
+	const staleScore = 0.1000
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_servers
+		   (id, organization_id, name, description, url, version, public_key,
+		    status, is_verified, verification_method, trust_score,
+		    created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'seeded description', $4, '1.0.0', 'test-key',
+		         'pending', false, 'manual', $5, $6, NOW(), NOW())`,
+		serverID, orgID,
+		"mcp-update-writepath-server-"+suffix,
+		"https://mcp-update-writepath-"+suffix+".example.com",
+		staleScore, userID)
+	require.NoError(t, err)
+
+	repo := NewMCPServerRepository(db)
+
+	// 1. Take the snapshot BEFORE the score moves. This is the in-memory value an
+	//    ordinary caller holds while it edits an unrelated field.
+	snapshot, err := repo.GetByID(serverID)
+	require.NoError(t, err)
+	require.InDelta(t, staleScore, snapshot.TrustScore, 0.00001,
+		"precondition: the snapshot must start at the pre-calculation score")
+
+	historyBefore := countTrustScoreHistory(t, db, ctx, serverID)
+
+	// 2. The calculator produces a real score. Inserting into `mcp_trust_scores`
+	//    fires the migration 094 mirror, which moves `mcp_servers.trust_score` and
+	//    legitimately records the change in history. The snapshot is now stale.
+	const calculatedScore = 0.8234
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO mcp_trust_scores
+		   (id, mcp_server_id, score, factors, confidence, last_calculated, created_at)
+		 VALUES (gen_random_uuid(), $1, $2, '{}'::jsonb, 0.95, NOW(), NOW())`,
+		serverID, calculatedScore)
+	require.NoError(t, err)
+
+	require.InDelta(t, calculatedScore, readCachedTrustScore(t, db, ctx, serverID), 0.00001,
+		"precondition: the migration 094 mirror must have moved the cache")
+
+	historyAfterCalculation := countTrustScoreHistory(t, db, ctx, serverID)
+	require.Equal(t, historyBefore+1, historyAfterCalculation,
+		"precondition: a genuine recalculation must still record exactly one history row — "+
+			"if this fails the audit trigger is not firing and the rest of this test is vacuous")
+
+	// 3. Save the stale snapshot with an unrelated field changed. This is the whole
+	//    defect: a description edit must not be able to touch a trust score.
+	const patchedDescription = "description patched by an unrelated caller"
+	snapshot.Description = patchedDescription
+	require.NoError(t, repo.Update(snapshot))
+
+	// The write must actually have landed. Without this the assertions below would
+	// also pass for an Update that silently did nothing.
+	var storedDescription string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT description FROM mcp_servers WHERE id = $1`, serverID,
+	).Scan(&storedDescription))
+	require.Equal(t, patchedDescription, storedDescription,
+		"the unrelated field must still be written; otherwise this test proves nothing")
+
+	// 4a and 4b are deliberately `assert`, not `require`: they describe two
+	// distinct consequences of the same write, and on unfixed code BOTH fail. A
+	// fatal 4a would abort before 4b was ever evaluated, which would leave the
+	// audit-trail assertion — the one that actually motivates this fix — unproven
+	// against the defect it was written for.
+
+	// 4a. The cache must still hold the calculated score, not the snapshot's.
+	assert.InDelta(t, calculatedScore, readCachedTrustScore(t, db, ctx, serverID), 0.00001,
+		"Update must not revert mcp_servers.trust_score to the caller's stale snapshot value")
+
+	// 4b. And no audit row may have been invented. This is the assertion that
+	//     matters most: a reverted cache is a bug, but a fabricated
+	//     'automated_recalculation' row is a false security event in an audit trail.
+	assert.Equal(t, historyAfterCalculation, countTrustScoreHistory(t, db, ctx, serverID),
+		"Update must not fire mcp_trust_score_change_trigger — a fabricated "+
+			"'automated_recalculation' row describes a recalculation that never ran")
+}
+
+func readCachedTrustScore(t *testing.T, db *sql.DB, ctx context.Context, serverID uuid.UUID) float64 {
+	t.Helper()
+	var score float64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT trust_score FROM mcp_servers WHERE id = $1`, serverID,
+	).Scan(&score))
+	return score
+}
+
+func countTrustScoreHistory(t *testing.T, db *sql.DB, ctx context.Context, serverID uuid.UUID) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM mcp_trust_score_history WHERE mcp_server_id = $1`, serverID,
+	).Scan(&n))
+	return n
+}


### PR DESCRIPTION
## The defect

`MCPServerRepository.Update` carried `trust_score` in its SET list. Three of its four callers patch an unrelated field from an in-memory snapshot fetched earlier, so each wrote back whatever `TrustScore` that snapshot happened to hold:

| Call site | Carries a stale `TrustScore`? |
|---|---|
| `mcp_service.go:201` (re-registration patch) | yes — patches capabilities/version only |
| `mcp_service.go:456` (`UpdateMCPServer`) | yes — the request has no trust-score field |
| `mcp_service.go:579` (`VerifyMCPServer`) | yes — writes before `scoreServer` recalculates |
| `mcp_trust_calculator.go:494` | no — this one set it deliberately |

When the snapshot is stale that write does two things. It reverts the calculated cache, and it fires `mcp_trust_score_change_trigger` (migration 051), inserting an `mcp_trust_score_history` row with `change_reason = 'automated_recalculation'` describing a recalculation that never ran.

The second is why this is a data-integrity defect rather than a cache bug: it fabricates a security event inside an audit trail. Migration 104's own header already names that exact fabrication as worse than the defect it was fixing, while this write path could still produce it.

## The fix

`mcp_servers.trust_score` is a denormalized cache of `mcp_trust_scores.score`, and migration 094 installed the trigger that maintains it. So:

- `trust_score` comes out of `Update`'s SET list.
- The calculator's manual write-back goes away — `mcpTrustScoreRepo.Create(score)` one line earlier already fires the mirror, in the same transaction.

The mirror becomes the single writer of score *changes*, which is what `cmd/server/main.go` has claimed in a comment since 094 landed. (`Create` still seeds the initial value at row creation; the doc comment says so rather than overclaiming.)

**No narrow `UpdateTrustScore` replaces it.** Every writer of `mcp_servers` was enumerated — `Update`, `VerifyServer`, and the attestation repo's `UpdateMCPConfidenceScore` / `UpdateMCPVerificationStatus`. Three of the four already avoid `trust_score`; `Update` was the outlier. After this change the only path that needs to set the cache is the calculator's, which 094 serves atomically. A second setter would reopen #170, the dual-source-of-truth defect 094 was written to close.

## Test

The staleness has to be real or the test proves nothing. `UpdateMCPServer` calls `GetByID` immediately before `Update`, so its snapshot is fresh, the trigger's `IF OLD.trust_score IS DISTINCT FROM NEW.trust_score` guard suppresses the insert, and a test mirroring that ordering passes on the unfixed code. So the test opens a genuine window: snapshot, move the cache through `mcp_trust_scores`, then save the snapshot.

Both final assertions are non-fatal (`assert`, not `require`) so both are evaluated — a fatal cache assertion would abort before the audit-trail one, leaving the assertion that actually motivates the fix unproven.

Proven red on pre-fix code, not assumed:

```
Error: Max difference between 0.8234 and 0.1 ... difference was 0.7234
  Update must not revert mcp_servers.trust_score to the caller's stale snapshot value
Error: Not equal: expected: 1, actual: 2
  Update must not fire mcp_trust_score_change_trigger — a fabricated
  'automated_recalculation' row describes a recalculation that never ran
```

Two mutants, both killed:

- Drop the 094 mirror trigger → the registration scoring path fails on every cache assertion, proving the trigger (not leftover code) is what maintains the cache after the manual write is removed.
- Drop the 051 audit trigger → this test fails **at its precondition**, so it cannot pass vacuously on "history did not grow."

## CI

The not-skipped assertion covered neither `./internal/infrastructure/repository/...` nor these test names, so the step above it ran the new test while the assertion silently stopped applying to it. Both the package list and the selector are extended — which also brings the pre-existing `TestTrustScoreRepository_RoundTrip...` inside the guard for the first time.

## Verification

- `go build`, `go vet`, `go test -race ./...`, `go test -tags=integration -race ./...` all green against Postgres 16 with migrations through 104.
- Backend boots and serves with the change in place (575 handlers, health 200, no 500s or panics).
- Follow-up left open deliberately, not bundled: neither `UpdateMCPServer` nor re-registration rescores after rewriting `url` / `capabilities`, both of which are scoring inputs. This change makes that gap *more* visible rather than worse — previously the stale write-back moved the number anyway, arbitrarily.