### PR TITLE
Scope the A2A agent-card list to the caller's organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Security
 
+- `GET /api/v1/a2a/cards` returned every organization's agent cards to any
+  authenticated caller: `cardUrl`, the full `cardData` agent-card document,
+  `agentId` and `attestationSignature`. The only predicate was `is_valid = TRUE`,
+  and the route carries no role middleware. Its pagination was weaker than the
+  endpoints fixed alongside it — the limit was parsed with no bound at all, not
+  even a positive check, so `?limit=-1` reached PostgreSQL as a negative `LIMIT`
+  and surfaced as a 500, and a large limit was unbounded. The query is now scoped
+  to the caller's organization by joining `agents` (`a2a_agent_cards` has no
+  organization column of its own) and the limit is capped.
+  **Cross-organization discovery is unaffected**: the public per-agent card is
+  still `/.well-known/agent.json`, and cross-organization search still lives on
+  the `/discovery/*` routes. This endpoint is an SDK-compatibility list whose
+  sibling routes all operate on a single card the caller owns.
+
 - `GET /api/v1/a2a/consents` and `GET /api/v1/a2a/trust-scores` returned every
   organization's rows to any authenticated caller. Neither query carried an
   `organization_id` predicate and neither route carried a role middleware, unlike

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -696,9 +696,24 @@ func scanCollectionDirectory(dir string) ([]violation, error) {
 // "ListAll" prefix is a NAMING convention, not the shape of the defect, so this
 // check is a regression guard for the two methods above and not yet a guard for
 // the class. Every same-shape method that happens to be named differently is
-// invisible to it -- A2AService.ListAgentCards and A2AService.ListA2ATasks are
-// both on this very service, both return a whole collection with no
-// organization parameter, and both pass this check today.
+// invisible to it.
+//
+// Measured over ./internal/application, not estimated: 88 exported methods
+// return a slice or map, 47 take an organization parameter and 41 do not, and
+// ZERO of those 41 are named ListAll* -- so this check sees none of them.
+// Examples that pass it today: AdminService.GetAllUsers, AuditService.SearchLogs,
+// CapabilityRequestService.ListRequests. Whether each of the 41 is a defect
+// needs triage -- several are scoped at another layer or are legitimately
+// global -- but none of them is guarded HERE.
+//
+// An earlier version of this comment cited A2AService.ListAgentCards and
+// A2AService.ListA2ATasks as the examples. Both were fixed within days, which
+// falsified the comment while the check itself was unchanged. Cite the
+// measurement and re-run it rather than trusting the names:
+//
+//	go run ./cmd/tenantscope-lint  # this check
+//	# and to re-derive the 41, walk the package for methods returning a
+//	# slice/map with no orgParamNames uuid.UUID parameter.
 //
 // The predicate that would cover the class is "returns a slice or map AND takes
 // no organization parameter". It is not enabled here because it fires across

--- a/apps/backend/internal/application/a2a_service.go
+++ b/apps/backend/internal/application/a2a_service.go
@@ -255,9 +255,11 @@ func (s *A2AService) GetAgentCard(ctx context.Context, agentID uuid.UUID) (*doma
 	return s.cardRepo.GetByAgentID(ctx, agentID)
 }
 
-// ListAgentCards returns all valid agent cards with pagination
-func (s *A2AService) ListAgentCards(ctx context.Context, limit, offset int) ([]*domain.A2AAgentCard, error) {
-	return s.cardRepo.GetValidCards(ctx, limit, offset)
+// ListAgentCards returns valid agent cards belonging to orgID. SECURITY: orgID
+// is required; without it any authenticated caller could page every tenant's
+// agent cards off GET /api/v1/a2a/cards.
+func (s *A2AService) ListAgentCards(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2AAgentCard, error) {
+	return s.cardRepo.GetValidCards(ctx, orgID, limit, offset)
 }
 
 // GetEnhancedAgentCard returns the agent card with AIM extensions

--- a/apps/backend/internal/domain/a2a.go
+++ b/apps/backend/internal/domain/a2a.go
@@ -522,7 +522,9 @@ type A2AAgentCardRepository interface {
 	GetByAgentID(ctx context.Context, agentID uuid.UUID) (*A2AAgentCard, error)
 	Update(ctx context.Context, card *A2AAgentCard) error
 	Delete(ctx context.Context, id uuid.UUID) error
-	GetValidCards(ctx context.Context, limit, offset int) ([]*A2AAgentCard, error)
+	// GetValidCards is org-scoped; it reaches the tenant boundary by joining
+	// agents, since a2a_agent_cards has no organization_id of its own.
+	GetValidCards(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*A2AAgentCard, error)
 	GetExpiredCards(ctx context.Context) ([]*A2AAgentCard, error)
 }
 

--- a/apps/backend/internal/infrastructure/repository/a2a_repository.go
+++ b/apps/backend/internal/infrastructure/repository/a2a_repository.go
@@ -21,6 +21,11 @@ type A2AAgentCardRepository struct {
 	db *sql.DB
 }
 
+// The interface carries the org-scoping contract in its doc comment, so bind it
+// to the implementation. See the note on A2AConsentRepository for why an
+// unasserted interface drifts silently.
+var _ domain.A2AAgentCardRepository = (*A2AAgentCardRepository)(nil)
+
 // NewA2AAgentCardRepository creates a new A2AAgentCardRepository
 func NewA2AAgentCardRepository(db *sql.DB) *A2AAgentCardRepository {
 	return &A2AAgentCardRepository{db: db}
@@ -188,18 +193,45 @@ func (r *A2AAgentCardRepository) Delete(ctx context.Context, id uuid.UUID) error
 	return nil
 }
 
-func (r *A2AAgentCardRepository) GetValidCards(ctx context.Context, limit, offset int) ([]*domain.A2AAgentCard, error) {
+// GetValidCards returns valid agent cards belonging to orgID.
+//
+// SECURITY: orgID is required. Before this fix the only predicate was
+// is_valid = TRUE, so GET /api/v1/a2a/cards returned every tenant's card_url,
+// full card_data agent-card JSON, agent_id and attestation_signature to any
+// authenticated caller. This is the third instance of the same class, after the
+// consent and trust-score lists (#364) and the consent oracle (#363).
+//
+// a2a_agent_cards carries no organization_id of its own -- it is keyed on
+// agent_id -- so the tenant boundary is reached by joining agents, the same way
+// the trust-score list does. The join cannot inflate or drop rows: agent_id is
+// NOT NULL REFERENCES agents(id) ON DELETE CASCADE with a UNIQUE constraint, and
+// agents.organization_id is NOT NULL.
+//
+// There is no COUNT here to scope, unlike the two list endpoints in #364. This
+// route reports no total, so there is no cardinality to disclose; adding one
+// would change the response shape for no security benefit.
+//
+// Cross-organization discovery is NOT what this route is for and is not broken
+// by scoping it. The public per-agent card is /.well-known/agent.json
+// (GetPublicAgentCard, deliberately unauthenticated), and cross-org search
+// lives on the /discovery/* routes. This is an SDK-compatibility list whose
+// siblings -- POST /cards, GET/PUT /cards/:id -- are all single-resource
+// operations on the caller's own cards.
+func (r *A2AAgentCardRepository) GetValidCards(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*domain.A2AAgentCard, error) {
 	query := `
 		SELECT
-			id, agent_id, card_url, card_data, card_hash, protocol_version,
-			attestation_signature, attestation_issued_at, attestation_expires_at,
-			is_valid, validation_error, last_fetched_at, fetch_count, created_at, updated_at
-		FROM a2a_agent_cards
-		WHERE is_valid = TRUE
-		ORDER BY updated_at DESC
-		LIMIT $1 OFFSET $2
+			c.id, c.agent_id, c.card_url, c.card_data, c.card_hash, c.protocol_version,
+			c.attestation_signature, c.attestation_issued_at, c.attestation_expires_at,
+			c.is_valid, c.validation_error, c.last_fetched_at, c.fetch_count,
+			c.created_at, c.updated_at
+		FROM a2a_agent_cards c
+		JOIN agents a ON a.id = c.agent_id
+		WHERE c.is_valid = TRUE
+			AND a.organization_id = $1
+		ORDER BY c.updated_at DESC
+		LIMIT $2 OFFSET $3
 	`
-	return r.queryCards(ctx, query, limit, offset)
+	return r.queryCards(ctx, query, orgID, limit, offset)
 }
 
 func (r *A2AAgentCardRepository) GetExpiredCards(ctx context.Context) ([]*domain.A2AAgentCard, error) {

--- a/apps/backend/internal/infrastructure/repository/cross_tenant_scoping_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/cross_tenant_scoping_integration_test.go
@@ -275,3 +275,112 @@ func seedA2AConsent(t *testing.T, db *sql.DB, ctx context.Context, orgID, granto
 		userID, orgID, grantor, recipient)
 	require.NoError(t, err)
 }
+
+// GET /api/v1/a2a/cards returned every tenant's agent cards. The only predicate
+// was is_valid = TRUE, so card_url, the full card_data document, agent_id and
+// attestation_signature crossed the organization boundary to any authenticated
+// caller. a2a_agent_cards has no organization_id of its own, so the boundary is
+// reached by joining agents -- this test is what proves that join is present and
+// filters on the right side.
+func TestCrossTenantAgentCardsAreScopedToTheCallersOrg(t *testing.T) {
+	ctx := context.Background()
+	db := agentListTestDB(t)
+	repo := NewA2AAgentCardRepository(db)
+
+	mine := seedTenant(t, db, ctx, "mine")
+	theirs := seedTenant(t, db, ctx, "theirs")
+
+	// Asymmetric on purpose: one card for my org, two for theirs. Equal counts
+	// would let a wrong-but-plausible implementation look right by coincidence.
+	theirsSecondAgent := seedExtraAgent(t, db, ctx, theirs)
+	mineCard := seedAgentCard(t, db, ctx, mine.agentID, true)
+	theirsCard := seedAgentCard(t, db, ctx, theirs.agentID, true)
+	theirsCard2 := seedAgentCard(t, db, ctx, theirsSecondAgent, true)
+
+	cards, err := repo.GetValidCards(ctx, mine.orgID, 100, 0)
+	require.NoError(t, err)
+
+	got := make(map[uuid.UUID]bool, len(cards))
+	for _, c := range cards {
+		got[c.ID] = true
+	}
+
+	assert.True(t, got[mineCard], "control: my own agent card must be listed")
+	assert.False(t, got[theirsCard],
+		"another organization's agent card was returned to a caller who asked for nothing but a page")
+	assert.False(t, got[theirsCard2],
+		"another organization's second agent card was returned")
+	assert.Len(t, cards, 1, "org mine owns exactly one valid card")
+
+	// The boundary must hold from the other side too, so the test cannot pass on
+	// an implementation that hardcodes or mixes up the parameter.
+	theirCards, err := repo.GetValidCards(ctx, theirs.orgID, 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, theirCards, 2, "org theirs owns exactly two valid cards")
+
+	// An organization with no cards sees nothing.
+	none, err := repo.GetValidCards(ctx, uuid.New(), 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+// The org predicate must not have displaced the is_valid filter it was added
+// alongside. A fix that scoped by organization and quietly started returning
+// invalid cards would pass every assertion above.
+func TestCrossTenantAgentCardsStillExcludeInvalidOnes(t *testing.T) {
+	ctx := context.Background()
+	db := agentListTestDB(t)
+	repo := NewA2AAgentCardRepository(db)
+
+	mine := seedTenant(t, db, ctx, "mine")
+	secondAgent := seedExtraAgent(t, db, ctx, mine)
+
+	validCard := seedAgentCard(t, db, ctx, mine.agentID, true)
+	invalidCard := seedAgentCard(t, db, ctx, secondAgent, false)
+
+	cards, err := repo.GetValidCards(ctx, mine.orgID, 100, 0)
+	require.NoError(t, err)
+
+	got := make(map[uuid.UUID]bool, len(cards))
+	for _, c := range cards {
+		got[c.ID] = true
+	}
+	assert.True(t, got[validCard], "control: the valid card must be listed")
+	assert.False(t, got[invalidCard], "an invalid card was listed; the is_valid filter was lost")
+}
+
+// seedExtraAgent adds a second agent to an existing tenant and returns its id.
+func seedExtraAgent(t *testing.T, db *sql.DB, ctx context.Context, f tenantFixture) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DELETE FROM agents WHERE id = $1`, id) })
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO agents (id, name, display_name, agent_type, created_by, organization_id)
+		 VALUES ($1, $2, $2, 'service', $3, $4)`,
+		id, "extra-agent-"+id.String()[:8], f.userID, f.orgID)
+	require.NoError(t, err)
+
+	return id
+}
+
+// seedAgentCard inserts one agent card for an agent and returns its id.
+func seedAgentCard(t *testing.T, db *sql.DB, ctx context.Context, agentID uuid.UUID, valid bool) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DELETE FROM a2a_agent_cards WHERE id = $1`, id) })
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO a2a_agent_cards
+		   (id, agent_id, card_url, card_data, card_hash, is_valid, attestation_signature)
+		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)`,
+		id, agentID,
+		"https://cards.example.invalid/"+id.String()[:8],
+		`{"name":"scoping-test","url":"https://example.invalid"}`,
+		id.String()[:16], valid, "sig-"+id.String()[:16])
+	require.NoError(t, err)
+
+	return id
+}

--- a/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/a2a_handler.go
@@ -1948,20 +1948,23 @@ func (h *A2AHandler) CapableOfPost(c fiber.Ctx) error {
 // ListAgentCards returns a list of registered agent cards
 // GET /api/v1/a2a/cards
 func (h *A2AHandler) ListAgentCards(c fiber.Ctx) error {
-	limit := 100
-	offset := 0
-	if limitStr := c.Query("limit"); limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil {
-			limit = l
-		}
+	// SECURITY: this route returned every tenant's agent cards -- card_url, the
+	// full card_data document, agent_id and attestation_signature -- to any
+	// authenticated caller. It had no organization predicate and no role
+	// middleware.
+	//
+	// Pagination now goes through the shared helper. The hand-rolled parsing it
+	// replaces had no bound at all, not even the `l > 0` the two endpoints fixed
+	// in #364 had: ?limit=-1 reached PostgreSQL as a negative LIMIT and came back
+	// as a 500 echoing the driver error, and ?limit=100000000 was unbounded.
+	orgID, err := RequireOrganizationID(c)
+	if err != nil {
+		return err
 	}
-	if offsetStr := c.Query("offset"); offsetStr != "" {
-		if o, err := strconv.Atoi(offsetStr); err == nil {
-			offset = o
-		}
-	}
+	p := ParsePaginationWithDefaults(c, 100, 100)
+	limit, offset := p.Limit, p.Offset
 
-	cards, err := h.a2aService.ListAgentCards(c.Context(), limit, offset)
+	cards, err := h.a2aService.ListAgentCards(c.Context(), orgID, limit, offset)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": err.Error(),


### PR DESCRIPTION
Third and last instance of the class #364 and #363 closed. `GET /api/v1/a2a/cards` filtered on `is_valid = TRUE` and nothing else, so any authenticated caller read every organization's `cardUrl`, full `cardData` document, `agentId` and `attestationSignature`. Like the two before it, the route carries no role middleware.

Measured against two seeded tenants (org A owns 1 card, org B owns 2), authenticated as org A only:

| | before | after |
|---|---|---|
| `GET /a2a/cards` | all 3 cards, both orgs | A's 1 card |
| `?limit=-1` | `500` — `pq: LIMIT must not be negative` | `200`, default limit |
| `?limit=100000000` | unbounded | capped to `100` |
| unauthenticated | 401 | 401 |

Its pagination was **weaker than either endpoint fixed before it**. The limit was parsed with no bound at all — not even the `l > 0` those two had:

```go
if l, err := strconv.Atoi(limitStr); err == nil { limit = l }
```

so a negative limit reached PostgreSQL and came back as a 500 echoing the driver error. It now goes through the shared `ParsePaginationWithDefaults(c, 100, 100)`.

## Why a join, and why no COUNT

`a2a_agent_cards` has no `organization_id`, so the boundary is reached by joining `agents` — the same shape as the trust-score list in #364. Verified against the schema rather than assumed: `agent_id` is `NOT NULL REFERENCES agents(id) ON DELETE CASCADE` with a `UNIQUE` constraint, and `agents.organization_id` is `NOT NULL`, so the join can neither inflate nor drop rows.

**There is no COUNT to scope here.** This route reports no total, so unlike the two list endpoints in #364 there is no cardinality to disclose; adding one would change the response shape for no security benefit.

## Cross-organization discovery is not affected

Checked before scoping, because over-scoping is the failure mode this series has already had to guard against once. `/cards` is an SDK-compatibility list, not a discovery surface:

- the public per-agent card is `/.well-known/agent.json` (`GetPublicAgentCard`), deliberately unauthenticated and already allowlisted as such;
- cross-organization search lives on `/discovery/route` and `/discovery/capable`;
- this endpoint's siblings — `POST /cards`, `GET /cards/:id`, `PUT /cards/:id` — all operate on a single card the caller owns.

## Red-proof

| mutation | result |
|---|---|
| org predicate neutralised | scoping test FAILS |
| `is_valid` filter dropped, org scoping intact | second test FAILS — that filter has teeth of its own and was not displaced |
| unmutated control | passes |

A fourth mutation, swapping `JOIN` for `LEFT JOIN`, **survived — and is an equivalent mutant, not a hole.** The `WHERE` on `agents.organization_id` filters NULL-extended rows anyway, and orphan cards cannot exist: an insert naming a nonexistent agent is rejected by `a2a_agent_cards_agent_id_fkey`, which I ran rather than inferred. Recording it so a later mutation run does not read it as a missing assertion. The useful consequence is that the join *type* is not what carries the boundary here — the foreign key prevents orphans and the `WHERE` does the scoping.

The new tests are already covered by the CI anti-skip step: its selector matches on `CrossTenant`, and both are named accordingly. Verified by running that step's exact selector rather than assuming the match.

## The lint's own comment was false and is corrected

`collectionscope-lint` (added in #364) cited `A2AService.ListAgentCards` and `A2AService.ListA2ATasks` as examples of same-shape methods that slip past its `ListAll` name prefix. **Both have since been fixed** — `ListA2ATasks` in #363, `ListAgentCards` here — so the comment became false within days while the check itself was unchanged.

It now cites a measurement instead of names. Over `internal/application`: 88 exported methods return a slice or map, 47 take an organization parameter, 41 do not, and **zero of those 41 are named `ListAll*`** — so this check sees none of them. Examples that pass it today: `AdminService.GetAllUsers`, `AuditService.SearchLogs`, `CapabilityRequestService.ListRequests`. Whether each of the 41 is a defect needs triage; several are scoped at another layer or are legitimately global. The point is only that none of them is guarded *here*.

Broadening the predicate to the real shape — returns a collection, takes no organization — is tracked separately; it fires across the package and every hit needs triage into a fix or an allowlist entry.
