### PR TITLE
Fix the invalid expression that has been rejecting the sync workflow since 8d79696

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,7 @@ jobs:
       [
         secrets-lint,
         tenant-scoping-lint,
+        workflow-lint,
         changes,
         backend,
         integration,
@@ -452,17 +453,18 @@ jobs:
         run: |
           sl='${{ needs.secrets-lint.result }}'
           tl='${{ needs.tenant-scoping-lint.result }}'
+          wl='${{ needs.workflow-lint.result }}'
           ch='${{ needs.changes.result }}'
           be='${{ needs.backend.result }}'
           it='${{ needs.integration.result }}'
           ax='${{ needs.atx-conformance.result }}'
           fe='${{ needs.frontend.result }}'
           ee='${{ needs.e2e-empty-state.result }}'
-          echo "secrets-lint=$sl tenant-scoping-lint=$tl changes=$ch"
+          echo "secrets-lint=$sl tenant-scoping-lint=$tl workflow-lint=$wl changes=$ch"
           echo "backend=$be integration=$it atx-conformance=$ax frontend=$fe e2e-empty-state=$ee"
           fail=0
           # Unconditional jobs must succeed outright.
-          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "changes:$ch"; do
+          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "workflow-lint:$wl" "changes:$ch"; do
             if [ "${pair#*:}" != "success" ]; then
               echo "::error::${pair%%:*} did not succeed (${pair#*:}); failing closed."
               fail=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,33 @@ jobs:
       - name: No ${VAR:-fallback} for secret-shaped env vars
         run: ./scripts/lint-no-secret-fallbacks.sh
 
+  # Validate the workflow files themselves. Nothing did, and it cost five days of a
+  # dead sync: a comment in sync-to-cloud.yml contained a literal expression-interpolation
+  # token to illustrate a point, Actions substitutes those inside a run: block before any
+  # shell exists so `#` did not protect it, and an empty pair is an invalid expression.
+  # GitHub rejected the whole file with "this run likely failed because of a workflow file
+  # issue" on every push from 8d79696 to 8ea0ceb -- which meant the alert step that exists
+  # to file the sync backlog never executed.
+  #
+  # The file parsed as valid YAML the whole time, and every other check on the PR was
+  # green, so nothing in this repo could see it. An invalid workflow file also bypasses
+  # `on.push.paths`, so it fails on pushes that do not even touch the filtered paths.
+  workflow-lint:
+    name: Workflow lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Workflow files must be valid to GitHub, not merely valid YAML
+        run: |
+          set -euo pipefail
+          ver=1.7.12
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz" \
+            | tar -xz actionlint
+          # shellcheck is absent on the runner image path actionlint probes; -shellcheck=
+          # disables that integration so this job fails on workflow-level defects only and
+          # does not become a shell-style gate by accident.
+          ./actionlint -shellcheck= -color
+
   # AST lint that catches HTTP handlers reading c.Params("id"|"agent_id")
   # without invoking the tenant-scoping helper (LoadOwned or
   # LoadOwnedViaAgent). The structural guarantee for the defect #18-25

--- a/.github/workflows/sync-to-cloud.yml
+++ b/.github/workflows/sync-to-cloud.yml
@@ -96,10 +96,20 @@ jobs:
           #
           # It is NOT a shell-injection vector, and the sanitising below is not what makes
           # it safe. The message reaches this script only as the COMMIT_TITLE env var
-          # declared above, never as a `${{ }}` interpolation into the script body, so the
-          # shell never re-parses its value -- parameter expansion of a value is not
-          # rescanned for command substitution. Do not relabel the line below as an
+          # declared above, never through workflow expression interpolation into the script
+          # body, so the shell never re-parses its value -- parameter expansion of a value
+          # is not rescanned for command substitution. Do not relabel the line below as an
           # injection fix; a false security claim is itself a defect.
+          #
+          # Do NOT write a literal expression-interpolation token in this comment to
+          # illustrate the point. Actions substitutes those inside a run: block before any
+          # shell exists, so a `#` does not protect one, and an empty pair is an invalid
+          # expression that makes GitHub reject the whole workflow file. That is not
+          # hypothetical: the first version of this comment did exactly that, and every
+          # sync run from 8d79696 (2026-08-08) to 8ea0ceb (2026-08-11) failed with "this
+          # run likely failed because of a workflow file issue" -- which meant the alert
+          # step below never executed and the backlog issue it exists to file was never
+          # filed. `actionlint` catches it; the repo's other lints and CI do not.
           #
           # head -1 keeps a multi-line message from breaking the markdown list or injecting
           # headings; head_commit is absent on workflow_dispatch. The `tr -d` drops the


### PR DESCRIPTION
## The sync workflow has not run since 2026-08-08, and it is my fault

Every push from `8d79696` to `8ea0ceb` failed with *"this run likely failed because of a
workflow file issue"*. The alert step added in #366 — whose entire purpose is to record a
skipped sync — **never executed**, so no backlog issue was ever filed.

```
$ actionlint .github/workflows/sync-to-cloud.yml
.github/workflows/sync-to-cloud.yml:88:564: unexpected end of input while parsing
variable access, function call, null, bool, int, float or string [expression]
```

**Cause.** The comment I added in #366, explaining that the commit message is never reached
through expression interpolation, contained a literal empty interpolation token as an
illustration. Actions substitutes those inside a `run:` block before any shell exists, so a
leading `#` does not protect one, and an empty pair is not a valid expression.

## Why it survived review and five days of pushes

- **The file parses as valid YAML.** `yaml.safe_load` succeeds — that is what I checked, and it
  is not the property that matters.
- **Nothing in this repo validates workflow files.** Every other check on #366 was green and
  still is; none of them can see this class.
- **An invalid workflow file bypasses `on.push.paths`.** The two failing runs on 2026-08-11 were
  pushes touching only `pr-review.yml`, which the sync's path filter excludes. So the breakage
  was *louder* than the filter and still nobody was told — red runs on a workflow nobody watches
  is the exact condition #366 existed to fix.

## The fix

One comment rewritten to describe the mechanism instead of demonstrating it, plus a note not to
write the literal token there, because the next person explaining this has the same accident
available.

Adds a **`workflow-lint`** CI job so the class cannot recur. Red-proofed both directions:

| tree | actionlint exit |
|---|---|
| broken `sync-to-cloud.yml` restored from `8ea0ceb` | **1** |
| fixed file | **0** |

The first attempt at that control exited 3 on *both* trees — actionlint refuses to run outside a
Git repository, so the "failure" was the harness, not detection. `git init` on the scratch tree
is what made the control real.

`-shellcheck=` disables the shellcheck integration so the job gates workflow validity only and
does not silently become a shell-style gate.

## Class swept

No other first-party workflow in this repo has an expression error. Two findings elsewhere,
neither in scope here:

- **`ai-browserguard/.github/workflows/pr-review.yml:40`** — `github.event.pull_request.title`
  used directly in an inline script. That is the *genuine* version of the injection shape I
  refuted on #366, and it deserves its own look.
- The stale `agent-identity-management-telemetry` and `-cco-text` working copies carry this same
  broken commit.

## Not fixed here

`AIM_CLOUD_SYNC_TOKEN` is now **absent** from this repo's secrets — deleted rather than
refreshed. Once this merges the workflow will run again and take the `-z "$GH_TOKEN"` branch,
which is the path that files the alert issue. That is the correct behaviour for a missing token,
but the sync still does not sync, and whether the token comes back or the pipeline moves to a
pull-based job / GitHub App is Abdel's call.

Roadmap: `todo/roadmap/aim-cloud-sync-silently-dead.md`.