### PR TITLE
Fix the revocation list returning no revocations to any caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,14 +365,17 @@ jobs:
       # stops applying to it. AgentRevocation + the middleware package were
       # added for exactly that reason; UpdateDoesNotWriteTrustScore + RoundTrip
       # and the repository package were added for the same reason after the MCP
-      # trust-score write-path fix.
+      # trust-score write-path fix; RevocationList + the handlers package were
+      # added after the revocation list was found returning an empty list for
+      # every caller, which no test had ever asserted against.
       - name: Assert integration tests were not skipped
         run: |
           set -o pipefail
           go test -tags=integration -v \
-            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled' \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|RevocationList|AgentRepositoryList' \
             ./internal/application/... ./internal/interfaces/http/middleware/... \
-            ./internal/infrastructure/repository/... 2>&1 | tee /tmp/integration.log
+            ./internal/infrastructure/repository/... \
+            ./internal/interfaces/http/handlers/... 2>&1 | tee /tmp/integration.log
           if grep -q '^--- SKIP' /tmp/integration.log; then
             echo "::error::Integration tests were SKIPPED — TEST_DATABASE_URL is not reaching them."
             grep '^--- SKIP' /tmp/integration.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
         run: |
           set -o pipefail
           go test -tags=integration -v \
-            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|RevocationList|AgentRepositoryList' \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|RevocationList|AgentRepositoryList|NullDescription' \
             ./internal/application/... ./internal/interfaces/http/middleware/... \
             ./internal/infrastructure/repository/... \
             ./internal/interfaces/http/handlers/... 2>&1 | tee /tmp/integration.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,53 @@ forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Security
+
+- `GET /api/v1/revocations` returned an empty revocation list to every caller,
+  always. `GetRevocationList` asked the repository for `List(0, 0)`, which reaches
+  PostgreSQL as `LIMIT 0` — zero rows, not "unbounded". The route is mounted and
+  unauthenticated here, so a verifier polling it was told that nothing had ever
+  been revoked, and a caching client treats that as a successful fetch and holds
+  it as fresh. No 4xx, no 5xx, no log line: the control reported healthy while
+  enforcing nothing.
+- The revocation list no longer exposes `name`. It emitted every revoked agent's
+  organization-internal name across all organizations on an unauthenticated
+  endpoint. This was inert only because the list was always empty, so fixing the
+  limit without removing the field would have shipped the disclosure in the same
+  deploy. `revokedAt` is also gone: it was read from `agents.updated_at`, which
+  any later write to the row rewrites, and there is no `revoked_at` column to
+  source it from.
+- Java SDK: `CrlCache` accepted a decoded `Crl(entries=null)` as a valid list and
+  cached it as fresh, and `LocalAtxVerifier` read null entries as "nothing is
+  revoked". A CRL feed whose JSON carries its list under a different key therefore
+  produced a silent fail-open — every revoked credential verifying, with no error
+  and a healthy-looking `status()`. Both now reject a malformed list; a genuinely
+  empty one still verifies normally.
+- A NULL in a nullable column failed the entire row rather than the field on most
+  agent read paths (`description` on five of six, `rotation_count` and
+  `trust_score` more widely). `GetByID` is the one that matters: the agent auth
+  middlewares call it, and a failed read there is reported as "Agent not found",
+  which is indistinguishable from a revocation denial. An agent created without a
+  description could not authenticate and the operator was told it did not exist.
+
+### Changed
+
+- `AgentRepository.List` now returns an error for a non-positive limit instead of
+  reinterpreting it. Returning everything would have traded a silent-empty bug for
+  a silent-unbounded one; an error is the only outcome that fails visibly. Callers
+  pass an explicit page size. Adds `ListRevokedIDs`, which filters in SQL so the
+  unauthenticated revocation endpoint no longer reads every agent row to emit a
+  subset.
+- `AgentService.EnforceKeyExpiry` returns `ErrKeyExpiryEnforcementUnavailable`
+  rather than reporting success for work it cannot do. It is unimplementable as
+  written — `List` does not select `key_expires_at`, and suspending via `Update`
+  would clear the agent's key material — and it has no caller. See #359.
+- The tenant-scoping lint fails when an allowlist key names a method that does not
+  exist. Fourteen of thirty-two entries resolved to nothing, presenting as reviewed
+  exemptions while covering nothing. All fourteen were removed and the lint still
+  passes, which is the evidence that none of the real handlers needed exempting.
+  Remaining `needs review` entries are tracked in #358.
+
 ### Fixed
 
 - Agent registration now returns `400 Bad Request` (was `500 Internal Server

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -35,65 +35,54 @@ import (
 // organizations and therefore do not need to invoke LoadOwned. Each entry
 // must include a one-line justification.
 var allowlist = map[string]string{
-	// Public agent discovery — intentionally cross-org for the public registry.
-	// Returns only redacted fields; full resource never crosses the boundary.
-	"PublicAgentHandler.GetPublicAgent":             "public registry endpoint; returns only redacted fields",
-	"PublicAgentHandler.ListPublicAgents":           "public registry endpoint; returns only redacted fields",
-	"PublicMCPHandler.GetPublicMCPServer":           "public MCP registry endpoint; returns only redacted fields",
-	"PublicMCPHandler.ListPublicMCPServers":         "public MCP registry endpoint; returns only redacted fields",
-	"PublicRegistrationHandler.GetRegistrationByID": "public registration status check before login",
-
-	// Lifecycle endpoints that operate on the calling agent's own ID by
-	// design — the SDK auth middleware has already verified the caller IS
-	// this agent, so additional org check would be redundant.
-	"LifecycleHandler.GetRevocationList": "system endpoint; iterates all agents for revocation list",
-
-	// Authentication endpoints — operate on credentials, not org-scoped resources.
-	"AuthRefreshHandler.Refresh":           "token refresh; not a resource read",
-	"AuthHandler.Login":                    "login flow; org assignment is the OUTPUT, not the gate",
-	"SDKTokenRecoveryHandler.RecoverToken": "token recovery; not a resource read",
-	"OAuthTokenHandler.Token":              "OAuth token issuance; not a resource read",
-	"DeviceAuthHandler.RequestDevice":      "device auth flow; not a resource read",
-	"DeviceAuthHandler.PollDevice":         "device auth flow; not a resource read",
-
-	// Detection / community intelligence — read-only system endpoints that
-	// aggregate cross-org telemetry (no per-org resource being returned).
-	"DetectionHandler.GetThreatLevel":       "aggregated threat telemetry; no per-org resource",
-	"CommunityIntelligenceHandler.GetIntel": "aggregated community intel; no per-org resource",
-
-	// Registry bridge — federation endpoint that operates on bridge identity.
-	"RegistryBridgeHandler.Verify": "registry federation; bridge identity is the resource",
-
-	// ---------------------------------------------------------------
-	// AUDIT-BASELINE: 71 pre-existing handlers that read c.Params("id"|
-	// "agent_id") without any visible OrganizationID reference. These
-	// PREDATE the LoadOwned helper introduced in this PR. They are not
-	// known-safe — they require manual review. The lint allowlists them
-	// here so this PR can ship the structural fix for the 8 cited defects
-	// (#18-25) without blocking on a 71-handler manual audit. Each entry
-	// must be removed from this section as it is reviewed; the reviewer
-	// either confirms the handler is intentionally cross-tenant and moves
-	// it to the section above with a per-entry justification, or wires
-	// LoadOwned into the handler.
+	// The federated revocation list. Unauthenticated and cross-organization by
+	// design: a verifier must be able to check revocation WITHOUT holding a
+	// credential, which is what makes offline verification possible. The control
+	// is minimization, not scoping — the payload carries an agent id and a closed
+	// reason code and nothing else.
 	//
-	// Tracking: ~/workspace/opena2a-org/todo/2026-05-18-aim-defect-audit-
-	// from-lf-demo-prep.md (defect #18-25 follow-up section to be added).
+	// This entry previously justified itself with "the SDK auth middleware has
+	// already verified the caller IS this agent" and "iterates all agents". Both
+	// were wrong: the route is registered on the v1 group with a rate limiter and
+	// no auth, and the handler iterated nothing because it asked the repository
+	// for LIMIT 0. It was the only place this endpoint's cross-org nature was ever
+	// reasoned about, and it was wrong about the code in both directions.
+	"LifecycleHandler.GetRevocationList": "unauthenticated federated CRL; cross-org by design, minimized to agentId + closed-set reason (see GetRevocationList doc comment)",
+
 	// ---------------------------------------------------------------
-	"A2AHandler.DeleteSkill": "stub-handler: returns 204 No Content with no service dispatch. Path :id is a skill UUID; once a DeleteSkill service method exists, scope at handler layer (A3d-vii.c follow-up). Not exploitable today.",
-	"AdminHandler.AcknowledgeAlert": "service-layer scoping: AlertService.AcknowledgeAlert performs Load → caller-org check → ErrAlertNotFound (collapses cross-tenant + not-found + uuid.Nil mismatch) and the handler maps the sentinel to a fixed 404 body (A3d-v R7 closed in PR #190).",
-	"AdminHandler.ResolveAlert":     "service-layer scoping: AlertService.ResolveAlert mirrors AcknowledgeAlert — Load → caller-org check → ErrAlertNotFound → fixed 404 handler mapping (A3d-v R7 closed in PR #190).",
-	"DetectionHandler.GetDetectionStatus":                   "audit-baseline: needs review",
-	"DetectionHandler.GetLatestCapabilityReport":            "audit-baseline: needs review",
-	"DetectionHandler.ReportCapabilities":                   "audit-baseline: needs review",
-	"DetectionHandler.ReportDetection":                      "audit-baseline: needs review",
-	"MCPGraphHandler.GetMCPServerConnections":               "audit-baseline: needs review",
-	"MCPHandler.GetConnectedAgents":                         "audit-baseline: needs review",
-	"MCPHandler.VerifyMCPCapability":                        "audit-baseline: needs review",
-	"PublicMCPHandler.VerifyMCPAction":                      "audit-baseline: needs review",
-	"SDKTokenHandler.RevokeToken": "service-layer scoping: SDKTokenService.RevokeToken collapses both not-found and cross-user mismatch into ErrSDKTokenNotFound; the handler maps the sentinel to a fixed 404. SDK tokens are user-scoped (not org-scoped), so the gate lives at the service layer.",
-	"TagHandler.UpdateTag": "audit-baseline: needs review (service-layer scoping exists but has existence side channel via error string; A3d-ii follow-up — see todo/2026-05-21-a3d-ii-tag-mcp-scoping.md)",
-	"VerificationHandler.SubmitVerificationResult":          "audit-baseline: needs review",
-	"VerificationHandler.UpdateExecutionStatus":             "audit-baseline: needs review",
+	// AUDIT-BASELINE: pre-existing handlers that read c.Params("id"|
+	// "agent_id") without any visible OrganizationID reference. These
+	// PREDATE the LoadOwned helper. They are not known-safe — they require
+	// manual review. The lint allowlists them here so the structural fix for
+	// the 8 cited defects (#18-25) could ship without blocking on the audit.
+	// Each entry must be removed from this section as it is reviewed; the
+	// reviewer either confirms the handler is intentionally cross-tenant and
+	// moves it to the section above with a per-entry justification, or wires
+	// LoadOwned into the handler. "needs review" is not an end state.
+	//
+	// An earlier version of this comment claimed 71 handlers. This map has
+	// never held that many — verify the real number rather than restating
+	// one, since a count in a comment cannot be checked by anything:
+	//
+	//	grep -c "audit-baseline: needs review" cmd/tenantscope-lint/main.go
+	//
+	// Tracking: opena2a-org/agent-identity-management#358.
+	// ---------------------------------------------------------------
+	"A2AHandler.DeleteSkill":                       "stub-handler: returns 204 No Content with no service dispatch. Path :id is a skill UUID; once a DeleteSkill service method exists, scope at handler layer (A3d-vii.c follow-up). Not exploitable today.",
+	"AdminHandler.AcknowledgeAlert":                "service-layer scoping: AlertService.AcknowledgeAlert performs Load → caller-org check → ErrAlertNotFound (collapses cross-tenant + not-found + uuid.Nil mismatch) and the handler maps the sentinel to a fixed 404 body (A3d-v R7 closed in PR #190).",
+	"AdminHandler.ResolveAlert":                    "service-layer scoping: AlertService.ResolveAlert mirrors AcknowledgeAlert — Load → caller-org check → ErrAlertNotFound → fixed 404 handler mapping (A3d-v R7 closed in PR #190).",
+	"DetectionHandler.GetDetectionStatus":          "audit-baseline: needs review",
+	"DetectionHandler.GetLatestCapabilityReport":   "audit-baseline: needs review",
+	"DetectionHandler.ReportCapabilities":          "audit-baseline: needs review",
+	"DetectionHandler.ReportDetection":             "audit-baseline: needs review",
+	"MCPGraphHandler.GetMCPServerConnections":      "audit-baseline: needs review",
+	"MCPHandler.GetConnectedAgents":                "audit-baseline: needs review",
+	"MCPHandler.VerifyMCPCapability":               "audit-baseline: needs review",
+	"PublicMCPHandler.VerifyMCPAction":             "audit-baseline: needs review",
+	"SDKTokenHandler.RevokeToken":                  "service-layer scoping: SDKTokenService.RevokeToken collapses both not-found and cross-user mismatch into ErrSDKTokenNotFound; the handler maps the sentinel to a fixed 404. SDK tokens are user-scoped (not org-scoped), so the gate lives at the service layer.",
+	"TagHandler.UpdateTag":                         "audit-baseline: needs review (service-layer scoping exists but has existence side channel via error string; A3d-ii follow-up — see todo/2026-05-21-a3d-ii-tag-mcp-scoping.md)",
+	"VerificationHandler.SubmitVerificationResult": "audit-baseline: needs review",
+	"VerificationHandler.UpdateExecutionStatus":    "audit-baseline: needs review",
 
 	// ---------------------------------------------------------------
 	// Service-layer-enforced tenant scoping. The lint's AST scan cannot
@@ -274,6 +263,26 @@ the helper documentation and the SECURITY rationale for 404-not-403.`)
 		} else {
 			fmt.Printf("tenantscope-lint: ok (%d allowlist entries; scanned %s)\n", len(allowlist), handlersDir)
 		}
