### PR TITLE
mcp: stop presenting MCP security policies as enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         run: |
           set -o pipefail
           go test -tags=integration -v \
-            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip' \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled' \
             ./internal/application/... ./internal/interfaces/http/middleware/... \
             ./internal/infrastructure/repository/... 2>&1 | tee /tmp/integration.log
           if grep -q '^--- SKIP' /tmp/integration.log; then

--- a/apps/backend/internal/application/mcp_policy_evaluator.go
+++ b/apps/backend/internal/application/mcp_policy_evaluator.go
@@ -12,7 +12,28 @@ import (
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
-// MCPPolicyEvaluator evaluates MCP servers against security policies
+// MCPPolicyEvaluator evaluates MCP servers against security policies.
+//
+// NOT WIRED. Nothing outside _test.go constructs this type, so no request is gated by it and no
+// mcp_* policy is enforced anywhere in the running system. SecurityPolicyService, the service
+// built in cmd/server/main.go, reaches only the six non-MCP policy types through
+// policyRepo.GetByType. The type is kept rather than deleted because the rest of the feature did
+// ship -- the admin security-policy routes are mounted, the admin page creates and toggles all
+// four mcp_* types, and migration 052 seeded six such policies -- so deleting the engine would
+// leave every promise in place with no implementation left to honour it.
+//
+// Migration 105 disables the seeded policies so the surface stops presenting enforcement that
+// does not happen. Three things must be fixed before this can be wired, or it will reject every
+// MCP server:
+//
+//  1. security_policies.rules.minTrustScore is seeded and stored 0-100, while evaluateAllowlist
+//     compares it against MCPServer.TrustScore, which migration 104 made canonical [0,1].
+//  2. matchDomainPattern does not treat a bare "*" as a wildcard -- only the "*." prefix is
+//     special-cased -- so the seeded 'allowedDomains': ['*'] matches no host at all.
+//  3. MCPAllowlistRules.AllowedCapabilities is declared and read by nothing, so an organization
+//     that configures it gets silent non-enforcement.
+//
+// Tracked in https://github.com/opena2a-org/agent-identity-management/issues/355.
 type MCPPolicyEvaluator struct {
 	policyRepo domain.SecurityPolicyRepository
 	mcpRepo    domain.MCPServerRepository

--- a/apps/backend/internal/application/mcp_policy_surface_integration_test.go
+++ b/apps/backend/internal/application/mcp_policy_surface_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package application
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// seedingMigration is the migration that introduced the default MCP security policies.
+const seedingMigration = "052_add_default_mcp_policies.sql"
+
+// mcpPolicyTypes are the policy types no running code path evaluates. SecurityPolicyService,
+// the service constructed in cmd/server/main.go, only ever asks policyRepo.GetByType for the
+// six non-MCP types; MCPPolicyEvaluator is the sole implementation of these four and has no
+// non-test call site in either repo.
+var mcpPolicyTypes = []string{"mcp_allowlist", "mcp_blocklist", "mcp_capabilities", "mcp_unverified"}
+
+// seededPolicyNames are the six policies migration 052 creates. Matching on name as well as type
+// keeps this guard off an operator's own MCP policies, which migration 105 deliberately does not
+// touch either.
+var seededPolicyNames = []string{
+	"Trusted MCP Server Domains",
+	"Blocked MCP Domains",
+	"MCP Capability Requirements",
+	"Unverified MCP Server Restrictions",
+	"MCP Minimum Trust Score",
+	"High-Risk MCP Server Block",
+}
+
+// TestSeededMCPPoliciesAreNotEnabled guards the invariant that a security policy is never shipped
+// enabled while nothing evaluates it.
+//
+// Migration 052 seeded six MCP policies with is_enabled = true, two of them 'block_and_alert' at
+// severity 'critical'. Because the admin security-policy page is mounted in production, an
+// administrator saw enabled blocking policies that had never run. Migration 105 disables them.
+//
+// The test applies every migration that touches security_policies, in order, against a real
+// database inside a transaction that is always rolled back. It asserts the pre-105 state
+// explicitly (six seeded policies, all enabled) before asserting the post-105 state (none
+// enabled), so it cannot pass vacuously on a database where the seeding never happened -- which
+// is exactly how this would silently rot, since migration 052 no-ops unless the admin
+// organization and admin user both exist.
+//
+// It fails if a future migration re-enables these rows. That is the intent: re-enabling is only
+// correct once MCPPolicyEvaluator is wired AND rules.minTrustScore is rescaled to [0,1] AND the
+// bare '*' allowedDomains entry is fixed. See https://github.com/opena2a-org/agent-identity-management/issues/355.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestSeededMCPPoliciesAreNotEnabled ./internal/application/...
+func TestSeededMCPPoliciesAreNotEnabled(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping MCP policy surface integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+
+	through, after := securityPolicyMigrations(t)
+	require.Contains(t, through, seedingMigration,
+		"the seeding migration must be among the files applied before the mid-state assertion")
+	require.NotEmpty(t, after,
+		"no migration after %s touches security_policies; migration 105 should", seedingMigration)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	// Always roll back. This test asserts over migration SQL, not over durable state, and must
+	// not leave the seeded policies behind on a shared database.
+	defer func() { _ = tx.Rollback() }()
+
+	// Migration 052 looks the admin organization and admin user up by name and email, and
+	// silently no-ops when either is missing. Create them so the seeding actually runs; without
+	// this the whole test would pass while asserting nothing.
+	adminOrgID := ensureRow(t, tx,
+		`SELECT id FROM organizations WHERE name = 'OpenA2A Admin' LIMIT 1`,
+		`INSERT INTO organizations (name, domain) VALUES ('OpenA2A Admin', 'mcp-policy-guard.invalid') RETURNING id`)
+	ensureRow(t, tx,
+		`SELECT id FROM users WHERE email = 'admin@opena2a.org' LIMIT 1`,
+		`INSERT INTO users (organization_id, email, name, provider, provider_id)
+		 VALUES ($1, 'admin@opena2a.org', 'Guard Admin', 'local', 'mcp-policy-guard')
+		 RETURNING id`, adminOrgID)
+
+	// Start from a clean slate for these six rows. Migration 052 inserts ON CONFLICT DO NOTHING,
+	// so on a database where it has already run -- and where 105 has therefore already disabled
+	// the rows -- re-applying it would insert nothing and the mid-state assertion below would
+	// read the post-fix state as if it were the pre-fix one. Deleting first makes the test
+	// deterministic on a fresh database and on a fully migrated one alike. Rolled back either way.
+	_, err = tx.Exec(`DELETE FROM security_policies WHERE policy_type = ANY($1) AND name = ANY($2)`,
+		pq.Array(mcpPolicyTypes), pq.Array(seededPolicyNames))
+	require.NoError(t, err)
+
+	for _, name := range through {
+		applyMigration(t, tx, name)
+	}
+
+	// Pre-105 state, asserted rather than assumed: this is the defect the fix closes, and
+	// asserting it here is what proves the post-fix assertion below is not vacuous.
+	total, enabled := countSeededMCPPolicies(t, tx)
+	require.Equal(t, 6, total,
+		"migration %s should seed 6 MCP policies; got %d. If the seed changed, update this guard.",
+		seedingMigration, total)
+	require.Equal(t, 6, enabled,
+		"expected all 6 seeded MCP policies enabled before the disabling migration runs")
+
+	for _, name := range after {
+		applyMigration(t, tx, name)
+	}
+
+	total, enabled = countSeededMCPPolicies(t, tx)
+	require.Equal(t, 6, total, "the disabling migration must not delete the seeded policies, only disable them")
+	require.Equal(t, 0, enabled,
+		"a security policy of a type nothing evaluates is enabled. Either wire MCPPolicyEvaluator "+
+			"(and rescale rules.minTrustScore to [0,1] and fix the bare '*' allowedDomains entry "+
+			"first), or keep these rows disabled. See https://github.com/opena2a-org/agent-identity-management/issues/355")
+}
+
+// securityPolicyMigrations returns the migration filenames that touch security_policies, split
+// at the seeding migration: everything up to and including it, then everything after. Derived
+// from the directory rather than hardcoded, so a future migration that re-enables these rows is
+// picked up automatically instead of slipping past a stale list.
+func securityPolicyMigrations(t *testing.T) (through, after []string) {
+	t.Helper()
+	entries, err := filepath.Glob(filepath.Join("..", "..", "migrations", "*.sql"))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "no migration files found")
+
+	var matched []string
+	for _, path := range entries {
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		if strings.Contains(string(body), "security_policies") {
+			matched = append(matched, filepath.Base(path))
+		}
+	}
+	require.NotEmpty(t, matched, "no migration mentions security_policies")
+	sort.Strings(matched) // zero-padded three-digit prefixes sort lexically in numeric order
+
+	seen := false
+	for _, name := range matched {
+		if seen {
+			after = append(after, name)
+			continue
+		}
+		through = append(through, name)
+		if name == seedingMigration {
+			seen = true
+		}
+	}
+	return through, after
+}
+
+func applyMigration(t *testing.T, tx *sql.Tx, name string) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "..", "migrations", name))
+	require.NoError(t, err)
+	_, err = tx.Exec(string(body))
+	require.NoErrorf(t, err, "applying %s", name)
+}
+
+// ensureRow returns the id from selectSQL, inserting via insertSQL first if there is no row.
+// insertArgs are bound as query parameters rather than interpolated, so no identifier read back
+// out of the database is ever concatenated into SQL text.
+func ensureRow(t *testing.T, tx *sql.Tx, selectSQL, insertSQL string, insertArgs ...any) string {
+	t.Helper()
+	var id string
+	err := tx.QueryRow(selectSQL).Scan(&id)
+	if err == sql.ErrNoRows {
+		require.NoError(t, tx.QueryRow(insertSQL, insertArgs...).Scan(&id))
+		return id
+	}
+	require.NoError(t, err)
+	return id
+}
+
+func countSeededMCPPolicies(t *testing.T, tx *sql.Tx) (total, enabled int) {
+	t.Helper()
+	err := tx.QueryRow(`
+		SELECT COUNT(*), COUNT(*) FILTER (WHERE is_enabled)
+		FROM security_policies
+		WHERE policy_type = ANY($1)
+		  AND name = ANY($2)`, pq.Array(mcpPolicyTypes), pq.Array(seededPolicyNames)).Scan(&total, &enabled)
+	require.NoError(t, err)
+	return total, enabled
+}

