### PR TITLE
Scope the A2A consent and trust-score list endpoints to the caller's organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,12 +380,15 @@ jobs:
       # trust-score write-path fix; RevocationList + the handlers package were
       # added after the revocation list was found returning an empty list for
       # every caller, which no test had ever asserted against; NakedTimestamp
-      # was added with migration 106.
+      # was added with migration 106; A2AListAllTenantScope was added with the
+      # A2A consent and trust-score org scoping, whose whole assertion is that
+      # one tenant cannot see another's rows -- a silent skip there restores the
+      # defect green.
       - name: Assert integration tests were not skipped
         run: |
           set -o pipefail
           go test -tags=integration -v \
-            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|RevocationList|AgentRepositoryList|NullDescription|NakedTimestamp' \
+            -run 'Trigger|Backfill|OutOfScale|AgentRevocation|UpdateDoesNotWriteTrustScore|RoundTrip|SeededMCPPoliciesAreNotEnabled|RevocationList|AgentRepositoryList|NullDescription|NakedTimestamp|A2AListAllTenantScope' \
             ./internal/application/... ./internal/interfaces/http/middleware/... \
             ./internal/infrastructure/repository/... \
             ./internal/interfaces/http/handlers/... 2>&1 | tee /tmp/integration.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Security
 