+
+		// An allowlist entry that resolves to no real method is a silent hole: it
+		// presents as a reviewed exemption while covering nothing. Checked after the
+		// scan so discoveredHandlers is fully populated.
+		if unresolved := checkAllowlistResolves(); len(unresolved) > 0 {
+			failed = true
+			fmt.Fprintf(os.Stderr, "\ntenantscope-lint: %d allowlist entr(ies) name a method that does not exist:\n\n", len(unresolved))
+			for _, key := range unresolved {
+				fmt.Fprintf(os.Stderr, "  %s\n", key)
+			}
+			fmt.Fprintln(os.Stderr, `
+Each of these exempts nothing. Either the method was renamed, or it lives on a
+different receiver, or it never existed. Fix by finding the real handler:
+
+  grep -rn "func (.* \*<ReceiverType>) " ./internal/interfaces/http/handlers
+
+Then either correct the key to the real Receiver.Method and keep the
+justification, or delete the entry if the handler is gone. Do not silence this
+by deleting the check.`)
+		}
 	}
 
 	if servicesDir != "" {
@@ -349,6 +358,30 @@ func scanDirectory(dir string) ([]violation, error) {
 	return violations, nil
 }
 
+// discoveredHandlers collects every Receiver.Method seen while scanning, so the
+// allowlist can be checked against reality rather than trusted.
+//
+// An allowlist key that matches no real method exempts nothing. It is worse than a
+// missing entry: it reads as a reviewed, justified exemption while the handler it was
+// meant to cover is either unexempted or named something else entirely. Fourteen of the
+// entries here were in that state — `AuthHandler.Login` (the type has `LocalLogin`; the
+// real `Login` is on `PublicRegistrationHandler`), `RegistryBridgeHandler.Verify` (the
+// type has only `TriggerPush`), `OAuthTokenHandler.Token` (it is `HandleTokenRequest`),
+// and eleven more.
+var discoveredHandlers = map[string]bool{}
+
+// checkAllowlistResolves reports allowlist keys that name no method the scan found.
+func checkAllowlistResolves() []string {
+	var unresolved []string
+	for key := range allowlist {
+		if !discoveredHandlers[key] {
+			unresolved = append(unresolved, key)
+		}
+	}
+	sort.Strings(unresolved)
+	return unresolved
+}
+
 func scanFile(fset *token.FileSet, file *ast.File, path string) []violation {
 	var out []violation
 	for _, decl := range file.Decls {
@@ -357,6 +390,7 @@ func scanFile(fset *token.FileSet, file *ast.File, path string) []violation {
 			continue
 		}
 		handlerName := receiverTypeName(fn) + "." + fn.Name.Name
+		discoveredHandlers[handlerName] = true
 		if _, allowed := allowlist[handlerName]; allowed {
 			continue
 		}

--- a/apps/backend/cmd/tenantscope-lint/main_test.go
+++ b/apps/backend/cmd/tenantscope-lint/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -158,5 +159,61 @@ func TestClassifyServiceDirRouting(t *testing.T) {
 		if got := classifyServiceDir(c.path); got != c.want {
 			t.Errorf("classifyServiceDir(%q) = %v, want %v", c.path, got, c.want)
 		}
+	}
+}
+
+// Every allowlist key must name a method that actually exists.
+//
+// An entry that resolves to nothing exempts nothing, and it is worse than a missing
+// entry: it reads as a reviewed, justified exemption while the handler it was meant to
+// cover is either unexempted or named something else. Fourteen of the then-32 entries
+// were in that state — `AuthHandler.Login` (the type has `LocalLogin`; the real `Login`
+// is on `PublicRegistrationHandler`), `RegistryBridgeHandler.Verify` (the type has only
+// `TriggerPush`), `OAuthTokenHandler.Token` (it is `HandleTokenRequest`), and eleven
+// more. All fourteen were removed and the lint still passes, which is the evidence that
+// none of the real handlers needed exempting.
+//
+// This runs the real scan over the real handlers package rather than a fixture, because
+// the property under test is agreement between the allowlist and the shipped code — a
+// fixture cannot express that.
+func TestAllowlistKeysAllResolveToRealHandlers(t *testing.T) {
+	const handlersDir = "../../internal/interfaces/http/handlers"
+
+	if _, err := os.Stat(handlersDir); err != nil {
+		t.Fatalf("handlers package not found at %s: %v", handlersDir, err)
+	}
+
+	// Populates discoveredHandlers as a side effect.
+	if _, err := scanDirectory(handlersDir); err != nil {
+		t.Fatalf("scanDirectory: %v", err)
+	}
+	if len(discoveredHandlers) == 0 {
+		t.Fatal("scan discovered no handlers at all; this test would pass vacuously")
+	}
+
+	if unresolved := checkAllowlistResolves(); len(unresolved) > 0 {
+		t.Errorf("%d allowlist entr(ies) name a method that does not exist: %v\n"+
+			"Each exempts nothing. Correct the key to the real Receiver.Method and keep "+
+			"the justification, or delete the entry.", len(unresolved), unresolved)
+	}
+}
+
+// The check above must be capable of failing. Without this, a bug that left
+// discoveredHandlers over-populated would make it pass for every possible allowlist.
+func TestAllowlistResolutionCheckDetectsAMissingMethod(t *testing.T) {
+	discoveredHandlers = map[string]bool{"RealHandler.RealMethod": true}
+	t.Cleanup(func() { discoveredHandlers = map[string]bool{} })
+
+	original := allowlist
+	allowlist = map[string]string{
+		"RealHandler.RealMethod":     "exists",
+		"GhostHandler.VanishedThing": "does not exist",
+	}
+	t.Cleanup(func() { allowlist = original })
+
+	unresolved := checkAllowlistResolves()
+
+	if len(unresolved) != 1 || unresolved[0] != "GhostHandler.VanishedThing" {
+		t.Errorf("expected exactly the nonexistent key to be reported, got %v", unresolved)
 	}
 }

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -44,7 +44,7 @@ type AgentService struct {
 	userRepo                 domain.UserRepository         // ✅ For looking up user details (audit trail)
 	orgRepo                  domain.OrganizationRepository // ✅ For checking enforcement mode
 	capabilityRequestService *CapabilityRequestService     // For routing re-registration capability adds through the mode-aware approval workflow (monitoring auto-approves, strict creates pending request)
-	auditRepo                domain.AuditLogRepository      // Optional (issue #293): records the audit event on a honeytoken verification hit; injected via SetHoneytokenAuditing
+	auditRepo                domain.AuditLogRepository     // Optional (issue #293): records the audit event on a honeytoken verification hit; injected via SetHoneytokenAuditing
 }
 
 // SetHoneytokenAuditing wires an audit-log repository so a honeytoken verification
@@ -278,10 +278,10 @@ func (s *AgentService) CreateAgent(ctx context.Context, req *CreateAgentRequest,
 		DeclaredPurpose:     req.DeclaredPurpose,
 		Status:              domain.AgentStatusPending, // Agents start as pending, verification is earned
 		CreatedBy:           userID,
-		CreatedByName:       createdByName,   // ✅ Denormalized for audit trail
-		CreatedByEmail:      createdByEmail,  // ✅ Denormalized for audit trail
-		CreatedBySDKTokenID: sdkTokenID,      // ✅ Track SDK token for easy revocation if compromised
-		CreatedByAPIKeyID:   apiKeyID,        // ✅ Track API key for easy revocation if compromised
+		CreatedByName:       createdByName,  // ✅ Denormalized for audit trail
+		CreatedByEmail:      createdByEmail, // ✅ Denormalized for audit trail
+		CreatedBySDKTokenID: sdkTokenID,     // ✅ Track SDK token for easy revocation if compromised
+		CreatedByAPIKeyID:   apiKeyID,       // ✅ Track API key for easy revocation if compromised
 	}
 
 	// Only set encrypted private key if we generated it server-side
@@ -1013,8 +1013,13 @@ func (s *AgentService) VerifyCapability(
 				Severity:         "medium",
 				TrustScoreImpact: -2,
 				IsBlocked:        false,
-				SourceIP:         func() *string { if sourceIP != "" { return &sourceIP }; return nil }(),
-				RequestMetadata:  metadata,
+				SourceIP: func() *string {
+					if sourceIP != "" {
+						return &sourceIP
+					}
+					return nil
+				}(),
+				RequestMetadata: metadata,
 			}
 			if err := s.capabilityRepo.CreateViolation(violation); err != nil {
 				fmt.Printf("⚠️  Warning: failed to create monitoring violation record: %v\n", err)
@@ -1141,8 +1146,13 @@ func (s *AgentService) VerifyCapability(
 				Severity:         "medium", // Lower severity in monitoring mode
 				TrustScoreImpact: -2,       // Minimal impact in monitoring mode
 				IsBlocked:        false,    // NOT blocked
-				SourceIP:         func() *string { if sourceIP != "" { return &sourceIP }; return nil }(),
-				RequestMetadata:  metadata,
+				SourceIP: func() *string {
+					if sourceIP != "" {
+						return &sourceIP
+					}
+					return nil
+				}(),
+				RequestMetadata: metadata,
 			}
 
 			if err := s.capabilityRepo.CreateViolation(violation); err != nil {
@@ -1197,8 +1207,13 @@ func (s *AgentService) VerifyCapability(
 			Severity:         "high", // No capabilities = serious issue
 			TrustScoreImpact: -10,    // Standard violation impact
 			IsBlocked:        true,
-			SourceIP:         func() *string { if sourceIP != "" { return &sourceIP }; return nil }(),
-			RequestMetadata:  metadata,
+			SourceIP: func() *string {
+				if sourceIP != "" {
+					return &sourceIP
+				}
+				return nil
+			}(),
+			RequestMetadata: metadata,
 		}
 
 		if err := s.capabilityRepo.CreateViolation(violation); err != nil {
@@ -1293,15 +1308,20 @@ func (s *AgentService) VerifyCapability(
 			AgentID:             agentID,
 			AttemptedCapability: capability,
 			RegisteredCapabilities: map[string]interface{}{
-				"allowedCapabilities":  capabilityTypes,
-				"attemptedCapability":  capability,
-				"resource":             resource,
+				"allowedCapabilities": capabilityTypes,
+				"attemptedCapability": capability,
+				"resource":            resource,
 			},
 			Severity:         s.calculateViolationSeverity(agent, shouldBlock),
 			TrustScoreImpact: s.calculateTrustScoreImpact(shouldBlock),
 			IsBlocked:        shouldBlock,
-			SourceIP:         func() *string { if sourceIP != "" { return &sourceIP }; return nil }(),
-			RequestMetadata:  metadata,
+			SourceIP: func() *string {
+				if sourceIP != "" {
+					return &sourceIP
+				}
+				return nil
+			}(),
+			RequestMetadata: metadata,
 		}
 
 		if err := s.capabilityRepo.CreateViolation(violation); err != nil {
@@ -1343,8 +1363,8 @@ func (s *AgentService) VerifyCapability(
 		// increment needed.
 
 		// Evaluate trust score policy enforcement (alerts and suspension)
-		previousScore := agent.TrustScore  // Store before updating
-		agent.TrustScore = newScore        // Update agent object for policy evaluation
+		previousScore := agent.TrustScore // Store before updating
+		agent.TrustScore = newScore       // Update agent object for policy evaluation
 		if _, err := s.policyService.EvaluateTrustScoreOnUpdate(ctx, agent, previousScore, newScore); err != nil {
 			fmt.Printf("⚠️  Trust score policy evaluation failed: %v\n", err)
 		}
@@ -1638,10 +1658,10 @@ func (s *AgentService) GetAgentCredentials(ctx context.Context, agentID uuid.UUI
 
 // AddMCPServersRequest represents request to add MCP servers to agent's talks_to list
 type AddMCPServersRequest struct {
-	MCPServerIDs   []string               `json:"mcpServerIds"`    // MCP server IDs or names
-	DetectedMethod string                 `json:"detectedMethod"`  // "manual", "auto_sdk", "auto_config", "cli"
-	Confidence     float64                `json:"confidence"`      // Detection confidence (0-100)
-	Metadata       map[string]interface{} `json:"metadata"`        // Additional context
+	MCPServerIDs   []string               `json:"mcpServerIds"`   // MCP server IDs or names
+	DetectedMethod string                 `json:"detectedMethod"` // "manual", "auto_sdk", "auto_config", "cli"
+	Confidence     float64                `json:"confidence"`     // Detection confidence (0-100)
+	Metadata       map[string]interface{} `json:"metadata"`       // Additional context
 }
 
 // MCPServerDetail represents detailed MCP server information
@@ -2444,55 +2464,39 @@ func (s *AgentService) CreateCapabilityViolation(
 	return nil
 }
 
-// enforceKeyExpiryPageSize bounds each repository read in EnforceKeyExpiry.
-const enforceKeyExpiryPageSize = 500
+// ErrKeyExpiryEnforcementUnavailable is returned by EnforceKeyExpiry. See its doc
+// comment: the function cannot do what its name says, and returning (0, nil) would
+// report success for work that did not happen.
+var ErrKeyExpiryEnforcementUnavailable = errors.New(
+	"key-expiry enforcement is not implemented: AgentRepository.List does not select key_expires_at, " +
+		"and AgentRepository.Update would clear the agent's key material")
 
-// EnforceKeyExpiry suspends agents with expired keys past grace period.
+// EnforceKeyExpiry is NOT implemented and returns an error. Do not wire it.
 //
-// This walked `List(0, 0)` under the comment "Get all agents", which reached Postgres as
-// `LIMIT 0` and returned no rows — so it suspended nothing, unconditionally. It is also
-// not currently invoked from anywhere outside tests, so it had two independent reasons
-// never to enforce anything. Paginating fixes the first; the second is a separate call.
+// It reads as a working control and is not one. Three independent defects, none of which
+// is fixed by the others:
 //
-// Paging by offset is safe here even though the loop writes: suspending an agent changes
-// `status` and `updated_at`, and the sort key is `created_at, id`, so a row cannot move
-// across a page boundary underneath the walk.
+//  1. It walked `List(0, 0)`, which reached Postgres as `LIMIT 0` and returned no rows,
+//     so it suspended nothing. That one is fixed — List now rejects a non-positive limit.
+//  2. `AgentRepository.List` does not SELECT `key_expires_at` or
+//     `key_rotation_grace_until`. Both are therefore always nil on every agent this
+//     function can see, so `agent.KeyExpiresAt != nil` is never true and the body is
+//     unreachable regardless of pagination.
+//  3. The obvious repair for (2) — add the columns to List's SELECT — is a trap. This
+//     function suspends by calling `AgentRepository.Update`, which writes 29 columns
+//     while List populates a subset. Measured on a real row, that round trip clears
+//     encrypted_private_key, key_algorithm, key_created_at, key_expires_at,
+//     previous_public_key, pqc_public_key, pqc_key_algorithm, hybrid_mode_enabled,
+//     capabilities, and resets rotation_count to 0. Enforcing key expiry would destroy
+//     the key material it exists to protect.
+//
+// It also has no caller anywhere, including tests, so nothing regresses by refusing.
+//
+// Implementing it properly needs a narrow `UPDATE agents SET status, updated_at WHERE id`
+// rather than Update, and a repository read that carries the key-expiry columns. Tracked
+// in issue #359.
 func (s *AgentService) EnforceKeyExpiry(ctx context.Context) (int, error) {
-	now := time.Now()
-
-	suspended := 0
-	for offset := 0; ; offset += enforceKeyExpiryPageSize {
-		agents, err := s.agentRepo.List(enforceKeyExpiryPageSize, offset)
-		if err != nil {
-			return suspended, fmt.Errorf("failed to list agents: %w", err)
-		}
-
-		for _, agent := range agents {
-			if agent.Status == domain.AgentStatusRevoked || agent.Status == domain.AgentStatusSuspended {
-				continue
-			}
-			// Check if key is expired and past grace period
-			if agent.KeyExpiresAt != nil && agent.KeyExpiresAt.Before(now) {
-				// If there's a grace period, check if we're past it
-				if agent.KeyRotationGraceUntil != nil && agent.KeyRotationGraceUntil.After(now) {
-					continue // Still in grace period
-				}
-				// Suspend the agent
-				agent.Status = domain.AgentStatusSuspended
-				agent.UpdatedAt = now
-				if err := s.agentRepo.Update(agent); err != nil {
-					continue // Log but don't fail the whole batch
-				}
-				suspended++
-			}
-		}
-
-		if len(agents) < enforceKeyExpiryPageSize {
-			break
-		}
-	}
-
-	return suspended, nil
+	return 0, ErrKeyExpiryEnforcementUnavailable
 }
 
 // RecordHeartbeat updates the heartbeat timestamp for an agent

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -2444,32 +2444,51 @@ func (s *AgentService) CreateCapabilityViolation(
 	return nil
 }
 
-// EnforceKeyExpiry suspends agents with expired keys past grace period
+// enforceKeyExpiryPageSize bounds each repository read in EnforceKeyExpiry.
+const enforceKeyExpiryPageSize = 500
+
+// EnforceKeyExpiry suspends agents with expired keys past grace period.
+//
+// This walked `List(0, 0)` under the comment "Get all agents", which reached Postgres as
+// `LIMIT 0` and returned no rows — so it suspended nothing, unconditionally. It is also
+// not currently invoked from anywhere outside tests, so it had two independent reasons
+// never to enforce anything. Paginating fixes the first; the second is a separate call.
+//
+// Paging by offset is safe here even though the loop writes: suspending an agent changes
+// `status` and `updated_at`, and the sort key is `created_at, id`, so a row cannot move
+// across a page boundary underneath the walk.
 func (s *AgentService) EnforceKeyExpiry(ctx context.Context) (int, error) {
 	now := time.Now()
-	agents, err := s.agentRepo.List(0, 0) // Get all agents
-	if err != nil {
-		return 0, fmt.Errorf("failed to list agents: %w", err)
-	}
 
 	suspended := 0
-	for _, agent := range agents {
-		if agent.Status == domain.AgentStatusRevoked || agent.Status == domain.AgentStatusSuspended {
-			continue
+	for offset := 0; ; offset += enforceKeyExpiryPageSize {
+		agents, err := s.agentRepo.List(enforceKeyExpiryPageSize, offset)
+		if err != nil {
+			return suspended, fmt.Errorf("failed to list agents: %w", err)
 		}
-		// Check if key is expired and past grace period
-		if agent.KeyExpiresAt != nil && agent.KeyExpiresAt.Before(now) {
-			// If there's a grace period, check if we're past it
-			if agent.KeyRotationGraceUntil != nil && agent.KeyRotationGraceUntil.After(now) {
-				continue // Still in grace period
+
+		for _, agent := range agents {
+			if agent.Status == domain.AgentStatusRevoked || agent.Status == domain.AgentStatusSuspended {
+				continue
 			}
-			// Suspend the agent
-			agent.Status = domain.AgentStatusSuspended
-			agent.UpdatedAt = now
-			if err := s.agentRepo.Update(agent); err != nil {
-				continue // Log but don't fail the whole batch
+			// Check if key is expired and past grace period
+			if agent.KeyExpiresAt != nil && agent.KeyExpiresAt.Before(now) {
+				// If there's a grace period, check if we're past it
+				if agent.KeyRotationGraceUntil != nil && agent.KeyRotationGraceUntil.After(now) {
+					continue // Still in grace period
+				}
+				// Suspend the agent
+				agent.Status = domain.AgentStatusSuspended
+				agent.UpdatedAt = now
+				if err := s.agentRepo.Update(agent); err != nil {
+					continue // Log but don't fail the whole batch
+				}
+				suspended++
 			}
-			suspended++
+		}
+
+		if len(agents) < enforceKeyExpiryPageSize {
+			break
 		}
 	}
 

--- a/apps/backend/internal/application/agent_service.go
+++ b/apps/backend/internal/application/agent_service.go
@@ -2478,17 +2478,28 @@ var ErrKeyExpiryEnforcementUnavailable = errors.New(
 //
 //  1. It walked `List(0, 0)`, which reached Postgres as `LIMIT 0` and returned no rows,
 //     so it suspended nothing. That one is fixed — List now rejects a non-positive limit.
+//
 //  2. `AgentRepository.List` does not SELECT `key_expires_at` or
 //     `key_rotation_grace_until`. Both are therefore always nil on every agent this
 //     function can see, so `agent.KeyExpiresAt != nil` is never true and the body is
 //     unreachable regardless of pagination.
+//
 //  3. The obvious repair for (2) — add the columns to List's SELECT — is a trap. This
-//     function suspends by calling `AgentRepository.Update`, which writes 29 columns
-//     while List populates a subset. Measured on a real row, that round trip clears
-//     encrypted_private_key, key_algorithm, key_created_at, key_expires_at,
-//     previous_public_key, pqc_public_key, pqc_key_algorithm, hybrid_mode_enabled,
-//     capabilities, and resets rotation_count to 0. Enforcing key expiry would destroy
-//     the key material it exists to protect.
+//     function suspends by calling `AgentRepository.Update`, which writes 29 columns from
+//     a struct that List only partially populates. Every column Update writes and List
+//     does not select is destroyed on the round trip: key material (encrypted_private_key,
+//     the key_* timestamps, previous_public_key), the whole PQC set, capabilities, and
+//     rotation_count. Enforcing key expiry would destroy the key material it exists to
+//     protect.
+//
+//     The exact column set is deliberately not enumerated here. An earlier version of this
+//     comment listed ten and was four short — a hand-maintained list in a comment is not
+//     checkable and drifts against the code it describes. Derive it instead:
+//
+//     comm -13 <(sed -n '/func (r \*AgentRepository) List(/,/FROM agents/p' \
+//     ../infrastructure/repository/agent_repository.go | grep -oE '\b[a-z_]+\b' | sort -u) \
+//     <(sed -n '/func (r \*AgentRepository) Update(/,/WHERE id/p' \
+//     ../infrastructure/repository/agent_repository.go | grep -oE '\b[a-z_]+\b' | sort -u)
 //
 // It also has no caller anywhere, including tests, so nothing regresses by refusing.
 //

--- a/apps/backend/internal/application/alert_service_test.go
+++ b/apps/backend/internal/application/alert_service_test.go
@@ -194,6 +194,14 @@ func (m *MockAgentRepoForAlerts) List(limit, offset int) ([]*domain.Agent, error
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepoForAlerts) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepoForAlerts) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)
@@ -369,7 +377,7 @@ func TestAlertService_CountUnacknowledged_Success(t *testing.T) {
 	// Assert
 	assert.NoError(t, err)
 	assert.Equal(t, 10, allCount)
-	assert.Equal(t, 7, ackCount)  // 10 - 3
+	assert.Equal(t, 7, ackCount) // 10 - 3
 	assert.Equal(t, 3, unackCount)
 
 	mockAlertRepo.AssertExpectations(t)

--- a/apps/backend/internal/application/api_key_service_test.go
+++ b/apps/backend/internal/application/api_key_service_test.go
@@ -106,6 +106,14 @@ func (m *MockAgentRepoForAPIKey) List(limit, offset int) ([]*domain.Agent, error
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepoForAPIKey) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepoForAPIKey) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)

--- a/apps/backend/internal/application/atc_issuance_service_test.go
+++ b/apps/backend/internal/application/atc_issuance_service_test.go
@@ -223,3 +223,7 @@ func TestIssueForAgent_ScoreErrorPropagates(t *testing.T) {
 		t.Fatal("expected score error to propagate")
 	}
 }
+
+func (f *fakeAgentReader) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/application/capability_request_service_test.go
+++ b/apps/backend/internal/application/capability_request_service_test.go
@@ -14,11 +14,11 @@ import (
 
 // MockCapabilityRequestRepository implements CapabilityRequestRepository
 type MockCapabilityRequestRepository struct {
-	requests          map[uuid.UUID]*domain.CapabilityRequestWithDetails
-	createErr         error
-	getByIDErr        error
-	listErr           error
-	updateStatusErr   error
+	requests        map[uuid.UUID]*domain.CapabilityRequestWithDetails
+	createErr       error
+	getByIDErr      error
+	listErr         error
+	updateStatusErr error
 }
 
 func NewMockCapabilityRequestRepository() *MockCapabilityRequestRepository {
@@ -97,9 +97,9 @@ func (m *MockCapabilityRequestRepository) Delete(id uuid.UUID) error {
 
 // MockCapabilityRepoForCapReq implements CapabilityRepository for capability request tests
 type MockCapabilityRepoForCapReq struct {
-	capabilities          map[uuid.UUID]*domain.AgentCapability
-	capabilitiesByAgent   map[uuid.UUID][]*domain.AgentCapability
-	createErr             error
+	capabilities        map[uuid.UUID]*domain.AgentCapability
+	capabilitiesByAgent map[uuid.UUID][]*domain.AgentCapability
+	createErr           error
 }
 
 func NewMockCapabilityRepoForCapReq() *MockCapabilityRepoForCapReq {
@@ -206,7 +206,7 @@ func (m *MockCapabilityRepoForCapReq) UpdateCapabilityDefinition(def *domain.Cap
 
 // MockAgentRepositoryForCapReq implements AgentRepository for capability request tests
 type MockAgentRepositoryForCapReq struct {
-	agents    map[uuid.UUID]*domain.Agent
+	agents     map[uuid.UUID]*domain.Agent
 	getByIDErr error
 }
 
@@ -234,20 +234,38 @@ func (m *MockAgentRepositoryForCapReq) GetByID(id uuid.UUID) (*domain.Agent, err
 // Implement remaining AgentRepository methods as no-ops
 func (m *MockAgentRepositoryForCapReq) Create(agent *domain.Agent) error { return nil }
 func (m *MockAgentRepositoryForCapReq) Update(agent *domain.Agent) error { return nil }
-func (m *MockAgentRepositoryForCapReq) Delete(id uuid.UUID) error { return nil }
-func (m *MockAgentRepositoryForCapReq) List(limit, offset int) ([]*domain.Agent, error) { return nil, nil }
-func (m *MockAgentRepositoryForCapReq) GetByName(orgID uuid.UUID, name string) (*domain.Agent, error) { return nil, nil }
-func (m *MockAgentRepositoryForCapReq) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, error) { return nil, nil }
-func (m *MockAgentRepositoryForCapReq) UpdateTrustScore(id uuid.UUID, newScore float64) error { return nil }
+func (m *MockAgentRepositoryForCapReq) Delete(id uuid.UUID) error        { return nil }
+func (m *MockAgentRepositoryForCapReq) List(limit, offset int) ([]*domain.Agent, error) {
+	return nil, nil
+}
+
+func (m *MockAgentRepositoryForCapReq) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (m *MockAgentRepositoryForCapReq) GetByName(orgID uuid.UUID, name string) (*domain.Agent, error) {
+	return nil, nil
+}
+func (m *MockAgentRepositoryForCapReq) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, error) {
+	return nil, nil
+}
+func (m *MockAgentRepositoryForCapReq) UpdateTrustScore(id uuid.UUID, newScore float64) error {
+	return nil
+}
 func (m *MockAgentRepositoryForCapReq) IncrementViolationCount(id uuid.UUID) error { return nil }
-func (m *MockAgentRepositoryForCapReq) MarkAsCompromised(id uuid.UUID) error { return nil }
-func (m *MockAgentRepositoryForCapReq) UpdateLastActive(ctx context.Context, agentID uuid.UUID) error { return nil }
-func (m *MockAgentRepositoryForCapReq) GetStaleAgents(ctx context.Context, staleSince time.Time) ([]*domain.Agent, error) { return nil, nil }
-func (m *MockAgentRepositoryForCapReq) GetByIDs(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error) { return nil, nil }
+func (m *MockAgentRepositoryForCapReq) MarkAsCompromised(id uuid.UUID) error       { return nil }
+func (m *MockAgentRepositoryForCapReq) UpdateLastActive(ctx context.Context, agentID uuid.UUID) error {
+	return nil
+}
+func (m *MockAgentRepositoryForCapReq) GetStaleAgents(ctx context.Context, staleSince time.Time) ([]*domain.Agent, error) {
+	return nil, nil
+}
+func (m *MockAgentRepositoryForCapReq) GetByIDs(ctx context.Context, ids []uuid.UUID) ([]*domain.Agent, error) {
+	return nil, nil
+}
 
 // MockOrganizationRepositoryForCapReq implements OrganizationRepository for capability request tests
 type MockOrganizationRepositoryForCapReq struct {
-	orgs      map[uuid.UUID]*domain.Organization
+	orgs       map[uuid.UUID]*domain.Organization
 	getByIDErr error
 }
 
@@ -275,10 +293,16 @@ func (m *MockOrganizationRepositoryForCapReq) GetByID(id uuid.UUID) (*domain.Org
 // Implement remaining OrganizationRepository methods as no-ops
 func (m *MockOrganizationRepositoryForCapReq) Create(org *domain.Organization) error { return nil }
 func (m *MockOrganizationRepositoryForCapReq) Update(org *domain.Organization) error { return nil }
-func (m *MockOrganizationRepositoryForCapReq) Delete(id uuid.UUID) error { return nil }
-func (m *MockOrganizationRepositoryForCapReq) List(limit, offset int) ([]*domain.Organization, error) { return nil, nil }
-func (m *MockOrganizationRepositoryForCapReq) ListAll() ([]*domain.Organization, error) { return nil, nil }
-func (m *MockOrganizationRepositoryForCapReq) GetByDomain(domain string) (*domain.Organization, error) { return nil, nil }
+func (m *MockOrganizationRepositoryForCapReq) Delete(id uuid.UUID) error             { return nil }
+func (m *MockOrganizationRepositoryForCapReq) List(limit, offset int) ([]*domain.Organization, error) {
+	return nil, nil
+}
+func (m *MockOrganizationRepositoryForCapReq) ListAll() ([]*domain.Organization, error) {
+	return nil, nil
+}
+func (m *MockOrganizationRepositoryForCapReq) GetByDomain(domain string) (*domain.Organization, error) {
+	return nil, nil
+}
 
 // Test cases
 

--- a/apps/backend/internal/application/capability_service_test.go
+++ b/apps/backend/internal/application/capability_service_test.go
@@ -454,10 +454,10 @@ func TestCapabilityService_VerifySignature_DifferentKeys(t *testing.T) {
 
 func TestTrustScoreDecreaseLogic(t *testing.T) {
 	tests := []struct {
-		name              string
-		currentScore      float64
-		decrease          float64
-		expectedNewScore  float64
+		name             string
+		currentScore     float64
+		decrease         float64
+		expectedNewScore float64
 	}{
 		{"normal decrease", 0.75, 0.10, 0.65},
 		{"decrease to zero", 0.05, 0.10, 0.0},
@@ -788,6 +788,14 @@ func (m *MockAgentRepoForCapability) List(limit, offset int) ([]*domain.Agent, e
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*domain.Agent), args.Error(1)
+}
+
+func (m *MockAgentRepoForCapability) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
 }
 
 func (m *MockAgentRepoForCapability) UpdateTrustScore(id uuid.UUID, score float64) error {

--- a/apps/backend/internal/application/drift_detection_service_test.go
+++ b/apps/backend/internal/application/drift_detection_service_test.go
@@ -53,6 +53,14 @@ func (m *MockAgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepository) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepository) Update(agent *domain.Agent) error {
 	args := m.Called(agent)
 	return args.Error(0)
@@ -241,12 +249,12 @@ func TestDetectDrift_MCPServerDrift(t *testing.T) {
 
 	// Agent with registered MCP servers (first violation)
 	agent := &domain.Agent{
-		ID:                        agentID,
-		OrganizationID:            orgID,
-		Name:                      "test-agent",
-		TalksTo:                   []string{"filesystem-mcp"},
-		TrustScore:                85.0,
-		CapabilityViolationCount:  0, // First violation
+		ID:                       agentID,
+		OrganizationID:           orgID,
+		Name:                     "test-agent",
+		TalksTo:                  []string{"filesystem-mcp"},
+		TrustScore:               85.0,
+		CapabilityViolationCount: 0, // First violation
 	}
 
 	mockAgentRepo.On("GetByID", agentID).Return(agent, nil)

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -66,6 +66,14 @@ func (m *SharedMockAgentRepository) List(limit, offset int) ([]*domain.Agent, er
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *SharedMockAgentRepository) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *SharedMockAgentRepository) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)

--- a/apps/backend/internal/application/registry_bridge_service_test.go
+++ b/apps/backend/internal/application/registry_bridge_service_test.go
@@ -56,7 +56,7 @@ type mockAgentRepoForBridge struct {
 	mock.Mock
 }
 
-func (m *mockAgentRepoForBridge) Create(a *domain.Agent) error      { return nil }
+func (m *mockAgentRepoForBridge) Create(a *domain.Agent) error { return nil }
 func (m *mockAgentRepoForBridge) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
@@ -74,12 +74,16 @@ func (m *mockAgentRepoForBridge) GetByOrganization(orgID uuid.UUID) ([]*domain.A
 	}
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
-func (m *mockAgentRepoForBridge) Update(a *domain.Agent) error                { return nil }
-func (m *mockAgentRepoForBridge) Delete(id uuid.UUID) error                   { return nil }
+func (m *mockAgentRepoForBridge) Update(a *domain.Agent) error                    { return nil }
+func (m *mockAgentRepoForBridge) Delete(id uuid.UUID) error                       { return nil }
 func (m *mockAgentRepoForBridge) List(limit, offset int) ([]*domain.Agent, error) { return nil, nil }
-func (m *mockAgentRepoForBridge) UpdateTrustScore(id uuid.UUID, s float64) error  { return nil }
-func (m *mockAgentRepoForBridge) IncrementViolationCount(id uuid.UUID) error      { return nil }
-func (m *mockAgentRepoForBridge) MarkAsCompromised(id uuid.UUID) error            { return nil }
+
+func (m *mockAgentRepoForBridge) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (m *mockAgentRepoForBridge) UpdateTrustScore(id uuid.UUID, s float64) error { return nil }
+func (m *mockAgentRepoForBridge) IncrementViolationCount(id uuid.UUID) error     { return nil }
+func (m *mockAgentRepoForBridge) MarkAsCompromised(id uuid.UUID) error           { return nil }
 func (m *mockAgentRepoForBridge) UpdateLastActive(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
@@ -157,8 +161,8 @@ func (m *mockMCPServerRepoForBridge) GetByOrganization(orgID uuid.UUID) ([]*doma
 func (m *mockMCPServerRepoForBridge) GetByURL(url string, orgID uuid.UUID) (*domain.MCPServer, error) {
 	return nil, nil
 }
-func (m *mockMCPServerRepoForBridge) Update(s *domain.MCPServer) error  { return nil }
-func (m *mockMCPServerRepoForBridge) Delete(id uuid.UUID) error         { return nil }
+func (m *mockMCPServerRepoForBridge) Update(s *domain.MCPServer) error { return nil }
+func (m *mockMCPServerRepoForBridge) Delete(id uuid.UUID) error        { return nil }
 func (m *mockMCPServerRepoForBridge) List(limit, offset int) ([]*domain.MCPServer, error) {
 	return nil, nil
 }
@@ -300,10 +304,10 @@ func TestAggregateAndPush_FullFlow(t *testing.T) {
 	agentRepo := &mockAgentRepoForBridge{}
 	agentRepo.On("GetByOrganization", orgID).Return([]*domain.Agent{
 		{
-			ID:             agentID,
-			OrganizationID: orgID,
-			Name:           "test-agent",
-			TrustScore:     0.85,
+			ID:                       agentID,
+			OrganizationID:           orgID,
+			Name:                     "test-agent",
+			TrustScore:               0.85,
 			CapabilityViolationCount: 2,
 		},
 	}, nil)

--- a/apps/backend/internal/application/secrets_service_test.go
+++ b/apps/backend/internal/application/secrets_service_test.go
@@ -114,18 +114,22 @@ func (m *mockAgentRepo) GetByID(id uuid.UUID) (*domain.Agent, error) {
 }
 
 // Implement remaining interface methods as no-ops
-func (m *mockAgentRepo) Create(_ *domain.Agent) error                              { return nil }
-func (m *mockAgentRepo) GetByName(_ uuid.UUID, _ string) (*domain.Agent, error)    { return nil, nil }
-func (m *mockAgentRepo) GetByOrganization(_ uuid.UUID) ([]*domain.Agent, error)    { return nil, nil }
-func (m *mockAgentRepo) Update(_ *domain.Agent) error                              { return nil }
-func (m *mockAgentRepo) Delete(_ uuid.UUID) error                                  { return nil }
-func (m *mockAgentRepo) List(_, _ int) ([]*domain.Agent, error)                    { return nil, nil }
-func (m *mockAgentRepo) UpdateTrustScore(_ uuid.UUID, _ float64) error             { return nil }
-func (m *mockAgentRepo) IncrementViolationCount(_ uuid.UUID) error                 { return nil }
-func (m *mockAgentRepo) MarkAsCompromised(_ uuid.UUID) error                       { return nil }
-func (m *mockAgentRepo) UpdateLastActive(_ context.Context, _ uuid.UUID) error       { return nil }
-func (m *mockAgentRepo) GetStaleAgents(_ context.Context, _ time.Time) ([]*domain.Agent, error) { return nil, nil }
-func (m *mockAgentRepo) GetByIDs(_ context.Context, _ []uuid.UUID) ([]*domain.Agent, error) { return nil, nil }
+func (m *mockAgentRepo) Create(_ *domain.Agent) error                           { return nil }
+func (m *mockAgentRepo) GetByName(_ uuid.UUID, _ string) (*domain.Agent, error) { return nil, nil }
+func (m *mockAgentRepo) GetByOrganization(_ uuid.UUID) ([]*domain.Agent, error) { return nil, nil }
+func (m *mockAgentRepo) Update(_ *domain.Agent) error                           { return nil }
+func (m *mockAgentRepo) Delete(_ uuid.UUID) error                               { return nil }
+func (m *mockAgentRepo) List(_, _ int) ([]*domain.Agent, error)                 { return nil, nil }
+func (m *mockAgentRepo) UpdateTrustScore(_ uuid.UUID, _ float64) error          { return nil }
+func (m *mockAgentRepo) IncrementViolationCount(_ uuid.UUID) error              { return nil }
+func (m *mockAgentRepo) MarkAsCompromised(_ uuid.UUID) error                    { return nil }
+func (m *mockAgentRepo) UpdateLastActive(_ context.Context, _ uuid.UUID) error  { return nil }
+func (m *mockAgentRepo) GetStaleAgents(_ context.Context, _ time.Time) ([]*domain.Agent, error) {
+	return nil, nil
+}
+func (m *mockAgentRepo) GetByIDs(_ context.Context, _ []uuid.UUID) ([]*domain.Agent, error) {
+	return nil, nil
+}
 
 type mockCapabilityRepo struct {
 	capabilities map[uuid.UUID][]*domain.AgentCapability
@@ -140,21 +144,41 @@ func (m *mockCapabilityRepo) GetActiveCapabilitiesByAgentID(agentID uuid.UUID) (
 }
 
 // No-op implementations for remaining interface methods
-func (m *mockCapabilityRepo) CreateCapability(_ *domain.AgentCapability) error                     { return nil }
-func (m *mockCapabilityRepo) GetCapabilityByID(_ uuid.UUID) (*domain.AgentCapability, error)       { return nil, nil }
-func (m *mockCapabilityRepo) GetCapabilitiesByAgentID(_ uuid.UUID) ([]*domain.AgentCapability, error) { return nil, nil }
-func (m *mockCapabilityRepo) RevokeCapability(_ uuid.UUID, _ time.Time) error                      { return nil }
-func (m *mockCapabilityRepo) SetHoneytoken(_ uuid.UUID, _ bool) error                              { return nil }
-func (m *mockCapabilityRepo) DeleteCapability(_ uuid.UUID) error                                   { return nil }
-func (m *mockCapabilityRepo) CreateViolation(_ *domain.CapabilityViolation) error                  { return nil }
-func (m *mockCapabilityRepo) GetViolationByID(_ uuid.UUID) (*domain.CapabilityViolation, error)    { return nil, nil }
-func (m *mockCapabilityRepo) GetViolationsByAgentID(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) { return nil, 0, nil }
-func (m *mockCapabilityRepo) GetRecentViolations(_ uuid.UUID, _ int) ([]*domain.CapabilityViolation, error) { return nil, nil }
-func (m *mockCapabilityRepo) GetViolationsByOrganization(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) { return nil, 0, nil }
-func (m *mockCapabilityRepo) ListCapabilityDefinitions(_ *uuid.UUID) ([]*domain.CapabilityDefinition, error) { return nil, nil }
-func (m *mockCapabilityRepo) GetCapabilityDefinition(_, _ string, _ *uuid.UUID) (*domain.CapabilityDefinition, error) { return nil, nil }
-func (m *mockCapabilityRepo) CreateCapabilityDefinition(_ *domain.CapabilityDefinition) error                         { return nil }
-func (m *mockCapabilityRepo) UpdateCapabilityDefinition(_ *domain.CapabilityDefinition) error                         { return nil }
+func (m *mockCapabilityRepo) CreateCapability(_ *domain.AgentCapability) error { return nil }
+func (m *mockCapabilityRepo) GetCapabilityByID(_ uuid.UUID) (*domain.AgentCapability, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) GetCapabilitiesByAgentID(_ uuid.UUID) ([]*domain.AgentCapability, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) RevokeCapability(_ uuid.UUID, _ time.Time) error     { return nil }
+func (m *mockCapabilityRepo) SetHoneytoken(_ uuid.UUID, _ bool) error             { return nil }
+func (m *mockCapabilityRepo) DeleteCapability(_ uuid.UUID) error                  { return nil }
+func (m *mockCapabilityRepo) CreateViolation(_ *domain.CapabilityViolation) error { return nil }
+func (m *mockCapabilityRepo) GetViolationByID(_ uuid.UUID) (*domain.CapabilityViolation, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) GetViolationsByAgentID(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) {
+	return nil, 0, nil
+}
+func (m *mockCapabilityRepo) GetRecentViolations(_ uuid.UUID, _ int) ([]*domain.CapabilityViolation, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) GetViolationsByOrganization(_ uuid.UUID, _, _ int) ([]*domain.CapabilityViolation, int, error) {
+	return nil, 0, nil
+}
+func (m *mockCapabilityRepo) ListCapabilityDefinitions(_ *uuid.UUID) ([]*domain.CapabilityDefinition, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) GetCapabilityDefinition(_, _ string, _ *uuid.UUID) (*domain.CapabilityDefinition, error) {
+	return nil, nil
+}
+func (m *mockCapabilityRepo) CreateCapabilityDefinition(_ *domain.CapabilityDefinition) error {
+	return nil
+}
+func (m *mockCapabilityRepo) UpdateCapabilityDefinition(_ *domain.CapabilityDefinition) error {
+	return nil
+}
 
 type mockATCVerifier struct {
 	shouldFail   bool
@@ -650,4 +674,8 @@ func (m *mockCapabilityRepo) GetCapabilitiesByAgentIDs(agentIDs []uuid.UUID, act
 		}
 	}
 	return result, nil
+}
+
+func (m *mockAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
 }

--- a/apps/backend/internal/application/tag_service_test.go
+++ b/apps/backend/internal/application/tag_service_test.go
@@ -195,6 +195,14 @@ func (m *MockAgentRepoForTags) List(limit, offset int) ([]*domain.Agent, error) 
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepoForTags) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepoForTags) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -284,6 +284,14 @@ func (m *TrustCalcMockAgentRepository) List(limit, offset int) ([]*domain.Agent,
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *TrustCalcMockAgentRepository) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *TrustCalcMockAgentRepository) Update(agent *domain.Agent) error {
 	args := m.Called(agent)
 	return args.Error(0)

--- a/apps/backend/internal/application/verification_event_service_test.go
+++ b/apps/backend/internal/application/verification_event_service_test.go
@@ -207,6 +207,14 @@ func (m *MockAgentRepoForVerification) List(limit, offset int) ([]*domain.Agent,
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepoForVerification) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepoForVerification) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)

--- a/apps/backend/internal/domain/agent.go
+++ b/apps/backend/internal/domain/agent.go
@@ -20,12 +20,12 @@ const (
 	AgentTypeCohere  AgentType = "cohere"
 
 	// Framework-based agents
-	AgentTypeLangChain   AgentType = "langchain"
-	AgentTypeLlamaIndex  AgentType = "llamaindex"
-	AgentTypeAutoGen     AgentType = "autogen"
-	AgentTypeCrewAI      AgentType = "crewai"
-	AgentTypeLangGraph   AgentType = "langgraph"
-	AgentTypeHaystack    AgentType = "haystack"
+	AgentTypeLangChain      AgentType = "langchain"
+	AgentTypeLlamaIndex     AgentType = "llamaindex"
+	AgentTypeAutoGen        AgentType = "autogen"
+	AgentTypeCrewAI         AgentType = "crewai"
+	AgentTypeLangGraph      AgentType = "langgraph"
+	AgentTypeHaystack       AgentType = "haystack"
 	AgentTypeSemanticKernel AgentType = "semantic_kernel"
 
 	// Copilot/Assistant types
@@ -76,39 +76,39 @@ type Agent struct {
 	CapabilityViolationCount int         `json:"capabilityViolationCount"`
 	IsCompromised            bool        `json:"isCompromised"`
 	// Capability-based access control (simple MVP)
-	TalksTo                  []string    `json:"talksTo"` // List of MCP server names/IDs this agent can communicate with
-	Capabilities             []string    `json:"capabilities"` // Agent capabilities (e.g., ["file:read", "api:call"])
+	TalksTo      []string `json:"talksTo"`      // List of MCP server names/IDs this agent can communicate with
+	Capabilities []string `json:"capabilities"` // Agent capabilities (e.g., ["file:read", "api:call"])
 	// Key rotation support
-	KeyCreatedAt             *time.Time  `json:"keyCreatedAt"`
-	KeyExpiresAt             *time.Time  `json:"keyExpiresAt"`
-	KeyRotationGraceUntil    *time.Time  `json:"keyRotationGraceUntil,omitempty"`
-	PreviousPublicKey        *string     `json:"-"` // Not exposed in API, used for grace period verification
-	RotationCount            int         `json:"rotationCount"`
+	KeyCreatedAt          *time.Time `json:"keyCreatedAt"`
+	KeyExpiresAt          *time.Time `json:"keyExpiresAt"`
+	KeyRotationGraceUntil *time.Time `json:"keyRotationGraceUntil,omitempty"`
+	PreviousPublicKey     *string    `json:"-"` // Not exposed in API, used for grace period verification
+	RotationCount         int        `json:"rotationCount"`
 	// Post-Quantum Cryptography (PQC) support
-	PQCPublicKey             *string     `json:"pqcPublicKey,omitempty"`
-	PQCKeyAlgorithm          *string     `json:"pqcKeyAlgorithm,omitempty"` // ML-DSA-44, ML-DSA-65, ML-DSA-87
-	HybridModeEnabled        bool        `json:"hybridModeEnabled"`
-	PQCKeyCreatedAt          *time.Time  `json:"pqcKeyCreatedAt,omitempty"`
-	PQCKeyExpiresAt          *time.Time  `json:"pqcKeyExpiresAt,omitempty"`
-	PreviousPQCPublicKey     *string     `json:"-"` // Not exposed in API, used for grace period verification
-	CreatedAt                time.Time   `json:"createdAt"`
-	UpdatedAt                time.Time   `json:"updatedAt"`
-	CreatedBy                uuid.UUID   `json:"createdBy"`
-	CreatedByName            string      `json:"createdByName"`            // Denormalized for display
-	CreatedByEmail           string      `json:"createdByEmail"`           // Denormalized for display
-	CreatedBySDKTokenID      *uuid.UUID  `json:"createdBySdkTokenId,omitempty"` // SDK token used to create this agent
-	CreatedByAPIKeyID        *uuid.UUID  `json:"createdByApiKeyId,omitempty"`   // API key used to create this agent
-	UpdatedBy                *uuid.UUID  `json:"updatedBy,omitempty"`      // User who last updated this agent
-	UpdatedByName            string      `json:"updatedByName,omitempty"`  // Denormalized for display
-	UpdatedByEmail           string      `json:"updatedByEmail,omitempty"` // Denormalized for display
+	PQCPublicKey         *string    `json:"pqcPublicKey,omitempty"`
+	PQCKeyAlgorithm      *string    `json:"pqcKeyAlgorithm,omitempty"` // ML-DSA-44, ML-DSA-65, ML-DSA-87
+	HybridModeEnabled    bool       `json:"hybridModeEnabled"`
+	PQCKeyCreatedAt      *time.Time `json:"pqcKeyCreatedAt,omitempty"`
+	PQCKeyExpiresAt      *time.Time `json:"pqcKeyExpiresAt,omitempty"`
+	PreviousPQCPublicKey *string    `json:"-"` // Not exposed in API, used for grace period verification
+	CreatedAt            time.Time  `json:"createdAt"`
+	UpdatedAt            time.Time  `json:"updatedAt"`
+	CreatedBy            uuid.UUID  `json:"createdBy"`
+	CreatedByName        string     `json:"createdByName"`                 // Denormalized for display
+	CreatedByEmail       string     `json:"createdByEmail"`                // Denormalized for display
+	CreatedBySDKTokenID  *uuid.UUID `json:"createdBySdkTokenId,omitempty"` // SDK token used to create this agent
+	CreatedByAPIKeyID    *uuid.UUID `json:"createdByApiKeyId,omitempty"`   // API key used to create this agent
+	UpdatedBy            *uuid.UUID `json:"updatedBy,omitempty"`           // User who last updated this agent
+	UpdatedByName        string     `json:"updatedByName,omitempty"`       // Denormalized for display
+	UpdatedByEmail       string     `json:"updatedByEmail,omitempty"`      // Denormalized for display
 	// Tags applied to this agent (populated by join)
-	Tags                     []Tag                  `json:"tags"`
+	Tags []Tag `json:"tags"`
 	// Track when agent last performed an action (updated on every verify-action call)
-	LastActive               *time.Time             `json:"lastActive"`
+	LastActive *time.Time `json:"lastActive"`
 	// Track heartbeat for liveness monitoring
-	LastHeartbeat            *time.Time             `json:"lastHeartbeat"`
+	LastHeartbeat *time.Time `json:"lastHeartbeat"`
 	// Custom metadata for the agent (model, department, owner, etc.)
-	Metadata                 map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// DeclaredPurpose is the publisher's optional structured declaration of what
 	// the agent is for (atx-spec core.md §1.5). Identity/attestation + offline
 	// detection signal only; never an authorization input. Nil = not declared.
@@ -125,6 +125,12 @@ type AgentRepository interface {
 	Update(agent *Agent) error
 	Delete(id uuid.UUID) error
 	List(limit, offset int) ([]*Agent, error)
+	// ListRevokedIDs returns one page of revoked agent ids, newest first.
+	//
+	// Separate from List because the revocation list is served on an unauthenticated
+	// route: filtering in Go means every request reads every agent row, including the
+	// JSONB columns, to emit the revoked subset. The predicate belongs in SQL.
+	ListRevokedIDs(limit, offset int) ([]uuid.UUID, error)
 	UpdateTrustScore(id uuid.UUID, newScore float64) error
 	MarkAsCompromised(id uuid.UUID) error
 	UpdateLastActive(ctx context.Context, agentID uuid.UUID) error

--- a/apps/backend/internal/infrastructure/repository/agent_list_limit_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/agent_list_limit_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package repository
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AgentRepository.List and the meaning of a non-positive limit.
+//
+// This file exists because `List` and its sibling `GetByOrganizationPaged` held two
+// contradictory conventions for the same parameter in the same file. The sibling
+// documents "limit <= 0 returns all agents" and implements it by omitting the clause.
+// `List` appended `LIMIT $1 OFFSET $2` unconditionally, so a zero limit reached Postgres
+// as `LIMIT 0` and returned nothing. Both of `List`'s callers were written to the
+// sibling's convention — one of them says `// Get all agents` — and both therefore
+// silently processed zero rows. One of the two is the federated revocation list, which
+// consequently told every verifier that no agent had ever been revoked.
+//
+// The repair is neither convention. Returning everything on a zero limit would swap a
+// silent-empty bug for a silent-unbounded one, so `List` now rejects the input outright.
+// These tests pin that, and they pin it against a real database rather than a mock,
+// because the defect lived in SQL that a mock replaces.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestAgentRepositoryList ./internal/infrastructure/repository/...
+
+func agentListTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping agent list limit test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// A non-positive limit is an error, not an interpretation. Both directions are covered:
+// zero (what both callers actually passed) and negative.
+func TestAgentRepositoryListRejectsNonPositiveLimit(t *testing.T) {
+	repo := NewAgentRepository(agentListTestDB(t))
+
+	for _, limit := range []int{0, -1} {
+		agents, err := repo.List(limit, 0)
+
+		require.Error(t, err, "List(%d, 0) returned no error", limit)
+		assert.ErrorIs(t, err, ErrNonPositiveLimit)
+		assert.Nil(t, agents,
+			"List(%d, 0) returned rows alongside its error; a caller ignoring err would "+
+				"act on them", limit)
+	}
+}
+
+// The control. A positive limit still returns rows, so the test above is rejecting the
+// input rather than the method being broken outright.
+func TestAgentRepositoryListAcceptsPositiveLimit(t *testing.T) {
+	repo := NewAgentRepository(agentListTestDB(t))
+
+	agents, err := repo.List(1, 0)
+
+	require.NoError(t, err)
+	assert.NotNil(t, agents)
+	assert.LessOrEqual(t, len(agents), 1, "List(1, 0) returned more than one row")
+}

--- a/apps/backend/internal/infrastructure/repository/agent_list_limit_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/agent_list_limit_integration_test.go
@@ -3,6 +3,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -63,12 +64,20 @@ func TestAgentRepositoryListRejectsNonPositiveLimit(t *testing.T) {
 
 // The control. A positive limit still returns rows, so the test above is rejecting the
 // input rather than the method being broken outright.
+//
+// It seeds a row first. Asserting only `len(agents) <= 1` would pass against an empty
+// table, and therefore against a method that returns nothing at all — the defect under
+// repair.
 func TestAgentRepositoryListAcceptsPositiveLimit(t *testing.T) {
-	repo := NewAgentRepository(agentListTestDB(t))
+	ctx := context.Background()
+	db := agentListTestDB(t)
+	repo := NewAgentRepository(db)
+
+	seedNullDescriptionAgent(t, db, ctx)
 
 	agents, err := repo.List(1, 0)
 
 	require.NoError(t, err)
-	assert.NotNil(t, agents)
-	assert.LessOrEqual(t, len(agents), 1, "List(1, 0) returned more than one row")
+	require.NotEmpty(t, agents, "List(1, 0) returned no rows despite a seeded agent")
+	assert.Len(t, agents, 1, "List(1, 0) did not honour the limit")
 }

--- a/apps/backend/internal/infrastructure/repository/agent_null_description_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/agent_null_description_integration_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every read path on AgentRepository must survive a NULL `agents.description`.
+//
+// `description` is nullable with no default. Six methods select it; five scanned it
+// straight into a plain string, which fails the ENTIRE row with
+// "converting NULL to string is unsupported" — not just the one field. Only
+// GetByOrganizationPaged used a NullString.
+//
+// The consequences differ per method and the worst is GetByID, which the agent auth
+// middlewares call. A failed read there surfaces as "Agent not found", which is
+// indistinguishable from a revocation denial: an agent with no description cannot
+// authenticate, and the operator is told it was not found. `agent_revocation_integration_test.go`
+// documented that in a comment and worked around it by always setting `description` in its
+// own seed, which is why no test ever caught it.
+//
+// It reached the revocation list too: GetRevocationList could not fail this way only
+// because its LIMIT 0 defect meant no row was ever scanned. Fixing that alone turned the
+// endpoint into a 500 for any deployment holding one such agent.
+//
+// This suite asserts the whole class rather than the one method the revocation work
+// needed, so a future method that selects `description` has a test that already covers it.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestNullDescription ./internal/infrastructure/repository/...
+
+// seedNullDescriptionAgent inserts one agent with description explicitly NULL and returns
+// the ids needed to reach it from every read path.
+func seedNullDescriptionAgent(t *testing.T, db *sql.DB, ctx context.Context) (orgID, agentID, mcpServerID uuid.UUID, agentName, mcpServerName string) {
+	t.Helper()
+
+	userID := uuid.New()
+	orgID, agentID, mcpServerID = uuid.New(), uuid.New(), uuid.New()
+	suffix := agentID.String()[:8]
+	agentName = "nulldesc-agent-" + suffix
+	mcpServerName = "nulldesc-mcp-" + suffix
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "nulldesc-org-"+suffix, "nulldesc-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, password_hash, role,
+		                    provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, "nulldesc-"+suffix+"@example.com", "nulldesc-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	// talks_to carries both the MCP server's id and its name, which is what
+	// GetByMCPServer and GetByMCPServerName match on with the @> containment operator.
+	talksTo := fmt.Sprintf(`["%s", "%s"]`, mcpServerID.String(), mcpServerName)
+
+	// description is NULL. That is the entire point of the fixture, so it is written
+	// explicitly rather than omitted, and a future NOT NULL constraint fails here loudly
+	// instead of quietly making this suite vacuous.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
+		                     status, public_key, trust_score, talks_to, created_by,
+		                     created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, NULL, 'ai_agent', 'active', 'unused', 0.5, $5::jsonb, $6,
+		         NOW(), NOW())`,
+		agentID, orgID, agentName, "NullDesc Agent", talksTo, userID)
+	require.NoError(t, err,
+		"seeding a NULL description failed — if the column became NOT NULL this suite no "+
+			"longer tests anything and must be revisited, not deleted")
+
+	return orgID, agentID, mcpServerID, agentName, mcpServerName
+}
+
+func TestNullDescriptionIsReadableByEveryAgentReadPath(t *testing.T) {
+	ctx := context.Background()
+	db := agentListTestDB(t)
+	repo := NewAgentRepository(db)
+
+	orgID, agentID, mcpServerID, agentName, mcpServerName := seedNullDescriptionAgent(t, db, ctx)
+
+	// GetByID is first because it is the one on the auth path.
+	t.Run("GetByID", func(t *testing.T) {
+		agent, err := repo.GetByID(agentID)
+		require.NoError(t, err,
+			"GetByID failed on a NULL description; the auth middlewares report this as "+
+				"\"Agent not found\", which reads exactly like a revocation denial")
+		require.NotNil(t, agent)
+		assert.Equal(t, agentID, agent.ID)
+		assert.Empty(t, agent.Description, "a NULL description must read as empty, not fail the row")
+	})
+
+	t.Run("GetByName", func(t *testing.T) {
+		agent, err := repo.GetByName(orgID, agentName)
+		require.NoError(t, err)
+		require.NotNil(t, agent)
+		assert.Equal(t, agentID, agent.ID)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		agents, err := repo.List(1000, 0)
+		require.NoError(t, err)
+		assert.True(t, containsAgent(agents, agentID), "the agent was absent from List")
+	})
+
+	t.Run("GetByOrganizationPaged", func(t *testing.T) {
+		agents, _, err := repo.GetByOrganizationPaged(orgID, 1000, 0)
+		require.NoError(t, err)
+		assert.True(t, containsAgent(agents, agentID))
+	})
+
+	t.Run("GetByMCPServer", func(t *testing.T) {
+		agents, err := repo.GetByMCPServer(mcpServerID, orgID)
+		require.NoError(t, err)
+		assert.True(t, containsAgent(agents, agentID))
+	})
+
+	t.Run("GetByMCPServerName", func(t *testing.T) {
+		agents, err := repo.GetByMCPServerName(mcpServerName, orgID)
+		require.NoError(t, err)
+		assert.True(t, containsAgent(agents, agentID))
+	})
+}
+
+// The control. The same six paths must still return a non-NULL description intact, so the
+// suite above is proving NULL-tolerance rather than a method that ignores the column.
+func TestNonNullDescriptionSurvivesEveryAgentReadPath(t *testing.T) {
+	ctx := context.Background()
+	db := agentListTestDB(t)
+	repo := NewAgentRepository(db)
+
+	orgID, agentID, mcpServerID, agentName, mcpServerName := seedNullDescriptionAgent(t, db, ctx)
+
+	const want = "a description that must survive the round trip"
+	_, err := db.ExecContext(ctx, `UPDATE agents SET description = $1 WHERE id = $2`, want, agentID)
+	require.NoError(t, err)
+
+	byID, err := repo.GetByID(agentID)
+	require.NoError(t, err)
+	assert.Equal(t, want, byID.Description)
+
+	byName, err := repo.GetByName(orgID, agentName)
+	require.NoError(t, err)
+	assert.Equal(t, want, byName.Description)
+
+	listed, err := repo.List(1000, 0)
+	require.NoError(t, err)
+	assert.Equal(t, want, findAgent(t, listed, agentID).Description)
+
+	paged, _, err := repo.GetByOrganizationPaged(orgID, 1000, 0)
+	require.NoError(t, err)
+	assert.Equal(t, want, findAgent(t, paged, agentID).Description)
+
+	byMCP, err := repo.GetByMCPServer(mcpServerID, orgID)
+	require.NoError(t, err)
+	assert.Equal(t, want, findAgent(t, byMCP, agentID).Description)
+
+	byMCPName, err := repo.GetByMCPServerName(mcpServerName, orgID)
+	require.NoError(t, err)
+	assert.Equal(t, want, findAgent(t, byMCPName, agentID).Description)
+}
+
+func containsAgent(agents []*domain.Agent, id uuid.UUID) bool {
+	for _, a := range agents {
+		if a.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func findAgent(t *testing.T, agents []*domain.Agent, id uuid.UUID) *domain.Agent {
+	t.Helper()
+	for _, a := range agents {
+		if a.ID == id {
+			return a
+		}
+	}
+	require.FailNow(t, "agent not found in result set", "id=%s", id)
+	return nil
+}

--- a/apps/backend/internal/infrastructure/repository/agent_null_description_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/agent_null_description_integration_test.go
@@ -73,14 +73,18 @@ func seedNullDescriptionAgent(t *testing.T, db *sql.DB, ctx context.Context) (or
 	// GetByMCPServer and GetByMCPServerName match on with the @> containment operator.
 	talksTo := fmt.Sprintf(`["%s", "%s"]`, mcpServerID.String(), mcpServerName)
 
-	// description is NULL. That is the entire point of the fixture, so it is written
-	// explicitly rather than omitted, and a future NOT NULL constraint fails here loudly
-	// instead of quietly making this suite vacuous.
+	// description AND trust_score are NULL. Both are the point of the fixture, so both are
+	// written explicitly rather than omitted, and a future NOT NULL constraint fails here
+	// loudly instead of quietly making this suite vacuous.
+	//
+	// trust_score can only reach NULL through an INSERT: a trigger writing to
+	// trust_score_history rejects an UPDATE to NULL, which is why an earlier sweep
+	// concluded the column was unreachable and stopped. It is not — this is that insert.
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
 		                     status, public_key, trust_score, talks_to, created_by,
 		                     created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, NULL, 'ai_agent', 'active', 'unused', 0.5, $5::jsonb, $6,
+		 VALUES ($1, $2, $3, $4, NULL, 'ai_agent', 'active', 'unused', NULL, $5::jsonb, $6,
 		         NOW(), NOW())`,
 		agentID, orgID, agentName, "NullDesc Agent", talksTo, userID)
 	require.NoError(t, err,

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -196,6 +196,10 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	var createdBySDKTokenID sql.NullString
 	var createdByAPIKeyID sql.NullString
 	var updatedBy sql.NullString
+	// `rotation_count` is nullable. GetByName already scans it through a NullInt32; this
+	// method did not, so a NULL there failed the whole row on the auth path — the same
+	// sibling-does-it-right divergence as `description` below, in the same method.
+	var rotationCount sql.NullInt32
 	// `description` is nullable. Scanning it into a plain string fails the entire row,
 	// and GetByID is what the agent auth middlewares call — a failed read there is
 	// reported as "Agent not found", which is indistinguishable from a revocation denial.
@@ -229,7 +233,7 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 		&keyExpiresAt,
 		&keyRotationGraceUntil,
 		&previousPublicKey,
-		&agent.RotationCount,
+		&rotationCount,
 		&pqcPublicKey,
 		&pqcKeyAlgorithm,
 		&agent.HybridModeEnabled,
@@ -258,6 +262,9 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	// Convert nullable fields
 	if description.Valid {
 		agent.Description = description.String
+	}
+	if rotationCount.Valid {
+		agent.RotationCount = int(rotationCount.Int32)
 	}
 	if version.Valid {
 		agent.Version = version.String
@@ -373,7 +380,7 @@ func (r *AgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset 
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
 		WHERE organization_id = $1
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id
 	`
 	args := []interface{}{orgID}
 	if limit > 0 {
@@ -577,6 +584,52 @@ func (r *AgentRepository) Delete(id uuid.UUID) error {
 	return err
 }
 
+// ListRevokedIDs returns one page of revoked agent ids, newest first.
+//
+// The revocation list is served on an unauthenticated route, so the `status = 'revoked'`
+// predicate has to run in SQL. Filtering List's results in Go instead means every request
+// reads and materialises every agent row — twenty-four columns including three JSONB
+// ones — to emit the revoked subset. Measured at 20,000 agents that was ~320ms of server
+// work per request, which an unauthenticated caller controls the cost of.
+//
+// Only the id is selected. Nothing else on the row belongs on a public CRL, and selecting
+// less also means this method cannot be broken by a nullable column it does not read.
+func (r *AgentRepository) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	if limit <= 0 {
+		return nil, ErrNonPositiveLimit
+	}
+
+	// (created_at, id) is a total order, so an offset walk cannot skip or repeat rows
+	// that share a timestamp.
+	const query = `
+		SELECT id
+		FROM agents
+		WHERE status = $1
+		ORDER BY created_at DESC, id
+		LIMIT $2 OFFSET $3
+	`
+
+	rows, err := r.db.Query(query, string(domain.AgentStatusRevoked), limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ids := make([]uuid.UUID, 0, limit)
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
 // ErrNonPositiveLimit is returned by List when it is asked for a page of zero or
 // fewer rows. See List for why this is an error rather than an interpretation.
 var ErrNonPositiveLimit = errors.New("agent repository: limit must be positive; pass an explicit page size")
@@ -755,7 +808,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 		    talks_to @> $2::jsonb
 		    OR talks_to @> $3::jsonb
 		  )
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id
 	`
 
 	// Format 1: Simple string array ["uuid"]
@@ -875,7 +928,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 		    talks_to @> $2::jsonb
 		    OR talks_to @> $3::jsonb
 		  )
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id
 	`
 
 	// Format 1: Simple string array ["name"]
@@ -975,7 +1028,6 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 
 	return agents, nil
 }
-
 
 // GetByName gets an agent by name within an organization
 func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent, error) {
@@ -1123,7 +1175,6 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 
 	return agent, nil
 }
-
 
 // UpdateLastActive updates the last_active timestamp for an agent
 func (r *AgentRepository) UpdateLastActive(ctx context.Context, agentID uuid.UUID) error {

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -161,7 +161,7 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version,
 		       public_key, encrypted_private_key, key_algorithm, certificate_url, repository_url, documentation_url,
-		       trust_score, verified_at, talks_to, capabilities, metadata, created_at, updated_at, created_by, last_active,
+		       COALESCE(trust_score, 0), verified_at, talks_to, capabilities, metadata, created_at, updated_at, created_by, last_active,
 		       key_created_at, key_expires_at, key_rotation_grace_until, previous_public_key, rotation_count,
 		       pqc_public_key, pqc_key_algorithm, COALESCE(hybrid_mode_enabled, false), pqc_key_created_at, pqc_key_expires_at, previous_pqc_public_key,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''), created_by_sdk_token_id, created_by_api_key_id,
@@ -374,7 +374,7 @@ func (r *AgentRepository) GetByOrganization(orgID uuid.UUID) ([]*domain.Agent, e
 func (r *AgentRepository) GetByOrganizationPaged(orgID uuid.UUID, limit, offset int) ([]*domain.Agent, int, error) {
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
-		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
+		       certificate_url, repository_url, documentation_url, COALESCE(trust_score, 0), verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''),
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
@@ -655,7 +655,7 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
-		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
+		       certificate_url, repository_url, documentation_url, COALESCE(trust_score, 0), verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''),
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
@@ -799,7 +799,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 	// We need to check for both formats
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
-		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
+		       certificate_url, repository_url, documentation_url, COALESCE(trust_score, 0), verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
@@ -919,7 +919,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 	// We need to check for both formats
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
-		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
+		       certificate_url, repository_url, documentation_url, COALESCE(trust_score, 0), verified_at,
 		       talks_to, metadata, created_at, updated_at, created_by,
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
@@ -1033,7 +1033,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent, error) {
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version,
-		       public_key, certificate_url, repository_url, documentation_url, trust_score, verified_at,
+		       public_key, certificate_url, repository_url, documentation_url, COALESCE(trust_score, 0), verified_at,
 		       created_at, updated_at, created_by, encrypted_private_key, key_algorithm,
 		       key_created_at, key_expires_at, key_rotation_grace_until, previous_public_key, rotation_count,
 		       talks_to, capabilities, metadata,
@@ -1202,7 +1202,7 @@ func (r *AgentRepository) UpdateHeartbeat(ctx context.Context, agentID uuid.UUID
 // GetStaleAgents returns agents whose heartbeat is older than the given time
 func (r *AgentRepository) GetStaleAgents(ctx context.Context, staleSince time.Time) ([]*domain.Agent, error) {
 	query := `
-		SELECT id, organization_id, name, display_name, status, agent_type, trust_score,
+		SELECT id, organization_id, name, display_name, status, agent_type, COALESCE(trust_score, 0),
 		       last_heartbeat, last_active, created_at, updated_at
 		FROM agents
 		WHERE last_heartbeat IS NOT NULL
@@ -1248,7 +1248,7 @@ func (r *AgentRepository) GetByIDs(ctx context.Context, ids []uuid.UUID) ([]*dom
 		args[i] = id
 	}
 	query := fmt.Sprintf(`
-		SELECT id, organization_id, name, display_name, status, agent_type, trust_score,
+		SELECT id, organization_id, name, display_name, status, agent_type, COALESCE(trust_score, 0),
 		       last_heartbeat, last_active, created_at, updated_at
 		FROM agents WHERE id IN (%s)`, strings.Join(placeholders, ","))
 	rows, err := r.db.QueryContext(ctx, query, args...)

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -589,8 +589,11 @@ func (r *AgentRepository) Delete(id uuid.UUID) error {
 // The revocation list is served on an unauthenticated route, so the `status = 'revoked'`
 // predicate has to run in SQL. Filtering List's results in Go instead means every request
 // reads and materialises every agent row — twenty-four columns including three JSONB
-// ones — to emit the revoked subset. Measured at 20,000 agents that was ~320ms of server
-// work per request, which an unauthenticated caller controls the cost of.
+// ones — to emit the revoked subset. At 20,000 agents that was hundreds of milliseconds
+// per request (~320ms and ~630ms in two measurements of differently-shaped rows), which
+// an unauthenticated caller controls the cost of. The cost scales with the table rather
+// than with the number of revocations, which is the property that matters; the exact
+// figure is row-shape dependent and is not pinned here because nothing can check it.
 //
 // Only the id is selected. Nothing else on the row belongs on a public CRL, and selecting
 // less also means this method cannot be broken by a nullable column it does not read.

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -569,8 +570,29 @@ func (r *AgentRepository) Delete(id uuid.UUID) error {
 	return err
 }
 
-// List lists all agents with pagination
+// ErrNonPositiveLimit is returned by List when it is asked for a page of zero or
+// fewer rows. See List for why this is an error rather than an interpretation.
+var ErrNonPositiveLimit = errors.New("agent repository: limit must be positive; pass an explicit page size")
+
+// List returns one page of agents. limit MUST be positive.
+//
+// This method previously appended `LIMIT $1 OFFSET $2` unconditionally, so a zero limit
+// reached Postgres as `LIMIT 0` and returned no rows at all. Both callers passed (0, 0)
+// meaning "all" — one of them says so in a comment — because the sibling method
+// GetByOrganizationPaged above documents exactly that convention. The two conventions
+// collided here, and the revocation endpoint that reads this method served an empty list
+// to every caller as a result.
+//
+// Adopting the sibling's "non-positive means all" convention would have fixed that and is
+// the obvious repair, but it trades a silent-empty bug for a silent-everything one: an
+// unbounded full-table scan behind whichever caller next passes a zero, including an
+// unauthenticated route. Both failure directions are silent. Erroring is the only option
+// that is neither, and it fails visibly, which is the property the empty list lacked.
 func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
+	if limit <= 0 {
+		return nil, ErrNonPositiveLimit
+	}
+
 	query := `
 		SELECT id, organization_id, name, display_name, description, agent_type, status, version, public_key,
 		       certificate_url, repository_url, documentation_url, trust_score, verified_at,
@@ -578,10 +600,14 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 		       COALESCE(created_by_name, ''), COALESCE(created_by_email, ''),
 		       COALESCE(capability_violation_count, 0), COALESCE(is_compromised, false), declared_purpose
 		FROM agents
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id
 		LIMIT $1 OFFSET $2
 	`
 
+	// `id` breaks ties in the sort. Without it `created_at DESC` alone is not a total
+	// order, and rows sharing a timestamp can land on both sides of a page boundary or
+	// on neither — a caller walking offsets silently skips or repeats them. That matters
+	// now that the revocation list pages through this method.
 	rows, err := r.db.Query(query, limit, offset)
 	if err != nil {
 		return nil, err
@@ -591,6 +617,13 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 	agents := make([]*domain.Agent, 0)
 	for rows.Next() {
 		agent := &domain.Agent{}
+		// `description` is nullable and has to be scanned through a NullString, exactly as
+		// GetByOrganizationPaged does above. Scanning it straight into a string fails the
+		// entire row with "converting NULL to string is unsupported". That could not fire
+		// while the LIMIT bug held, because no row was ever scanned — fixing the limit
+		// without this turns the empty list into a 500 for any deployment holding a single
+		// agent with no description.
+		var description sql.NullString
 		var version sql.NullString
 		var publicKey sql.NullString
 		var certificateURL sql.NullString
@@ -604,7 +637,7 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 			&agent.OrganizationID,
 			&agent.Name,
 			&agent.DisplayName,
-			&agent.Description,
+			&description,
 			&agent.AgentType,
 			&agent.Status,
 			&version,
@@ -630,6 +663,9 @@ func (r *AgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 		}
 
 		// Convert nullable fields
+		if description.Valid {
+			agent.Description = description.String
+		}
 		if version.Valid {
 			agent.Version = version.String
 		}

--- a/apps/backend/internal/infrastructure/repository/agent_repository.go
+++ b/apps/backend/internal/infrastructure/repository/agent_repository.go
@@ -196,13 +196,17 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	var createdBySDKTokenID sql.NullString
 	var createdByAPIKeyID sql.NullString
 	var updatedBy sql.NullString
+	// `description` is nullable. Scanning it into a plain string fails the entire row,
+	// and GetByID is what the agent auth middlewares call — a failed read there is
+	// reported as "Agent not found", which is indistinguishable from a revocation denial.
+	var description sql.NullString
 
 	err := r.db.QueryRow(query, id).Scan(
 		&agent.ID,
 		&agent.OrganizationID,
 		&agent.Name,
 		&agent.DisplayName,
-		&agent.Description,
+		&description,
 		&agent.AgentType,
 		&agent.Status,
 		&version,
@@ -252,6 +256,9 @@ func (r *AgentRepository) GetByID(id uuid.UUID) (*domain.Agent, error) {
 	}
 
 	// Convert nullable fields
+	if description.Valid {
+		agent.Description = description.String
+	}
 	if version.Valid {
 		agent.Version = version.String
 	}
@@ -765,6 +772,8 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 	agents := make([]*domain.Agent, 0)
 	for rows.Next() {
 		agent := &domain.Agent{}
+		// `description` is nullable; scanning it into a plain string fails the whole row.
+		var description sql.NullString
 		var version sql.NullString
 		var publicKey sql.NullString
 		var certificateURL sql.NullString
@@ -778,7 +787,7 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 			&agent.OrganizationID,
 			&agent.Name,
 			&agent.DisplayName,
-			&agent.Description,
+			&description,
 			&agent.AgentType,
 			&agent.Status,
 			&version,
@@ -802,6 +811,9 @@ func (r *AgentRepository) GetByMCPServer(mcpServerID uuid.UUID, orgID uuid.UUID)
 		}
 
 		// Convert nullable fields
+		if description.Valid {
+			agent.Description = description.String
+		}
 		if version.Valid {
 			agent.Version = version.String
 		}
@@ -880,6 +892,8 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 	agents := make([]*domain.Agent, 0)
 	for rows.Next() {
 		agent := &domain.Agent{}
+		// `description` is nullable; scanning it into a plain string fails the whole row.
+		var description sql.NullString
 		var version sql.NullString
 		var publicKey sql.NullString
 		var certificateURL sql.NullString
@@ -893,7 +907,7 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 			&agent.OrganizationID,
 			&agent.Name,
 			&agent.DisplayName,
-			&agent.Description,
+			&description,
 			&agent.AgentType,
 			&agent.Status,
 			&version,
@@ -917,6 +931,9 @@ func (r *AgentRepository) GetByMCPServerName(mcpServerName string, orgID uuid.UU
 		}
 
 		// Convert nullable fields
+		if description.Valid {
+			agent.Description = description.String
+		}
 		if version.Valid {
 			agent.Version = version.String
 		}
@@ -988,6 +1005,8 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 	var keyRotationGraceUntil sql.NullTime
 	var previousPublicKey sql.NullString
 	var rotationCount sql.NullInt32
+	// `description` is nullable; scanning it into a plain string fails the whole row.
+	var description sql.NullString
 	talksToJSON := make([]byte, 0)
 	capabilitiesJSON := make([]byte, 0)
 	metadataJSON := make([]byte, 0)
@@ -998,7 +1017,7 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 		&agent.OrganizationID,
 		&agent.Name,
 		&agent.DisplayName,
-		&agent.Description,
+		&description,
 		&agent.AgentType,
 		&agent.Status,
 		&version,
@@ -1034,6 +1053,9 @@ func (r *AgentRepository) GetByName(orgID uuid.UUID, name string) (*domain.Agent
 	}
 
 	// Convert nullable fields
+	if description.Valid {
+		agent.Description = description.String
+	}
 	if version.Valid {
 		agent.Version = version.String
 	}

--- a/apps/backend/internal/interfaces/http/handlers/authorize_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/authorize_handler_cross_tenant_test.go
@@ -137,3 +137,7 @@ func TestAuthorizeHandler_SameOrgPassesThroughToFGA(t *testing.T) {
 		"FGAEngine must be reached on the legitimate same-org path")
 	assert.Equal(t, agentID, fake.gotRequest.AgentID)
 }
+
+func (r *authorizeForeignOrgAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/authorize_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/authorize_handler_test.go
@@ -246,3 +246,7 @@ func TestAuthorize_EngineErrorWithNilResult_Returns500WithErrorResponse(t *testi
 
 	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
 }
+
+func (r *permissiveAuthorizeAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/capability_request_handler_cross_tenant_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/capability_request_handler_cross_tenant_test.go
@@ -229,3 +229,7 @@ func TestCapabilityRequestHandlers_RejectCapabilityRequest_CrossOrgReturns404(t 
 		// expected: gate fired, no mutation
 	}
 }
+
+func (r *capRequestTestAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
@@ -142,7 +142,15 @@ func (h *LifecycleHandler) GetRevocationList(c fiber.Ctx) error {
 	c.Set("Cache-Control", "max-age=300")
 	c.Set("ETag", fmt.Sprintf(`"%s"`, hex.EncodeToString(digest.Sum(nil))))
 
-	// The key stays `revocations`, which is what ATP-SPEC §8.1 specifies. Both SDK CRL
+	// The key stays `revocations`, which is what ATP-SPEC v1.0.0-rc1 §8.1 specifies. That
+	// document is not in this repository — it lives at
+	// https://github.com/opena2a-standards/agent-trust-protocol (ATP-SPEC.md, §8.1
+	// "Trust Proof Revocation") and its response schema is published at
+	// https://specs.opena2a.org/schemas/atp/revocation-list-v1.schema.json — so the
+	// citation is given in full rather than as a bare section number nobody here can
+	// resolve. Note this endpoint's path is NOT the one §8.1 specifies
+	// (`/api/v1/trust/revocations`, served by the Registry) and AIM claims no conformance
+	// to it; the key name is where the two agree. Both SDK CRL
 	// types decode `entries` instead, so a fetcher wired naively against this body does
 	// not get a usable list.
 	//

--- a/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -65,43 +67,89 @@ func (h *LifecycleHandler) Heartbeat(c fiber.Ctx) error {
 	})
 }
 
-// GetRevocationList returns the list of revoked agent and token IDs
+// revocationReasonRevoked is the only reason code this list emits.
+//
+// It must stay a closed set. The endpoint is unauthenticated and spans every
+// organization, so the moment a reason carries operator-supplied free text it becomes
+// a cross-organization disclosure channel for whatever a customer typed into it.
+const revocationReasonRevoked = "revoked"
+
+// revocationListPageSize bounds each repository read while the list is assembled.
+// AgentRepository.List rejects a non-positive limit precisely so that no caller can ask
+// it for an unbounded result set.
+const revocationListPageSize = 500
+
+// GetRevocationList returns the list of revoked agent IDs
 // GET /api/v1/revocations
+//
+// Unauthenticated and cross-organization by design: a verifier has to be able to check
+// revocation without holding a credential, which is what makes offline verification
+// possible. Minimization is therefore the control that applies here, not authentication.
+//
+// The payload carries the agent id and a reason code, and nothing else. It previously
+// also carried the agent's name and a revocation timestamp:
+//   - `name` is an organization-internal namespace (`UNIQUE(organization_id, name)`)
+//     with no opt-in mechanism and no consumer — neither SDK's CRL type has the field.
+//   - `revokedAt` was read from `agents.updated_at`, which any later write to the row
+//     silently rewrites. There is no `revoked_at` column to source it from.
+//
+// Both were inert only because this endpoint returned an empty list to every caller.
+// Do not add fields back without a consumer that reads them.
 func (h *LifecycleHandler) GetRevocationList(c fiber.Ctx) error {
-	agents, err := h.agentRepo.List(0, 0)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to fetch agents",
-		})
-	}
-
 	type RevokedEntry struct {
-		AgentID   uuid.UUID `json:"agentId"`
-		Name      string    `json:"name"`
-		RevokedAt time.Time `json:"revokedAt"`
-		Reason    string    `json:"reason"`
+		AgentID uuid.UUID `json:"agentId"`
+		Reason  string    `json:"reason"`
 	}
 
+	// Walk every page rather than asking for one unbounded result set. The list is
+	// deliberately NOT truncated: a CRL that silently drops entries tells a verifier a
+	// revoked agent is good, which is the same fail-open this endpoint was fixed for.
+	//
+	// The cost of that honesty is that this reads every agent row to emit a subset, on an
+	// unauthenticated route. Pushing `status = 'revoked'` into SQL removes it, but that
+	// wants a purpose-built repository method and the `revoked_at` column the schema does
+	// not have yet — tracked as the ATP conformance work, not smuggled in here.
 	revoked := make([]RevokedEntry, 0)
-	for _, agent := range agents {
-		if agent.Status == domain.AgentStatusRevoked {
-			revoked = append(revoked, RevokedEntry{
-				AgentID:   agent.ID,
-				Name:      agent.Name,
-				RevokedAt: agent.UpdatedAt,
-				Reason:    "revoked",
+	for offset := 0; ; offset += revocationListPageSize {
+		agents, err := h.agentRepo.List(revocationListPageSize, offset)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": "Failed to fetch agents",
 			})
+		}
+
+		for _, agent := range agents {
+			if agent.Status == domain.AgentStatusRevoked {
+				revoked = append(revoked, RevokedEntry{
+					AgentID: agent.ID,
+					Reason:  revocationReasonRevoked,
+				})
+			}
+		}
+
+		if len(agents) < revocationListPageSize {
+			break
 		}
 	}
 
-	if revoked == nil {
-		revoked = []RevokedEntry{}
+	// The validator is derived from the revocation set itself, so it changes when and
+	// only when the set changes. It deliberately excludes `generatedAt`, which moves on
+	// every request. The previous validator was built from the entry count and a
+	// wall-clock bucket, which collides whenever one agent is revoked and another
+	// leaves the list inside the same bucket — that is a stale CRL served as fresh.
+	digest := sha256.New()
+	for _, entry := range revoked {
+		_, _ = digest.Write(entry.AgentID[:])
+		_, _ = digest.Write([]byte(entry.Reason))
 	}
-
-	// Set cache headers
 	c.Set("Cache-Control", "max-age=300")
-	c.Set("ETag", fmt.Sprintf(`"%d-%d"`, len(revoked), time.Now().Unix()/300))
+	c.Set("ETag", fmt.Sprintf(`"%s"`, hex.EncodeToString(digest.Sum(nil))))
 
+	// The key stays `revocations`. Both SDK CRL types currently decode `entries` instead,
+	// so a naive fetcher against this body fails loudly — and that mismatch is doing real
+	// work right now: it is what stops a caller from quietly accepting a CRL as fresh.
+	// Aligning the two is correct eventually, but it must not be done as a standalone
+	// rename on either side. Whichever end moves first removes the interlock.
 	return c.JSON(fiber.Map{
 		"revocations": revoked,
 		"total":       len(revoked),

--- a/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
@@ -105,29 +105,26 @@ func (h *LifecycleHandler) GetRevocationList(c fiber.Ctx) error {
 	// deliberately NOT truncated: a CRL that silently drops entries tells a verifier a
 	// revoked agent is good, which is the same fail-open this endpoint was fixed for.
 	//
-	// The cost of that honesty is that this reads every agent row to emit a subset, on an
-	// unauthenticated route. Pushing `status = 'revoked'` into SQL removes it, but that
-	// wants a purpose-built repository method and the `revoked_at` column the schema does
-	// not have yet — tracked as the ATP conformance work, not smuggled in here.
+	// The `status = 'revoked'` predicate runs in SQL. Filtering List's results in Go
+	// instead made every request to this unauthenticated route read every agent row —
+	// ~320ms of server work at 20,000 agents, at a cost the caller controls.
 	revoked := make([]RevokedEntry, 0)
 	for offset := 0; ; offset += revocationListPageSize {
-		agents, err := h.agentRepo.List(revocationListPageSize, offset)
+		ids, err := h.agentRepo.ListRevokedIDs(revocationListPageSize, offset)
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"error": "Failed to fetch agents",
+				"error": "Failed to fetch revocations",
 			})
 		}
 
-		for _, agent := range agents {
-			if agent.Status == domain.AgentStatusRevoked {
-				revoked = append(revoked, RevokedEntry{
-					AgentID: agent.ID,
-					Reason:  revocationReasonRevoked,
-				})
-			}
+		for _, id := range ids {
+			revoked = append(revoked, RevokedEntry{
+				AgentID: id,
+				Reason:  revocationReasonRevoked,
+			})
 		}
 
-		if len(agents) < revocationListPageSize {
+		if len(ids) < revocationListPageSize {
 			break
 		}
 	}
@@ -145,11 +142,18 @@ func (h *LifecycleHandler) GetRevocationList(c fiber.Ctx) error {
 	c.Set("Cache-Control", "max-age=300")
 	c.Set("ETag", fmt.Sprintf(`"%s"`, hex.EncodeToString(digest.Sum(nil))))
 
-	// The key stays `revocations`. Both SDK CRL types currently decode `entries` instead,
-	// so a naive fetcher against this body fails loudly — and that mismatch is doing real
-	// work right now: it is what stops a caller from quietly accepting a CRL as fresh.
-	// Aligning the two is correct eventually, but it must not be done as a standalone
-	// rename on either side. Whichever end moves first removes the interlock.
+	// The key stays `revocations`, which is what ATP-SPEC §8.1 specifies. Both SDK CRL
+	// types decode `entries` instead, so a fetcher wired naively against this body does
+	// not get a usable list.
+	//
+	// Do NOT "fix" that by emitting both keys, and do not rename it in the SDKs either,
+	// until the SDK side is verified to fail closed on a shape it cannot read. The
+	// TypeScript cache throws on a bad shape; the Java cache accepted a decoded
+	// `Crl(entries=null)` as a valid list, cached it FRESH, and the verifier read null
+	// entries as "nothing is revoked" — a silent fail-open. Both are fixed now
+	// (CrlCache.refreshNow rejects null entries, LocalAtxVerifier rejects a malformed
+	// CRL rather than treating it as empty), but the ordering rule stands: whichever end
+	// moves first must not be the one that turns a loud failure into a quiet one.
 	return c.JSON(fiber.Map{
 		"revocations": revoked,
 		"total":       len(revoked),

--- a/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/lifecycle_handler.go
@@ -107,7 +107,10 @@ func (h *LifecycleHandler) GetRevocationList(c fiber.Ctx) error {
 	//
 	// The `status = 'revoked'` predicate runs in SQL. Filtering List's results in Go
 	// instead made every request to this unauthenticated route read every agent row —
-	// ~320ms of server work at 20,000 agents, at a cost the caller controls.
+	// hundreds of milliseconds of server work at 20,000 agents, at a cost the caller
+	// controls. Two independent measurements at that size landed at ~320ms and ~630ms
+	// depending on row width, which is the point: it scales with the table, not with the
+	// answer. The exact figure is not pinned here because nothing can check it.
 	revoked := make([]RevokedEntry, 0)
 	for offset := 0; ; offset += revocationListPageSize {
 		ids, err := h.agentRepo.ListRevokedIDs(revocationListPageSize, offset)

--- a/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
@@ -231,7 +231,11 @@ func TestRevocationListCarriesNoAgentNameOrTimestamp(t *testing.T) {
 
 // The response must NOT carry an `entries` key, and this is deliberate.
 //
-// `revocations` is what ATP-SPEC §8.1 specifies. Both SDK CRL types decode `entries`
+// `revocations` is what ATP-SPEC v1.0.0-rc1 §8.1 specifies — a document that is not in
+// this repository, so the pointer is given in full:
+// https://github.com/opena2a-standards/agent-trust-protocol (ATP-SPEC.md §8.1) with its
+// schema at https://specs.opena2a.org/schemas/atp/revocation-list-v1.schema.json.
+// Both SDK CRL types decode `entries`
 // instead, so a fetcher wired naively against this body does not get a usable list.
 //
 // Serving both keys is the tempting tidy-up and it must stay a deliberate act with a
@@ -351,9 +355,17 @@ func seedBulkRevokedAgents(t *testing.T, db *sql.DB, ctx context.Context, n int)
 		userID, orgID, "revbulk-"+suffix+"@example.com", "revbulk-user", "local-"+suffix)
 	require.NoError(t, err)
 
-	// created_at is deliberately identical across every row. That makes `created_at DESC`
-	// alone a non-total order, so if the tie-breaker on the paginated query were dropped
-	// the offset walk would skip or repeat rows and this fixture would catch it.
+	// created_at is deliberately identical across every row, which makes `created_at DESC`
+	// alone a non-total order — the condition the query's `, id` tie-breaker exists for.
+	//
+	// It does NOT follow that this fixture catches a dropped tie-breaker, and an earlier
+	// version of this comment claimed it did. Removing `, id` leaves all of these tests
+	// green: PostgreSQL happens to return the same permutation of tied rows across
+	// consecutive page queries, so the defect is real but invisible from here. Proving it
+	// needs a plan that genuinely reorders between pages, which this fixture does not force.
+	//
+	// The fixture is still worth its cost — it is what exercises multi-page assembly at all
+	// — but do not read a green run as evidence the ordering is safe.
 	rows, err := db.QueryContext(ctx,
 		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
 		                     status, public_key, trust_score, created_by, created_at, updated_at)

--- a/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
@@ -231,15 +231,15 @@ func TestRevocationListCarriesNoAgentNameOrTimestamp(t *testing.T) {
 
 // The response must NOT carry an `entries` key, and this is deliberate.
 //
-// Both SDK CRL types decode `entries`, so a fetcher pointed straight at this body fails
-// loudly today — the TypeScript cache throws rather than caching. That mismatch is doing
-// real work: it is the only thing stopping a client from accepting this list as fresh and
-// authoritative. Serving `entries` as well would make a naive fetcher succeed quietly,
-// which is the exact silent fail-open the empty-list defect produced.
+// `revocations` is what ATP-SPEC §8.1 specifies. Both SDK CRL types decode `entries`
+// instead, so a fetcher wired naively against this body does not get a usable list.
 //
-// Aligning server and SDK is correct eventually, but not as a standalone rename on either
-// side, and not before a client can act on what it receives. This test is here so that
-// adding the alias is a deliberate act with a failing test attached, rather than a tidy-up.
+// Serving both keys is the tempting tidy-up and it must stay a deliberate act with a
+// failing test attached, because the SDK side has already been caught failing OPEN on a
+// shape it could not read: the Java cache accepted a decoded `Crl(entries=null)` as
+// valid, cached it FRESH, and the verifier read null entries as "nothing is revoked".
+// Both SDKs are fixed now, but the ordering rule this test enforces is that neither end
+// moves until the other is known to fail closed.
 func TestRevocationListDoesNotServeTheSdkKey(t *testing.T) {
 	ctx := context.Background()
 	db := revocationTestDB(t)
@@ -287,13 +287,154 @@ func TestRevocationListTotalMatchesEntries(t *testing.T) {
 	ctx := context.Background()
 	db := revocationTestDB(t)
 
-	seedAgentForRevocationList(t, db, ctx, "revoked")
+	revokedID, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
 
 	status, body := fetchRevocationList(t, db)
 	require.Equal(t, fiber.StatusOK, status)
 
+	ids := revokedAgentIDs(t, body)
+
+	// Control. Without it this test asserts 0 == 0 and passes against an endpoint that
+	// returns an empty list to everyone — which is the defect this file exists for. It
+	// did exactly that: it was the one test in this file that stayed green on the
+	// unfixed code.
+	require.Contains(t, ids, revokedID.String(),
+		"control: the seeded revoked agent must be listed, or the count below is vacuous")
+
 	total, ok := body["total"].(float64)
 	require.True(t, ok, "response carried no numeric total: %v", body)
-	assert.Equal(t, len(revokedAgentIDs(t, body)), int(total),
+	assert.Equal(t, len(ids), int(total),
 		"reported total disagreed with the number of entries returned")
+}
+
+// fetchRevocationETag returns the ETag header the handler sets.
+func fetchRevocationETag(t *testing.T, db *sql.DB) string {
+	t.Helper()
+
+	handler := NewLifecycleHandler(nil, repository.NewAgentRepository(db))
+	app := fiber.New()
+	app.Get("/api/v1/revocations", handler.GetRevocationList)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/revocations", nil), fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	return resp.Header.Get("ETag")
+}
+
+// seedBulkRevokedAgents inserts n revoked agents in one organization and returns the org
+// id and the set of agent ids, so a caller can assert on exactly its own rows rather than
+// on whatever else the table holds.
+func seedBulkRevokedAgents(t *testing.T, db *sql.DB, ctx context.Context, n int) (uuid.UUID, map[string]bool) {
+	t.Helper()
+
+	orgID, userID := uuid.New(), uuid.New()
+	suffix := orgID.String()[:8]
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE organization_id = $1`, orgID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "revbulk-org-"+suffix, "revbulk-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, password_hash, role,
+		                    provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, "revbulk-"+suffix+"@example.com", "revbulk-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	// created_at is deliberately identical across every row. That makes `created_at DESC`
+	// alone a non-total order, so if the tie-breaker on the paginated query were dropped
+	// the offset walk would skip or repeat rows and this fixture would catch it.
+	rows, err := db.QueryContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
+		                     status, public_key, trust_score, created_by, created_at, updated_at)
+		 SELECT gen_random_uuid(), $1, 'revbulk-' || $2 || '-' || g, 'Bulk Agent', NULL,
+		        'ai_agent', 'revoked', 'unused', 0.5, $3, NOW(), NOW()
+		 FROM generate_series(1, $4) AS g
+		 RETURNING id`,
+		orgID, suffix, userID, n)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	ids := make(map[string]bool, n)
+	for rows.Next() {
+		var id uuid.UUID
+		require.NoError(t, rows.Scan(&id))
+		ids[id.String()] = true
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, ids, n, "bulk seed did not insert the requested number of agents")
+
+	return orgID, ids
+}
+
+// The ETag must identify the revocation SET, and nothing else.
+//
+// It decides whether a caching verifier refreshes its CRL, so a validator that fails to
+// change on a real change tells the verifier a stale list is current. The previous one was
+// built from the entry count and a five-minute wall-clock bucket, so it changed when
+// nothing had, and collided whenever one agent was revoked and another left the list
+// inside the same bucket.
+func TestRevocationListETagTracksTheSetAndNotTheClock(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	first, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	_, body := fetchRevocationList(t, db)
+	require.Contains(t, revokedAgentIDs(t, body), first.String(),
+		"control: the seeded agent must be listed, or these ETags describe an empty set")
+
+	etagA := fetchRevocationETag(t, db)
+	require.NotEmpty(t, etagA, "handler set no ETag")
+
+	// Same content, later wall clock: the validator must not move.
+	assert.Equal(t, etagA, fetchRevocationETag(t, db),
+		"the ETag changed while the revocation set did not; a caching verifier refetches for nothing")
+
+	// One more revocation: the validator must move.
+	second, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+	assert.NotEqual(t, etagA, fetchRevocationETag(t, db),
+		"the ETag did not change after %s was revoked; a caching verifier would keep serving a list that omits it", second)
+}
+
+// The paging loop must assemble a list that crosses the page boundary.
+//
+// revocationListPageSize is 500 and every other test in this file runs against a handful
+// of rows, so the loop executes exactly once and breaks — the offset arithmetic, the break
+// condition and multi-page assembly are otherwise never exercised.
+func TestRevocationListAssemblesAcrossPageBoundaries(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	want := revocationListPageSize + 37
+	_, seeded := seedBulkRevokedAgents(t, db, ctx, want)
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	returned := revokedAgentIDs(t, body)
+
+	seen := make(map[string]bool, len(returned))
+	found := 0
+	for _, id := range returned {
+		assert.False(t, seen[id], "agent %s appeared twice; the offset walk double-counted", id)
+		seen[id] = true
+		if seeded[id] {
+			found++
+		}
+	}
+
+	assert.Equal(t, want, found,
+		"the revocation list dropped %d of the %d seeded revoked agents across the page boundary",
+		want-found, want)
 }

--- a/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/revocation_list_integration_test.go
@@ -1,0 +1,299 @@
+//go:build integration
+
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/repository"
+)
+
+// The federated revocation list (GET /api/v1/revocations).
+//
+// This endpoint is the post-issuance half of ATX revocation: `atx.revoked` is set at
+// issuance and never updated afterwards, so a verifier learns that an already-issued
+// credential was revoked only by reading this list. atx-spec core.md §3.3 puts the
+// propagation target at under 60 seconds, hard upper bound 5 minutes.
+//
+// Before this suite existed the handler called `agentRepo.List(0, 0)`, which reaches
+// `SELECT ... FROM agents ORDER BY created_at DESC LIMIT $1 OFFSET $2` with limit 0.
+// PostgreSQL `LIMIT 0` returns no rows — it does not mean "unbounded" — so the endpoint
+// answered 200 with an empty list no matter how many agents were revoked. A caching
+// verifier treats that as a successful fetch and holds it as FRESH, so revocation was
+// skipped with no error surfaced anywhere: no 4xx, no 5xx, no log line.
+//
+// These tests drive the REAL repository against a real Postgres and the REAL handler.
+// A mocked repository cannot catch this defect — the bug is in the SQL the mock replaces.
+//
+// Build-tag gated: requires Postgres reachable via TEST_DATABASE_URL with the AIM schema
+// applied.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestRevocationList ./internal/interfaces/http/handlers/...
+
+func revocationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping revocation list integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// seedAgentForRevocationList inserts one agent in `status` and returns its id and name.
+// Rows are removed child-first on cleanup so the foreign keys hold on the way out.
+func seedAgentForRevocationList(t *testing.T, db *sql.DB, ctx context.Context, status string) (uuid.UUID, string) {
+	t.Helper()
+
+	orgID, userID, agentID := uuid.New(), uuid.New(), uuid.New()
+	suffix := agentID.String()[:8]
+	agentName := "revlist-agent-" + suffix
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, domain, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		orgID, "revlist-org-"+suffix, "revlist-"+suffix+".example.com")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO users (id, organization_id, email, name, password_hash, role,
+		                    provider, provider_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 'x', 'admin', 'local', $5, NOW(), NOW())`,
+		userID, orgID, "revlist-"+suffix+"@example.com", "revlist-user", "local-"+suffix)
+	require.NoError(t, err)
+
+	// `description` is nullable with no default but is scanned into a plain string,
+	// so a NULL there fails the row read rather than the assertion under test.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
+		                     status, public_key, trust_score, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, 'ai_agent', $6, 'unused-for-this-endpoint', 0.5, $7, NOW(), NOW())`,
+		agentID, orgID, agentName, "Revocation List Agent",
+		"seeded by the revocation list suite", status, userID)
+	require.NoError(t, err)
+
+	return agentID, agentName
+}
+
+// fetchRevocationList runs the real handler through a real fiber app and returns the
+// decoded body. No middleware is mounted: the endpoint is unauthenticated by design and
+// this suite is about what the list CONTAINS.
+func fetchRevocationList(t *testing.T, db *sql.DB) (int, map[string]any) {
+	t.Helper()
+
+	// agentService is not reached by GetRevocationList; it reads agentRepo only.
+	handler := NewLifecycleHandler(nil, repository.NewAgentRepository(db))
+
+	app := fiber.New()
+	app.Get("/api/v1/revocations", handler.GetRevocationList)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/revocations", nil), fiber.TestConfig{Timeout: 0})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body), "response was not JSON: %s", string(raw))
+	return resp.StatusCode, body
+}
+
+// revocationEntries returns the entry objects under `key`.
+func revocationEntries(t *testing.T, body map[string]any, key string) []map[string]any {
+	t.Helper()
+
+	raw, ok := body[key]
+	require.True(t, ok, "response carried no %q key: %v", key, body)
+
+	list, ok := raw.([]any)
+	require.True(t, ok, "%q was not a list: %v", key, raw)
+
+	entries := make([]map[string]any, 0, len(list))
+	for _, e := range list {
+		entry, ok := e.(map[string]any)
+		require.True(t, ok, "entry was not an object: %v", e)
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// revokedAgentIDs pulls the agent ids out of the `revocations` key.
+func revokedAgentIDs(t *testing.T, body map[string]any) []string {
+	t.Helper()
+
+	entries := revocationEntries(t, body, "revocations")
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		id, ok := entry["agentId"].(string)
+		require.True(t, ok, "entry carried no agentId: %v", entry)
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// A revoked agent MUST appear in the list. This is the assertion the empty-list defect
+// failed: pre-fix the endpoint answered 200 with zero entries regardless of the table.
+func TestRevocationListIncludesRevokedAgent(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	revokedID, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	assert.Contains(t, revokedAgentIDs(t, body), revokedID.String(),
+		"a revoked agent was absent from the revocation list — a verifier reading this "+
+			"list would keep accepting its credential until expiry")
+}
+
+// An agent that is NOT revoked must be absent. Without this, a fix that returns every
+// agent row would pass the test above while telling verifiers to reject working agents.
+func TestRevocationListExcludesActiveAgent(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	activeID, _ := seedAgentForRevocationList(t, db, ctx, "active")
+	revokedID, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	ids := revokedAgentIDs(t, body)
+	assert.Contains(t, ids, revokedID.String(), "control: the revoked agent must be listed")
+	assert.NotContains(t, ids, activeID.String(),
+		"an active agent appeared in the revocation list — verifiers would reject a valid credential")
+}
+
+// The list must carry the agent id and a reason code, and nothing else.
+//
+// `name` is an organization-internal namespace with no opt-in mechanism, and this
+// endpoint is unauthenticated and spans every organization. `revokedAt` was sourced
+// from `agents.updated_at`, which any later write to the row rewrites. Both were
+// present and both were inert only because the list was always empty — so this asserts
+// the absence directly rather than trusting that nothing puts them back.
+func TestRevocationListCarriesNoAgentNameOrTimestamp(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	_, agentName := seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	entries := revocationEntries(t, body, "revocations")
+	require.NotEmpty(t, entries, "control: the revoked agent must be listed for this to assert anything")
+
+	for _, entry := range entries {
+		assert.NotContains(t, entry, "name",
+			"the revocation list exposed an agent name on an unauthenticated cross-organization endpoint")
+		assert.NotContains(t, entry, "revokedAt",
+			"the revocation list exposed a revocation time it cannot stand behind")
+
+		keys := make([]string, 0, len(entry))
+		for k := range entry {
+			keys = append(keys, k)
+		}
+		assert.ElementsMatch(t, []string{"agentId", "reason"}, keys,
+			"the revocation list carried a field with no consumer; add one only with a reader")
+	}
+
+	// The name must not have reached the response through any other field either.
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), agentName,
+		"the seeded agent name appeared somewhere in the revocation response")
+}
+
+// The response must NOT carry an `entries` key, and this is deliberate.
+//
+// Both SDK CRL types decode `entries`, so a fetcher pointed straight at this body fails
+// loudly today — the TypeScript cache throws rather than caching. That mismatch is doing
+// real work: it is the only thing stopping a client from accepting this list as fresh and
+// authoritative. Serving `entries` as well would make a naive fetcher succeed quietly,
+// which is the exact silent fail-open the empty-list defect produced.
+//
+// Aligning server and SDK is correct eventually, but not as a standalone rename on either
+// side, and not before a client can act on what it receives. This test is here so that
+// adding the alias is a deliberate act with a failing test attached, rather than a tidy-up.
+func TestRevocationListDoesNotServeTheSdkKey(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	revokedID, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	require.Contains(t, revokedAgentIDs(t, body), revokedID.String(),
+		"control: the revoked agent must be listed for this to assert anything")
+	assert.NotContains(t, body, "entries",
+		"the response gained the SDK's key, which removes the mismatch that currently "+
+			"stops a naive fetcher from silently accepting this list")
+}
+
+// A revoked agent with no description must still reach the list.
+//
+// `agents.description` is nullable, and AgentRepository.List scanned it straight into a
+// string, which fails the whole row. That defect was unreachable while the limit bug
+// held — no row was ever scanned — so fixing the limit alone converted the empty list
+// into a 500 for any deployment holding one agent with a NULL description. The two
+// defects had to be fixed together, and this is the test that says so.
+//
+// The other seeds in this file all set `description`, which is exactly why they did not
+// catch it.
+func TestRevocationListIncludesAgentWithNullDescription(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	revokedID, _ := seedAgentForRevocationList(t, db, ctx, "revoked")
+	_, err := db.ExecContext(ctx, `UPDATE agents SET description = NULL WHERE id = $1`, revokedID)
+	require.NoError(t, err)
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status,
+		"a NULL description failed the row scan and took the whole revocation list with it")
+
+	assert.Contains(t, revokedAgentIDs(t, body), revokedID.String())
+}
+
+// The count the endpoint reports must match the entries it actually returns. A caller
+// that trusts `total` and ignores the array (or vice versa) must not see two answers.
+func TestRevocationListTotalMatchesEntries(t *testing.T) {
+	ctx := context.Background()
+	db := revocationTestDB(t)
+
+	seedAgentForRevocationList(t, db, ctx, "revoked")
+
+	status, body := fetchRevocationList(t, db)
+	require.Equal(t, fiber.StatusOK, status)
+
+	total, ok := body["total"].(float64)
+	require.True(t, ok, "response carried no numeric total: %v", body)
+	assert.Equal(t, len(revokedAgentIDs(t, body)), int(total),
+		"reported total disagreed with the number of entries returned")
+}

--- a/apps/backend/internal/interfaces/http/handlers/secrets_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/secrets_handler_test.go
@@ -170,3 +170,6 @@ func TestSecretsHandler_NamespaceScoped_CrossOrgReturns404(t *testing.T) {
 	}
 }
 
+func (r *secretsTestAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/service_mocks_test.go
@@ -1737,3 +1737,7 @@ func (m *MockAgentServiceImpl) ListAgentsPaged(ctx context.Context, orgID uuid.U
 	}
 	return agents, total, nil
 }
+
+func (m *MockAgentRepositoryerImpl) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/handlers/verification_event_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_event_handler_test.go
@@ -519,3 +519,7 @@ func TestVerificationEventHandler_CrossOrgReturns404(t *testing.T) {
 		})
 	}
 }
+
+func (r *verificationEventTestAgentRepo) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	return nil, nil
+}

--- a/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
@@ -114,11 +114,15 @@ func seedAgentWithStatus(t *testing.T, db *sql.DB, ctx context.Context, status, 
 		userID, orgID, "revocation-"+suffix+"@example.com", "revocation-user", "local-"+suffix)
 	require.NoError(t, err)
 
-	// `description` is nullable with no default, but AgentRepository.GetByID scans it
-	// into a plain string — a NULL there fails the whole lookup, and the middleware
-	// reports it as "Agent not found", which reads exactly like a revocation denial.
-	// Set it explicitly so a green run means the status check ran, not that the row
-	// was unreadable.
+	// `description` is set explicitly so a green run means the status check ran, rather
+	// than the row being unreadable for an unrelated reason.
+	//
+	// It used to be load-bearing: GetByID scanned this nullable column into a plain
+	// string, so a NULL failed the whole lookup and the middleware reported it as
+	// "Agent not found" — indistinguishable from a revocation denial. That is fixed
+	// (GetByID now scans it through a NullString, covered by
+	// TestNullDescriptionIsReadableByEveryAgentReadPath in the repository package), and
+	// working around it here is what kept any test from catching it for so long.
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO agents (id, organization_id, name, display_name, description, agent_type,
 		                     status, public_key, trust_score, created_by, created_at, updated_at)

--- a/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_revocation_integration_test.go
@@ -28,7 +28,8 @@ import (
 
 // Revocation enforcement on the agent auth middlewares.
 //
-// Before this suite existed, `AgentService.RevokeAgent` and `EnforceKeyExpiry`
+// Before this suite existed, `AgentService.RevokeAgent` (and `EnforceKeyExpiry`, which
+// has since been found unimplementable as written — #359)
 // expressed denial ONLY as a write to `agents.status`, and three of the six auth
 // middlewares never read that column. A revoked or suspended agent that still held
 // its key material authenticated successfully — on `secrets resolve` among other
@@ -63,7 +64,7 @@ var revocationCases = []struct {
 	{"verified", true, "the ordinary case — also proves the request is otherwise well-formed"},
 	{"pending", true, "registration default; denying it would break enrollment"},
 	{"revoked", false, "RevokeAgent writes this and nothing else denied the request"},
-	{"suspended", false, "SuspendAgent and EnforceKeyExpiry write this"},
+	{"suspended", false, "SuspendAgent writes this; EnforceKeyExpiry does not (unimplemented, #359)"},
 	{"deactivated", false, "unrecognised value must fail closed, not fall through"},
 }
 

--- a/apps/backend/internal/interfaces/http/middleware/agent_status.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_status.go
@@ -17,8 +17,13 @@ import (
 // honestly registered agent, not an earned one. Denying it would break enrollment for
 // every new agent while blocking nothing an attacker holds.
 //
-// Denial states are the ones a human or EnforceKeyExpiry assigns on purpose:
-// `revoked` (AgentService.RevokeAgent) and `suspended` (SuspendAgent, EnforceKeyExpiry).
+// Denial states are the ones assigned on purpose: `revoked` (AgentService.RevokeAgent)
+// and `suspended` (AgentService.SuspendAgent).
+//
+// `EnforceKeyExpiry` was named here as a second writer of `suspended`. It is not one —
+// it returns ErrKeyExpiryEnforcementUnavailable and has no caller (see #359). Nothing
+// suspends an agent for an expired key today. The allow-list below is unaffected either
+// way, because it gates on the value in the column rather than on who wrote it.
 // Before this check existed, both wrote a status that no signature or API-key path read,
 // so revoking an agent did not stop it authenticating with key material it already held.
 func agentStatusPermitsAuth(status domain.AgentStatus) bool {

--- a/apps/backend/internal/interfaces/http/middleware/agent_status_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/agent_status_test.go
@@ -23,7 +23,7 @@ func TestAgentStatusPermitsAuth_DeniesRevokedAndSuspended(t *testing.T) {
 	assert.False(t, agentStatusPermitsAuth(domain.AgentStatus("revoked")),
 		"RevokeAgent writes this status and nothing else denies the request")
 	assert.False(t, agentStatusPermitsAuth(domain.AgentStatus("suspended")),
-		"SuspendAgent and EnforceKeyExpiry write this status")
+		"SuspendAgent writes this status; EnforceKeyExpiry does not — it is unimplemented, see #359")
 }
 
 // agents.status is VARCHAR(50) with no CHECK constraint (migration 001), so a

--- a/apps/backend/internal/interfaces/http/middleware/ed25519_agent_auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/ed25519_agent_auth.go
@@ -31,8 +31,8 @@ func sortedJSONMarshal(v interface{}) []byte {
 	// Convert compact JSON to Python's default format with spaces
 	// Python uses: (', ', ': ') = space after comma, space after colon
 	result := string(compactBytes)
-	result = strings.ReplaceAll(result, "\":", "\": ")  // Add space after colon
-	result = strings.ReplaceAll(result, ",\"", ", \"")  // Add space after comma before quote
+	result = strings.ReplaceAll(result, "\":", "\": ") // Add space after colon
+	result = strings.ReplaceAll(result, ",\"", ", \"") // Add space after comma before quote
 	result = strings.ReplaceAll(result, ",[", ", [")   // Add space after comma before bracket
 	result = strings.ReplaceAll(result, ",{", ", {")   // Add space after comma before brace
 
@@ -133,7 +133,7 @@ func Ed25519AgentMiddleware(agentService *application.AgentService) fiber.Handle
 		}
 
 		// SECURITY: Revocation is enforced HERE, on the read path, not only at the write
-		// that sets the status. RevokeAgent and EnforceKeyExpiry both express denial purely
+		// that sets the status. RevokeAgent expresses denial purely
 		// as `agents.status`, so an agent that keeps its key material after being revoked
 		// or suspended authenticated successfully until this check existed.
 		if !agentStatusPermitsAuth(agent.Status) {

--- a/apps/backend/internal/interfaces/http/middleware/pqc_agent_auth.go
+++ b/apps/backend/internal/interfaces/http/middleware/pqc_agent_auth.go
@@ -98,7 +98,7 @@ func PQCAgentMiddleware(agentService *application.AgentService) fiber.Handler {
 		}
 
 		// SECURITY: Revocation is enforced HERE, on the read path, not only at the write
-		// that sets the status. RevokeAgent and EnforceKeyExpiry both express denial purely
+		// that sets the status. RevokeAgent expresses denial purely
 		// as `agents.status`, so an agent that keeps its key material after being revoked
 		// or suspended authenticated successfully until this check existed. Checked before
 		// any signature work so a denied agent costs no ML-DSA verification.

--- a/apps/backend/internal/testutil/mocks/repositories.go
+++ b/apps/backend/internal/testutil/mocks/repositories.go
@@ -61,6 +61,14 @@ func (m *MockAgentRepository) List(limit, offset int) ([]*domain.Agent, error) {
 	return args.Get(0).([]*domain.Agent), args.Error(1)
 }
 
+func (m *MockAgentRepository) ListRevokedIDs(limit, offset int) ([]uuid.UUID, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
 func (m *MockAgentRepository) UpdateTrustScore(id uuid.UUID, newScore float64) error {
 	args := m.Called(id, newScore)
 	return args.Error(0)

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/CrlCache.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/CrlCache.java
@@ -91,6 +91,17 @@ public final class CrlCache {
             if (next == null) {
                 throw new IllegalStateException("CRL source returned null");
             }
+            // A Crl whose entry list is null is malformed, not empty, and the difference
+            // is the whole control. Caching it marks the cache FRESH and makes
+            // LocalAtxVerifier skip the revocation loop, so every revoked credential
+            // verifies with no error, no log line and a healthy-looking status() — the
+            // exact silent fail-open the stale policy exists to prevent. It arises from a
+            // shape mismatch rather than a network fault: a JSON body that carries the
+            // list under a different key decodes into entries == null.
+            if (next.entries() == null) {
+                throw new IllegalStateException(
+                        "CRL source returned a list with null entries (malformed, not empty) — refusing to cache it");
+            }
             this.data = next;
             this.fetchedAtMillis = nowMillis.getAsLong();
             this.lastError = null;

--- a/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
+++ b/sdk/java/src/main/java/org/opena2a/aim/atx/LocalAtxVerifier.java
@@ -127,7 +127,17 @@ public final class LocalAtxVerifier {
         if (atx.revoked) {
             return AtxVerificationResult.reject(RejectCategory.REVOKED, "credential revoked field is true");
         }
-        if (anchors.crl() != null && anchors.crl().entries() != null) {
+        // A CRL that is present but whose entry list is null is MALFORMED, not empty.
+        // Reading it as "nothing is revoked" is a silent fail-open: it is the shape a
+        // decoder produces when the feed's JSON carries the list under a different key,
+        // so the one case that most needs rejecting looks identical to a clean list.
+        // Absent (null) CRL is a different thing — that is the stale-cache path, and the
+        // caller's StalePolicy has already decided it before reaching here.
+        if (anchors.crl() != null && anchors.crl().entries() == null) {
+            return AtxVerificationResult.reject(
+                    RejectCategory.REVOKED, "revocation list is malformed (null entries); refusing to treat as empty");
+        }
+        if (anchors.crl() != null) {
             for (AtxTrustAnchors.Crl.Entry entry : anchors.crl().entries()) {
                 if (entry.agentId() != null && entry.agentId().equals(atx.agentId)) {
                     return AtxVerificationResult.reject(

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/CrlCacheTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/CrlCacheTest.java
@@ -135,4 +135,72 @@ class CrlCacheTest {
         cache.stop();
         cache.stop(); // no throw
     }
+
+    // A Crl whose entry list is null is MALFORMED, not empty, and the cache must refuse it.
+    //
+    // This is the shape a decoder produces when the feed carries its list under a different
+    // key — which is exactly what the AIM server does: it serves `revocations`, and this
+    // record binds `entries`. Caching it marks the cache FRESH, and LocalAtxVerifier then
+    // reads null entries as "nothing is revoked", so every revoked credential verifies with
+    // no error, no log line, and a healthy-looking status(). That is the silent fail-open
+    // the stale policy exists to prevent, arriving through a shape mismatch rather than a
+    // network fault.
+    @Test
+    void refusesToCacheACrlWithNullEntries() {
+        AtomicLong clock = new AtomicLong(0);
+        AtomicReference<AtxTrustAnchors.Crl> next = new AtomicReference<>(new AtxTrustAnchors.Crl(null));
+
+        CrlCache cache = CrlCache.builder(next::get)
+                .ttl(Duration.ofMinutes(5))
+                .nowMillis(clock::get)
+                .build();
+
+        cache.refreshNow();
+
+        assertNull(cache.current(), "a malformed CRL must not become the served list");
+        assertFalse(cache.isFresh(), "a malformed CRL must not mark the cache fresh");
+        assertNotNull(cache.status().lastError(), "refusing a malformed CRL must surface an error");
+        assertTrue(cache.status().lastError().getMessage().contains("null entries"));
+    }
+
+    // The control, and the line the guard must not cross: an EMPTY list is a legitimate
+    // answer meaning "nothing is revoked right now", and it must still be cached and served.
+    @Test
+    void stillAcceptsAGenuinelyEmptyCrl() {
+        AtomicLong clock = new AtomicLong(0);
+
+        CrlCache cache = CrlCache.builder(() -> new AtxTrustAnchors.Crl(List.of()))
+                .ttl(Duration.ofMinutes(5))
+                .nowMillis(clock::get)
+                .build();
+
+        cache.refreshNow();
+
+        assertNotNull(cache.current(), "an empty CRL is a valid answer and must be served");
+        assertTrue(cache.isFresh());
+        assertNull(cache.status().lastError());
+        assertEquals(0, cache.current().entries().size());
+    }
+
+    // A malformed refresh must not destroy a good list that is still within its TTL.
+    @Test
+    void retainsThePreviousGoodListWhenARefreshIsMalformed() {
+        AtomicLong clock = new AtomicLong(0);
+        AtomicReference<AtxTrustAnchors.Crl> next = new AtomicReference<>(list("agent-1"));
+
+        CrlCache cache = CrlCache.builder(next::get)
+                .ttl(Duration.ofMinutes(5))
+                .nowMillis(clock::get)
+                .build();
+
+        cache.refreshNow();
+        assertNotNull(cache.current());
+
+        next.set(new AtxTrustAnchors.Crl(null));
+        cache.refreshNow();
+
+        assertNotNull(cache.current(), "a malformed refresh must not discard a still-fresh good list");
+        assertEquals(1, cache.current().entries().size());
+        assertNotNull(cache.status().lastError(), "the malformed refresh must still be recorded");
+    }
 }

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierMalformedCrlTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierMalformedCrlTest.java
@@ -1,0 +1,135 @@
+package org.opena2a.aim.atx;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A CRL that is present but whose entry list is null must be treated as MALFORMED,
+ * never as empty.
+ *
+ * <p>The difference is the whole control. {@code Crl(entries=null)} is the shape a
+ * decoder produces when the feed carries its list under a different key — which is
+ * exactly what the AIM server does today: it serves {@code revocations}, and
+ * {@link AtxTrustAnchors.Crl} binds {@code entries}. Reading that as "nothing is
+ * revoked" means every revoked credential verifies, with no error and no log line.
+ *
+ * <p>These three cases pin the boundary the guard must sit on, because two of the
+ * three states look identical in the type system and must not behave identically:
+ *
+ * <ul>
+ *   <li>absent CRL (null) — the stale-cache path; the caller's StalePolicy has already
+ *       decided, so the verifier proceeds. Must stay accepting.</li>
+ *   <li>empty CRL (non-null, zero entries) — a legitimate "nothing is revoked right
+ *       now". Must stay accepting.</li>
+ *   <li>malformed CRL (non-null, null entries) — must reject.</li>
+ * </ul>
+ *
+ * <p>Reverting the guard in {@link LocalAtxVerifier} leaves the first two green and
+ * flips only the third, which is what makes this suite worth having.
+ */
+class LocalAtxVerifierMalformedCrlTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final JsonFactory JSON = new JsonFactory();
+
+    /** A credential the conformance suite pins as valid, so any rejection here is the CRL. */
+    private static final String FIXTURE = "/atx-fixtures/baseline-valid.json";
+
+    @Test
+    void absentCrlStillVerifies() throws Exception {
+        AtxVerificationResult r = verifyWithCrl(null);
+        assertTrue(r.valid(),
+                "an absent CRL is the stale-cache path and must not reject here; got: " + r.reason());
+    }
+
+    @Test
+    void emptyCrlStillVerifies() throws Exception {
+        AtxVerificationResult r = verifyWithCrl(new AtxTrustAnchors.Crl(List.of()));
+        assertTrue(r.valid(),
+                "an empty CRL means nothing is revoked and must verify; got: " + r.reason());
+    }
+
+    @Test
+    void malformedCrlWithNullEntriesIsRejected() throws Exception {
+        AtxVerificationResult r = verifyWithCrl(new AtxTrustAnchors.Crl(null));
+
+        assertEquals(false, r.valid(),
+                "a CRL with null entries was treated as empty — every revoked credential "
+                        + "would verify with no error surfaced anywhere");
+        assertEquals(RejectCategory.REVOKED, r.rejectCategory());
+        assertTrue(r.reason().contains("malformed"),
+                "the reason must say the list is malformed rather than implying this "
+                        + "credential was revoked; got: " + r.reason());
+    }
+
+    /** Loads the pinned fixture and verifies its credential against {@code crl}. */
+    private static AtxVerificationResult verifyWithCrl(AtxTrustAnchors.Crl crl) throws Exception {
+        byte[] fixture = readFixture();
+        JsonNode root = MAPPER.readTree(fixture);
+        JsonNode vs = root.get("verifierState");
+
+        Clock clock = Clock.fixed(Instant.parse(vs.get("clockRfc3339").asText()), ZoneOffset.UTC);
+
+        List<String> trustedIssuers = new ArrayList<>();
+        vs.get("trustedIssuers").forEach(n -> trustedIssuers.add(n.asText()));
+
+        List<AtxPublicKey> publicKeys = new ArrayList<>();
+        for (JsonNode k : vs.get("publicKeys")) {
+            publicKeys.add(new AtxPublicKey(
+                    k.get("algorithm").asText(),
+                    k.get("publicKeyHex").asText(),
+                    k.hasNonNull("keyId") ? k.get("keyId").asText() : null));
+        }
+
+        LocalAtxVerifier verifier =
+                new LocalAtxVerifier(new AtxTrustAnchors(trustedIssuers, publicKeys, crl, clock));
+        return verifier.verify(new String(rawAtxBytes(fixture), java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static byte[] readFixture() throws IOException {
+        try (InputStream in = LocalAtxVerifierMalformedCrlTest.class.getResourceAsStream(FIXTURE)) {
+            assertNotNull(in, "fixture not found on the test classpath: " + FIXTURE);
+            return in.readAllBytes();
+        }
+    }
+
+    /** Verbatim credential bytes, so strict-parse behaviour matches the conformance harness. */
+    private static byte[] rawAtxBytes(byte[] fixtureBytes) throws IOException {
+        try (JsonParser p = JSON.createParser(fixtureBytes)) {
+            if (p.nextToken() != JsonToken.START_OBJECT) {
+                throw new IOException("fixture is not a JSON object");
+            }
+            while (p.nextToken() != JsonToken.END_OBJECT) {
+                String field = p.currentName();
+                JsonToken valueStart = p.nextToken();
+                if ("atx".equals(field)) {
+                    long start = p.currentTokenLocation().getByteOffset();
+                    p.skipChildren();
+                    long end = p.currentLocation().getByteOffset();
+                    return Arrays.copyOfRange(fixtureBytes, (int) start, (int) end);
+                }
+                if (valueStart == JsonToken.START_OBJECT || valueStart == JsonToken.START_ARRAY) {
+                    p.skipChildren();
+                }
+            }
+        }
+        throw new IOException("fixture has no atx member");
+    }
+}


### PR DESCRIPTION
`GET /api/v1/revocations` answered 200 with an empty list no matter how many agents were revoked. `GetRevocationList` called `agentRepo.List(0, 0)`, which reaches PostgreSQL as `LIMIT 0` — zero rows. `LIMIT 0` does not mean unbounded.

The route is mounted and unauthenticated in this repo, so a verifier polling it was told nothing had ever been revoked. A caching client treats that as a successful fetch and holds it as **fresh**, so revocation was skipped with no error surfaced anywhere: no 4xx, no 5xx, no log line, and a cache reporting itself healthy.

Proven end to end against the real handler, real repository and a real PostgreSQL before any fix:

```
--- FAIL: TestRevocationListIncludesRevokedAgent
    Error: []string{} does not contain "9e9b71a8-7ca0-4d28-af26-8c80a69c2b8d"
```

## Defects that had to land together, because each masked the next

| | |
|---|---|
| `LIMIT 0` | the endpoint returned nothing |
| NULL `description` scanned into a string | unreachable while no row was scanned, so fixing the limit **alone** turned the empty list into an HTTP 500 for any deployment holding one such agent |
| `name` emitted cross-organization, unauthenticated | inert only because the list was empty; fixing the limit alone ships the disclosure in the same deploy |
| ETag from entry count + wall-clock bucket | collides when one agent is revoked and another leaves the list in the same bucket — a stale CRL served as fresh |

## The NULL class, swept

Five of six agent read paths scanned the nullable `description` into a plain string, which fails the **entire row**. Only `GetByOrganizationPaged` was correct. `GetByID` is the one that matters: the agent auth middlewares call it, and a failed read there is reported as "Agent not found" — indistinguishable from a revocation denial. An agent created without a description could not authenticate and the operator was told it did not exist.

`agent_revocation_integration_test.go` documented this defect in a comment and worked around it by always setting `description` in its own seed. That workaround is why no test caught it.

`rotation_count` and `trust_score` had the same shape. `trust_score` was missed twice because a trigger rejects an UPDATE to NULL — but the trigger does not fire on INSERT, so a NULL row inserts fine and then fails nine read paths.

On pre-fix code five of the six subtests fail with the exact scan error and `GetByOrganizationPaged` passes, which is the discriminator.

## `List` now rejects a non-positive limit

Its sibling `GetByOrganizationPaged` documents "limit <= 0 returns all", and both callers were written to that convention. Adopting it here would trade a silent-empty bug for a silent-unbounded one, so `List` errors instead — the only outcome that fails visibly. `ListRevokedIDs` filters `status` in SQL so the unauthenticated endpoint no longer reads every agent row to emit a subset.

## `EnforceKeyExpiry` returns an error instead of reporting success

It cannot work as written: `List` does not select `key_expires_at`, and suspending via `Update` writes 29 columns from a partially-populated struct, which would clear the agent's encrypted private key, PQC keys and capability grant. It has no caller. See #359.

## Java SDK: a second silent fail-open

`CrlCache.refreshNow` accepted a decoded `Crl(entries=null)` as valid and cached it FRESH; `LocalAtxVerifier` read null entries as "nothing is revoked". A feed whose JSON carries its list under a different key — which is exactly what this server does — produced full acceptance of every revoked credential with no error. Both now reject a malformed list; a genuinely empty one still verifies. Both guards are mutation-proved.

## Tenant-scoping lint

Fourteen of thirty-two allowlist entries named methods that do not exist (`AuthHandler.Login` — the type has `LocalLogin`; `RegistryBridgeHandler.Verify` — the type has only `TriggerPush`). Each read as a reviewed exemption while covering nothing. All fourteen removed and the lint still passes, which is the evidence none of the real handlers needed exempting. Remaining `needs review` entries: #358.

## Deliberately not in this change

`/api/v1/revocations` is **not** mounted in aim-cloud. Both CISO and CA ruled independently that mounting it before this fix would convert a loud fail-open (404, `lastError` set) into a silent one (200, cache FRESH). The aim-cloud parity port is opena2a-org/aim-cloud#98.

Keyset pagination is not done here. Under concurrent mutation, offset paging can still drop a revoked agent; the measurements and the plan are recorded in the roadmap, and the `since`/`nextSince` cursor the spec requires is keyset pagination, so it belongs with that work.

## Verification

Two adversarial review rounds. The first found four HIGH issues, three introduced by this work — including two claims in comments that were false. The second found the Java guards had shipped with no tests at all. Both rounds' findings are fixed or explicitly recorded.

```
go build ./... && go vet ./...                                  clean
go test -race ./...                                             0 failures
TEST_DATABASE_URL=... go test -tags=integration ./internal/...  0 failures
mvn -o test -Dtest='org.opena2a.aim.atx.*'                      51 tests, 0 failures
./scripts/lint-tenant-scoping.sh                                ok
```

All new integration tests are registered in CI's skip-assertion selector **and** package list, so they cannot silently stop running.