--- a/apps/backend/migrations/105_disable_unenforced_mcp_policies.sql
+++ b/apps/backend/migrations/105_disable_unenforced_mcp_policies.sql
@@ -1,0 +1,46 @@
+-- Disable the seeded MCP security policies, because nothing evaluates them
+-- Purpose: migration 052 seeded six MCP policies with is_enabled = true, two of them
+--          enforcement_action 'block_and_alert' at severity 'critical'. No code path evaluates
+--          any mcp_* policy type. SecurityPolicyService -- the service wired in
+--          cmd/server/main.go -- reaches only the six non-MCP types through
+--          policyRepo.GetByType, and MCPPolicyEvaluator, which is the sole implementation,
+--          has no non-test call site in either repo.
+--
+--          The admin security-policy page is mounted in production and renders these rows with
+--          an enable toggle and their enforcement action, so an administrator sees enabled
+--          blocking policies that have never run. A control that is not running must not
+--          present as running.
+-- Migration: 105_disable_unenforced_mcp_policies.sql
+-- Date: 2026-08-06
+--
+-- Scope: only the six rows migration 052 seeded, matched on policy type AND the exact seeded
+-- name. A policy an operator created, or renamed, keeps whatever state the operator set. This
+-- resets our own defaults; it does not manage anyone else's configuration.
+--
+-- Do NOT simply revert this when the evaluator is wired. Re-enabling these rows as they stand
+-- would reject every MCP server, for two independent reasons:
+--
+--   1. rules.minTrustScore is seeded 50 and 30 on a 0-100 scale, while the evaluator compares it
+--      against MCPServer.TrustScore, which migration 104 made canonical [0,1].
+--   2. 'allowedDomains': ['*'] matches no host at all. matchDomainPattern only special-cases the
+--      '*.' prefix and otherwise falls through to an equality test, so a bare '*' means "allow
+--      nothing", not "allow everything" -- and 'High-Risk MCP Server Block' is block_and_alert.
+--
+-- Both are prerequisites of the wiring unit: https://github.com/opena2a-org/agent-identity-management/issues/355.
+
+UPDATE security_policies
+SET is_enabled = false,
+    updated_at = NOW()
+WHERE policy_type IN ('mcp_allowlist', 'mcp_blocklist', 'mcp_capabilities', 'mcp_unverified')
+  AND name IN (
+      'Trusted MCP Server Domains',
+      'Blocked MCP Domains',
+      'MCP Capability Requirements',
+      'Unverified MCP Server Restrictions',
+      'MCP Minimum Trust Score',
+      'High-Risk MCP Server Block'
+  )
+  AND is_enabled = true;
+
+COMMENT ON COLUMN security_policies.policy_type IS
+    'Type of policy: capability_violation, trust_score_low, unusual_activity, unauthorized_access, data_exfiltration, config_drift. The mcp_* types (mcp_allowlist, mcp_blocklist, mcp_capabilities, mcp_unverified) are stored and editable but NOT evaluated by any running code path as of migration 105; see https://github.com/opena2a-org/agent-identity-management/issues/355.';

