### PR TITLE
db: convert all naked TIMESTAMP columns to TIMESTAMPTZ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,18 @@ jobs:
             internal/infrastructure/repository \
             internal/application
 
+      # A `timestamp without time zone` column silently shifts the stored instant by the
+      # writing process's UTC offset — and, for DEFAULT NOW(), by the PostgreSQL session's.
+      # The baseline holds the declarations that predate migration 106 and must never grow.
+      - name: timestamptz-lint (naked TIMESTAMP guard)
+        run: |
+          LINT_TMP=$(mktemp -d -t timestamptz-lint.XXXXXX)
+          trap 'rm -rf "$LINT_TMP"' EXIT
+          go build -o "$LINT_TMP/timestamptz-lint" ./cmd/timestamptz-lint/
+          "$LINT_TMP/timestamptz-lint" \
+            --baseline cmd/timestamptz-lint/historical-baseline.txt \
+            migrations
+
       - name: Test with coverage
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -365,12 +377,12 @@ jobs:
       # stops applying to it. AgentRevocation + the middleware package were
       # added for exactly that reason; UpdateDoesNotWriteTrustScore + RoundTrip
       # and the repository package were added for the same reason after the MCP
-      # trust-score write-path fix.
+      # trust-score write-path fix; NakedTimestamp was added with migration 106.
       - name: Assert integration tests were not skipped
         run: |
           set -o pipefail
           go test -tags=integration -v \
-            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled' \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|NakedTimestamp' \
             ./internal/application/... ./internal/interfaces/http/middleware/... \
             ./internal/infrastructure/repository/... 2>&1 | tee /tmp/integration.log
           if grep -q '^--- SKIP' /tmp/integration.log; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,51 @@ forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Fixed
 
+- **Timestamp columns no longer depend on the writer's time zone.** Every
+  `TIMESTAMP` (without time zone) column is now `TIMESTAMPTZ` (migration 106):
+  42 application columns, plus `schema_migrations.applied_at` on deployments
+  whose database was bootstrapped by the server rather than the migrate command.
+  A naked `TIMESTAMP` drops the UTC offset on write and is read back labelled
+  UTC, so the stored instant shifted by the writing process's offset. The
+  one case that changes an access decision is `api_keys.expires_at`: a key
+  written east of UTC stayed valid past its stated expiry by exactly that offset
+  (measured: +9h at `Asia/Tokyo`, +2h at `Europe/Berlin`). West of UTC keys
+  expired early.
+
+  The other converted columns are correctness and audit fixes, not access-control
+  fixes, and it is worth being exact about which is which:
+  `audit_logs.timestamp` recorded the time of an audited action in the writer's
+  zone, which is an evidentiary problem; `agent_capabilities.revoked_at` is
+  enforced only as `revoked_at IS NULL`, which is zone-independent; and
+  `agents.pqc_key_expires_at` reaches no enforcement path at all — the expiry
+  `EnforceKeyExpiry` reads is `key_expires_at`, which was already `TIMESTAMPTZ`.
+
+  A second path needed no Go code at all: the DSN sets no `TimeZone`, so
+  `DEFAULT NOW()` and migration 092's `verified_at` trigger were cast under
+  whatever zone the PostgreSQL *session* had. Converting the column type is what
+  closes both paths — the columns are now correct regardless of either zone.
+
+  **Who was affected:** deployments running at a non-UTC offset. The published
+  container image sets no `TZ` and has no `/etc/localtime`, so it runs at UTC and
+  was not affected. Self-hosters running the backend natively, setting `TZ`, or
+  on a PostgreSQL whose session zone is not UTC were.
+
+  **Upgrade note.** The conversion does not rewrite table heaps, but it does
+  rebuild the 20 indexes that touch the converted columns, and every affected
+  table is locked until the migration commits. Measured at 2,000,000 rows:
+  238 ms for an indexed column, versus 0.33 ms with no index. Budget accordingly
+  on a large `audit_logs`.
+
+  **Existing rows** are reinterpreted as UTC, which is exact for anything written
+  at UTC and adopts the already-shifted instant otherwise. `agents` writes one
+  `TIMESTAMPTZ` and one naked column from the same clock in a single INSERT, so
+  operators can check their own history before upgrading — the query is in the
+  migration header.
+
+  Two guards keep the class closed: `cmd/timestamptz-lint` fails CI on a naked
+  `TIMESTAMP` in any migration, and an integration test asserts the applied
+  schema holds none.
+
 - Agent registration now returns `400 Bad Request` (was `500 Internal Server
   Error`) when the request references an organization or user that no longer
   exists — a foreign-key violation surfaced when a stale API key or deleted org

