### PR TITLE
Stop claiming security audits and compliance we have not had

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,8 +169,8 @@ First stable release of the AIM platform. The stage in
 [STATUS.md](STATUS.md) is `stable`, and every gate criterion in
 [HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" was met (PRs #247, #248, #250).
 Semver is honored from this release forward: breaking changes go through a
-deprecation cycle and ship in a major bump; security patches are triaged within
-24 hours per [SECURITY.md](SECURITY.md).
+deprecation cycle and ship in a major bump; security reports are handled per
+[SECURITY.md](SECURITY.md).
 
 See [README.md](README.md) for the full feature set (agent identity and
 attestation, Ed25519 key management, per-capability trust and execution modes,

--- a/README.md
+++ b/README.md
@@ -312,9 +312,9 @@ Full index: [docs/USE-CASES.md](docs/USE-CASES.md).
 
 ## Contributing
 
-Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, test conventions, and pre-push review gates.
+Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop and the pull request process.
 
-Security issues: `info@opena2a.org` (coordinated disclosure, response within 24 hours).
+Security issues: `info@opena2a.org`. Coordinated disclosure; see [SECURITY.md](SECURITY.md) for what to expect and when.
 
 ## Links
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-> **AIM 1.0.** Every Roadmap-to-1.0 gate criterion in [HARDENING.md](HARDENING.md) is met as of 2026-05-28. The capabilities described in this document reflect shipped behavior; items still tracked as "Partial" or "Roadmap" in the Enterprise Compliance section below are flagged inline so consumers can plan around the actual enforcement boundary. Semver is honored from 1.0 forward, and security patches are triaged within 24 hours per the reporting flow below.
+> **AIM 1.0.** Every Roadmap-to-1.0 gate criterion in [HARDENING.md](HARDENING.md) is met as of 2026-05-28. The capabilities described in this document reflect shipped behavior; items still tracked as "Partial" or "Roadmap" in the Enterprise Compliance section below are flagged inline so consumers can plan around the actual enforcement boundary. Semver is honored from 1.0 forward. Response times for security reports are in the reporting flow below.
 
 ## Reporting Security Vulnerabilities
 
@@ -118,14 +118,19 @@ AIM includes the following security features:
 6. **Validate all inputs** from users
 7. **Test authentication** and authorization flows
 
-## Security Audits
+## Security audits
 
-We conduct regular security assessments:
+AIM has not had a third-party security assessment. No SOC 2, HIPAA or GDPR assessment and no
+external penetration test has been performed on this project. If one is performed, this section
+will name the assessor and the date.
 
-- **Code Reviews**: All code changes are reviewed
-- **Dependency Scanning**: Automated vulnerability scanning
-- **Penetration Testing**: Periodic security audits
-- **Compliance Reviews**: SOC 2, HIPAA, GDPR assessments
+What runs automatically today is dependency and secret scanning, in
+[.github/workflows/security.yml](.github/workflows/security.yml). Each run's result is on that
+workflow's page under the repository's Actions tab.
+
+Changes reach `main` through pull requests, and the checks and approvals recorded on each pull
+request are the record of what ran for that change. Read the reviewer on a given pull request
+rather than inferring one from this document.
 
 ## Enterprise Compliance
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,13 +6,13 @@
 
 ## Stage rationale
 
-AIM 1.0. Every gate criterion in [HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" is met as of 2026-05-28 (last criterion — the CI-integrated Playwright empty-state suite — closed in PR #247 + PR #248 + PR #250). Semver is honored from this release forward; breaking changes go through a deprecation cycle and ship in a major bump. Security patches are triaged within 24 hours per the policy in [SECURITY.md](SECURITY.md).
+AIM 1.0. Every gate criterion in [HARDENING.md](HARDENING.md)'s "Roadmap to 1.0" is met as of 2026-05-28 (last criterion — the CI-integrated Playwright empty-state suite — closed in PR #247 + PR #248 + PR #250). Semver is honored from this release forward; breaking changes go through a deprecation cycle and ship in a major bump. Security reports are handled per the policy in [SECURITY.md](SECURITY.md).
 
 A paid third-party security review was previously listed as a 1.0 criterion but has been [rescoped to a post-1.0 investment](HARDENING.md#third-party-security-review) (CHIEF-CSR decision 2026-05-28): AIM is open source under Apache-2.0, so the codebase itself is the audit surface, and a community-review path through SECURITY.md is welcome before and after 1.0. A paid engagement is appropriate when a regulated customer requires formal attestation.
 
 ## Stage definitions
 
-- **stable**: production-ready, semver honored, breaking changes documented, security patches triaged within 24 hours.
+- **stable**: production-ready, semver honored, breaking changes documented, security reports handled per [SECURITY.md](SECURITY.md).
 - **beta**: feature-complete or near, breaking changes possible with notice, actively developed.
 - **experimental**: early stage, breaking changes expected, use at your own risk.
 - **reference-only**: spec or reference implementation, not intended for production use.

--- a/apps/web/app/dashboard/a2a/page.tsx
+++ b/apps/web/app/dashboard/a2a/page.tsx
@@ -379,15 +379,15 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
             </h3>
             <p className="mt-2 text-sm text-blue-800 dark:text-blue-200">
               The Agent-to-Agent (A2A) protocol enables secure communication between AI agents.
-              AIM enhances A2A with cryptographic attestation, trust scoring, and GDPR/PSD2 compliant
-              consent management for enterprise-grade agent interoperability.
+              AIM enhances A2A with cryptographic attestation, trust scoring, and recorded, revocable
+              consent for agent-to-agent data sharing.
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200">
                 <Shield className="h-3 w-3" /> Ed25519 Signatures
               </span>
               <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">
-                <ShieldCheck className="h-3 w-3" /> GDPR Compliant
+                <ShieldCheck className="h-3 w-3" /> Consent Records
               </span>
               <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200">
                 <TrendingUp className="h-3 w-3" /> Trust Scoring

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -150,7 +150,7 @@ Following the **Atomic Habits Philosophy**: Make it Obvious. Make it Easy. Make 
 
 ## 🔒 Security & Compliance
 
-### SOC 2, HIPAA, GDPR Ready
+### Security and audit evidence
 
 1. **[Security Architecture](./security/architecture.md)** *(Coming Soon)*
    - How AIM secures agents

--- a/docs/examples/database-agent.md
+++ b/docs/examples/database-agent.md
@@ -745,7 +745,8 @@ Every database operation is logged:
 - Admin approval (if required)
 - Result status
 
-**SOC 2, HIPAA, GDPR compliant!**
+This is the kind of access and execution record SOC 2, HIPAA and GDPR programs ask for. AIM
+itself has not been assessed against any of them - see [SECURITY.md](../../SECURITY.md).
 
 ---
 

--- a/docs/guides/SECURITY.md
+++ b/docs/guides/SECURITY.md
@@ -520,12 +520,11 @@ AIM token security supports SOC 2 requirements:
 
 **DO NOT** create public GitHub issues for security vulnerabilities.
 
-**Contact**:
-- Email: info@opena2a.org
-- PGP Key: [Link to public key]
-- Response Time: Within 24 hours
+**Contact**: info@opena2a.org
 
-**Bug Bounty**: We offer rewards for responsibly disclosed vulnerabilities.
+Response times, the coordinated-disclosure timeline, supported versions, and what we do
+and do not offer for a report are all in the repository's single security policy:
+[SECURITY.md](../../SECURITY.md). This page does not set its own terms.
 
 ## Additional Resources
 

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -455,7 +455,8 @@ Every tool use is logged:
 - Agent identity
 - Verification status
 
-**SOC 2, HIPAA, GDPR compliant!**
+This is the kind of access and execution record SOC 2, HIPAA and GDPR programs ask for. AIM
+itself has not been assessed against any of them - see [SECURITY.md](../../SECURITY.md).
 
 ---
 

--- a/docs/security/token-rotation.md
+++ b/docs/security/token-rotation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AIM uses **token rotation** to protect your organization from token theft and unauthorized access. This is a security feature that is **required for SOC 2, HIPAA, and GDPR compliance**.
+AIM uses **token rotation** to protect your organization from token theft and unauthorized access. Rotating short-lived credentials is a control SOC 2, HIPAA and GDPR programs commonly expect.
 
 ## What is Token Rotation?
 
@@ -292,7 +292,7 @@ The SDK handles rotation automatically:
 
 ### Q: Can I disable token rotation?
 
-**A:** No. Token rotation is **required for security** and compliance (SOC 2, HIPAA, GDPR).
+**A:** No. Token rotation is **required for security**, and it is a control SOC 2, HIPAA and GDPR programs commonly expect.
 
 If you need long-lived credentials:
 - Use **API keys** instead (different security model)
@@ -468,7 +468,7 @@ CREATE INDEX idx_sdk_tokens_revoked
 
 ✅ **You only need to download fresh SDK when you see errors**
 
-✅ **This is required for compliance (SOC 2, HIPAA, GDPR)**
+✅ **This is a control SOC 2, HIPAA and GDPR programs commonly expect**
 
 **Bottom line**: Token rotation makes AIM more secure. The minor inconvenience of occasionally downloading fresh credentials is far outweighed by the security benefits.
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -53,7 +53,7 @@ Your SDK credentials have expired due to token rotation (security policy).
    ```
 
 **Why This Happens**:
-- AIM uses **token rotation** for security (SOC 2 / HIPAA compliant)
+- AIM uses **token rotation** for security
 - When you use a refresh token → backend issues NEW token
 - OLD token is revoked → prevents token theft
 - This is **correct behavior**, not a bug

--- a/docs/troubleshooting/authentication.md
+++ b/docs/troubleshooting/authentication.md
@@ -678,7 +678,7 @@ curl -X POST http://localhost:8080/api/v1/admin/force-password-reset \
 **Why Short TTL**:
 - Limits damage if token stolen
 - Forces regular re-authentication
-- Meets compliance requirements (SOC 2, HIPAA)
+- Produces the credential-rotation evidence SOC 2 and HIPAA programs ask for
 
 **If You Need Longer**:
 - Use API keys (no expiration, different security model)

--- a/examples/flight-search-agent/README.md
+++ b/examples/flight-search-agent/README.md
@@ -234,7 +234,7 @@ cp -r ./fresh-sdk/aim-sdk-python/.aim ~/.aim
 AIM uses **token rotation** for security:
 - When you use a refresh token → backend issues NEW token
 - OLD token is immediately revoked → prevents reuse attacks
-- This is SOC 2 / HIPAA compliant behavior
+- Rotating short-lived credentials is a control SOC 2 and HIPAA programs commonly expect
 
 See `NEXT_STEPS.md` for detailed explanation.
 

--- a/sdk/python/docs/MCP_INTEGRATION.md
+++ b/sdk/python/docs/MCP_INTEGRATION.md
@@ -827,7 +827,7 @@ except PermissionError as e:
 | ❌ No audit trail of MCP actions | ✅ Complete audit trail of all actions |
 | ❌ No trust scoring for servers | ✅ ML-powered trust scoring |
 | ❌ Manual security reviews | ✅ Automatic security verification |
-| ❌ No compliance reporting | ✅ SOC 2/HIPAA/GDPR compliance ready |
+| ❌ No compliance reporting | ✅ Exportable audit record for compliance reporting |
 
 ---
 


### PR DESCRIPTION
Three unsupported claims in `README.md` and `SECURITY.md`, and the ten other places in the tree that contradicted the corrected text.

## What was wrong

`SECURITY.md` advertised a "Security Audits" section listing **Penetration Testing: Periodic security audits** and **Compliance Reviews: SOC 2, HIPAA, GDPR assessments**. Neither has happened. That section now states plainly that AIM has had no third-party security assessment, names what does run automatically (dependency and secret scanning in `.github/workflows/security.yml`), and points at the pull request record rather than implying a review process that does not exist.

Correcting that sentence alone would have published a repository that contradicts itself, so the rest of this PR is the sweep that makes it true everywhere.

## Compliance claims

The strongest of these was product UI, not documentation: the A2A dashboard shipped a green **GDPR Compliant** badge with a check icon, plus prose calling the consent management "GDPR/PSD2 compliant". Users saw that directly. It now names the mechanism — recorded, revocable consent — which is what the feature actually provides.

Also withdrawn, all replaced with what the audit trail genuinely produces:

- `docs/integrations/langchain.md`, `docs/examples/database-agent.md` — a bare "SOC 2, HIPAA, GDPR compliant!" under the audit-field list
- `sdk/python/docs/MCP_INTEGRATION.md` — "SOC 2/HIPAA/GDPR compliance ready"
- `docs/DOCUMENTATION_INDEX.md` heading, `docs/troubleshooting/README.md`, `docs/troubleshooting/authentication.md`, `examples/flight-search-agent/README.md`, `docs/security/token-rotation.md` (three places) — token rotation is a control these programs commonly expect, which is true, rather than something AIM is compliant with, which is not

Deliberately left: "GDPR/PSD2 compliant consent record" in the A2A SDK sources and one demo docstring. Those describe the shape of a consent record rather than an assessment of AIM, and are a separate claim to judge on their own terms.

## Response-time numbers

`SECURITY.md` is now the single source, at 48 hours. Four other 24-hour claims survived elsewhere, and two of them cited `SECURITY.md` as their authority — so they refuted themselves the moment a reader followed the link. `STATUS.md` (twice) and the 1.0 `CHANGELOG.md` entry now point at the policy without restating a number.

`docs/guides/SECURITY.md` carried a second, independent reporting policy for the same mailbox: a 24-hour response time and **"We offer rewards for responsibly disclosed vulnerabilities"**, against root `SECURITY.md`'s "We do not currently have a formal bug bounty program". A promise of payment we do not make is the worst claim in this set. That block now defers to the single policy, which also retires a `PGP Key: [Link to public key]` placeholder that had been shipping as guidance to reporters.

The only response-time numbers left in the tree are `SECURITY.md:30` and `:223`, both 48 hours.

## Verification

- `tsc --noEmit` on `apps/web`: exit 0, 0 errors. `next build`: exit 0, 33/33 pages.
- The shipped client bundle contains `Consent Records` and no longer contains `GDPR Compliant` (0 occurrences); the sibling `Ed25519 Signatures` badge was used as a positive control to prove the check could fire.
- All five relative `SECURITY.md` links resolve from their own directory depth.
- Repository-wide greps for compliance assertions and for security response-time numbers both come back to the intended set and nothing else.
- No test or snapshot asserted any of the replaced strings.

Not verified: a logged-in visual pass at 375px. `/dashboard/a2a` renders client-side behind auth, so it needs the full backend stack. No CSS or class names changed, the badge sits in an existing `flex flex-wrap` row, and the replacement text is one character longer while the paragraph above it got shorter.