--- a/apps/web/app/dashboard/admin/security-policies/page.tsx
+++ b/apps/web/app/dashboard/admin/security-policies/page.tsx
@@ -92,6 +92,9 @@ const MCP_POLICY_TYPES = [
   "mcp_unverified",
 ];
 
+// Descriptions state what a policy RECORDS, not what it does. No MCP policy type is evaluated by
+// any running code path today, so active-voice enforcement wording ("Block specific MCP servers")
+// would describe behavior that does not happen. See MCPNotEnforcedNotice below.
 const MCP_POLICY_TYPE_CONFIGS = [
   {
     type: "mcp_allowlist",
@@ -99,7 +102,7 @@ const MCP_POLICY_TYPE_CONFIGS = [
     icon: CheckCircle,
     color: "text-green-600",
     bgColor: "bg-green-100 dark:bg-green-900/30",
-    description: "Only allow listed MCP servers",
+    description: "Records which MCP servers are intended to be allowed",
   },
   {
     type: "mcp_blocklist",
@@ -107,7 +110,7 @@ const MCP_POLICY_TYPE_CONFIGS = [
     icon: Ban,
     color: "text-red-600",
     bgColor: "bg-red-100 dark:bg-red-900/30",
-    description: "Block specific MCP servers",
+    description: "Records which MCP servers are intended to be blocked",
   },
   {
     type: "mcp_capabilities",
@@ -115,7 +118,7 @@ const MCP_POLICY_TYPE_CONFIGS = [
     icon: Shield,
     color: "text-blue-600",
     bgColor: "bg-blue-100 dark:bg-blue-900/30",
-    description: "Require or forbid specific capabilities",
+    description: "Records required and forbidden capabilities",
   },
   {
     type: "mcp_unverified",
@@ -123,9 +126,28 @@ const MCP_POLICY_TYPE_CONFIGS = [
     icon: FileWarning,
     color: "text-yellow-600",
     bgColor: "bg-yellow-100 dark:bg-yellow-900/30",
-    description: "Handle unverified MCP servers",
+    description: "Records how unverified MCP servers should be handled",
   },
 ];
+
+// MCP policies are stored and editable, but no running code path evaluates them: the policy
+// evaluator has no call site, so nothing reads these rules at connection or registration time.
+// Saying so plainly is the point. An administrator who configures a blocking policy and is not
+// told it does not run has been given a control that only looks like one.
+function MCPNotEnforcedNotice({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/40 ${className}`}
+    >
+      <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-500" />
+      <div className="text-amber-900 dark:text-amber-200">
+        <span className="font-medium">MCP policies are not enforced yet.</span> These rules are
+        saved and can be edited, but nothing evaluates them, so no MCP server is currently allowed,
+        blocked, or alerted on by them. Agent policies are unaffected and continue to be enforced.
+      </div>
+    </div>
+  );
+}
 
 const enforcementColors = {
   alert_only: "bg-yellow-100 text-yellow-800 border-yellow-300",
@@ -331,8 +353,19 @@ export default function SecurityPoliciesPage() {
   const agentPolicies = policies.filter(isAgentPolicy);
   const mcpPolicies = policies.filter(isMCPPolicy);
   const enabledCount = policies.filter(p => p.isEnabled).length;
-  const blockingCount = policies.filter(p => p.isEnabled && p.enforcementAction === "block_and_alert").length;
-  const monitoringCount = policies.filter(p => p.isEnabled && p.enforcementAction === "alert_only").length;
+  // The blocking and monitoring tiles describe what is actually happening, so they count only
+  // policies that something evaluates. MCP policies are stored but never evaluated, so counting
+  // them here would report enforcement that does not occur -- "Blocking: 1" beside a policy the
+  // system has never once acted on.
+  const blockingCount = agentPolicies.filter(p => p.isEnabled && p.enforcementAction === "block_and_alert").length;
+  const monitoringCount = agentPolicies.filter(p => p.isEnabled && p.enforcementAction === "alert_only").length;
+
+  // The blocking-mode confirmation dialog is shared by agent and MCP policies, but its warning
+  // ("blocks in real-time", "403 Forbidden") is only true for agent policies. Resolve which kind
+  // is being changed so the dialog does not promise an effect that will not happen.
+  const pendingPolicyId = pendingEnforcementChange?.policyId || pendingPolicyToggle?.policyId;
+  const pendingIsMCPPolicy = !!pendingPolicyId
+    && policies.some(p => p.id === pendingPolicyId && isMCPPolicy(p));
 
   // Policy toggle with blocking warning
   const togglePolicy = async (policyId: string, currentlyEnabled: boolean) => {
@@ -977,6 +1010,11 @@ export default function SecurityPoliciesPage() {
                     <EnforcementIcon className="h-3 w-3 mr-1" />
                     {enforcementLabels[policy.enforcementAction] || policy.enforcementAction}
                   </Badge>
+                  {/* The enforcement badge above states an intent, not a behavior: nothing
+                      evaluates MCP policies, so it must not be the only thing an admin reads. */}
+                  <Badge className="border border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                    Not enforced
+                  </Badge>
                   <Badge variant="outline" className="text-xs">
                     Priority: {policy.priority}
                   </Badge>
@@ -1035,10 +1073,14 @@ export default function SecurityPoliciesPage() {
             </div>
 
             {isBlocking && policy.isEnabled && (
-              <div className="flex items-center gap-2 pl-14 p-3 bg-red-50 dark:bg-red-950/20 rounded-md border border-red-200 dark:border-red-800">
-                <AlertOctagon className="h-4 w-4 text-red-600" />
-                <p className="text-xs text-red-800 dark:text-red-200 font-medium">
-                  BLOCKING MODE ACTIVE: This policy will block MCP server connections in real-time
+              // Deliberately not the red "BLOCKING MODE ACTIVE" banner the agent card uses. That
+              // banner states a present-tense behavior, and for MCP policies no such behavior
+              // occurs -- printing it beside the "Not enforced" badge would contradict it.
+              <div className="flex items-center gap-2 pl-14 p-3 bg-gray-50 dark:bg-gray-900 rounded-md border border-gray-200 dark:border-gray-700">
+                <AlertOctagon className="h-4 w-4 text-gray-500" />
+                <p className="text-xs text-gray-700 dark:text-gray-300 font-medium">
+                  Set to block, but not blocking: this policy takes effect only once MCP policy
+                  enforcement ships. No connection is being blocked by it today.
                 </p>
               </div>
             )}
@@ -1143,7 +1185,7 @@ export default function SecurityPoliciesPage() {
               Security Policies
             </h1>
             <p className="text-muted-foreground mt-1">
-              Manage security enforcement for agents and MCP servers
+              Manage security policies for agents and MCP servers
             </p>
           </div>
           {mainFilter === "mcp" && (
@@ -1276,7 +1318,8 @@ export default function SecurityPoliciesPage() {
                 </p>
                 <p className="text-blue-800 dark:text-blue-200">
                   Manage both agent and MCP server security policies in one place. Agent policies protect against capability violations,
-                  trust score issues, and unusual activity. MCP policies control server allowlists, blocklists, and verification requirements.
+                  trust score issues, and unusual activity, and are enforced today. MCP policies record intended server allowlists,
+                  blocklists, and verification requirements, and are not yet enforced.
                 </p>
                 <ul className="space-y-1 text-blue-800 dark:text-blue-200 mt-2">
                   <li className="flex items-center gap-2">
@@ -1338,6 +1381,7 @@ export default function SecurityPoliciesPage() {
                     Create MCP Policy
                   </Button>
                 </div>
+                <MCPNotEnforcedNotice />
                 <div className="space-y-4">
                   {mcpPolicies.map(renderMCPPolicyCard)}
                 </div>
@@ -1384,9 +1428,9 @@ export default function SecurityPoliciesPage() {
               <CardHeader>
                 <CardTitle>MCP Server Policies ({mcpPolicies.length})</CardTitle>
                 <CardDescription>
-                  Policies that control MCP server allowlists, blocklists, and verification requirements.
-                  Toggle policies on/off or adjust enforcement actions.
+                  Allowlist, blocklist, capability, and verification rules for MCP servers.
                 </CardDescription>
+                <MCPNotEnforcedNotice className="mt-3" />
               </CardHeader>
               <CardContent>
                 {/* MCP Sub-tabs */}
@@ -1444,6 +1488,18 @@ export default function SecurityPoliciesPage() {
                   </strong>{" "}
                   {pendingEnforcementChange ? "to" : "in"} blocking mode.
                 </div>
+                {pendingIsMCPPolicy ? (
+                  <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-800 p-4 rounded-md space-y-2">
+                    <div className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                      This will not block anything yet
+                    </div>
+                    <ul className="text-sm text-amber-800 dark:text-amber-300 space-y-1 list-disc list-inside">
+                      <li>MCP policies are <strong>not evaluated</strong> by any running code path</li>
+                      <li>The setting is saved, but <strong>no connection will be blocked</strong></li>
+                      <li>It takes effect only once MCP policy enforcement ships</li>
+                    </ul>
+                  </div>
+                ) : (
                 <div className="bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 p-4 rounded-md space-y-2">
                   <div className="text-sm font-semibold text-red-800 dark:text-red-200">
                     Warning: Production Impact
@@ -1455,6 +1511,7 @@ export default function SecurityPoliciesPage() {
                     <li>Consider testing in "Alert Only" mode first</li>
                   </ul>
                 </div>
+                )}
                 <div className="text-sm">
                   Are you sure you want to {pendingEnforcementChange ? "switch to" : "enable"} blocking mode for this policy?
                 </div>
@@ -1536,6 +1593,7 @@ export default function SecurityPoliciesPage() {
                 Define rules for MCP server access and compliance
               </DialogDescription>
             </DialogHeader>
+            <MCPNotEnforcedNotice />
             <div className="space-y-6 py-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>
@@ -1641,6 +1699,7 @@ export default function SecurityPoliciesPage() {
                 Update the policy rules and settings
               </DialogDescription>
             </DialogHeader>
+            <MCPNotEnforcedNotice />
             <div className="space-y-6 py-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>


### PR DESCRIPTION
Closes part of #355.

## The defect

None of the four `mcp_*` security policy types are evaluated by any running code path.
`SecurityPolicyService` only requests the six non-MCP types through `policyRepo.GetByType`, and
`MCPPolicyEvaluator` — the sole implementation — has no non-test call site.

The surface says otherwise, and it is mounted in production: the admin security-policy routes are
registered (`cmd/server/main.go:1616`), the admin page creates, edits and toggles all four types,
and migration 052 seeded six MCP policies **enabled**, two of them `block_and_alert` at `critical`.
An administrator could read "High-Risk MCP Server Block — Block & Alert — Enabled" and reasonably
conclude connections were being blocked. None ever were.

## Why the evaluator is kept rather than deleted

This was originally scoped as dead-code removal. Deleting it would not have removed one word of the
promise — the UI, the CRUD API and the six seeded policies would all have survived — it would only
have removed the ability to ever honour them, turning a recoverable gap into a permanent one.

## What changed

- **Migration 105** disables the six seeded policies, matched on policy type AND the exact seeded
  name, so a policy an operator created or renamed keeps whatever state the operator set.
- **Admin page** states plainly that MCP policies are not enforced: a notice on the MCP tab, the
  overview section and both dialogs, a `Not enforced` badge on every MCP policy card, and type
  descriptions that say what a policy records rather than what it does.
- Three further claims, caught by walking the page rather than reading it:
  - the red `BLOCKING MODE ACTIVE: This policy will block MCP server connections in real-time`
    banner, which rendered directly beneath the new `Not enforced` badge and contradicted it;
  - the Blocking and Monitoring stat tiles, which counted MCP policies as enforcement and are now
    computed from agent policies only;
  - the blocking-mode confirmation dialog, which promised `403 Forbidden` responses for a policy
    that blocks nothing.
- **`MCPPolicyEvaluator`** carries a NOT WIRED doc comment naming the prerequisites.

## A third blocker, found here

Wiring the evaluator as it stands would reject every MCP server for a reason unrelated to the
known `minTrustScore` scale mismatch: `matchDomainPattern` special-cases only the `*.` prefix and
otherwise falls through to an equality test, so the seeded `'allowedDomains': ['*']` matches no
host at all. Verified by executing the function — `*` against `api.example.com`, `localhost` and
`anything` is false in every case, while `*.company.com` against `api.company.com` is true. Seeded
policies 5 and 6 therefore mean "allow nothing", and policy 6 is `block_and_alert`.

## Verification

- `TestSeededMCPPoliciesAreNotEnabled` applies every migration touching `security_policies` in
  order against real Postgres inside a rolled-back transaction. It asserts the six policies exist
  and are **enabled** before the disabling migration runs, so it cannot pass vacuously on a
  database where migration 052 no-opped for want of the admin organization — which is exactly how
  this would rot silently.
- Red-proofed four ways: migration 105 absent, a later migration re-enabling all four types, a
  later migration re-enabling one type, and on a database where 105 had already run.
- Added to the CI not-skipped selector. Without that the assertion would have run while silently
  no longer applying to this test, which is the failure mode the comment above it warns about.
- Admin page walked as a logged-in administrator against a real backend at 1280px and 375px, in
  light and dark: notice present, seven `Not enforced` badges, no horizontal overflow, no console
  errors.