--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -2009,7 +2009,7 @@ func createMigrationsTable(db *sql.DB) error {
 		CREATE TABLE IF NOT EXISTS schema_migrations (
 			id SERIAL PRIMARY KEY,
 			version VARCHAR(255) NOT NULL UNIQUE,
-			applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
 	`
 	_, err := db.Exec(query)

--- a/apps/backend/cmd/timestamptz-lint/historical-baseline.txt
+++ b/apps/backend/cmd/timestamptz-lint/historical-baseline.txt
@@ -1,0 +1,64 @@
+# timestamptz-lint baseline — declarations that predate migration 106.
+#
+# These are the naked TIMESTAMP declarations that existed when the lint was written.
+# They are NOT unfixed defects: migration 106 converted every column they produce to
+# TIMESTAMPTZ, and TestNakedTimestampSchemaHasNoNakedTimestampColumns asserts the applied
+# schema holds zero naked columns.
+#
+# They stay listed because 106 converts the DATABASE, not these files. Editing an already
+# applied migration would make the history describe something other than what production ran,
+# so the text stays as it was and the result is corrected forward.
+#
+# Entries are <basename>:<line> — never a path prefix, because CI scans `migrations` from
+# apps/backend while the package test scans `../../migrations`, and a prefixed key would stop
+# matching under one of them. They are COUNTED, not merely matched: a location listed once
+# suppresses exactly one finding there, so a baselined line that grows a SECOND naked
+# declaration is still reported. TestHistoricalBaselineMatchesTheTreeExactly asserts this file
+# and the tree agree exactly in both directions, so a stale entry cannot sit here absorbing a
+# future defect.
+#
+# This file must never grow. A new entry means a new naked column was added after 106, which
+# is the exact regression the lint exists to prevent. Fix the column; do not extend this list.
+001_initial_schema.sql:104
+001_initial_schema.sql:105
+001_initial_schema.sql:123
+001_initial_schema.sql:13
+001_initial_schema.sql:14
+001_initial_schema.sql:144
+001_initial_schema.sql:145
+001_initial_schema.sql:30
+001_initial_schema.sql:31
+001_initial_schema.sql:32
+001_initial_schema.sql:56
+001_initial_schema.sql:57
+001_initial_schema.sql:58
+001_initial_schema.sql:77
+001_initial_schema.sql:78
+001_initial_schema.sql:80
+012_create_user_registration_requests_table.sql:12
+012_create_user_registration_requests_table.sql:13
+012_create_user_registration_requests_table.sql:19
+012_create_user_registration_requests_table.sql:20
+014_fix_alerts_schema.sql:33
+016_create_agent_capabilities_table.sql:10
+016_create_agent_capabilities_table.sql:11
+016_create_agent_capabilities_table.sql:12
+016_create_agent_capabilities_table.sql:13
+017_create_capability_violations_table.sql:14
+018_create_operational_metrics_tables.sql:12
+018_create_operational_metrics_tables.sql:30
+018_create_operational_metrics_tables.sql:48
+018_create_operational_metrics_tables.sql:49
+018_create_operational_metrics_tables.sql:50
+018_create_operational_metrics_tables.sql:51
+018_create_operational_metrics_tables.sql:72
+018_create_operational_metrics_tables.sql:8
+018_create_operational_metrics_tables.sql:91
+037_add_last_active_to_agents.sql:7
+065_add_pqc_support.sql:8
+065_add_pqc_support.sql:9
+090_add_execution_isolation.sql:13
+090_add_execution_isolation.sql:14
+090_add_execution_isolation.sql:30
+090_add_execution_isolation.sql:31
+101_create_user_feedback.sql:12

--- a/apps/backend/cmd/timestamptz-lint/main.go
+++ b/apps/backend/cmd/timestamptz-lint/main.go
@@ -1,0 +1,524 @@
+// timestamptz-lint enforces the schema invariant "TIMESTAMPTZ always, never TIMESTAMP".
+//
+// A `timestamp without time zone` column silently shifts the stored instant by the writing
+// process's UTC offset: lib/pq sends a Go time.Time as its wall clock, Postgres drops the
+// offset, and on read lib/pq labels the naked value UTC. East of UTC an API key stays valid
+// past its stated expiry by exactly that offset. The same corruption reaches columns no Go
+// code touches, because `DEFAULT NOW()` is cast under the PostgreSQL *session* zone.
+//
+// This is the source half of the guard: it flags a naked column in a migration file before it
+// is ever applied. The database half is TestNakedTimestampSchemaHasNoNakedTimestampColumns,
+// which asserts the applied schema holds zero of them. Both are needed — the lint cannot see a
+// column that entered through a path other than this repo's migrations, and the test cannot
+// see a migration that has not been applied yet.
+//
+// It exists because the convention alone did not hold. "TIMESTAMPTZ always" was already
+// written into the CA charter, and migrations 065, 090 and 101 each added naked columns after
+// it was. Migration 106 converted the 42 that had accumulated.
+//
+// Findings are reported as file:line: <text>; exit code 1 if any, 0 otherwise.
+//
+// Baseline support: pass --baseline <path> to a file of file:line entries to allowlist during
+// a staged migration. It should stay empty — a non-empty baseline is a review trigger.
+//
+// KNOWN LIMITATIONS — this is a line-oriented tokenizer, not a SQL parser, and these shapes are
+// measured misses rather than assumed ones. Each is caught by the database half of the guard
+// (TestNakedTimestampSchemaHasNoNakedTimestampColumns and migration 106's postcondition, both
+// of which resolve domains and read pg_attribute), which is why the pair is the guard and
+// neither half is:
+//
+//   - A quoted column name: `"my col" TIMESTAMP`. A quoted previous token returns false.
+//   - A column named with a non-reserved keyword this file lists, e.g. `key TIMESTAMP`.
+//     `system_config.key` shows the repo really does use such names.
+//   - `CREATE DOMAIN d AS TIMESTAMP`, and a type declared on a continuation line.
+//   - `now()::timestamp` in a materialized view body.
+//
+// And two false-positive shapes, which cost a spurious CI failure rather than a missed column:
+// `TIMESTAMP(3) WITH TIME ZONE` (the precision paren sits where WITH is looked for), and a
+// PL/pgSQL local like `DECLARE v_now timestamp;` inside a DO block.
+//
+// A single stray backslash-escaped quote inside an E-string still blanks the rest of a FILE,
+// because the string scanner understands a doubled single quote but not backslash escapes. No
+// migration currently contains one. Inside a dollar-quoted block the damage is bounded to that
+// block.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+// maxFindingTextLen bounds the source excerpt carried on a finding.
+//
+// The excerpt exists to orient a reader who already has file:line; it is not the fix. Without
+// a bound, every finding on a line carries that whole line, so a single long line with many
+// declarations amplifies quadratically: a 440 KB one-line file with 20,000 declarations
+// produced 8.8 GB of output — enough to fill a CI runner's disk while the lint itself ran in
+// under two seconds. Measured, not hypothesised.
+const maxFindingTextLen = 200
+
+type finding struct {
+	File string
+	Line int
+	Text string
+	Why  string
+}
+
+// Location is the human-facing position, carrying whatever path the caller passed in.
+func (f finding) Location() string {
+	return fmt.Sprintf("%s:%d", f.File, f.Line)
+}
+
+// BaselineKey is the position as the baseline records it: base filename and line, never the
+// caller's path prefix. CI runs the lint as `timestamptz-lint migrations` from apps/backend
+// while the package test scans `../../migrations`; keying on the full path would make the same
+// declaration two different entries, so the baseline would silently stop applying under one of
+// them. Migration filenames are unique, which is what makes the basename sufficient.
+func (f finding) BaselineKey() string {
+	return fmt.Sprintf("%s:%d", filepath.Base(f.File), f.Line)
+}
+
+func main() {
+	baselinePath := flag.String("baseline", "", "path to baseline file of file:line entries to allowlist")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: timestamptz-lint [--baseline path] <dir> [<dir>...]\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	dirs := flag.Args()
+	if len(dirs) == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	baseline, err := loadBaseline(*baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "timestamptz-lint: load baseline: %v\n", err)
+		os.Exit(2)
+	}
+
+	var findings []finding
+	for _, dir := range dirs {
+		fs, err := scanDir(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "timestamptz-lint: scan %s: %v\n", dir, err)
+			os.Exit(2)
+		}
+		findings = append(findings, fs...)
+	}
+
+	reported := applyBaseline(findings, baseline)
+	sort.Slice(reported, func(i, j int) bool {
+		if reported[i].File != reported[j].File {
+			return reported[i].File < reported[j].File
+		}
+		return reported[i].Line < reported[j].Line
+	})
+
+	for _, f := range reported {
+		fmt.Printf("%s: %s (%s)\n", f.Location(), strings.TrimSpace(f.Text), f.Why)
+	}
+
+	if len(reported) > 0 {
+		fmt.Fprintf(os.Stderr, "\ntimestamptz-lint: %d naked TIMESTAMP declaration(s) found.\n", len(reported))
+		fmt.Fprintf(os.Stderr,
+			"Use TIMESTAMPTZ. A naked TIMESTAMP shifts the stored instant by the writer's UTC\n"+
+				"offset, and by the PG session's for DEFAULT NOW(). See migration 106.\n")
+		os.Exit(1)
+	}
+}
+
+// applyBaseline returns the findings that survive the baseline, consuming one allowance per
+// baselined location.
+//
+// This lives in its own function so a test can exercise the REAL filtering. A test that
+// re-implements this loop inline proves nothing about the binary: reverting the decrement here
+// (the exact defect the counting fix closes) leaves such a test green while the shipped tool
+// silently allows a new naked column through.
+func applyBaseline(findings []finding, baseline map[string]int) []finding {
+	remaining := make(map[string]int, len(baseline))
+	for loc, n := range baseline {
+		remaining[loc] = n
+	}
+	var reported []finding
+	for _, f := range findings {
+		if remaining[f.BaselineKey()] > 0 {
+			remaining[f.BaselineKey()]--
+			continue
+		}
+		reported = append(reported, f)
+	}
+	return reported
+}
+
+// loadBaseline reads allowlisted locations as a COUNT per location, not a set.
+//
+// A set silently masks a new defect: one baselined line that grows a second naked declaration
+// still matches the same file:line, so the new column is allowed through with the baseline file
+// unchanged. Counting means the baseline suppresses exactly as many findings as were recorded
+// at that location and no more — a second declaration on a baselined line is reported.
+func loadBaseline(path string) (map[string]int, error) {
+	if path == "" {
+		return map[string]int{}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]int{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	entries := map[string]int{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entries[line]++
+	}
+	return entries, scanner.Err()
+}
+
+func scanDir(dir string) ([]finding, error) {
+	var findings []finding
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(strings.ToLower(path), ".sql") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		findings = append(findings, scanSQL(path, string(data))...)
+		return nil
+	})
+	return findings, err
+}
+
+// scanSQL reports naked TIMESTAMP type declarations in one SQL file.
+//
+// Comments and string literals are blanked before tokenizing, so prose in a migration header
+// and a literal like 'timestamp without time zone' (which the migration 106 postcondition
+// legitimately queries for) cannot produce a finding.
+func scanSQL(path, src string) []finding {
+	var findings []finding
+	stripped := blankNonCode(src)
+	lines := strings.Split(stripped, "\n")
+	rawLines := strings.Split(src, "\n")
+
+	for i, line := range lines {
+		for _, why := range nakedTimestampsIn(line) {
+			findings = append(findings, finding{
+				File: path,
+				Line: i + 1,
+				Text: truncateExcerpt(rawLines[i]),
+				Why:  why,
+			})
+		}
+	}
+	return findings
+}
+
+// truncateExcerpt bounds one source line to maxFindingTextLen, marking any elision so a reader
+// is never shown a silently shortened line and told it is the whole one.
+func truncateExcerpt(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxFindingTextLen {
+		return s
+	}
+	// Back off to a rune boundary. A plain byte slice splits multi-byte characters and emits a
+	// lone continuation byte, which makes the whole output invalid UTF-8 — 16 migration files
+	// already contain non-ASCII, so this is reachable, not theoretical.
+	cut := maxFindingTextLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "… (line truncated)"
+}
+
+// sqlKeywords are words that can appear immediately before a type but are not column names.
+// A TIMESTAMP preceded by one of these is not a column's declared type — except for TYPE
+// itself, which is exactly the `ALTER COLUMN x TYPE TIMESTAMP` shape we do want to flag.
+var sqlKeywords = map[string]bool{
+	"ADD": true, "ALTER": true, "AND": true, "AS": true, "ASC": true, "BY": true,
+	"CHECK": true, "COLUMN": true, "CREATE": true, "DEFAULT": true, "DESC": true,
+	"DISTINCT": true, "EXISTS": true, "FROM": true, "IF": true, "INDEX": true,
+	"INTO": true, "IS": true, "KEY": true, "NOT": true, "NULL": true, "ON": true,
+	"OR": true, "ORDER": true, "PRIMARY": true, "REFERENCES": true, "RETURNS": true,
+	"SELECT": true, "SET": true, "TABLE": true, "UNIQUE": true, "USING": true,
+	"VALUES": true, "WHERE": true,
+}
+
+// nakedTimestampsIn returns a reason string per naked TIMESTAMP type usage on the line.
+//
+// A TIMESTAMP token is a declared TYPE only when what precedes it can introduce one: a column
+// name (a bare identifier), or the keyword TYPE. Deciding from the PRECEDING token rather than
+// the following one is what keeps three real shapes straight:
+//
+//	created_at TIMESTAMP, timestamp TIMESTAMPTZ   -> flags created_at, ignores the column named
+//	                                                 `timestamp` (an earlier rule that looked
+//	                                                  FORWARD for a type keyword missed the
+//	                                                  naked column entirely on this line)
+//	CREATE INDEX ... ON audit_logs(timestamp DESC) -> ignored; `timestamp` follows a paren, so
+//	                                                  it is a column reference, not a type
+//	ALTER COLUMN x TYPE TIMESTAMP                  -> flagged once, on TYPE
+func nakedTimestampsIn(line string) []string {
+	toks := tokenize(line)
+	var out []string
+
+	for i, tok := range toks {
+		if tok.quoted || tok.punct || !strings.EqualFold(tok.text, "TIMESTAMP") {
+			continue
+		}
+		if !introducesAType(toks, i) {
+			continue
+		}
+
+		switch {
+		case followedBy(toks, i, "WITH", "TIME", "ZONE"):
+			// TIMESTAMP WITH TIME ZONE — correct, just spelled the long way.
+			continue
+		case followedBy(toks, i, "WITHOUT", "TIME", "ZONE"):
+			out = append(out, "TIMESTAMP WITHOUT TIME ZONE; use TIMESTAMPTZ")
+		default:
+			out = append(out, "bare TIMESTAMP; use TIMESTAMPTZ")
+		}
+	}
+	return out
+}
+
+// introducesAType reports whether the token before position i can introduce a column type.
+func introducesAType(toks []token, i int) bool {
+	if i == 0 {
+		// Nothing precedes it on this line. A type continued from the previous line is
+		// possible; flagging here would false-positive on a bare `timestamp` reference, and
+		// the multi-line case is covered by the schema-invariant integration test.
+		return false
+	}
+	prev := toks[i-1]
+	if prev.quoted || prev.punct {
+		// `(timestamp DESC)` or `, timestamp` — a column reference or a column NAME.
+		return false
+	}
+	if strings.EqualFold(prev.text, "TYPE") {
+		return true
+	}
+	// Any other bare identifier that is not a SQL keyword is a column name, so this
+	// TIMESTAMP is its declared type.
+	return !sqlKeywords[strings.ToUpper(prev.text)]
+}
+
+type token struct {
+	text   string
+	quoted bool // double-quoted identifier — never a type
+	punct  bool // a single punctuation byte, e.g. ( , ; :
+}
+
+func nextToken(toks []token, i int) (token, bool) {
+	if i+1 >= len(toks) {
+		return token{}, false
+	}
+	return toks[i+1], true
+}
+
+func followedBy(toks []token, i int, want ...string) bool {
+	for n, w := range want {
+		t, ok := nextToken(toks, i+n)
+		if !ok || t.quoted || !strings.EqualFold(t.text, w) {
+			return false
+		}
+	}
+	return true
+}
+
+// tokenize splits a line into word tokens, double-quoted identifiers, and punctuation.
+//
+// `_` counts as a word character, which is what keeps CURRENT_TIMESTAMP from tokenizing as a
+// bare TIMESTAMP. Punctuation is emitted rather than discarded because the preceding token is
+// how a type is told apart from a column reference: `(timestamp DESC)` and `, timestamp` are
+// both column references, and only a bare identifier before it makes it a declared type.
+func tokenize(line string) []token {
+	var toks []token
+	var cur strings.Builder
+
+	flush := func() {
+		if cur.Len() > 0 {
+			toks = append(toks, token{text: cur.String()})
+			cur.Reset()
+		}
+	}
+
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case c == '"':
+			flush()
+			j := i + 1
+			for j < len(line) && line[j] != '"' {
+				j++
+			}
+			toks = append(toks, token{text: line[i+1 : min(j, len(line))], quoted: true})
+			i = j
+		case isWordByte(c):
+			cur.WriteByte(c)
+		case c == ' ' || c == '\t' || c == '\r':
+			flush()
+		default:
+			flush()
+			toks = append(toks, token{text: string(c), punct: true})
+		}
+	}
+	flush()
+	return toks
+}
+
+func isWordByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+// blankNonCode replaces the contents of -- comments, /* */ comments, '...' string literals and
+// $tag$...$tag$ dollar-quoted blocks with spaces, preserving line structure so reported line
+// numbers stay correct.
+//
+// Dollar-quoting is handled FIRST and is not optional. Every migration in this repo that uses a
+// DO block contains prose with apostrophes inside `$$ ... $$`. Without this case, the first such
+// apostrophe opens a string literal that never closes, blanking the remainder of the FILE — so
+// the lint reports nothing and exits 0 for every declaration after it. A guard whose failure
+// mode is silence is worse than no guard, because the green result is indistinguishable.
+func blankNonCode(src string) string {
+	out := []byte(src)
+	blankRegion(src, out, 0, len(src))
+	return string(out)
+}
+
+// blankRegion blanks non-code within [start,end), recursing into dollar-quoted bodies.
+//
+// A dollar-quoted body is scanned as CODE, not blanked. In this repo the conditional migrations
+// put real DDL inside `DO $$ ... $$` — migration 014 declares `alerts.acknowledged_at TIMESTAMP`
+// there — so blanking those bodies would make the lint blind to exactly the migrations that are
+// hardest to review by eye.
+//
+// Recursing is also what contains the failure. An apostrophe in prose inside a dollar-quoted
+// block (`$msg$agent's key$msg$`) still opens a phantom literal, but the region bounds it: it
+// can swallow the rest of that BLOCK and no further. Before, it silenced the rest of the FILE.
+func blankRegion(src string, out []byte, start, end int) {
+	blank := func(from, to int) {
+		for k := from; k < to && k < len(out); k++ {
+			if out[k] != '\n' {
+				out[k] = ' '
+			}
+		}
+	}
+
+	for i := start; i < end; i++ {
+		switch {
+		case src[i] == '$':
+			tag, ok := dollarTagAt(src, i)
+			if !ok {
+				continue
+			}
+			bodyStart := i + len(tag)
+			if bodyStart > end {
+				continue
+			}
+			rel := strings.Index(src[bodyStart:end], tag)
+			if rel < 0 {
+				// Unterminated within this region. Blank the delimiter and keep reading the
+				// remainder as code rather than giving up on the rest of the file.
+				blank(i, bodyStart)
+				i = bodyStart - 1
+				continue
+			}
+			bodyEnd := bodyStart + rel
+			closeEnd := bodyEnd + len(tag)
+			blank(i, bodyStart)      // opening delimiter
+			blank(bodyEnd, closeEnd) // closing delimiter
+			blankRegion(src, out, bodyStart, bodyEnd)
+			i = closeEnd - 1
+		case src[i] == '"':
+			// A double-quoted identifier is code, and its contents are not. Skip over it
+			// without interpreting them, or an identifier like "a--b" reads as a comment
+			// start and blanks the rest of the line.
+			j := i + 1
+			for j < end && src[j] != '"' {
+				j++
+			}
+			i = min(j, end-1)
+		case src[i] == '-' && i+1 < end && src[i+1] == '-':
+			j := strings.IndexByte(src[i:end], '\n')
+			if j < 0 {
+				blank(i, end)
+				return
+			}
+			blank(i, i+j)
+			i += j
+		case src[i] == '/' && i+1 < end && src[i+1] == '*':
+			j := strings.Index(src[i+2:end], "*/")
+			if j < 0 {
+				blank(i, end)
+				return
+			}
+			blank(i, i+2+j+2)
+			i += 2 + j + 1
+		case src[i] == '\'':
+			j := i + 1
+			for j < end {
+				if src[j] == '\'' {
+					// '' is an escaped quote inside the literal.
+					if j+1 < end && src[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			blank(i, min(j+1, end))
+			i = j
+		}
+	}
+}
+
+// dollarTagAt returns the dollar-quote tag starting at i, e.g. "$$" or "$body$".
+//
+// A tag is `$`, an optional identifier that must not start with a digit, then `$`. Anything
+// else beginning with `$` (a positional parameter like `$1`, or a lone `$`) is not a tag.
+func dollarTagAt(src string, i int) (string, bool) {
+	if i >= len(src) || src[i] != '$' {
+		return "", false
+	}
+	j := i + 1
+	for j < len(src) && src[j] != '$' {
+		if !isWordByte(src[j]) || (j == i+1 && src[j] >= '0' && src[j] <= '9') {
+			return "", false
+		}
+		j++
+	}
+	if j >= len(src) {
+		return "", false
+	}
+	return src[i : j+1], true
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/apps/backend/cmd/timestamptz-lint/main_test.go
+++ b/apps/backend/cmd/timestamptz-lint/main_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// The cases that matter are the ones where a naive `grep -i timestamp` gets it wrong.
+// This repo really does have a column named `timestamp` (audit_logs), migration headers
+// really do discuss the word in prose, and migration 106's postcondition really does query
+// for the string literal 'timestamp without time zone'. A lint that fires on any of those
+// gets disabled within a week.
+func TestScanSQL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want int
+	}{
+		// --- must flag ---
+		{
+			name: "bare TIMESTAMP column",
+			sql:  `CREATE TABLE t (created_at TIMESTAMP NOT NULL DEFAULT NOW());`,
+			want: 1,
+		},
+		{
+			name: "explicit WITHOUT TIME ZONE",
+			sql:  `CREATE TABLE t (created_at TIMESTAMP WITHOUT TIME ZONE);`,
+			want: 1,
+		},
+		{
+			name: "lowercase bare timestamp",
+			sql:  `ALTER TABLE t ADD COLUMN expires_at timestamp;`,
+			want: 1,
+		},
+		{
+			name: "ADD COLUMN IF NOT EXISTS, the shape migration 065 used",
+			sql:  `ALTER TABLE agents ADD COLUMN IF NOT EXISTS pqc_key_expires_at TIMESTAMP;`,
+			want: 1,
+		},
+		{
+			name: "two naked columns on separate lines",
+			sql: `CREATE TABLE t (
+				a TIMESTAMP,
+				b TIMESTAMP
+			);`,
+			want: 2,
+		},
+
+		// --- must NOT flag ---
+		{
+			name: "TIMESTAMPTZ",
+			sql:  `CREATE TABLE t (created_at TIMESTAMPTZ NOT NULL DEFAULT NOW());`,
+			want: 0,
+		},
+		{
+			name: "TIMESTAMP WITH TIME ZONE spelled long",
+			sql:  `CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);`,
+			want: 0,
+		},
+		{
+			name: "CURRENT_TIMESTAMP default",
+			sql:  `CREATE TABLE t (created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP);`,
+			want: 0,
+		},
+		{
+			name: "column named timestamp, correctly typed — the audit_logs case",
+			sql:  `CREATE TABLE audit_logs (timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW());`,
+			want: 0,
+		},
+		{
+			name: "quoted identifier named timestamp",
+			sql:  `ALTER TABLE audit_logs ALTER COLUMN "timestamp" TYPE timestamptz;`,
+			want: 0,
+		},
+		{
+			name: "index on a column named timestamp",
+			sql:  `CREATE INDEX idx_audit_logs_timestamp ON audit_logs USING btree ("timestamp" DESC);`,
+			want: 0,
+		},
+		{
+			name: "line comment discussing TIMESTAMP in prose",
+			sql:  `-- A naked TIMESTAMP column drops the offset; use TIMESTAMPTZ instead.`,
+			want: 0,
+		},
+		{
+			name: "block comment discussing TIMESTAMP in prose",
+			sql:  "/* migration notes: TIMESTAMP columns were converted here.\n   TIMESTAMP again. */",
+			want: 0,
+		},
+		{
+			name: "string literal naming the type — migration 106's postcondition",
+			sql:  `SELECT count(*) FROM information_schema.columns WHERE data_type = 'timestamp without time zone';`,
+			want: 0,
+		},
+		{
+			name: "SET LOCAL TimeZone",
+			sql:  `SET LOCAL TimeZone = 'UTC';`,
+			want: 0,
+		},
+		{
+			name: "trailing comment after a valid declaration",
+			sql:  `created_at TIMESTAMPTZ NOT NULL, -- was TIMESTAMP before migration 106`,
+			want: 0,
+		},
+
+		// --- bypasses found by adversarial review; each was a miss before the fix, and each
+		// --- is red-proofed by a mutation that reverts exactly the property it guards ---
+		{
+			// The earlier rule looked FORWARD for a type keyword to spot a column named
+			// `timestamp`. On this line that swallowed the real naked declaration entirely.
+			name: "naked column on the same line as a column NAMED timestamp",
+			sql:  `CREATE TABLE audit2 (created_at TIMESTAMP, timestamp TIMESTAMPTZ NOT NULL);`,
+			want: 1,
+		},
+		{
+			// Migration 014 declares alerts.acknowledged_at exactly this way. Blanking
+			// dollar-quoted bodies as if they were string data made it invisible.
+			name: "DDL inside a DO block is real code and must be scanned",
+			sql: `DO $$ BEGIN
+    ALTER TABLE alerts ADD COLUMN acknowledged_at TIMESTAMP;
+END $$;`,
+			want: 1,
+		},
+		{
+			// An apostrophe inside a dollar-quoted block used to open a phantom string
+			// literal that ran to EOF, silencing every later declaration in the file.
+			name: "apostrophe inside a dollar-quoted block does not silence what follows",
+			sql: `DO $mig$ BEGIN RAISE NOTICE $msg$agent's key rotated$msg$; END $mig$;
+ALTER TABLE agents ADD COLUMN key_rotated_at TIMESTAMP NOT NULL DEFAULT NOW();`,
+			want: 1,
+		},
+		{
+			name: "ALTER COLUMN ... TYPE TIMESTAMP is one finding, not two",
+			sql:  `ALTER TABLE t ALTER COLUMN x TYPE TIMESTAMP;`,
+			want: 1,
+		},
+		{
+			// A column reference inside an index definition is not a type declaration.
+			// This exact line exists at migrations/001_initial_schema.sql:130.
+			name: "unquoted column reference named timestamp in an index",
+			sql:  `CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp ON audit_logs(timestamp DESC);`,
+			want: 0,
+		},
+		{
+			name: "double-quoted identifier containing a comment marker",
+			sql:  `CREATE INDEX ix ON t ("a--b"); ALTER TABLE u ADD COLUMN c TIMESTAMP;`,
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanSQL("test.sql", tt.sql)
+			if len(got) != tt.want {
+				t.Errorf("scanSQL() = %d finding(s), want %d\nSQL: %s\nfindings: %+v",
+					len(got), tt.want, tt.sql, got)
+			}
+		})
+	}
+}
+
+// A column declared naked on a multi-line CREATE TABLE must be reported on its own line, or
+// the finding sends the reader to the wrong place in a 200-line migration.
+func TestScanSQLReportsCorrectLine(t *testing.T) {
+	sql := `-- header comment
+CREATE TABLE t (
+    id UUID PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMP
+);`
+	got := scanSQL("test.sql", sql)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 5 {
+		t.Errorf("finding reported on line %d, want 5", got[0].Line)
+	}
+	if !strings.Contains(got[0].Text, "expires_at") {
+		t.Errorf("finding text %q does not name the offending column", got[0].Text)
+	}
+}
+
+// The migration this lint shipped alongside must itself pass — it converts naked columns and
+// legitimately mentions the type in prose, in a string literal, and as a quoted identifier.
+func TestMigration106IsClean(t *testing.T) {
+	got := scanDirOrSkip(t, "../../migrations")
+	for _, f := range got {
+		if strings.Contains(f.File, "106_convert_naked_timestamps") {
+			t.Errorf("migration 106 flagged itself at line %d: %s", f.Line, f.Text)
+		}
+	}
+}
+
+// A finding carries a source excerpt so the reader can see the offending declaration. Carrying
+// the WHOLE line means a long line with many declarations amplifies quadratically — measured at
+// 8.8 GB of output from a 440 KB one-line file with 20,000 declarations, which fills a CI
+// runner's disk while the lint itself finishes in under two seconds.
+//
+// The bound is asserted from both sides: the total output must stay far below the input's own
+// worst case, AND each excerpt must be individually bounded. Asserting only a total would pass
+// against a build that truncated to 10 KB per finding.
+func TestFindingExcerptIsBounded(t *testing.T) {
+	const declarations = 2000
+	line := strings.Repeat("created_at TIMESTAMP, ", declarations)
+
+	got := scanSQL("long.sql", line)
+	if len(got) != declarations {
+		t.Fatalf("expected %d findings, got %d", declarations, len(got))
+	}
+
+	total := 0
+	for i, f := range got {
+		if len(f.Text) > maxFindingTextLen+len("… (line truncated)") {
+			t.Fatalf("finding %d carries a %d-byte excerpt; bound is %d",
+				i, len(f.Text), maxFindingTextLen)
+		}
+		total += len(f.Text)
+	}
+
+	// Pre-fix this is declarations * len(line) — about 88 MB for these inputs. Post-fix it is
+	// declarations * ~200. The bound sits between the two so removing the truncation fails it.
+	untruncated := declarations * len(line)
+	if total >= untruncated/10 {
+		t.Errorf("total excerpt bytes %d is not meaningfully below the untruncated %d;"+
+			" the excerpt bound is not being applied", total, untruncated)
+	}
+}
+
+// The excerpt must say that it was shortened. A silently truncated line reads as the whole
+// declaration and sends the reader looking for a syntax error that is not there.
+func TestTruncatedExcerptIsMarked(t *testing.T) {
+	long := "created_at TIMESTAMP" + strings.Repeat(" /*pad*/", 200)
+	got := scanSQL("long.sql", long)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "truncated") {
+		t.Errorf("excerpt was shortened without saying so: %q", got[0].Text)
+	}
+
+	short := "created_at TIMESTAMP;"
+	got = scanSQL("short.sql", short)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got))
+	}
+	if strings.Contains(got[0].Text, "truncated") {
+		t.Errorf("a short line must not be marked truncated: %q", got[0].Text)
+	}
+}
+
+// The baseline suppresses a COUNT per location, not a location. Treating it as a set let a
+// baselined line grow a second naked declaration with the baseline file unchanged — the guard
+// reporting success on a brand-new defect, which is the worst failure a guard can have.
+func TestBaselineDoesNotMaskAnAdditionalFindingOnABaselinedLine(t *testing.T) {
+	dir := t.TempDir()
+	sql := "CREATE TABLE t (\n    created_at TIMESTAMP NOT NULL, secret_rotated_at TIMESTAMP NOT NULL\n);\n"
+	if err := os.WriteFile(filepath.Join(dir, "090_probe.sql"), []byte(sql), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := scanDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("fixture must produce 2 findings on one line, got %d: %+v", len(found), found)
+	}
+	loc := found[0].BaselineKey()
+	if found[1].BaselineKey() != loc {
+		t.Fatalf("fixture must put both findings on the same line, got %s and %s",
+			loc, found[1].BaselineKey())
+	}
+
+	// A baseline recording ONE finding at that location must still report the second.
+	baselinePath := filepath.Join(dir, "baseline.txt")
+	if err := os.WriteFile(baselinePath, []byte(loc+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := loadBaseline(baselinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := baseline[loc]; got != 1 {
+		t.Fatalf("baseline should record 1 allowance for %s, got %d", loc, got)
+	}
+
+	// Exercise the REAL filter, not a copy of it. An inline re-implementation here would stay
+	// green while the shipped binary regressed to set semantics.
+	reported := applyBaseline(found, baseline)
+	if len(reported) != 1 {
+		t.Errorf("a second naked declaration on a baselined line must be reported; got %d (%+v)",
+			len(reported), reported)
+	}
+}
+
+// The baseline must cover the historical declarations exactly, with nothing left over. An entry
+// with no matching finding is an allowance sitting idle, ready to absorb a future defect.
+func TestHistoricalBaselineMatchesTheTreeExactly(t *testing.T) {
+	found := scanDirOrSkip(t, "../../migrations")
+	baseline, err := loadBaseline("historical-baseline.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counts := map[string]int{}
+	for _, f := range found {
+		counts[f.BaselineKey()]++
+	}
+
+	for loc, want := range baseline {
+		if counts[loc] != want {
+			t.Errorf("baseline allows %d finding(s) at %s but the tree has %d;"+
+				" a stale baseline entry can absorb a future defect", want, loc, counts[loc])
+		}
+	}
+	for loc, got := range counts {
+		if baseline[loc] != got {
+			t.Errorf("tree has %d finding(s) at %s but the baseline records %d",
+				got, loc, baseline[loc])
+		}
+	}
+}
+
+func scanDirOrSkip(t *testing.T, dir string) []finding {
+	t.Helper()
+	got, err := scanDir(dir)
+	if err != nil {
+		t.Skipf("cannot scan %s: %v", dir, err)
+	}
+	return got
+}
+
+// A byte-slice truncation splits multi-byte runes and emits a lone continuation byte, making
+// the tool's whole output invalid UTF-8 and breaking any strict consumer (JSON encoders, CI
+// annotation parsers). 16 migration files already contain non-ASCII, so this is reachable.
+func TestTruncatedExcerptStaysValidUTF8(t *testing.T) {
+	// Place an em dash (3 bytes) so that it straddles the truncation boundary.
+	for pad := maxFindingTextLen - 4; pad <= maxFindingTextLen+2; pad++ {
+		line := "created_at TIMESTAMP " + strings.Repeat("x", pad) + "—tail"
+		got := scanSQL("utf8.sql", line)
+		if len(got) != 1 {
+			t.Fatalf("pad=%d: expected 1 finding, got %d", pad, len(got))
+		}
+		if !utf8.ValidString(got[0].Text) {
+			t.Errorf("pad=%d: excerpt is not valid UTF-8: %q", pad, got[0].Text)
+		}
+	}
+}

--- a/apps/backend/internal/infrastructure/repository/naked_timestamp_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/naked_timestamp_integration_test.go
@@ -1,0 +1,290 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for migration 106 — `timestamp without time zone` columns losing the
+// writing process's UTC offset.
+//
+// `lib/pq` sends a Go `time.Time` as its wall clock. A naked `timestamp` column drops the
+// offset; on read `lib/pq` labels the value UTC. The instant therefore shifts by the writer's
+// offset, and east of UTC an API key stays valid past its stated expiry by exactly that much.
+//
+// There are two independent paths to the same corruption and the tests below cover one each:
+//
+//	axis (a) the Go process zone — a `time.Time` carried into the INSERT
+//	axis (b) the PostgreSQL session zone — `DEFAULT NOW()` and migration 092's
+//	         `NEW.verified_at := NOW()` trigger, neither of which any Go code touches
+//
+// Axis (b) is why the fix is the column type and not a `.UTC()` sweep at the write sites:
+// no amount of Go-side discipline reaches a `DEFAULT NOW()`.
+//
+// The existing TestAgentRevocation_APIKeyMiddlewareEnforcesKeyFields deliberately sidesteps
+// this bug by calling `.UTC()` before writing, and documents why. These tests are the ones
+// that do not sidestep it.
+//
+// Red-proof: all three fail against the schema at migration 105 and pass at 106. Verified by
+// running them at both revisions, not by inspection.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL with migrations
+// through 106 applied.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run NakedTimestamp ./internal/infrastructure/repository/...
+
+// zoneEastOfUTC is the security-relevant direction: a credential written here outlives its
+// stated expiry by the offset. Asia/Tokyo is +09:00 year-round, so the test does not depend
+// on when it runs relative to a DST boundary.
+const zoneEastOfUTC = "Asia/Tokyo"
+
+func openNakedTimestampTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping naked timestamp integration test")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	return db
+}
+
+// seedOrgUserAgent creates the FK chain api_keys requires and registers its teardown.
+func seedOrgUserAgent(t *testing.T, db *sql.DB, ctx context.Context, label string) (orgID, userID, agentID uuid.UUID) {
+	t.Helper()
+
+	orgID, userID, agentID = uuid.New(), uuid.New(), uuid.New()
+	suffix := agentID.String()[:8]
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM api_keys WHERE agent_id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, label+"-org-"+suffix, label+"-"+suffix+".test")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'test', $5, NOW(), NOW())`,
+		userID, orgID, label+"-"+suffix+"@test.invalid", label+"-user", label+"-"+suffix)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, agent_type, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'service', $5, NOW(), NOW())`,
+		agentID, orgID, label+"-agent-"+suffix, label+"-agent", userID)
+	require.NoError(t, err)
+
+	return orgID, userID, agentID
+}
+
+// TestNakedTimestampSchemaHasNoNakedTimestampColumns is the invariant that keeps the class
+// closed. The convention "TIMESTAMPTZ always, never TIMESTAMP" already existed in the CA
+// charter and migrations 065, 090 and 101 each violated it anyway, so it is asserted here
+// rather than left to review.
+//
+// This is the database half of the guard. cmd/timestamptz-lint is the source half; it catches
+// a naked column in a migration file before it is ever applied. Both are needed: the lint
+// cannot see a column that entered through a path other than this repo's migrations.
+func TestNakedTimestampSchemaHasNoNakedTimestampColumns(t *testing.T) {
+	db := openNakedTimestampTestDB(t)
+	ctx := context.Background()
+
+	// pg_attribute, not information_schema.columns, for the same two reasons migration 106's
+	// postcondition uses it: information_schema is privilege-filtered (the identical schema
+	// returned 5 rows as superuser and 0 as a dedicated migration role), and it reports an
+	// array column's data_type as 'ARRAY', so `timestamp[]` is invisible to a data_type
+	// comparison. Checking atttypid also reaches matviews, views and composite types.
+	rows, err := db.QueryContext(ctx,
+		`SELECT n.nspname || '.' || c.relname || '.' || a.attname
+		   FROM pg_attribute a
+		   JOIN pg_class c     ON c.oid = a.attrelid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		   JOIN pg_type ty     ON ty.oid = a.atttypid
+		  WHERE a.attnum > 0
+		    AND NOT a.attisdropped
+		    -- Direct naked timestamp, or a DOMAIN over one: a domain column's atttypid is the
+		    -- domain's OID, so comparing atttypid alone would miss CREATE DOMAIN d AS TIMESTAMP.
+		    AND (
+		          a.atttypid IN ('pg_catalog.timestamp'::regtype, 'pg_catalog.timestamp[]'::regtype)
+		       OR (ty.typtype = 'd'
+		           AND ty.typbasetype IN ('pg_catalog.timestamp'::regtype,
+		                                  'pg_catalog.timestamp[]'::regtype))
+		    )
+		    AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+		    -- Exclude temp relations: the integration packages share one database and
+		    -- fga_engine_pq_integration_test.go creates a TEMP TABLE, so without this the
+		    -- assertion fails or passes depending on test interleaving.
+		    AND c.relpersistence <> 't'
+		    AND c.relkind IN ('r', 'p', 'm', 'v', 'f', 'c')
+		    AND NOT EXISTS (
+		        SELECT 1 FROM pg_depend d
+		         WHERE d.classid = 'pg_class'::regclass
+		           AND d.objid = c.oid AND d.deptype = 'e'
+		    )
+		  ORDER BY 1`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var offenders []string
+	for rows.Next() {
+		var col string
+		require.NoError(t, rows.Scan(&col))
+		offenders = append(offenders, col)
+	}
+	require.NoError(t, rows.Err())
+
+	require.Emptyf(t, offenders,
+		"%d column(s) are `timestamp without time zone`: %v\n"+
+			"Every timestamp column must be TIMESTAMPTZ. A naked timestamp silently shifts the "+
+			"stored instant by the writing process's UTC offset (and, for DEFAULT NOW(), by the "+
+			"PostgreSQL session's). Add the column as TIMESTAMPTZ, or convert it the way "+
+			"migration 106 does.",
+		len(offenders), offenders)
+}
+
+// TestNakedTimestampAPIKeyExpiryRoundTripFromNonUTCZone covers axis (a): a Go `time.Time` in a
+// non-UTC location carried into the INSERT.
+//
+// This is the write path api_key_service.CreateAPIKey uses — it computes
+// `time.Now().AddDate(0, 0, expiresInDays)`, which carries the process's zone.
+func TestNakedTimestampAPIKeyExpiryRoundTripFromNonUTCZone(t *testing.T) {
+	db := openNakedTimestampTestDB(t)
+	ctx := context.Background()
+
+	orgID, userID, agentID := seedOrgUserAgent(t, db, ctx, "naked-ts-expiry")
+
+	loc, err := time.LoadLocation(zoneEastOfUTC)
+	require.NoError(t, err)
+
+	// One instant, expressed in a zone east of UTC. Whole seconds so the assertion cannot
+	// trip on Postgres storing microseconds against Go's nanoseconds.
+	intended := time.Date(2027, 3, 14, 9, 26, 53, 0, time.UTC)
+	expiresAt := intended.In(loc)
+
+	// Precondition: the value really is offset from UTC, or the test proves nothing.
+	_, offsetSeconds := expiresAt.Zone()
+	require.NotZero(t, offsetSeconds,
+		"precondition: %s must have a non-zero UTC offset for this test to exercise the bug",
+		zoneEastOfUTC)
+
+	keyID := uuid.New()
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO api_keys (id, organization_id, agent_id, name, key_hash, prefix, expires_at, created_by)
+		 VALUES ($1, $2, $3, 'naked-ts-expiry-key', $4, 'aim_live_naked', $5, $6)`,
+		keyID, orgID, agentID, keyID.String(), expiresAt, userID)
+	require.NoError(t, err)
+
+	var readBack time.Time
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT expires_at FROM api_keys WHERE id = $1`, keyID).Scan(&readBack))
+
+	require.Truef(t, readBack.Equal(intended),
+		"expires_at came back as a different instant than it was written as.\n"+
+			"  wrote  : %s (%s, offset %+d)\n"+
+			"  intended: %s\n"+
+			"  read back: %s\n"+
+			"  drift  : %s\n"+
+			"A key written east of UTC stays valid past its stated expiry by the offset, at the "+
+			"`time.Now().After(*apiKey.ExpiresAt)` check in api_key_service.go.",
+		expiresAt.Format(time.RFC3339), zoneEastOfUTC, offsetSeconds/3600,
+		intended.Format(time.RFC3339), readBack.UTC().Format(time.RFC3339),
+		readBack.Sub(intended))
+}
+
+// TestNakedTimestampDefaultNowRoundTripUnderNonUTCSession covers axis (b): no Go time value is
+// involved at all. The column default supplies the value, and it is cast under the PostgreSQL
+// *session* zone.
+//
+// cmd/server/main.go builds its DSN with no TimeZone parameter, so a self-hoster whose
+// PostgreSQL defaults to a local zone hits this with entirely stock configuration. A `.UTC()`
+// sweep at the Go write sites would not have moved this test.
+func TestNakedTimestampDefaultNowRoundTripUnderNonUTCSession(t *testing.T) {
+	db := openNakedTimestampTestDB(t)
+	ctx := context.Background()
+
+	// Pin one connection: SET TIME ZONE is per-session, and database/sql would otherwise
+	// hand the INSERT to a different pooled connection than the SET.
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var restore string
+	require.NoError(t, conn.QueryRowContext(ctx, `SHOW TimeZone`).Scan(&restore))
+	_, err = conn.ExecContext(ctx, `SET TIME ZONE `+quoteLiteral(zoneEastOfUTC))
+	require.NoError(t, err)
+	defer func() { _, _ = conn.ExecContext(ctx, `SET TIME ZONE `+quoteLiteral(restore)) }()
+
+	var sessionTZ string
+	require.NoError(t, conn.QueryRowContext(ctx, `SHOW TimeZone`).Scan(&sessionTZ))
+	require.Equalf(t, zoneEastOfUTC, sessionTZ,
+		"precondition: the session zone must actually be %s for this test to exercise the bug",
+		zoneEastOfUTC)
+
+	orgID := uuid.New()
+	suffix := orgID.String()[:8]
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	before := time.Now().UTC()
+	// created_at is NOT in the column list: the DEFAULT NOW() supplies it.
+	_, err = conn.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, updated_at)
+		 VALUES ($1, $2, $3, NOW())`,
+		orgID, "naked-ts-defaultnow-org-"+suffix, "naked-ts-defaultnow-"+suffix+".test")
+	require.NoError(t, err)
+	after := time.Now().UTC()
+
+	var readBack time.Time
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT created_at FROM organizations WHERE id = $1`, orgID).Scan(&readBack))
+
+	require.Truef(t,
+		!readBack.Before(before.Add(-time.Minute)) && !readBack.After(after.Add(time.Minute)),
+		"created_at from DEFAULT NOW() came back outside the window in which it was written.\n"+
+			"  session zone : %s\n"+
+			"  window       : %s .. %s\n"+
+			"  read back    : %s\n"+
+			"  drift        : %s\n"+
+			"No Go time value was involved — the column default was cast under the session zone. "+
+			"This is the path a `.UTC()` sweep at the write sites cannot reach.",
+		sessionTZ, before.Format(time.RFC3339), after.Format(time.RFC3339),
+		readBack.UTC().Format(time.RFC3339), readBack.Sub(before))
+}
+
+// quoteLiteral wraps a zone name as a SQL string literal. SET TIME ZONE takes no placeholder,
+// and the values here are test constants rather than user input, but doubling any quote keeps
+// the helper from being a copy-paste injection footgun later.
+func quoteLiteral(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	out = append(out, '\'')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\'')
+		}
+		out = append(out, s[i])
+	}
+	return string(append(out, '\''))
+}

