### PR TITLE
Fix having to sign in twice, caused by a login that looked like a token refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,13 @@ jobs:
         working-directory: apps/web
         run: npm run lint
 
+      # Unit tests were never run in CI. `npm run test` (vitest) existed, and the one
+      # spec in the tree ran nowhere that could block a merge -- so a regression test
+      # added here would have gated nothing.
+      - name: Unit tests (vitest)
+        working-directory: apps/web
+        run: npm run test -- --run
+
       - name: Build
         working-directory: apps/web
         run: npm run build

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -179,7 +179,9 @@ function DashboardContent() {
   const fetchAllDashboardData = useCallback(async () => {
     const token = searchParams.get("token");
     if (token) {
-      api.setToken(token);
+      // A token arriving in the URL is a sign-in handoff, so it starts a new
+      // session window rather than extending whatever was left in localStorage.
+      api.setToken(token, undefined, "new-session");
       window.history.replaceState({}, "", "/dashboard");
     }
 

--- a/apps/web/lib/api.session-window.test.ts
+++ b/apps/web/lib/api.session-window.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { api } from "@/lib/api";
+
+/**
+ * The absolute session window must start on a NEW SESSION and must not move on a
+ * TOKEN REFRESH.
+ *
+ * The bug these tests exist for: `setToken` used to infer which case it was in, via
+ * `!this.token && !localStorage.getItem("auth_token")`. Any login that happened while
+ * a stale `auth_token` was still in localStorage was therefore treated as a refresh,
+ * so `session_start` kept its old value and use-idle-timeout immediately signed the
+ * user out with "Your 8-hour session ended." That logout cleared the keys, so the
+ * next login worked — which is why the symptom was having to sign in exactly twice.
+ *
+ * The stale-token state is routine, not exotic: the 8h cap is only enforced by a
+ * timer on a mounted dashboard, so closing the tab and returning the next day leaves
+ * both `auth_token` and a day-old `session_start` in place.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function seedStaleSession(ageMs: number) {
+  const old = String(Date.now() - ageMs);
+  localStorage.setItem("auth_token", "stale.token.value");
+  localStorage.setItem("session_start", old);
+  localStorage.setItem("last_activity", old);
+  return old;
+}
+
+describe("session window bookkeeping in setToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Drop the in-memory token too, so each case starts from a known state rather
+    // than inheriting one from the previous test.
+    api.clearToken();
+    localStorage.clear();
+  });
+
+  it("restarts the window on login even when a stale token is still in localStorage", () => {
+    const stale = seedStaleSession(DAY_MS);
+
+    api.setToken("fresh.token.value", "fresh.refresh.value", "new-session");
+
+    const after = localStorage.getItem("session_start");
+    expect(after).not.toBeNull();
+    // The load-bearing assertion. Pre-fix this stayed equal to `stale`, which is
+    // what produced the immediate cap logout.
+    expect(after).not.toBe(stale);
+    expect(Number(after)).toBeGreaterThan(Number(stale));
+    // And it must be a window that has not already expired.
+    expect(Date.now() - Number(after)).toBeLessThan(60 * 1000);
+  });
+
+  it("also restarts it when no previous session is present at all", () => {
+    api.setToken("fresh.token.value", "fresh.refresh.value", "new-session");
+    const start = localStorage.getItem("session_start");
+    expect(start).not.toBeNull();
+    expect(Date.now() - Number(start)).toBeLessThan(60 * 1000);
+  });
+
+  it("does NOT move the window on a token refresh", () => {
+    // A live session, 3h old: past no boundary, so a refresh must leave it alone.
+    const start = seedStaleSession(3 * 60 * 60 * 1000);
+
+    api.setToken("rotated.token.value", "rotated.refresh.value", "token-refresh");
+
+    // If this ever equals "now", the 8h cap can never be reached, because a refresh
+    // happens well inside every 8h period.
+    expect(localStorage.getItem("session_start")).toBe(start);
+  });
+
+  it("defaults to starting a new window when the caller does not say", () => {
+    const stale = seedStaleSession(DAY_MS);
+    api.setToken("fresh.token.value");
+    // The default is deliberately the safe-for-the-user direction: a caller that
+    // forgets gets a usable session rather than a login loop.
+    expect(localStorage.getItem("session_start")).not.toBe(stale);
+  });
+
+  it("clearToken removes the window so it cannot be inherited", () => {
+    api.setToken("fresh.token.value", "fresh.refresh.value", "new-session");
+    api.clearToken();
+    expect(localStorage.getItem("session_start")).toBeNull();
+    expect(localStorage.getItem("last_activity")).toBeNull();
+    expect(localStorage.getItem("auth_token")).toBeNull();
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -519,13 +519,31 @@ class APIClient {
     return this._baseURL;
   }
 
-  setToken(token: string, refreshToken?: string) {
-    // Detect a fresh login (logged-out -> logged-in) vs a token refresh, so the
-    // absolute session-timeout window is started on login but NOT reset on every
-    // refresh (which would defeat the 8h cap).
-    const isFreshLogin =
-      !this.token &&
-      (typeof window === "undefined" || !localStorage.getItem("auth_token"));
+  /**
+   * Stores the access token, and starts the absolute session window when this is a
+   * new session rather than a token refresh.
+   *
+   * `sessionKind` is EXPLICIT and must stay explicit. It was previously inferred:
+   *
+   *     const isFreshLogin = !this.token && !localStorage.getItem("auth_token")
+   *
+   * which conflated "this is a refresh" with "a login happened while a stale token
+   * was still in localStorage" — and the second case is routine, because the 8h cap
+   * is only enforced by a timer on a mounted dashboard. Close the tab, come back a
+   * day later, and `auth_token` plus a day-old `session_start` are both still there.
+   * The login then took the refresh path, left `session_start` untouched, and
+   * use-idle-timeout logged the user straight back out with "Your 8-hour session
+   * ended." That logout cleared the keys, so the SECOND login worked — the reported
+   * symptom was having to sign in twice, every time.
+   *
+   * A caller knows which operation it is performing; this function cannot know. Do
+   * not reintroduce an inference here.
+   */
+  setToken(
+    token: string,
+    refreshToken?: string,
+    sessionKind: "new-session" | "token-refresh" = "new-session"
+  ) {
     this.token = token;
     if (typeof window !== "undefined") {
       localStorage.setItem("auth_token", token);
@@ -533,7 +551,11 @@ class APIClient {
         this.refreshToken = refreshToken;
         localStorage.setItem("refresh_token", refreshToken);
       }
-      if (isFreshLogin) {
+      // Default is "new-session": a caller that forgets to say gets a usable
+      // session rather than a login loop. The cap is a client-side convenience
+      // boundary (see use-idle-timeout.ts) — the real boundaries are the access
+      // token exp and the refresh-token expiry, which this does not touch.
+      if (sessionKind === "new-session") {
         const t = String(Date.now());
         localStorage.setItem("session_start", t);
         localStorage.setItem("last_activity", t);
@@ -598,7 +620,9 @@ class APIClient {
 
       const data = await response.json();
       // Store new tokens (token rotation - old refresh token is now invalid)
-      this.setToken(data?.accessToken, data?.refreshToken);
+      // "token-refresh": must NOT restart the absolute session window, or the 8h
+      // cap would never be reached because every refresh would push it out.
+      this.setToken(data?.accessToken, data?.refreshToken, "token-refresh");
       return data;
     } catch (error) {
       // Network error or other issue
@@ -743,7 +767,8 @@ class APIClient {
 
     // Store tokens if password change was successful
     if (data_response.success && data_response.accessToken) {
-      this.setToken(data_response.accessToken, data_response.refreshToken);
+      // "new-session": the credential changed and the old tokens were invalidated.
+      this.setToken(data_response.accessToken, data_response.refreshToken, "new-session");
     }
 
     return data_response;
@@ -801,7 +826,7 @@ class APIClient {
 
     // If login successful and user is approved, store tokens
     if (response.success && response.isApproved && response.accessToken) {
-      this.setToken(response.accessToken, response.refreshToken);
+      this.setToken(response.accessToken, response.refreshToken, "new-session");
     }
 
     return response;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,6 +4,15 @@ import path from 'path'
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    // jsdom only exposes localStorage/sessionStorage on a real origin; the default
+    // about:blank document has no storage area, so anything touching localStorage
+    // fails with "Cannot read properties of undefined". Pin an origin.
+    environmentOptions: {
+      jsdom: { url: 'http://localhost:3000' },
+    },
+    // Installs a Storage shim when the environment does not provide one. See
+    // vitest.setup.ts — jsdom 27 under this Node version exposes no localStorage.
+    setupFiles: ['./vitest.setup.ts'],
     passWithNoTests: true,
     exclude: [
       '**/node_modules/**',

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,74 @@
+/**
+ * Test-environment storage.
+ *
+ * jsdom 27 under this Node version does not expose `window.localStorage` even with a
+ * real origin configured — Node's own experimental `localStorage` is gated behind
+ * `--localstorage-file` and jsdom's is absent, so anything touching storage failed
+ * with "Cannot read properties of undefined (reading 'clear')".
+ *
+ * This installs a `Storage`-shaped shim ONLY when one is missing, so a future
+ * environment that provides the real thing is used instead of being shadowed. The
+ * behaviours the tests depend on are the ones the spec defines and code relies on:
+ * values are coerced to strings, a missing key reads as `null` (not `undefined`), and
+ * `removeItem`/`clear` actually drop keys.
+ */
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+
+  get length(): number {
+    return this.map.size;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  getItem(key: string): string | null {
+    // Must be null, not undefined: callers do `Number(getItem(k)) || fallback` and
+    // `=== null` checks, and undefined would change both.
+    const v = this.map.get(String(key));
+    return v === undefined ? null : v;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(String(key));
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(String(key), String(value));
+  }
+}
+
+function install(name: "localStorage" | "sessionStorage") {
+  const g = globalThis as unknown as Record<string, unknown>;
+  const existing = g[name] as Storage | undefined;
+  // Treat a present-but-broken implementation as absent.
+  let usable = false;
+  try {
+    usable = !!existing && typeof existing.setItem === "function";
+  } catch {
+    usable = false;
+  }
+  if (usable) return;
+
+  const store = new MemoryStorage();
+  Object.defineProperty(globalThis, name, {
+    value: store,
+    configurable: true,
+    writable: true,
+  });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, name, {
+      value: store,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+install("localStorage");
+install("sessionStorage");


### PR DESCRIPTION
## Symptom

Reported from the hosted product: **every** sign-in immediately bounced back to the login page
with *"Your 8-hour session ended. Please sign in again."* Signing in a second time worked. Every
time, so it read as "you must always log in twice."

## Root cause

`setToken` decided whether to start the absolute session window by inference:

```js
const isFreshLogin = !this.token && !localStorage.getItem("auth_token");
```

That treats "no token anywhere" as a login and anything else as a token refresh. But **a login
with a stale `auth_token` still in localStorage is routine**: the 8h cap is only enforced by a
timer on a mounted dashboard, so closing the tab and returning the next day leaves both
`auth_token` and a day-old `session_start` behind.

So the login took the refresh path → `session_start` kept yesterday's value → `use-idle-timeout`'s
**first tick** saw `sessionAge >= 8h` and signed the user out → that logout ran `clearToken`,
which removes `session_start` → the second login started clean and worked.

That also explains why it was never reproducible immediately after a successful login.

## Fix

`sessionKind` is now explicit. A caller knows which operation it is performing; this function
cannot. Every call site states it:

| call site | kind |
|---|---|
| `refreshAccessToken` | `"token-refresh"` — the one site that must **not** restart the window, or the 8h cap is unreachable since a refresh always lands inside 8h |
| login, register auto-approve, password change, `?token=` handoff | `"new-session"` |

Default is `"new-session"`, deliberately the safe-for-the-user direction: a caller that forgets
gets a usable session rather than a login loop. The cap is a client-side convenience boundary —
the real ones are the access-token `exp` and the refresh-token expiry, and this touches neither.

## Regression test, red-proofed by restoring the old inference

| case | pre-fix | post-fix |
|---|---|---|
| login with a day-old token in localStorage | **FAILS** — `session_start` unchanged | passes |
| default when the caller omits the kind | **FAILS** — `session_start` unchanged | passes |
| refresh must not move the window | passes | passes |
| login with no prior session | passes | passes |
| `clearToken` removes the window | passes | passes |

The two failures assert on the stale value surviving *verbatim* — the defect itself, not a proxy
for it.

## Two blockers that were the same shape as the bug

- **`npm run test` was never wired into CI.** The frontend job ran lint and build only, so the
  one existing vitest spec ran nowhere that could block a merge — a regression test added here
  would have gated nothing. Now runs in CI.
- **vitest could not touch localStorage.** jsdom 27 under this Node version exposes no
  `window.localStorage` (Node's own is gated behind `--localstorage-file`), so every storage test
  died on *"Cannot read properties of undefined"*. Pinned a jsdom origin and added a `Storage`
  shim that installs **only when one is absent**, so a future environment providing the real
  thing is not shadowed.

## Verification

`npm run lint` clean (3 pre-existing warnings), `npm run build` succeeds, full vitest suite
23 passed / 2 files.

aim-cloud carries the identical defect in its own `.sync-protect` copy of `api.ts` — and is where
the report came from — so the same fix is applied there separately.