+- `GET /api/v1/a2a/consents` and `GET /api/v1/a2a/trust-scores` returned every
+  organization's rows to any authenticated caller. Neither query carried an
+  `organization_id` predicate and neither route carried a role middleware, unlike
+  its neighbours on the same group, so one tenant's token read every tenant's
+  consent records — `userId`, `purpose`, `dataTypes`, both agent IDs, `userAgent`
+  — and every tenant's agent IDs and behavioural metrics. `limit` was
+  caller-controlled with no upper bound, so a single request could page the whole
+  table. Both queries are now scoped to the caller's organization; the trust-score
+  query reaches the boundary by joining `agents`, since `a2a_trust_scores` has no
+  organization column of its own. Present since the A2A routes were introduced.
+- The row COUNT on both endpoints is scoped as well, not just the rows. An
+  unscoped total tells a caller how much data every other tenant holds without
+  returning a single row, so scoping the rows alone would have left a cardinality
+  disclosure behind.
 - `GET /api/v1/revocations` returned an empty revocation list to every caller,
   always. `GetRevocationList` asked the repository for `List(0, 0)`, which reaches
   PostgreSQL as `LIMIT 0` — zero rows, not "unbounded". The route is mounted and

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -181,6 +181,16 @@ type violation struct {
 // Each entry must include a one-line justification. The allowlist must
 // stay small; the goal is to refactor or remove the unused parameter
 // rather than to add entries.
+// collectionScopeAllowlist names service methods that legitimately return a
+// collection across every organization. Each entry must carry a one-line
+// justification naming what makes the cross-tenant read safe — minimization,
+// an admin-only route gate, or a genuinely public dataset. "It is an admin
+// endpoint" is only a justification if a role middleware actually enforces it;
+// both of the methods that motivated this check were documented as admin
+// endpoints in their doc comments and were mounted with no role middleware at
+// all.
+var collectionScopeAllowlist = map[string]string{}
+
 var serviceParamAllowlist = map[string]string{
 	// AUDIT-BASELINE: pre-existing methods discovered when the
 	// class-#3 scan first landed. Each entry MUST cite the rationale
@@ -320,6 +330,37 @@ the broader taxonomy. False-negative class: orgID referenced only in
 logging without flowing to the repo call still passes this check.`)
 		} else {
 			fmt.Printf("serviceparam-lint: ok (%d allowlist entries; scanned %s)\n", len(serviceParamAllowlist), servicesDir)
+		}
+
+		collectionViolations, err := scanCollectionDirectory(servicesDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tenantscope-lint: %v\n", err)
+			os.Exit(2)
+		}
+		if len(collectionViolations) > 0 {
+			failed = true
+			sort.Slice(collectionViolations, func(i, j int) bool {
+				if collectionViolations[i].File != collectionViolations[j].File {
+					return collectionViolations[i].File < collectionViolations[j].File
+				}
+				return collectionViolations[i].Line < collectionViolations[j].Line
+			})
+			fmt.Fprintf(os.Stderr, "\ncollectionscope-lint: %d service method(s) return a collection with no organization parameter to scope it by:\n\n", len(collectionViolations))
+			for _, v := range collectionViolations {
+				fmt.Fprintf(os.Stderr, "  %s:%d  %s\n", v.File, v.Line, v.Handler)
+			}
+			fmt.Fprintln(os.Stderr, `
+A ListAll* method that takes no organization returns every tenant's rows to
+whoever calls it. Fix by adding an orgID uuid.UUID parameter, threading it to
+the repository, and putting the predicate in the SQL — including the COUNT,
+since an unscoped total discloses other tenants' cardinality on its own.
+
+If the method is genuinely global, add it to collectionScopeAllowlist in
+cmd/tenantscope-lint/main.go with a one-line justification naming the control
+that makes it safe. A doc comment calling it an "admin endpoint" is not that
+control; verify a role middleware is actually mounted on the route.`)
+		} else {
+			fmt.Printf("collectionscope-lint: ok (%d allowlist entries; scanned %s)\n", len(collectionScopeAllowlist), servicesDir)
 		}
 	}
 
@@ -579,6 +620,34 @@ func scanServiceDirectory(dir string) ([]violation, error) {
 	return violations, nil
 }
 
+// scanCollectionDirectory walks the service package for unscoped collection
+// readers. Kept separate from scanServiceDirectory so the two failure modes
+// report distinct remediation text; they scan the same files.
+func scanCollectionDirectory(dir string) ([]violation, error) {
+	var violations []violation
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		violations = append(violations, scanCollectionFile(fset, file, path)...)
+	}
+	return violations, nil
+}
+
 // scanServiceFile walks one parsed Go file for class-#3 service-method
 // violations. A method qualifies for inspection when:
 //   - It has a receiver (i.e. it's a method, not a free function).
@@ -587,6 +656,60 @@ func scanServiceDirectory(dir string) ([]violation, error) {
 //
 // For each qualifying parameter, the body is searched for any *ast.Ident
 // matching the parameter name. Zero matches → violation.
+// scanCollectionFile catches the class that both of the other two checks are
+// structurally blind to: a service method that returns a WHOLE COLLECTION and
+// never takes an organization to scope it by.
+//
+// The handler check triggers on reading a tenant-scoped c.Params(...) key, and
+// the service check triggers on accepting an orgID and not using it. A method
+// that asks for no identifier at all and returns everything trips neither. That
+// is exactly how A2AService.ListAllConsents and ListAllTrustScores served every
+// tenant's rows to any authenticated caller for seven months while this lint
+// reported ok on every run.
+//
+// The predicate is deliberately mechanical: a method whose name begins with
+// "ListAll" must accept a uuid.UUID parameter with an organization-ish name. A
+// genuinely global lister goes on collectionScopeAllowlist with a written
+// justification, the same as every other exemption here.
+func scanCollectionFile(fset *token.FileSet, file *ast.File, path string) []violation {
+	var out []violation
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || fn.Recv == nil {
+			continue
+		}
+		if !strings.HasPrefix(fn.Name.Name, "ListAll") {
+			continue
+		}
+		methodName := receiverTypeName(fn) + "." + fn.Name.Name
+		if _, allowed := collectionScopeAllowlist[methodName]; allowed {
+			continue
+		}
+		if fn.Type == nil || fn.Type.Params == nil {
+			continue
+		}
+		scoped := false
+		for _, field := range fn.Type.Params.List {
+			if !isUUIDType(field.Type) {
+				continue
+			}
+			for _, name := range field.Names {
+				if orgParamNames[name.Name] {
+					scoped = true
+				}
+			}
+		}
+		if !scoped {
+			out = append(out, violation{
+				File:    path,
+				Line:    fset.Position(fn.Pos()).Line,
+				Handler: methodName,
+			})
+		}
+	}
+	return out
+}
+
 func scanServiceFile(fset *token.FileSet, file *ast.File, path string) []violation {
 	var out []violation
 	for _, decl := range file.Decls {

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -671,6 +671,19 @@ func scanCollectionDirectory(dir string) ([]violation, error) {
 // "ListAll" must accept a uuid.UUID parameter with an organization-ish name. A
 // genuinely global lister goes on collectionScopeAllowlist with a written
 // justification, the same as every other exemption here.
+//
+// KNOWN LIMIT, stated so nobody reads a green run as more than it is. The
+// "ListAll" prefix is a NAMING convention, not the shape of the defect, so this
+// check is a regression guard for the two methods above and not yet a guard for
+// the class. Every same-shape method that happens to be named differently is
+// invisible to it -- A2AService.ListAgentCards and A2AService.ListA2ATasks are
+// both on this very service, both return a whole collection with no
+// organization parameter, and both pass this check today.
+//
+// The predicate that would cover the class is "returns a slice or map AND takes
+// no organization parameter". It is not enabled here because it fires across
+// the package and every hit needs triage into either a fix or an allowlist
+// entry -- that is its own change, not a rider on this one.
 func scanCollectionFile(fset *token.FileSet, file *ast.File, path string) []violation {
 	var out []violation
 	for _, decl := range file.Decls {

--- a/apps/backend/internal/application/a2a_service.go
+++ b/apps/backend/internal/application/a2a_service.go
@@ -834,7 +834,6 @@ func (s *A2AService) ListUserConsents(ctx context.Context, userID string, orgID 
 	return s.consentRepo.ListByUser(ctx, userID, orgID, includeRevoked)
 }
 
-// ListAllConsents lists all consent records with pagination
 // ListAllConsents lists consent records belonging to orgID. SECURITY: orgID is
 // required; without it any authenticated caller could page every tenant's
 // consent records off GET /api/v1/a2a/consents.
@@ -842,7 +841,6 @@ func (s *A2AService) ListAllConsents(ctx context.Context, orgID uuid.UUID, limit
 	return s.consentRepo.ListAll(ctx, orgID, limit, offset)
 }
 
-// ListAllTrustScores lists all A2A trust scores with pagination
 // ListAllTrustScores lists A2A trust scores for agents in orgID. SECURITY:
 // orgID is required; see ListAllConsents.
 func (s *A2AService) ListAllTrustScores(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2ATrustScore, int, error) {

--- a/apps/backend/internal/application/a2a_service.go
+++ b/apps/backend/internal/application/a2a_service.go
@@ -67,21 +67,21 @@ func getNonceExpiryMinutes() int {
 
 // A2AService handles A2A (Agent-to-Agent) protocol operations
 type A2AService struct {
-	cardRepo          *repository.A2AAgentCardRepository
-	skillRepo         *repository.A2ASkillRepository
-	taskRepo          *repository.A2ATaskRepository
-	peerTrustRepo     *repository.A2APeerTrustRepository
-	consentRepo       *repository.A2AConsentRepository
-	trustScoreRepo    *repository.A2ATrustScoreRepository
-	nonceRepo         *repository.A2ARequestNonceRepository
-	policyRepo        *repository.A2APolicyRepository
-	attestationRepo   *repository.A2AAgentAttestationRepository
-	revokedRepo       *repository.A2ARevokedAgentRepository
-	securityRepo      *repository.A2ASecuritySettingsRepository
-	violationRepo     *repository.A2ASecurityViolationRepository
-	agentRepo         *repository.AgentRepository
-	keyVault          *crypto.KeyVault
-	httpClient        *http.Client
+	cardRepo        *repository.A2AAgentCardRepository
+	skillRepo       *repository.A2ASkillRepository
+	taskRepo        *repository.A2ATaskRepository
+	peerTrustRepo   *repository.A2APeerTrustRepository
+	consentRepo     *repository.A2AConsentRepository
+	trustScoreRepo  *repository.A2ATrustScoreRepository
+	nonceRepo       *repository.A2ARequestNonceRepository
+	policyRepo      *repository.A2APolicyRepository
+	attestationRepo *repository.A2AAgentAttestationRepository
+	revokedRepo     *repository.A2ARevokedAgentRepository
+	securityRepo    *repository.A2ASecuritySettingsRepository
+	violationRepo   *repository.A2ASecurityViolationRepository
+	agentRepo       *repository.AgentRepository
+	keyVault        *crypto.KeyVault
+	httpClient      *http.Client
 }
 
 // NewA2AService creates a new A2A service
@@ -141,11 +141,11 @@ type RegisterAgentCardRequest struct {
 
 // RegisterAgentCardResponse is the response after registering an agent card
 type RegisterAgentCardResponse struct {
-	CardID             uuid.UUID  `json:"cardId"`
-	AgentID            uuid.UUID  `json:"agentId"`
-	CardURL            string     `json:"cardUrl"`
-	AttestationExpires time.Time  `json:"attestationExpires"`
-	Skills             []string   `json:"skills"`
+	CardID             uuid.UUID `json:"cardId"`
+	AgentID            uuid.UUID `json:"agentId"`
+	CardURL            string    `json:"cardUrl"`
+	AttestationExpires time.Time `json:"attestationExpires"`
+	Skills             []string  `json:"skills"`
 }
 
 // RegisterAgentCard registers an A2A agent card and creates AIM attestation
@@ -661,11 +661,11 @@ func (s *A2AService) ListA2ATasks(ctx context.Context, agentID *uuid.UUID, state
 
 // LogA2ATaskRequest is the request to log an A2A task
 type LogA2ATaskRequest struct {
-	ExternalTaskID string       `json:"externalTaskId"`
-	ContextID      string       `json:"contextId"`
-	ClientAgentID  uuid.UUID    `json:"clientAgentId"`
-	RemoteAgentID  uuid.UUID    `json:"remoteAgentId"`
-	SkillID        string       `json:"skillId"`
+	ExternalTaskID string    `json:"externalTaskId"`
+	ContextID      string    `json:"contextId"`
+	ClientAgentID  uuid.UUID `json:"clientAgentId"`
+	RemoteAgentID  uuid.UUID `json:"remoteAgentId"`
+	SkillID        string    `json:"skillId"`
 }
 
 // LogA2ATask logs an A2A task for audit trail
@@ -756,18 +756,18 @@ func (s *A2AService) UpdateA2ATaskState(
 
 // RecordConsentRequest is the request to record user consent
 type RecordConsentRequest struct {
-	UserID           string    `json:"userId"`
+	UserID           string     `json:"userId"`
 	OrganizationID   *uuid.UUID `json:"organizationId"`
-	GrantorAgentID   uuid.UUID `json:"grantorAgentId"`
-	RecipientAgentID uuid.UUID `json:"recipientAgentId"`
-	Scope            []string  `json:"scope"`
-	Purpose          string    `json:"purpose"`
-	DataTypes        []string  `json:"dataTypes"`
-	ExpiresInHours   int       `json:"expiresInHours"`
-	ConsentMethod    string    `json:"consentMethod"`
-	Evidence         string    `json:"evidence"`
-	IPAddress        string    `json:"ipAddress"`
-	UserAgent        string    `json:"userAgent"`
+	GrantorAgentID   uuid.UUID  `json:"grantorAgentId"`
+	RecipientAgentID uuid.UUID  `json:"recipientAgentId"`
+	Scope            []string   `json:"scope"`
+	Purpose          string     `json:"purpose"`
+	DataTypes        []string   `json:"dataTypes"`
+	ExpiresInHours   int        `json:"expiresInHours"`
+	ConsentMethod    string     `json:"consentMethod"`
+	Evidence         string     `json:"evidence"`
+	IPAddress        string     `json:"ipAddress"`
+	UserAgent        string     `json:"userAgent"`
 }
 
 // RecordConsent records user consent for cross-agent data sharing
@@ -835,13 +835,18 @@ func (s *A2AService) ListUserConsents(ctx context.Context, userID string, orgID 
 }
 
 // ListAllConsents lists all consent records with pagination
-func (s *A2AService) ListAllConsents(ctx context.Context, limit, offset int) ([]*domain.A2AConsentRecord, int, error) {
-	return s.consentRepo.ListAll(ctx, limit, offset)
+// ListAllConsents lists consent records belonging to orgID. SECURITY: orgID is
+// required; without it any authenticated caller could page every tenant's
+// consent records off GET /api/v1/a2a/consents.
+func (s *A2AService) ListAllConsents(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2AConsentRecord, int, error) {
+	return s.consentRepo.ListAll(ctx, orgID, limit, offset)
 }
 
 // ListAllTrustScores lists all A2A trust scores with pagination
-func (s *A2AService) ListAllTrustScores(ctx context.Context, limit, offset int) ([]*domain.A2ATrustScore, int, error) {
-	return s.trustScoreRepo.ListAll(ctx, limit, offset)
+// ListAllTrustScores lists A2A trust scores for agents in orgID. SECURITY:
+// orgID is required; see ListAllConsents.
+func (s *A2AService) ListAllTrustScores(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2ATrustScore, int, error) {
+	return s.trustScoreRepo.ListAll(ctx, orgID, limit, offset)
 }
 
 // ============================================================================

--- a/apps/backend/internal/domain/a2a.go
+++ b/apps/backend/internal/domain/a2a.go
@@ -574,7 +574,7 @@ type A2AConsentRepository interface {
 	Create(ctx context.Context, consent *A2AConsentRecord) error
 	GetByID(ctx context.Context, id uuid.UUID) (*A2AConsentRecord, error)
 	CheckConsent(ctx context.Context, userID string, grantorID, recipientID uuid.UUID, scope string) (bool, error)
-	ListByUser(ctx context.Context, userID string, includeRevoked bool) ([]*A2AConsentRecord, error)
+	ListByUser(ctx context.Context, userID string, orgID uuid.UUID, includeRevoked bool) ([]*A2AConsentRecord, error)
 	// ListAll is org-scoped despite the name. orgID is required; see the
 	// implementation comment for why an unscoped variant must not exist.
 	ListAll(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*A2AConsentRecord, int, error)

--- a/apps/backend/internal/domain/a2a.go
+++ b/apps/backend/internal/domain/a2a.go
@@ -76,14 +76,14 @@ type A2AAgentCard struct {
 
 // A2AAgentCardParsed represents the parsed content of an A2A Agent Card
 type A2AAgentCardParsed struct {
-	Name            string                 `json:"name"`
-	Description     string                 `json:"description"`
-	URL             string                 `json:"url"`
-	Version         string                 `json:"version"`
-	Skills          []A2ASkillDefinition   `json:"skills"`
-	SecuritySchemes map[string]interface{} `json:"securitySchemes,omitempty"`
-	DefaultInputModes  []string            `json:"defaultInputModes,omitempty"`
-	DefaultOutputModes []string            `json:"defaultOutputModes,omitempty"`
+	Name               string                 `json:"name"`
+	Description        string                 `json:"description"`
+	URL                string                 `json:"url"`
+	Version            string                 `json:"version"`
+	Skills             []A2ASkillDefinition   `json:"skills"`
+	SecuritySchemes    map[string]interface{} `json:"securitySchemes,omitempty"`
+	DefaultInputModes  []string               `json:"defaultInputModes,omitempty"`
+	DefaultOutputModes []string               `json:"defaultOutputModes,omitempty"`
 
 	// AIM extension
 	AIM *A2AAIMExtension `json:"aim,omitempty"`
@@ -208,9 +208,9 @@ type A2ATask struct {
 
 // A2AMessage represents a message within an A2A task
 type A2AMessage struct {
-	ID                uuid.UUID      `json:"id"`
-	TaskID            uuid.UUID      `json:"taskId"`
-	ExternalMessageID string         `json:"externalMessageId,omitempty"`
+	ID                uuid.UUID `json:"id"`
+	TaskID            uuid.UUID `json:"taskId"`
+	ExternalMessageID string    `json:"externalMessageId,omitempty"`
 
 	// Message info
 	Role          A2AMessageRole `json:"role"`
@@ -222,8 +222,8 @@ type A2AMessage struct {
 	PIITypes     []string        `json:"piiTypes,omitempty"`
 
 	// Signature verification
-	AIMSignature       string     `json:"aimSignature,omitempty"`
-	SignatureValid     *bool      `json:"signatureValid,omitempty"`
+	AIMSignature        string     `json:"aimSignature,omitempty"`
+	SignatureValid      *bool      `json:"signatureValid,omitempty"`
 	SignatureVerifiedAt *time.Time `json:"signatureVerifiedAt,omitempty"`
 
 	CreatedAt time.Time `json:"createdAt"`
@@ -257,9 +257,9 @@ type A2APeerTrust struct {
 	TasksReceivedFailed    int `json:"tasksReceivedFailed"`
 
 	// Performance metrics
-	SuccessRate        *float64 `json:"successRate,omitempty"`
-	AvgResponseTimeMs  *int     `json:"avgResponseTimeMs,omitempty"`
-	P95ResponseTimeMs  *int     `json:"p95ResponseTimeMs,omitempty"`
+	SuccessRate       *float64 `json:"successRate,omitempty"`
+	AvgResponseTimeMs *int     `json:"avgResponseTimeMs,omitempty"`
+	P95ResponseTimeMs *int     `json:"p95ResponseTimeMs,omitempty"`
 
 	// Trust metrics
 	PeerTrustScore  *float64   `json:"peerTrustScore,omitempty"`
@@ -326,9 +326,9 @@ type A2ATrustScore struct {
 	TasksCancelled     int `json:"tasksCancelled"`
 
 	// Performance metrics
-	AvgResponseTimeMs  *int `json:"avgResponseTimeMs,omitempty"`
-	P95ResponseTimeMs  *int `json:"p95ResponseTimeMs,omitempty"`
-	AvgTaskDurationMs  *int `json:"avgTaskDurationMs,omitempty"`
+	AvgResponseTimeMs *int `json:"avgResponseTimeMs,omitempty"`
+	P95ResponseTimeMs *int `json:"p95ResponseTimeMs,omitempty"`
+	AvgTaskDurationMs *int `json:"avgTaskDurationMs,omitempty"`
 
 	// Trust components
 	A2ATrustScore    *float64 `json:"a2aTrustScore,omitempty"`
@@ -403,13 +403,13 @@ type A2ARequestSignature struct {
 
 // A2ASignatureVerificationResult represents the result of signature verification
 type A2ASignatureVerificationResult struct {
-	Valid       bool       `json:"valid"`
-	AgentID     uuid.UUID  `json:"agentId,omitempty"`
-	AgentName   string     `json:"agentName,omitempty"`
-	TrustScore  float64    `json:"trustScore,omitempty"`
-	Capabilities []string  `json:"capabilities,omitempty"`
-	AttestationValid bool  `json:"attestationValid"`
-	Error       string     `json:"error,omitempty"`
+	Valid            bool      `json:"valid"`
+	AgentID          uuid.UUID `json:"agentId,omitempty"`
+	AgentName        string    `json:"agentName,omitempty"`
+	TrustScore       float64   `json:"trustScore,omitempty"`
+	Capabilities     []string  `json:"capabilities,omitempty"`
+	AttestationValid bool      `json:"attestationValid"`
+	Error            string    `json:"error,omitempty"`
 }
 
 // ============================================================================
@@ -418,9 +418,9 @@ type A2ASignatureVerificationResult struct {
 
 // A2APolicyDecision represents the result of policy evaluation
 type A2APolicyDecision struct {
-	Decision          string   `json:"decision"` // ALLOW, DENY
-	PoliciesEvaluated []string `json:"policiesEvaluated"`
-	Reason            string   `json:"reason,omitempty"`
+	Decision          string    `json:"decision"` // ALLOW, DENY
+	PoliciesEvaluated []string  `json:"policiesEvaluated"`
+	Reason            string    `json:"reason,omitempty"`
 	EvaluatedAt       time.Time `json:"evaluatedAt"`
 }
 
@@ -575,7 +575,9 @@ type A2AConsentRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*A2AConsentRecord, error)
 	CheckConsent(ctx context.Context, userID string, grantorID, recipientID uuid.UUID, scope string) (bool, error)
 	ListByUser(ctx context.Context, userID string, includeRevoked bool) ([]*A2AConsentRecord, error)
-	ListAll(ctx context.Context, limit, offset int) ([]*A2AConsentRecord, int, error)
+	// ListAll is org-scoped despite the name. orgID is required; see the
+	// implementation comment for why an unscoped variant must not exist.
+	ListAll(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*A2AConsentRecord, int, error)
 	Revoke(ctx context.Context, id uuid.UUID, reason string) error
 }
 
@@ -583,7 +585,9 @@ type A2AConsentRepository interface {
 type A2ATrustScoreRepository interface {
 	Upsert(ctx context.Context, score *A2ATrustScore) error
 	GetByAgentID(ctx context.Context, agentID uuid.UUID) (*A2ATrustScore, error)
-	ListAll(ctx context.Context, limit, offset int) ([]*A2ATrustScore, int, error)
+	// ListAll is org-scoped despite the name; it reaches the tenant boundary
+	// by joining agents, since a2a_trust_scores has no organization_id.
+	ListAll(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*A2ATrustScore, int, error)
 	IncrementTaskStats(ctx context.Context, agentID uuid.UUID, asClient bool, completed bool) error
 	UpdatePerformanceMetrics(ctx context.Context, agentID uuid.UUID, responseTimeMs, durationMs int) error
 }
@@ -714,9 +718,9 @@ type A2ASecurityViolation struct {
 	ActionTaken A2ASecurityAction `json:"actionTaken"`
 
 	// Request context
-	RequestSignature  string     `json:"requestSignature,omitempty"`
-	RequestNonce      string     `json:"requestNonce,omitempty"`
-	RequestTimestamp  *time.Time `json:"requestTimestamp,omitempty"`
+	RequestSignature string     `json:"requestSignature,omitempty"`
+	RequestNonce     string     `json:"requestNonce,omitempty"`
+	RequestTimestamp *time.Time `json:"requestTimestamp,omitempty"`
 
 	// Metadata
 	CreatedAt time.Time `json:"createdAt"`
@@ -775,9 +779,9 @@ const (
 
 // A2ACallChain represents a single call in an agent-to-agent chain
 type A2ACallChain struct {
-	ID             uuid.UUID `json:"id"`
-	ChainID        uuid.UUID `json:"chainId"`
-	SequenceNumber int       `json:"sequenceNumber"`
+	ID             uuid.UUID  `json:"id"`
+	ChainID        uuid.UUID  `json:"chainId"`
+	SequenceNumber int        `json:"sequenceNumber"`
 	ParentCallID   *uuid.UUID `json:"parentCallId,omitempty"`
 
 	// Participants
@@ -851,8 +855,8 @@ const (
 
 // A2AAgentDependency represents a dependency between agents
 type A2AAgentDependency struct {
-	ID              uuid.UUID `json:"id"`
-	AgentID         uuid.UUID `json:"agentId"`
+	ID               uuid.UUID `json:"id"`
+	AgentID          uuid.UUID `json:"agentId"`
 	DependsOnAgentID uuid.UUID `json:"dependsOnAgentId"`
 
 	// Dependency details
@@ -872,17 +876,17 @@ type A2AAgentDependency struct {
 
 // A2AChainSummary provides an overview of an agent call chain
 type A2AChainSummary struct {
-	ChainID         uuid.UUID   `json:"chainId"`
-	TotalCalls      int         `json:"totalCalls"`
-	MaxDepth        int         `json:"maxDepth"`
-	UniqueAgents    int         `json:"uniqueAgents"`
-	AgentIDs        []uuid.UUID `json:"agentIds"`
-	IsHumanInitiated bool       `json:"isHumanInitiated"`
-	OriginUserID    *uuid.UUID  `json:"originUserId,omitempty"`
-	StartedAt       time.Time   `json:"startedAt"`
-	CompletedAt     *time.Time  `json:"completedAt,omitempty"`
-	Status          A2ACallChainStatus `json:"status"`
-	HasPII          bool        `json:"hasPii"`
+	ChainID          uuid.UUID          `json:"chainId"`
+	TotalCalls       int                `json:"totalCalls"`
+	MaxDepth         int                `json:"maxDepth"`
+	UniqueAgents     int                `json:"uniqueAgents"`
+	AgentIDs         []uuid.UUID        `json:"agentIds"`
+	IsHumanInitiated bool               `json:"isHumanInitiated"`
+	OriginUserID     *uuid.UUID         `json:"originUserId,omitempty"`
+	StartedAt        time.Time          `json:"startedAt"`
+	CompletedAt      *time.Time         `json:"completedAt,omitempty"`
+	Status           A2ACallChainStatus `json:"status"`
+	HasPII           bool               `json:"hasPii"`
 }
 
 // A2ACallChainRepository defines operations for call chain tracking

--- a/apps/backend/internal/infrastructure/repository/a2a_list_all_tenant_scope_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_list_all_tenant_scope_integration_test.go
@@ -1,0 +1,234 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A2AConsentRepository.ListAll and A2ATrustScoreRepository.ListAll, and the
+// organization boundary they did not have.
+//
+// Both queries ran with no organization predicate whatsoever. GET
+// /api/v1/a2a/consents therefore returned every tenant's consent records —
+// user_id, purpose, data_types, both agent IDs, user_agent — to any
+// authenticated caller, and GET /api/v1/a2a/trust-scores did the same for
+// every tenant's agent IDs and behavioural metrics. Neither route carried a
+// role middleware, unlike its neighbours on the same group.
+//
+// These tests run against a real database rather than a mock, because the
+// defect lived entirely in SQL that a mock replaces. Each asserts three
+// things, and all three are needed:
+//
+//   - presence: the caller's own rows ARE returned, so the test cannot pass
+//     by returning nothing;
+//   - absence: the other tenant's rows are NOT returned, which is the actual
+//     security property;
+//   - the reported total is the caller's count, not the global count. An
+//     unscoped COUNT leaks how much data every other tenant holds without
+//     returning a single row, so scoping the rows alone is not sufficient.
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestA2AListAllTenantScope ./internal/infrastructure/repository/...
+
+func a2aScopeTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping A2A ListAll tenant scope test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// a2aScopeFixture stands up two organizations, one agent in each, and returns
+// their IDs. Everything it creates is removed on cleanup.
+func a2aScopeFixture(t *testing.T, db *sql.DB) (orgA, orgB, agentA, agentB uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	orgA, orgB = uuid.New(), uuid.New()
+	agentA, agentB = uuid.New(), uuid.New()
+	suffix := uuid.NewString()[:8]
+
+	for _, o := range []struct {
+		id   uuid.UUID
+		name string
+	}{{orgA, "scope-test-a-" + suffix}, {orgB, "scope-test-b-" + suffix}} {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO organizations (id, name, domain) VALUES ($1, $2, $3)`,
+			o.id, o.name, o.name+".invalid")
+		require.NoError(t, err)
+	}
+
+	// agents.created_by is a real FK to users, so each org needs a user.
+	userA, userB := uuid.New(), uuid.New()
+	for _, u := range []struct {
+		id  uuid.UUID
+		org uuid.UUID
+	}{{userA, orgA}, {userB, orgB}} {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO users (id, organization_id, email, name, provider, provider_id)
+			 VALUES ($1, $2, $3, 'scope test user', 'local', $4)`,
+			u.id, u.org, "scope-"+u.id.String()[:8]+"@example.invalid", u.id.String())
+		require.NoError(t, err)
+	}
+
+	for _, a := range []struct {
+		id      uuid.UUID
+		org     uuid.UUID
+		creator uuid.UUID
+	}{{agentA, orgA, userA}, {agentB, orgB, userB}} {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO agents (id, name, display_name, agent_type, created_by, organization_id)
+			 VALUES ($1, $2, $2, 'service', $3, $4)`,
+			a.id, "scope-agent-"+a.id.String()[:8], a.creator, a.org)
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_trust_scores WHERE agent_id = ANY($1)`,
+			pqUUIDArray(agentA, agentB))
+		_, _ = db.ExecContext(ctx, `DELETE FROM a2a_consent_records WHERE organization_id = ANY($1)`,
+			pqUUIDArray(orgA, orgB))
+		_, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = ANY($1)`,
+			pqUUIDArray(agentA, agentB))
+		_, _ = db.ExecContext(ctx, `DELETE FROM users WHERE id = ANY($1)`,
+			pqUUIDArray(userA, userB))
+		_, _ = db.ExecContext(ctx, `DELETE FROM organizations WHERE id = ANY($1)`,
+			pqUUIDArray(orgA, orgB))
+	})
+
+	return orgA, orgB, agentA, agentB
+}
+
+func pqUUIDArray(ids ...uuid.UUID) interface{} {
+	out := "{"
+	for i, id := range ids {
+		if i > 0 {
+			out += ","
+		}
+		out += id.String()
+	}
+	return out + "}"
+}
+
+func TestA2AListAllTenantScope_Consents(t *testing.T) {
+	db := a2aScopeTestDB(t)
+	ctx := context.Background()
+	orgA, orgB, agentA, agentB := a2aScopeFixture(t, db)
+
+	// Two consent records for org A, three for org B. The asymmetry matters:
+	// equal counts would let a wrong-but-plausible implementation (say, one
+	// that scoped the rows but not the COUNT) pass the total assertion by
+	// coincidence.
+	insert := func(org, grantor, recipient uuid.UUID, userID string) {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO a2a_consent_records
+			   (user_id, organization_id, grantor_agent_id, recipient_agent_id,
+			    scope, purpose, data_types, consent_method)
+			 VALUES ($1, $2, $3, $4, '["pii"]'::jsonb, 'test', '["email"]'::jsonb, 'api')`,
+			userID, org, grantor, recipient)
+		require.NoError(t, err)
+	}
+	insert(orgA, agentA, agentA, "user-a-1")
+	insert(orgA, agentA, agentA, "user-a-2")
+	insert(orgB, agentB, agentB, "user-b-1")
+	insert(orgB, agentB, agentB, "user-b-2")
+	insert(orgB, agentB, agentB, "user-b-3")
+
+	repo := NewA2AConsentRepository(db)
+
+	rowsA, totalA, err := repo.ListAll(ctx, orgA, 100, 0)
+	require.NoError(t, err)
+
+	assert.Len(t, rowsA, 2, "org A must see exactly its own two consent records")
+	assert.Equal(t, 2, totalA,
+		"total must be org A's count, not the global count; an unscoped COUNT "+
+			"discloses how much consent data other tenants hold")
+	for _, r := range rowsA {
+		require.NotNil(t, r.OrganizationID)
+		assert.Equal(t, orgA, *r.OrganizationID,
+			"a row from another organization crossed the tenant boundary")
+	}
+
+	// Absence, stated over the field an attacker would actually read.
+	seen := map[string]bool{}
+	for _, r := range rowsA {
+		seen[r.UserID] = true
+	}
+	assert.True(t, seen["user-a-1"] && seen["user-a-2"], "org A's own rows must be present")
+	for _, leaked := range []string{"user-b-1", "user-b-2", "user-b-3"} {
+		assert.False(t, seen[leaked], "org B's user_id %q was returned to org A", leaked)
+	}
+
+	// The boundary must hold from the other side too, so the test cannot pass
+	// on an implementation that hardcodes or mixes up the parameter.
+	rowsB, totalB, err := repo.ListAll(ctx, orgB, 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, rowsB, 3)
+	assert.Equal(t, 3, totalB)
+	for _, r := range rowsB {
+		require.NotNil(t, r.OrganizationID)
+		assert.Equal(t, orgB, *r.OrganizationID)
+	}
+
+	// An organization with no records sees nothing and is told nothing about
+	// the size of the table.
+	rowsNone, totalNone, err := repo.ListAll(ctx, uuid.New(), 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rowsNone)
+	assert.Equal(t, 0, totalNone)
+}
+
+func TestA2AListAllTenantScope_TrustScores(t *testing.T) {
+	db := a2aScopeTestDB(t)
+	ctx := context.Background()
+	orgA, orgB, agentA, agentB := a2aScopeFixture(t, db)
+
+	// a2a_trust_scores carries no organization_id of its own — it is keyed on
+	// agent_id — so the boundary can only be reached by joining agents. This
+	// test is what proves that join is present and filters on the right side.
+	for _, a := range []uuid.UUID{agentA, agentB} {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO a2a_trust_scores (agent_id, a2a_trust_score, data_points)
+			 VALUES ($1, 0.5, 1)`, a)
+		require.NoError(t, err)
+	}
+
+	repo := NewA2ATrustScoreRepository(db)
+
+	scoresA, totalA, err := repo.ListAll(ctx, orgA, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, scoresA, 1, "org A must see exactly its own agent's score")
+	assert.Equal(t, agentA, scoresA[0].AgentID)
+	assert.Equal(t, 1, totalA, "total must not count agents in other organizations")
+
+	for _, s := range scoresA {
+		assert.NotEqual(t, agentB, s.AgentID,
+			"org B's agent ID was returned to org A")
+	}
+
+	scoresB, totalB, err := repo.ListAll(ctx, orgB, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, scoresB, 1)
+	assert.Equal(t, agentB, scoresB[0].AgentID)
+	assert.Equal(t, 1, totalB)
+
+	scoresNone, totalNone, err := repo.ListAll(ctx, uuid.New(), 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, scoresNone)
+	assert.Equal(t, 0, totalNone)
+}