--- a/apps/backend/migrations/106_convert_naked_timestamps_to_timestamptz.sql
+++ b/apps/backend/migrations/106_convert_naked_timestamps_to_timestamptz.sql
@@ -1,0 +1,261 @@
+-- Migration 106: convert every `timestamp without time zone` column to `timestamptz`.
+--
+-- WHY
+-- ---
+-- `lib/pq` sends a Go `time.Time` as its wall clock. A `timestamp` column drops the offset,
+-- and on read `lib/pq` labels the naked value UTC. The instant therefore shifts by the writing
+-- process's UTC offset. Measured with the repo's pinned lib/pq v1.10.9 on PostgreSQL 16,
+-- writing one intended instant (2026-08-06T12:00:00Z) from four process zones:
+--
+--   process zone     offset   read back (naked)      read back (timestamptz)  drift
+--   Etc/UTC          +0       2026-08-06T12:00:00Z   2026-08-06T12:00:00Z     +0h
+--   Europe/Berlin    +2       2026-08-06T14:00:00Z   2026-08-06T12:00:00Z     +2h
+--   Asia/Tokyo       +9       2026-08-06T21:00:00Z   2026-08-06T12:00:00Z     +9h
+--   America/Denver   -6       2026-08-06T06:00:00Z   2026-08-06T12:00:00Z     -6h
+--
+-- East of UTC an API key stays valid past its stated expiry by the offset, at the
+-- `time.Now().After(*apiKey.ExpiresAt)` check in api_key_service.go. West of UTC it expires
+-- early. A `timestamptz` column is correct in every zone.
+--
+-- `api_keys.expires_at` is the only converted column where a wrong instant changes an ACCESS
+-- DECISION. Stating the other named columns precisely, because it is easy to overclaim here:
+--   * `agents.pqc_key_expires_at` is NOT read by EnforceKeyExpiry -- that reads
+--     `agent.KeyExpiresAt`, i.e. `key_expires_at`, which was already timestamptz. The naked
+--     column reaches three JSON responses and no enforcement path.
+--   * `agent_capabilities.revoked_at` is enforced only as `revoked_at IS NULL`, which is
+--     zone-independent. The stored instant was wrong for audit and display, not for access.
+--   * `audit_logs.timestamp` is an evidentiary-integrity problem: the recorded time of an
+--     audited action depended on the writer's zone.
+--
+-- There is a second, independent path that no amount of Go-side discipline reaches: the
+-- PostgreSQL *session* zone. The DSN sets no TimeZone, so every `DEFAULT NOW()` on these
+-- columns -- and migration 092's `NEW.verified_at := NOW()` trigger -- casts a timestamptz
+-- into a naked column under whatever zone the operator's session has. Converting the column
+-- type is the only fix that closes both paths.
+--
+-- SCOPE
+-- -----
+-- All 42 naked columns, not a security-semantic subset. The boundary is the column TYPE, not
+-- its name: a name-based predicate over expires/revoked/grace finds only 3 of the 42 and misses
+-- `audit_logs.timestamp`, `agent_capabilities.granted_at` and `agents.verified_at`.
+--
+-- EXISTING ROWS
+-- -------------
+-- The conversion reinterprets each stored wall-clock value as UTC. For rows written by a
+-- process at UTC that preserves the instant exactly; for rows written at an offset it adopts
+-- the shifted instant that the application was already reading back. Operators can check their
+-- own data before running this -- `agents` writes one timestamptz and one naked column from the
+-- same clock in a single INSERT, so any historical drift is visible directly:
+--
+--   SELECT count(*) AS rows_checked,
+--          max(abs(extract(epoch FROM
+--            ((pqc_key_created_at AT TIME ZONE 'UTC') - key_created_at)))) AS max_drift_seconds
+--   FROM agents
+--   WHERE pqc_key_created_at IS NOT NULL AND key_created_at IS NOT NULL;
+--
+-- A `rows_checked` of 0 means the probe proved nothing -- it is not a pass. Drift under a
+-- minute means the rows were written at UTC and the reinterpretation is exact.
+--
+-- FORM
+-- ----
+-- The implicit cast under a UTC session does not rewrite the TABLE HEAP: verified by comparing
+-- `pg_class.relfilenode` before and after on all affected tables at 5,000,000 rows (unchanged).
+-- The `USING col AT TIME ZONE 'UTC'` spelling produces identical values but forces a full heap
+-- rewrite (relfilenode changes), so it is not used here.
+--
+-- INDEXES ON A CONVERTED COLUMN ARE STILL REBUILT, and that is the real cost. 20 indexes touch
+-- these columns. Measured at 2,000,000 rows: the ALTER takes 0.33 ms with no index on the
+-- column and 238 ms with one btree -- i.e. the cost is an index build, and it scales with the
+-- table. Every ACCESS EXCLUSIVE lock is held until COMMIT, so all the tables below are locked
+-- for as long as the slowest index rebuild takes. `lock_timeout` bounds how long we WAIT for a
+-- lock, not how long we hold one.
+--
+-- `SET LOCAL TimeZone` below is load-bearing, not cosmetic. Under a session at, say,
+-- America/Denver the same implicit cast silently converts a stored `12:00:00` to the instant
+-- `18:00:00Z` -- six hours wrong, no error raised. The assertion that follows turns that silent
+-- corruption into a hard abort. Both the correctness of the cast and the no-rewrite
+-- optimization depend on the session being UTC.
+--
+-- No BEGIN/COMMIT here: cmd/migrate/main.go and cmd/server's runMigrations both run each
+-- migration inside one transaction, which is also what scopes the SET LOCAL statements below.
+--
+-- RUN THIS THROUGH ONE OF THOSE RUNNERS. Applied by hand with `psql -f` and no explicit
+-- transaction, every guarantee above inverts: `SET LOCAL` outside a transaction is a no-op that
+-- only WARNs, the assertion's EXCEPTION does not stop the script without ON_ERROR_STOP, and a
+-- failing postcondition cannot roll back statements that already autocommitted. If you must run
+-- it manually, use `psql -v ON_ERROR_STOP=1 --single-transaction`.
+
+SET LOCAL TimeZone = 'UTC';
+
+-- Fail fast rather than queueing an ACCESS EXCLUSIVE request in front of every subsequent
+-- read and write to these tables. A pending lock behind one long-running SELECT on audit_logs
+-- would stall audit writes and saturate the connection pool. Timing out is retryable; that is
+-- not.
+SET LOCAL lock_timeout = '5s';
+
+-- `SET LOCAL` outside a transaction is a no-op that raises only a WARNING. If that ever
+-- happens, the casts below would silently reinterpret every value in the ambient zone.
+DO $$
+BEGIN
+    IF current_setting('TimeZone') <> 'UTC' THEN
+        RAISE EXCEPTION
+            'migration 106 requires the session TimeZone to be UTC, got %. '
+            'Values would be reinterpreted in the wrong zone.', current_setting('TimeZone');
+    END IF;
+END $$;
+
+ALTER TABLE agent_actions
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE agent_behavioral_baselines
+    ALTER COLUMN baseline_period_end   TYPE timestamptz,
+    ALTER COLUMN baseline_period_start TYPE timestamptz,
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz;
+
+ALTER TABLE agent_capabilities
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN granted_at            TYPE timestamptz,
+    ALTER COLUMN revoked_at            TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz;
+
+ALTER TABLE agent_compliance_events
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE agent_health_checks
+    ALTER COLUMN check_time            TYPE timestamptz,
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE agent_user_feedback
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE agents
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN last_active           TYPE timestamptz,
+    ALTER COLUMN pqc_key_created_at    TYPE timestamptz,
+    ALTER COLUMN pqc_key_expires_at    TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz,
+    ALTER COLUMN verified_at           TYPE timestamptz;
+
+ALTER TABLE alerts
+    ALTER COLUMN acknowledged_at       TYPE timestamptz,
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE api_keys
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN expires_at            TYPE timestamptz,
+    ALTER COLUMN last_used_at          TYPE timestamptz;
+
+ALTER TABLE audit_logs
+    ALTER COLUMN "timestamp"           TYPE timestamptz;
+
+ALTER TABLE capability_violations
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE isolation_attestations
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN reported_at           TYPE timestamptz;
+
+ALTER TABLE nanomind_tme_evaluations
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN evaluated_at          TYPE timestamptz;
+
+ALTER TABLE organizations
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz;
+
+ALTER TABLE trust_scores
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN last_calculated       TYPE timestamptz;
+
+ALTER TABLE user_feedback
+    ALTER COLUMN created_at            TYPE timestamptz;
+
+ALTER TABLE user_registration_requests
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN requested_at          TYPE timestamptz,
+    ALTER COLUMN reviewed_at           TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz;
+
+ALTER TABLE users
+    ALTER COLUMN created_at            TYPE timestamptz,
+    ALTER COLUMN last_login_at         TYPE timestamptz,
+    ALTER COLUMN updated_at            TYPE timestamptz;
+
+-- The migration bookkeeping table itself. The two runners disagreed about its type:
+-- cmd/migrate creates `applied_at TIMESTAMPTZ`, but cmd/server (the container's CMD, which
+-- auto-migrates at boot) created it naked. So on every container-bootstrapped deployment this
+-- column is `timestamp without time zone`, and the postcondition below would abort the whole
+-- migration on exactly the deployments that matter most.
+--
+-- `CREATE TABLE IF NOT EXISTS` never changes an existing table, so cmd/server's corrected DDL
+-- only helps brand-new databases; this statement is what fixes the ones already out there.
+-- Converting the table we are about to INSERT into is safe: the same transaction already holds
+-- the lock, and on a database created by cmd/migrate this is a no-op.
+ALTER TABLE schema_migrations
+    ALTER COLUMN applied_at            TYPE timestamptz;
+
+-- The statements above are enumerated against this repo's schema. A deployment carrying extra
+-- tables -- aim-cloud's superset, or a self-hoster's own -- may hold naked columns this file
+-- does not name. Abort rather than half-converting: a partially converted schema is the state
+-- this migration exists to eliminate.
+--
+-- This reads pg_attribute rather than information_schema.columns, for two reasons that were
+-- both measured rather than assumed:
+--
+--   1. information_schema is PRIVILEGE-FILTERED. It shows only objects the current role has
+--      some privilege on, so the same query returned 5 rows as superuser and 0 rows as a
+--      dedicated migration role against an identical schema. The guard would have passed
+--      silently in precisely the case it exists for -- extra tables owned by another role.
+--   2. information_schema.columns reports an array column's data_type as 'ARRAY', so a
+--      `timestamp without time zone[]` column is invisible to a data_type comparison.
+--
+-- Checking atttypid directly against both the scalar and array types is privilege-independent
+-- and also reaches matviews, views, foreign tables and standalone composite types. Objects
+-- owned by an extension are excluded: their schema is the extension's business, not ours.
+DO $$
+DECLARE
+    remaining int;
+    offenders text;
+BEGIN
+    SELECT count(*),
+           coalesce(string_agg(n.nspname || '.' || c.relname || '.' || a.attname,
+                               ', ' ORDER BY n.nspname, c.relname, a.attname), '')
+      INTO remaining, offenders
+      FROM pg_attribute a
+      JOIN pg_class c     ON c.oid = a.attrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_type ty     ON ty.oid = a.atttypid
+     WHERE a.attnum > 0
+       AND NOT a.attisdropped
+       -- Direct naked timestamp, or a DOMAIN over one. A domain's atttypid is the domain's own
+       -- OID, so comparing atttypid alone would let `CREATE DOMAIN d AS TIMESTAMP` through --
+       -- and that is the one shape the source lint also misses, so the guard would have no
+       -- half covering it.
+       AND (
+             a.atttypid IN ('pg_catalog.timestamp'::regtype, 'pg_catalog.timestamp[]'::regtype)
+          OR (ty.typtype = 'd'
+              AND ty.typbasetype IN ('pg_catalog.timestamp'::regtype,
+                                     'pg_catalog.timestamp[]'::regtype))
+       )
+       AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+       -- Another session's TEMP table is visible in pg_class and lives in a pg_temp_N schema.
+       -- Without this, the migration aborts based on what unrelated sessions happen to be
+       -- doing, and names a schema the operator cannot inspect.
+       AND c.relpersistence <> 't'
+       AND c.relkind IN ('r', 'p', 'm', 'v', 'f', 'c')
+       -- pg_depend.objid is only meaningful together with its classid; without the filter any
+       -- extension-owned function or type whose OID happens to equal a table's OID would
+       -- silently exempt that table.
+       AND NOT EXISTS (
+           SELECT 1 FROM pg_depend d
+            WHERE d.classid = 'pg_class'::regclass
+              AND d.objid = c.oid
+              AND d.deptype = 'e'
+       );
+
+    IF remaining <> 0 THEN
+        RAISE EXCEPTION
+            'migration 106 left % naked timestamp column(s): %', remaining, offenders;
+    END IF;
+END $$;


### PR DESCRIPTION
## The defect

A `timestamp without time zone` column drops the writer's UTC offset. `lib/pq` sends a Go `time.Time` as its wall clock, Postgres discards the offset, and on read `lib/pq` labels the naked value UTC — so the stored instant shifts by the writing process's offset.

Measured with the repo's pinned `lib/pq v1.10.9` on PostgreSQL 16, writing one intended instant (`2026-08-06T12:00:00Z`) from four process zones into a naked column and a `timestamptz` control in the same INSERT:

| process zone | offset | read back (naked) | read back (tz control) | drift |
|---|---|---|---|---|
| `Etc/UTC` | +0 | `2026-08-06T12:00:00Z` | `2026-08-06T12:00:00Z` | +0h |
| `Europe/Berlin` | +2 | `2026-08-06T14:00:00Z` | `2026-08-06T12:00:00Z` | **+2h** |
| `Asia/Tokyo` | +9 | `2026-08-06T21:00:00Z` | `2026-08-06T12:00:00Z` | **+9h** |
| `America/Denver` | -6 | `2026-08-06T06:00:00Z` | `2026-08-06T12:00:00Z` | -6h |

East of UTC an API key stays valid past its stated expiry by the offset, at the `time.Now().After(*apiKey.ExpiresAt)` check in `api_key_service.go`. West of UTC it expires early.