--- a/apps/backend/internal/infrastructure/repository/a2a_repository.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_repository.go
@@ -1268,6 +1268,13 @@ type A2AConsentRepository struct {
 	db *sql.DB
 }
 
+// The interface carries the org-scoping contract in its doc comments, so bind
+// it to the implementation. Without this assertion nothing referenced the
+// interface as a type and it had already drifted -- it declared ListByUser
+// without the orgID the implementation has taken since PR #149, so a comment
+// promising a required organization parameter was enforcing nothing.
+var _ domain.A2AConsentRepository = (*A2AConsentRepository)(nil)
+
 // NewA2AConsentRepository creates a new A2AConsentRepository
 func NewA2AConsentRepository(db *sql.DB) *A2AConsentRepository {
 	return &A2AConsentRepository{db: db}
@@ -1706,6 +1713,10 @@ func parseIP(s string) net.IP {
 type A2ATrustScoreRepository struct {
 	db *sql.DB
 }
+
+// See the note on A2AConsentRepository: the assertion is what makes the
+// interface's org-scoping comment binding.
+var _ domain.A2ATrustScoreRepository = (*A2ATrustScoreRepository)(nil)
 
 // NewA2ATrustScoreRepository creates a new A2ATrustScoreRepository
 func NewA2ATrustScoreRepository(db *sql.DB) *A2ATrustScoreRepository {

--- a/apps/backend/internal/infrastructure/repository/a2a_repository.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_repository.go
@@ -1401,10 +1401,25 @@ func (r *A2AConsentRepository) ListByUser(ctx context.Context, userID string, or
 	return r.queryConsents(ctx, query, userID, orgID)
 }
 
-func (r *A2AConsentRepository) ListAll(ctx context.Context, limit, offset int) ([]*domain.A2AConsentRecord, int, error) {
-	countQuery := `SELECT COUNT(*) FROM a2a_consent_records`
+// ListAll lists consent records belonging to one organization.
+//
+// SECURITY: the org predicate is required, and the name is a misnomer kept
+// only for continuity — this never listed "all" safely. Before this fix the
+// query had no organization_id predicate at all, so GET /api/v1/a2a/consents
+// returned every tenant's consent rows (user_id, purpose, data_types, both
+// agent IDs, user_agent) to any authenticated caller.
+//
+// The COUNT is scoped too, deliberately. An unscoped count returns the global
+// row total, which is a cross-tenant cardinality disclosure on its own — the
+// caller learns how much consent data every other tenant holds without reading
+// a single row.
+//
+// organization_id is the ownership column for a consent record (migration 097)
+// and is NOT NULL, so the predicate excludes no legitimately-owned row.
+func (r *A2AConsentRepository) ListAll(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2AConsentRecord, int, error) {
+	countQuery := `SELECT COUNT(*) FROM a2a_consent_records WHERE organization_id = $1`
 	var total int
-	if err := r.db.QueryRowContext(ctx, countQuery).Scan(&total); err != nil {
+	if err := r.db.QueryRowContext(ctx, countQuery, orgID).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("failed to count consents: %w", err)
 	}
 
@@ -1415,10 +1430,11 @@ func (r *A2AConsentRepository) ListAll(ctx context.Context, limit, offset int) (
 			revoked, revoked_at, revoked_reason, consent_method, evidence,
 			ip_address, user_agent, created_at, updated_at
 		FROM a2a_consent_records
+		WHERE organization_id = $1
 		ORDER BY granted_at DESC
-		LIMIT $1 OFFSET $2
+		LIMIT $2 OFFSET $3
 	`
-	consents, err := r.queryConsents(ctx, query, limit, offset)
+	consents, err := r.queryConsents(ctx, query, orgID, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1827,27 +1843,44 @@ func (r *A2ATrustScoreRepository) GetByAgentID(ctx context.Context, agentID uuid
 	return score, nil
 }
 
-func (r *A2ATrustScoreRepository) ListAll(ctx context.Context, limit, offset int) ([]*domain.A2ATrustScore, int, error) {
-	countQuery := `SELECT COUNT(*) FROM a2a_trust_scores`
+// ListAll lists A2A trust scores for agents belonging to one organization.
+//
+// SECURITY: a2a_trust_scores carries no organization_id of its own — it is
+// keyed on agent_id — so the tenant boundary is reached by joining agents and
+// filtering on agents.organization_id. Before this fix the query had no
+// predicate, so GET /api/v1/a2a/trust-scores returned every tenant's agent IDs
+// and behavioural metrics to any authenticated caller.
+//
+// The COUNT is scoped for the same reason as in A2AConsentRepository.ListAll:
+// an unscoped total is a cross-tenant cardinality disclosure by itself.
+func (r *A2ATrustScoreRepository) ListAll(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2ATrustScore, int, error) {
+	countQuery := `
+		SELECT COUNT(*)
+		FROM a2a_trust_scores ts
+		JOIN agents a ON a.id = ts.agent_id
+		WHERE a.organization_id = $1
+	`
 	var total int
-	if err := r.db.QueryRowContext(ctx, countQuery).Scan(&total); err != nil {
+	if err := r.db.QueryRowContext(ctx, countQuery, orgID).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("failed to count trust scores: %w", err)
 	}
 
 	query := `
 		SELECT
-			agent_id, total_tasks_as_client, total_tasks_as_remote,
-			tasks_completed, tasks_failed, tasks_cancelled,
-			avg_response_time_ms, p95_response_time_ms, avg_task_duration_ms,
-			a2a_trust_score, peer_trust_average, unique_peers_count,
-			positive_feedback_count, negative_feedback_count,
-			computed_at, data_points, created_at, updated_at
-		FROM a2a_trust_scores
-		ORDER BY a2a_trust_score DESC NULLS LAST
-		LIMIT $1 OFFSET $2
+			ts.agent_id, ts.total_tasks_as_client, ts.total_tasks_as_remote,
+			ts.tasks_completed, ts.tasks_failed, ts.tasks_cancelled,
+			ts.avg_response_time_ms, ts.p95_response_time_ms, ts.avg_task_duration_ms,
+			ts.a2a_trust_score, ts.peer_trust_average, ts.unique_peers_count,
+			ts.positive_feedback_count, ts.negative_feedback_count,
+			ts.computed_at, ts.data_points, ts.created_at, ts.updated_at
+		FROM a2a_trust_scores ts
+		JOIN agents a ON a.id = ts.agent_id
+		WHERE a.organization_id = $1
+		ORDER BY ts.a2a_trust_score DESC NULLS LAST
+		LIMIT $2 OFFSET $3
 	`
 
-	rows, err := r.db.QueryContext(ctx, query, limit, offset)
+	rows, err := r.db.QueryContext(ctx, query, orgID, limit, offset)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list trust scores: %w", err)
 	}

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -1061,7 +1061,9 @@ func (h *A2AHandler) ListUserConsents(c fiber.Ctx) error {
 	})
 }
 
-// ListAllConsents lists all consent records with pagination (admin endpoint)
+// ListAllConsents lists the calling organization's consent records, paginated.
+// Not an admin endpoint: the route carries no role middleware, so the org
+// predicate below is the only tenant boundary this handler has.
 func (h *A2AHandler) ListAllConsents(c fiber.Ctx) error {
 	// SECURITY: this route returned every tenant's consent records — user_id,
 	// purpose, data_types, both agent IDs and user_agent — to any
@@ -1093,7 +1095,9 @@ func (h *A2AHandler) ListAllConsents(c fiber.Ctx) error {
 	})
 }
 
-// ListAllTrustScores lists all A2A trust scores with pagination (admin endpoint)
+// ListAllTrustScores lists A2A trust scores for the calling organization's
+// agents, paginated. Not an admin endpoint, for the same reason as
+// ListAllConsents.
 func (h *A2AHandler) ListAllTrustScores(c fiber.Ctx) error {
 	// SECURITY: same defect as ListAllConsents — no organization predicate and
 	// an uncapped limit. This one exposed every tenant's agent IDs and

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -131,9 +131,9 @@ func (h *A2AHandler) RegisterAgentCard(c fiber.Ctx) error {
 		c.IP(),
 		c.Get("User-Agent"),
 		map[string]interface{}{
-			"agentId":   agentID,
-			"cardUrl":   req.CardURL,
-			"skills":    resp.Skills,
+			"agentId": agentID,
+			"cardUrl": req.CardURL,
+			"skills":  resp.Skills,
 		},
 	)
 
@@ -216,16 +216,16 @@ func (h *A2AHandler) RefreshCardAttestation(c fiber.Ctx) error {
 		c.IP(),
 		c.Get("User-Agent"),
 		map[string]interface{}{
-			"agentId":           agentID,
+			"agentId":            agentID,
 			"attestationExpires": card.AttestationExpiresAt,
 		},
 	)
 
 	return c.JSON(fiber.Map{
-		"cardId":              card.ID,
-		"agentId":             card.AgentID,
+		"cardId":             card.ID,
+		"agentId":            card.AgentID,
 		"attestationExpires": card.AttestationExpiresAt,
-		"message":             "Attestation refreshed successfully",
+		"message":            "Attestation refreshed successfully",
 	})
 }
 
@@ -307,17 +307,17 @@ func (h *A2AHandler) VerifyRequest(c fiber.Ctx) error {
 
 	if !result.Valid {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"valid":  false,
-			"error":  result.Error,
+			"valid": false,
+			"error": result.Error,
 		})
 	}
 
 	return c.JSON(fiber.Map{
-		"valid":             true,
-		"agentId":           result.AgentID,
-		"agentName":         result.AgentName,
-		"trustScore":        result.TrustScore,
-		"capabilities":      result.Capabilities,
+		"valid":            true,
+		"agentId":          result.AgentID,
+		"agentName":        result.AgentName,
+		"trustScore":       result.TrustScore,
+		"capabilities":     result.Capabilities,
 		"attestationValid": result.AttestationValid,
 	})
 }
@@ -514,12 +514,12 @@ func (h *A2AHandler) LogTask(c fiber.Ctx) error {
 	// Accept SDK format with field name variations
 	var sdkReq struct {
 		// SDK format
-		TargetAgentID   string `json:"targetAgentId"`
-		TaskID          string `json:"taskId"`
-		TaskType        string `json:"taskType"`
-		Status          string `json:"status"`
-		SkillID         string `json:"skillId"`
-		SdkClientAgent  string `json:"clientAgentId"` // SDK can also send clientAgentId as string
+		TargetAgentID  string `json:"targetAgentId"`
+		TaskID         string `json:"taskId"`
+		TaskType       string `json:"taskType"`
+		Status         string `json:"status"`
+		SkillID        string `json:"skillId"`
+		SdkClientAgent string `json:"clientAgentId"` // SDK can also send clientAgentId as string
 		// Internal format
 		ExternalTaskID string    `json:"externalTaskId"`
 		ContextID      string    `json:"contextId"`
@@ -773,9 +773,9 @@ func (h *A2AHandler) SearchSkills(c fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{
-		"query":   query,
-		"skills":  skills,
-		"count":   len(skills),
+		"query":  query,
+		"skills": skills,
+		"count":  len(skills),
 	})
 }
 
@@ -1063,16 +1063,22 @@ func (h *A2AHandler) ListUserConsents(c fiber.Ctx) error {
 
 // ListAllConsents lists all consent records with pagination (admin endpoint)
 func (h *A2AHandler) ListAllConsents(c fiber.Ctx) error {
-	limit := 100
-	offset := 0
-	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
-		limit = l
+	// SECURITY: this route returned every tenant's consent records — user_id,
+	// purpose, data_types, both agent IDs and user_agent — to any
+	// authenticated caller. It had no organization predicate and no role
+	// middleware, unlike its neighbours on the same route group.
+	//
+	// Pagination now goes through the shared helper, which caps limit and
+	// offset. The hand-rolled parsing it replaces accepted any positive limit,
+	// so ?limit=100000 paged the whole table in one request.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
 	}
-	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o >= 0 {
-		offset = o
-	}
+	p := ParsePaginationWithDefaults(c, 100, 100)
+	limit, offset := p.Limit, p.Offset
 
-	consents, total, err := h.a2aService.ListAllConsents(c.Context(), limit, offset)
+	consents, total, err := h.a2aService.ListAllConsents(c.Context(), orgID, limit, offset)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),
@@ -1089,16 +1095,17 @@ func (h *A2AHandler) ListAllConsents(c fiber.Ctx) error {
 
 // ListAllTrustScores lists all A2A trust scores with pagination (admin endpoint)
 func (h *A2AHandler) ListAllTrustScores(c fiber.Ctx) error {
-	limit := 100
-	offset := 0
-	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
-		limit = l
+	// SECURITY: same defect as ListAllConsents — no organization predicate and
+	// an uncapped limit. This one exposed every tenant's agent IDs and
+	// behavioural metrics (task counts, response times, trust score).
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
 	}
-	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o >= 0 {
-		offset = o
-	}
+	p := ParsePaginationWithDefaults(c, 100, 100)
+	limit, offset := p.Limit, p.Offset
 
-	scores, total, err := h.a2aService.ListAllTrustScores(c.Context(), limit, offset)
+	scores, total, err := h.a2aService.ListAllTrustScores(c.Context(), orgID, limit, offset)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),
@@ -1198,9 +1205,9 @@ func (h *A2AHandler) CleanupExpiredNonces(c fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{
-		"message":         "Nonces cleaned up",
-		"deletedCount":   count,
-		"timestamp":       time.Now().UTC(),
+		"message":      "Nonces cleaned up",
+		"deletedCount": count,
+		"timestamp":    time.Now().UTC(),
 	})
 }
 


### PR DESCRIPTION
`GET /api/v1/a2a/consents` and `GET /api/v1/a2a/trust-scores` returned every organization's rows to any authenticated caller. Neither query carried an `organization_id` predicate, and neither route carries a role middleware — unlike its neighbours on the same group, which do (`ManagerMiddleware` on `/agents/:id/trust-score/compute`, and the separate `a2aAdmin` group behind `AdminMiddleware`). `limit` was caller-controlled with a `> 0` check and no upper bound, so one request could page the whole table.

Measured against a two-tenant database, authenticated as organization A only:

| | before | after |
|---|---|---|
| `/a2a/consents` rows | all 4 orgs' rows | A's row only |
| `/a2a/consents` total | `6` (global) | `1` (A's) |
| `?limit=100000` | echoed `100000` | capped to `100` |
| `/a2a/trust-scores` | all 4 agents, all orgs | A's agent only |

Before the fix, a token scoped to org A read `userId`, `purpose`, `dataTypes`, both agent IDs and `userAgent` for every other tenant, plus every tenant's agent IDs and behavioural metrics.

## What changed

The predicate goes in the SQL, at the layer that owns the data, so the handler check is defence in depth rather than the only gate — a handler-only fix leaves the repository method exposed to its next caller. `ListByUser` in the same repository already carried `WHERE user_id = $1 AND organization_id = $2`; `ListAll` was the outlier.

- **Consents** — `WHERE organization_id = $1`. That column is the ownership column for a consent record and is `NOT NULL` since migration 097, so the predicate excludes no legitimately-owned row.
- **Trust scores** — `a2a_trust_scores` has no organization column of its own, so the boundary is reached by `JOIN agents a ON a.id = ts.agent_id WHERE a.organization_id = $1`. The join cannot inflate or drop rows: `agent_id` is `PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE`, and `agents.organization_id` is `NOT NULL`.
- **The COUNT is scoped too, deliberately.** An unscoped total discloses how much data every other tenant holds without returning a single row, so scoping only the rows would have left a cardinality leak behind.
- **Pagination** now goes through the shared `ParsePaginationWithDefaults(c, 100, 100)` instead of hand-rolled parsing, which caps `limit` and bounds `offset`.

## Tests

Integration tests against a real database, because the defect lived entirely in SQL that a mock replaces. The fixture seeds two organizations with **asymmetric** row counts (2 consents for A, 3 for B) so that an implementation scoping the rows but not the COUNT cannot pass the total assertion by coincidence. Each test asserts presence (own rows returned, so it cannot pass by returning nothing), absence (the other tenant's rows are not), and that the reported total is the caller's count.

Every assertion was mutation-proven rather than assumed — each mutant applied to the real query, test run, source restored from a pristine copy:

| mutation | result |
|---|---|
| consent rows predicate neutralised | Consents FAILS |
| consent COUNT neutralised, rows still scoped | Consents FAILS — the count assertion is independently load-bearing |
| trust-score join filter neutralised | TrustScores FAILS |
| trust-score COUNT filter neutralised, rows still scoped | TrustScores FAILS |
| unmutated control | passes |

## Recurrence guard, and what it does not cover

`collectionscope-lint` (in `cmd/tenantscope-lint`, wired into the existing CI job) fails a service method named `ListAll*` that takes no organization parameter. The two existing checks are structurally blind to this shape: the handler check triggers on reading a tenant-scoped `c.Params(...)` key, and the service check triggers on accepting an `orgID` and not using it. A method that asks for no identifier at all and returns everything trips neither, which is how these two endpoints reported `ok` on every lint run.

**Stated plainly so a green run is not read as more than it is:** `ListAll` is a naming convention, not the shape of the defect. This check is a regression guard for the two methods fixed here, not a guard for the class. `ListAgentCards` and `ListA2ATasks` are on this same service, have the same shape, and pass it. The predicate that would cover the class — *returns a collection and takes no organization* — fires across the package and every hit needs triage into a fix or an allowlist entry; that is its own change, not a rider on this one. The allowlist ships empty, and an entry must name the control that makes a cross-tenant read safe. A doc comment calling something an admin endpoint is not that control: both methods fixed here said exactly that, and neither route has role middleware.

The new tests are added to the CI step that fails when an integration test silently skips. That step selects by name, and its own comment requires any new test to be covered — a skip there would restore this defect green.

Also in this branch: the domain repository interfaces now have compile-time assertions binding them to their implementations. The org-scoping contract was written into their doc comments but nothing referenced them as types, so they enforced nothing — and had already drifted, declaring `ListByUser` without the `orgID` the implementation has taken since #149.

## Notes for the reviewer

- **No recipient-organization check, deliberately.** An A2A consent grant naming another organization's agent as recipient is the entire point of cross-agent consent; scoping the recipient would break the feature.
- **`?limit` above 100 is now clamped rather than rejected**, and `offset` is bounded. Both responses echo the applied values, so the API does not misreport what it did, but an SDK client passing `?limit=500` now receives 100 rows.
- `RequireOrganizationID` **fails closed** — no organization in context means no query runs. It returns a plain error that the global handler renders as a 500 rather than a 401; that is the existing pattern at 68 of its 69 call sites, not something introduced here, and it is unreachable on this route group because `AuthMiddleware` already rejects a missing or unparseable organization claim.