**Being exact about impact**, because it is easy to overclaim: `api_keys.expires_at` is the only converted column where a wrong instant changes an access decision. `audit_logs.timestamp` is evidentiary. `agent_capabilities.revoked_at` is enforced only as `revoked_at IS NULL`, which is zone-independent. `agents.pqc_key_expires_at` reaches no enforcement path — `EnforceKeyExpiry` reads `key_expires_at`, which was already `TIMESTAMPTZ`.

### Who is affected

Deployments running at a non-UTC offset. The published image is alpine with no `TZ` and no `/etc/localtime` (`date +%z` → `+0000`), so it runs at UTC and does not show the symptom. Self-hosters running the backend natively, setting `TZ`, or on a PostgreSQL whose session zone is not UTC do. Note the image ships `tzdata`, so this is one environment variable away.

There is a second path that involves no Go code at all: the DSN sets no `TimeZone`, so `DEFAULT NOW()` and migration 092's `verified_at` trigger are cast under whatever zone the PostgreSQL *session* has. Converting the column type is the only fix that closes both paths — a `.UTC()` sweep at the write sites would close neither for existing rows.

## Scope

Every naked column, not a security-semantic subset. The boundary is the column TYPE: a name-based predicate over `expires`/`revoked`/`grace` finds 3 of the 42 and misses `audit_logs.timestamp`, `agent_capabilities.granted_at` and `agents.verified_at`.

The migration also converts `schema_migrations.applied_at`. The two runners disagreed about it — `cmd/migrate` creates the table with `TIMESTAMPTZ`, but `cmd/server` (the container's `CMD`, which auto-migrates at boot) created it naked. Without this, the postcondition aborts on every container-bootstrapped deployment and `log.Fatal` turns the upgrade into a boot crash loop under `restart: unless-stopped`. `cmd/server`'s DDL is corrected too, but `CREATE TABLE IF NOT EXISTS` never alters an existing table, so the migration is what repairs deployments already out there.

## Migration form

The implicit cast under `SET LOCAL TimeZone='UTC'` does not rewrite table heaps — verified by comparing `pg_class.relfilenode` before and after on all 18 affected tables at 5,000,000 rows. The `USING col AT TIME ZONE 'UTC'` spelling produces identical values but forces a full heap rewrite.

**Indexes on converted columns are still rebuilt, and that is the real cost.** 20 indexes touch these columns. Measured at 2,000,000 rows: 0.33 ms with no index on the column, 238 ms with one btree. Every `ACCESS EXCLUSIVE` lock is held until commit, so all affected tables are locked for as long as the slowest index rebuild.

The `SET LOCAL` is load-bearing, not cosmetic: under a session at `America/Denver` the same cast silently converted a stored `12:00:00` to the instant `18:00:00Z` — six hours wrong, no error. The migration therefore asserts `current_setting('TimeZone')` and aborts otherwise, sets `lock_timeout`, and ends with a postcondition that aborts if any naked column remains.

The postcondition reads `pg_attribute`, not `information_schema.columns`, for reasons that were measured rather than assumed: `information_schema` is privilege-filtered (the same schema returned 5 rows as superuser and 0 as a dedicated migration role, so the guard would have passed silently in exactly the case it exists for), and it reports an array column's `data_type` as `ARRAY`, hiding `timestamp[]`. Checking `atttypid` also reaches matviews, views, composite types, other schemas, and domains over `timestamp`.

## Existing rows

The conversion reinterprets each stored wall-clock value as UTC: exact for anything written at UTC, and otherwise adopting the shifted instant the application was already reading back. Operators can check their own history first — `agents` writes one `TIMESTAMPTZ` and one naked column from the same clock in a single INSERT, so drift is directly visible. The query is in the migration header. A `rows_checked` of 0 means the probe proved nothing; it is not a pass.

## Guards

The convention alone did not hold — "TIMESTAMPTZ always" was already written down, and migrations 065, 090 and 101 each added naked columns afterwards. So the recurrence guard is the actual deliverable:

- **`cmd/timestamptz-lint`** fails CI on a naked `TIMESTAMP` in any migration (source half).
- **`TestNakedTimestamp*`** asserts the applied schema holds none, covering both the process-zone and session-zone paths (database half).

Both are needed: the lint cannot see a column that enters through a path other than this repo's migrations, and the test cannot see a migration that has not been applied yet.

All three integration tests fail against the schema at migration 105 and pass at 106, verified by running them at both revisions rather than by inspection.

The lint decides a type from the *preceding* token, so `created_at TIMESTAMP, timestamp TIMESTAMPTZ` reports the real declaration while `ON audit_logs(timestamp DESC)` stays clean. Dollar-quoted bodies are scanned as code rather than blanked, because migration 014 declares a column inside a `DO` block; recursing into them also contains an apostrophe in PL/pgSQL prose to its own block instead of silencing the rest of the file. The baseline counts findings per location rather than matching locations, so a baselined line that grows a second declaration is still reported, and a test asserts the baseline and the tree agree exactly in both directions. Known limitations are enumerated in the lint's doc comment.

## Test plan

- All 106 migrations applied to a clean PostgreSQL 16; 0 naked columns remain.
- Rehearsed against a 5,000,000-row / 1.4 GB shaped copy: no heap rewrite on any of the 18 tables, whole migration ~1.1 s, `idx_audit_logs_timestamp` rebuilt 107 MB → 86 MB, 0 invalid indexes, all rows intact.
- Both guards proven to fire: a non-UTC session aborts with the zone named; an unenumerated naked column aborts with the column named.
- Verified on the container-bootstrap path (naked `schema_migrations.applied_at`) and with a concurrent session holding a temp table.
- Full unit suite under `-race` and full `-tags=integration` suite green against the converted schema.