### PR TITLE
Authenticate the SDK verification write routes, and stop /result writing the decision

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -320,15 +320,23 @@ func main() {
 	// NOTE: Revocation list route moved into setupRoutes() to avoid Fiber v3 beta
 	// route shadowing when the /api/v1 group is registered with middleware.
 
-	// Action verification for SDK (signature-based auth, NO API key required)
-	// IMPORTANT: Register directly on app (not through group) to avoid API key middleware
-	// These endpoints verify Ed25519 signatures instead of requiring API keys
+	// SECURITY: only routes that establish their own caller identity may be
+	// registered here, above the sdkAPI group. Fiber matches in registration
+	// order, so a route registered on this line is not reached by the group's
+	// middleware below — that is exactly how the two write routes below stayed
+	// unauthenticated from 2025-11-06 until this change. Both remaining entries
+	// verify a signature inside the handler:
+	//   CreateVerification  — verifySignature + agent.Status gate
+	//   GetVerificationSDK  — three X-AIM-* headers, an Ed25519 signature, and
+	//                         event ownership (404, not 403, on mismatch)
+	// Anything else belongs in the group. routes_gate_test.go requires every
+	// app-level /api/v1/sdk-api/verifications registration to be listed there
+	// with the control that justifies it, and asserts the group's middleware is
+	// registered before the routes it is supposed to guard.
 	app.Post("/api/v1/sdk-api/verifications", middleware.RateLimitMiddleware(), h.Verification.CreateVerification)
 	// Defect #160: SDK GET is now signature-authed (Ed25519 headers) and
 	// agent-scoped inside the handler. JWT GET continues at /api/v1/verifications/:id.
 	app.Get("/api/v1/sdk-api/verifications/:id", middleware.RateLimitMiddleware(), h.Verification.GetVerificationSDK)
-	app.Post("/api/v1/sdk-api/verifications/:id/result", middleware.RateLimitMiddleware(), h.Verification.SubmitVerificationResult)
-	app.Post("/api/v1/sdk-api/verifications/:id/execution-status", middleware.RateLimitMiddleware(), h.Verification.UpdateExecutionStatus)
 
 	// ⭐ SDK API routes - MUST be at app level to avoid middleware inheritance
 	// These routes use Ed25519 agent authentication for SDK/programmatic access
@@ -338,6 +346,14 @@ func main() {
 	sdkAPI.Use(middleware.AuthMiddleware(jwtService))                   // Fallback to JWT if Ed25519 not present
 	sdkAPI.Use(middleware.AgentActivityTouchMiddleware(services.Agent)) // Touches agents.last_active on agent-authed responses (#167)
 	sdkAPI.Use(middleware.RateLimitMiddleware())
+	// Verification WRITE routes. Moved off the bare app registration above: they
+	// authenticated nothing there — a rate limiter was their only middleware, and
+	// neither handler read c.Locals. The group supplies a body-bound canonical
+	// message, a ±30s window and revocation enforcement; the handlers add the
+	// agent-ownership check, because the group authenticates *an* agent and also
+	// falls through to JWT for human callers (pqc_agent_auth.go:39-41, :50-52).
+	sdkAPI.Post("/verifications/:id/result", h.Verification.SubmitVerificationResult)        // Withdrawn: 403 for every caller
+	sdkAPI.Post("/verifications/:id/execution-status", h.Verification.UpdateExecutionStatus) // Agent-owned execution report
 	sdkAPI.Get("/agents/:identifier", h.Agent.GetAgentByIdentifier)                                // Get agent by ID or name (SDK)
 	sdkAPI.Post("/agents/:id/capabilities", h.Capability.GrantCapability)                          // SDK capability reporting (legacy)
 	sdkAPI.Post("/agents/:id/capabilities/register", h.Capability.RegisterCapability)              // SDK capability registration (respects enforcement mode)
@@ -1752,7 +1768,14 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	verifications.Use(middleware.RateLimitMiddleware())
 	verifications.Post("/", h.Verification.CreateVerification)                 // Request verification for agent action
 	verifications.Get("/:id", h.Verification.GetVerification)                  // Get verification status by ID
-	verifications.Post("/:id/result", h.Verification.SubmitVerificationResult) // Submit verification result
+	// REMOVED: `verifications.Post("/:id/result", ...)`. This mount authenticated a
+	// JWT user but the handler had no ownership check, so any authenticated user of
+	// any organization could rewrite any verification by UUID. It is deleted rather
+	// than org-scoped: SubmitVerificationResult now refuses every caller, so an
+	// org-scoped mount would authenticate a manager in order to refuse them. It had
+	// no caller — apps/web referenced it only in lib/api-documentation.ts, which
+	// published a `roleRequired: "manager"` contract the handler never implemented;
+	// that entry is removed with it. The live approval path is the admin group.
 
 	// Verification Event routes (authentication required) - Real-time monitoring
 	verificationEvents := v1.Group("/verification-events")

--- a/apps/backend/cmd/server/routes_gate_test.go
+++ b/apps/backend/cmd/server/routes_gate_test.go
@@ -61,3 +61,142 @@ func TestSensitiveAgentRoutesAreMemberGated(t *testing.T) {
 		}
 	}
 }
+
+// TestSDKVerificationRoutesRequireJustifiedBareMount is a source-wiring guard for
+// the class, not for two routes.
+//
+// The `/api/v1/sdk-api/verifications*` routes are registered on the bare `app`,
+// ABOVE the sdkAPI group. Fiber matches in registration order, so a route
+// registered there is never reached by the group's Ed25519/JWT middleware — its
+// only middleware is a rate limiter, which authenticates nothing. That is how
+// POST .../result and POST .../execution-status served unauthenticated writes to
+// production for months.
+//
+// Nothing in either tree previously treated "registered on app, above the group"
+// as a condition requiring justification, which is why PR #236 fixed the GET on
+// one line and left the two POSTs on the next two. This guard makes the bare
+// mount an explicit, enumerated decision: every app-level registration under
+// that prefix must appear below with the in-handler control that makes it safe.
+// A new one fails until someone writes down why it does not need the group.
+func TestSDKVerificationRoutesRequireJustifiedBareMount(t *testing.T) {
+	// route registration substring -> the in-handler authentication that makes
+	// serving it outside the sdkAPI group acceptable.
+	justifiedBareMounts := map[string]string{
+		`app.Post("/api/v1/sdk-api/verifications"`: "CreateVerification verifies an Ed25519 signature over the request " +
+			"(verifySignature) and gates on agent.Status before writing.",
+		`app.Get("/api/v1/sdk-api/verifications/:id"`: "read path; the SDK-signature handler GetVerificationSDK verifies three " +
+			"X-AIM-* headers, an Ed25519 signature and event ownership. NOTE: cloud currently mounts GetVerification here, " +
+			"not GetVerificationSDK; that divergence is tracked separately and must not be shipped ahead of this change.",
+	}
+
+	_, thisFile, ok := callerFile()
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate main.go")
+	}
+	mainPath := filepath.Join(filepath.Dir(thisFile), "main.go")
+	src, err := os.ReadFile(mainPath) //nolint:gosec // G304: path derived from runtime.Caller, not user input
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+
+	const prefix = `"/api/v1/sdk-api/verifications`
+	for _, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Comments describe routes; they do not register them.
+		if strings.HasPrefix(trimmed, "//") || !strings.Contains(trimmed, prefix) {
+			continue
+		}
+		// Group-relative registrations (sdkAPI.Post("/verifications/...")) do not
+		// carry the full path, so anything matching here is app-level.
+		if !strings.HasPrefix(trimmed, "app.") {
+			continue
+		}
+		var justified bool
+		for mount := range justifiedBareMounts {
+			if strings.Contains(trimmed, mount) {
+				justified = true
+				break
+			}
+		}
+		if !justified {
+			t.Errorf("route registered on bare `app` above the sdkAPI group with no recorded justification:\n  %s\n\n"+
+				"Routes registered here are NOT reached by the group's Ed25519/JWT middleware — their only middleware is a "+
+				"rate limiter, which authenticates nothing. Either move it onto the sdkAPI group, or add it to "+
+				"justifiedBareMounts in this test naming the in-handler authentication that makes the bare mount safe.",
+				trimmed)
+		}
+	}
+
+	// ORDER, not just presence. Fiber applies a group's Use() chain only to routes
+	// registered AFTER it. Asserting that `sdkAPI.Post("/verifications/:id/result"`
+	// merely EXISTS is satisfied by a file where the three sdkAPI.Use(...) lines sit
+	// BELOW it — which serves the route with no middleware at all and re-opens the
+	// unauthenticated write with this guard still green. The pre-existing guard in
+	// this file avoids the problem by requiring the gate on the same LINE as the
+	// registration; a group chain cannot be expressed that way, so the ordering is
+	// asserted explicitly instead.
+	lines := strings.Split(string(src), "\n")
+	lastUse, firstGuardedRoute := -1, -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "sdkAPI.Use(") {
+			lastUse = i
+		}
+		if strings.Contains(trimmed, `sdkAPI.Post("/verifications/:id/`) && firstGuardedRoute == -1 {
+			firstGuardedRoute = i
+		}
+	}
+	switch {
+	case lastUse == -1:
+		t.Error("no sdkAPI.Use(...) found: the group carries no middleware, so its routes are unauthenticated")
+	case firstGuardedRoute == -1:
+		t.Error("no sdkAPI.Post(\"/verifications/:id/...\") found: the write routes are not on the group")
+	case firstGuardedRoute < lastUse:
+		t.Errorf("verification write route registered at line %d, BEFORE the last sdkAPI.Use(...) at line %d. "+
+			"Fiber applies a group's middleware only to routes registered after it, so this route is served "+
+			"with no authentication. Move the registration below every sdkAPI.Use(...) line.",
+			firstGuardedRoute+1, lastUse+1)
+	}
+
+	// The two write routes must be on the group, and must not have come back.
+	stripped := stripComments(string(src))
+	for _, forbidden := range []string{
+		`app.Post("/api/v1/sdk-api/verifications/:id/result"`,
+		`app.Post("/api/v1/sdk-api/verifications/:id/execution-status"`,
+		`verifications.Post("/:id/result"`,
+	} {
+		if strings.Contains(stripped, forbidden) {
+			t.Errorf("registration %s must not exist: it bypasses authentication (bare app mount) or "+
+				"authenticates a user without checking ownership (JWT mount)", forbidden)
+		}
+	}
+	for _, required := range []string{
+		`sdkAPI.Post("/verifications/:id/result"`,
+		`sdkAPI.Post("/verifications/:id/execution-status"`,
+	} {
+		if !strings.Contains(stripped, required) {
+			t.Errorf("registration %s is missing: the write routes must be served from the authenticated sdkAPI group", required)
+		}
+	}
+}
+
+func callerFile() (uintptr, string, bool) {
+	pc, file, _, ok := runtime.Caller(1)
+	return pc, file, ok
+}
+
+// stripComments drops whole-line comments so an absence assertion is not
+// satisfied or defeated by prose. main.go documents the removed JWT mount by
+// name; that comment is the explanation, not a route.
+func stripComments(src string) string {
+	var code []string
+	for _, line := range strings.Split(src, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "//") {
+			code = append(code, line)
+		}
+	}
+	return strings.Join(code, "\n")
+}

--- a/apps/backend/cmd/tenantscope-lint/main.go
+++ b/apps/backend/cmd/tenantscope-lint/main.go
@@ -87,8 +87,14 @@ var allowlist = map[string]string{
 	"PublicMCPHandler.VerifyMCPAction":             "audit-baseline: needs review",
 	"SDKTokenHandler.RevokeToken":                  "service-layer scoping: SDKTokenService.RevokeToken collapses both not-found and cross-user mismatch into ErrSDKTokenNotFound; the handler maps the sentinel to a fixed 404. SDK tokens are user-scoped (not org-scoped), so the gate lives at the service layer.",
 	"TagHandler.UpdateTag":                         "audit-baseline: needs review (service-layer scoping exists but has existence side channel via error string; A3d-ii follow-up — see todo/2026-05-21-a3d-ii-tag-mcp-scoping.md)",
-	"VerificationHandler.SubmitVerificationResult": "audit-baseline: needs review",
-	"VerificationHandler.UpdateExecutionStatus":    "audit-baseline: needs review",
+	// VerificationHandler.SubmitVerificationResult and .UpdateExecutionStatus were
+	// carried here as "audit-baseline: needs review" from 2025 until 2026-08-10,
+	// when the review they were waiting for found both routes reachable with no
+	// authentication at all and one of them writing the authorization decision.
+	// The lint detected them; the finding was deferred and not returned to. Both
+	// entries are REMOVED rather than re-justified: SubmitVerificationResult now
+	// reads no path param and touches no store, and UpdateExecutionStatus scopes
+	// through the recognized LoadOwnedByAgent helper. Do not add either back.
 
 	// ---------------------------------------------------------------
 	// Service-layer-enforced tenant scoping. The lint's AST scan cannot
@@ -124,9 +130,16 @@ var allowlist = map[string]string{
 // lint recognizes it the same as LoadOwned because the unwrapping is
 // a one-line forwarder; treating it as a recognized helper avoids
 // every A2A handler having to repeat the closure inline.
+//
+// `LoadOwnedByAgent` scopes to the calling AGENT rather than the calling
+// organization, for sdkAPI-group routes where the group authenticates an agent
+// (and falls through to JWT) but ownership of the specific row still has to be
+// established in the handler. It refuses a uuid.Nil caller before the loader
+// runs, so a non-agent principal cannot reach the lookup.
 var recognizedHelpers = map[string]bool{
 	"LoadOwned":         true,
 	"LoadOwnedViaAgent": true,
+	"LoadOwnedByAgent":  true,
 	"loadOwnedAgent":    true,
 }
 

--- a/apps/backend/internal/infrastructure/repository/verification_event_repository.go
+++ b/apps/backend/internal/infrastructure/repository/verification_event_repository.go
@@ -842,7 +842,19 @@ func (r *VerificationEventRepositorySimple) UpdateResult(id uuid.UUID, result do
 	return nil
 }
 
-// UpdateExecutionStatus updates the execution status reported by the SDK
+// UpdateExecutionStatus records the SDK's execution report. Append-once.
+//
+// SECURITY: `AND executed IS NULL` makes the report immutable after the first
+// write. These four columns have exactly one writer in the backend — the
+// reporting agent's own SDK — and they are the inputs the dashboard's
+// enforcement text is derived from, so an agent must not be able to revise its
+// own record of what happened after the fact. (They are write-only today: no
+// SELECT in this file lists them, so nothing reads them back yet. The
+// immutability is for when something does.) Migration 053 declares all four nullable
+// with no default, so IS NULL is a well-defined "not yet reported" and this
+// needs no schema change. A second report affects zero rows and surfaces as the
+// same 404 as an unknown ID; the Python decorator's eight call sites sit in
+// mutually exclusive branches, so at most one report fires per invocation.
 func (r *VerificationEventRepositorySimple) UpdateExecutionStatus(id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
 	query := `
     UPDATE verification_events
@@ -851,7 +863,7 @@ func (r *VerificationEventRepositorySimple) UpdateExecutionStatus(id uuid.UUID, 
         strict_mode = $2,
         executed_at = $3,
         execution_error = $4
-    WHERE id = $5`
+    WHERE id = $5 AND executed IS NULL`
 
 	execResult, err := r.db.Exec(query, executed, strictMode, executedAt, executionError, id)
 	if err != nil {

--- a/apps/backend/internal/infrastructure/repository/verification_execution_append_once_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/verification_execution_append_once_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package repository
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The execution-report columns (executed, strict_mode, executed_at,
+// execution_error) have exactly one writer in the backend: the reporting agent's
+// own SDK. They are rendered to an operator as claims about what happened, so an
+// agent must not be able to revise its own record after the fact.
+//
+// UpdateExecutionStatus therefore carries `AND executed IS NULL`. That predicate
+// lives in SQL, so a mocked repository cannot exercise it — the mock replaces the
+// statement under test. These tests drive the REAL repository against a real
+// Postgres.
+//
+// Build-tag gated; requires the AIM schema:
+//
+//	TEST_DATABASE_URL=postgres://... go test -tags=integration \
+//	  -run TestUpdateExecutionStatusAppendOnce ./internal/infrastructure/repository/...
+
+func execAppendOnceDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping execution-status append-once integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// seedVerificationEvent creates its OWN organization and agent rather than
+// borrowing whatever happens to be in the database. Selecting an ambient agent
+// makes the test depend on seed data it does not control: it would pass today
+// only because a migration happens to insert some, and would hard-fail rather
+// than skip if that ever changed. Every other integration test in this package
+// creates its own fixture; this follows them.
+func seedVerificationEvent(t *testing.T, db *sql.DB) uuid.UUID {
+	t.Helper()
+
+	orgID, agentID, eventID := uuid.New(), uuid.New(), uuid.New()
+	userID := uuid.New()
+
+	_, err := db.Exec(`
+        INSERT INTO organizations
+            (id, name, domain, plan_type, max_agents, max_users, is_active,
+             created_at, updated_at, max_mcp_servers, enforcement_mode,
+             community_intelligence_enabled)
+        VALUES ($1, $2, $3, 'free', 100, 100, true, NOW(), NOW(), 100, 'monitoring', false)`,
+		orgID, "append-once-"+orgID.String()[:8], "append-once-"+orgID.String()[:8]+".invalid")
+	require.NoError(t, err, "seed organization")
+
+	// agents.created_by carries an FK to users, so the fixture needs its own user.
+	_, err = db.Exec(`
+        INSERT INTO users
+            (id, organization_id, email, name, role, provider, provider_id,
+             created_at, updated_at, status)
+        VALUES ($1, $2, $3, 'Append Once Fixture', 'member', 'local', $4, NOW(), NOW(), 'active')`,
+		userID, orgID, "append-once-"+userID.String()[:8]+"@fixture.invalid", userID.String())
+	require.NoError(t, err, "seed user")
+
+	_, err = db.Exec(`
+        INSERT INTO agents
+            (id, organization_id, name, display_name, agent_type, status,
+             created_at, updated_at, created_by)
+        VALUES ($1, $2, $3, 'Append Once Fixture', 'service', 'active', NOW(), NOW(), $4)`,
+		agentID, orgID, "append-once-agent-"+agentID.String()[:8], userID)
+	require.NoError(t, err, "seed agent")
+
+	_, err = db.Exec(`
+        INSERT INTO verification_events
+            (id, organization_id, agent_id, protocol, verification_type, status,
+             initiator_type, started_at, created_at)
+        VALUES ($1, $2, $3, 'a2a', 'capability', 'pending', 'agent', NOW(), NOW())`,
+		eventID, orgID, agentID)
+	require.NoError(t, err, "seed verification event")
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM verification_events WHERE organization_id = $1`, orgID)
+		_, _ = db.Exec(`DELETE FROM agents WHERE organization_id = $1`, orgID)
+		_, _ = db.Exec(`DELETE FROM users WHERE organization_id = $1`, orgID)
+		_, _ = db.Exec(`DELETE FROM organizations WHERE id = $1`, orgID)
+	})
+	return eventID
+}
+
+func TestUpdateExecutionStatusAppendOnce_FirstReportWins(t *testing.T) {
+	db := execAppendOnceDB(t)
+	repo := &VerificationEventRepositorySimple{db: db}
+	id := seedVerificationEvent(t, db)
+
+	// First report: the agent says it did NOT run the action, under strict mode.
+	require.NoError(t, repo.UpdateExecutionStatus(id, false, true, time.Now(), nil),
+		"the first execution report must be accepted")
+
+	// Second report, same event: the agent tries to revise its own record.
+	err := repo.UpdateExecutionStatus(id, true, false, time.Now(), nil)
+	require.Error(t, err,
+		"a second execution report must be rejected; the record is append-once")
+
+	var executed, strictMode bool
+	require.NoError(t, db.QueryRow(
+		`SELECT executed, strict_mode FROM verification_events WHERE id = $1`, id).
+		Scan(&executed, &strictMode))
+
+	assert.False(t, executed, "the stored report must still be the FIRST one")
+	assert.True(t, strictMode, "the second report must not have rewritten strict_mode either")
+}
+
+// TestUpdateExecutionStatusAppendOnce_ExecutedTrueIsAlsoSealed pins that the
+// predicate keys on NULL, not on falsiness. `executed IS NULL` and
+// `executed = false` are different conditions, and a predicate written as
+// `AND executed IS NOT TRUE` would leave a first report of false rewritable —
+// which is exactly the direction an agent would want to revise.
+func TestUpdateExecutionStatusAppendOnce_ExecutedTrueIsAlsoSealed(t *testing.T) {
+	db := execAppendOnceDB(t)
+	repo := &VerificationEventRepositorySimple{db: db}
+	id := seedVerificationEvent(t, db)
+
+	require.NoError(t, repo.UpdateExecutionStatus(id, true, true, time.Now(), nil))
+	require.Error(t, repo.UpdateExecutionStatus(id, false, false, time.Now(), nil))
+
+	var executed bool
+	require.NoError(t, db.QueryRow(
+		`SELECT executed FROM verification_events WHERE id = $1`, id).Scan(&executed))
+	assert.True(t, executed, "a true first report is sealed the same as a false one")
+}
+
+// TestUpdateExecutionStatusAppendOnce_UnknownEventStillErrors keeps the
+// not-found signal distinguishable at the repository seam: adding a predicate to
+// a WHERE clause must not turn "no such row" into a silent success.
+func TestUpdateExecutionStatusAppendOnce_UnknownEventStillErrors(t *testing.T) {
+	db := execAppendOnceDB(t)
+	repo := &VerificationEventRepositorySimple{db: db}
+
+	assert.Error(t, repo.UpdateExecutionStatus(uuid.New(), true, false, time.Now(), nil),
+		"an unknown id must still error rather than report success")
+}

--- a/apps/backend/internal/infrastructure/repository/verification_execution_append_once_integration_test.go
+++ b/apps/backend/internal/infrastructure/repository/verification_execution_append_once_integration_test.go
@@ -54,12 +54,18 @@ func seedVerificationEvent(t *testing.T, db *sql.DB) uuid.UUID {
 	orgID, agentID, eventID := uuid.New(), uuid.New(), uuid.New()
 	userID := uuid.New()
 
+	// NOTE: no max_mcp_servers here. That column is aim-cloud-only — it comes from
+	// cloud's migration 020_create_platform_admin_tables (a SaaS quota field) and
+	// does not exist in this tree's organizations table. This test was ported from
+	// cloud and carried the column with it, which CI caught as
+	// `pq: column "max_mcp_servers" of relation "organizations" does not exist`.
+	// Every other column below is present in both trees.
 	_, err := db.Exec(`
         INSERT INTO organizations
             (id, name, domain, plan_type, max_agents, max_users, is_active,
-             created_at, updated_at, max_mcp_servers, enforcement_mode,
+             created_at, updated_at, enforcement_mode,
              community_intelligence_enabled)
-        VALUES ($1, $2, $3, 'free', 100, 100, true, NOW(), NOW(), 100, 'monitoring', false)`,
+        VALUES ($1, $2, $3, 'free', 100, 100, true, NOW(), NOW(), 'monitoring', false)`,
 		orgID, "append-once-"+orgID.String()[:8], "append-once-"+orgID.String()[:8]+".invalid")
 	require.NoError(t, err, "seed organization")
 

--- a/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
+++ b/apps/backend/internal/interfaces/http/handlers/tenant_scope.go
@@ -172,6 +172,100 @@ func LoadOwnedViaAgent[T any](
 	return resource
 }
 
+// CallerAgentID returns the agent UUID established by an agent-authenticating
+// middleware. A principal that set no "agent_id" local, or set it as some other
+// type, yields uuid.Nil.
+//
+// SCOPE, and read this before mounting a handler that uses it on another group:
+// several middlewares in this package set a uuid.UUID under "agent_id" —
+// pqc_agent_auth.go:162, ed25519_agent_auth.go:215, api_key.go:130 and :224,
+// atc_auth.go:97, service_principal.go:121. This helper does NOT distinguish
+// between them. It is safe on the sdkAPI group specifically because that chain
+// is PQC → JWT → activity-touch → rate limit (cmd/server/main.go), so the only
+// principal that can set agent_id there is the signature-authenticated one.
+// Mount a handler that relies on this under an API-key, ATC or service-principal
+// group and the ownership check silently begins accepting those principals as
+// the agent.
+//
+// NOTE for anyone diffing this against aim-cloud: the two trees mount DIFFERENT
+// middleware on this group — public runs PQCAgentMiddleware, cloud runs
+// Ed25519AgentMiddleware. Both set agent_id as a uuid.UUID and both fall through
+// to JWT, so the reasoning holds in both, but the file to read differs.
+//
+// SECURITY: this exists so the ownership check cannot be written as
+//
+//	if id, ok := c.Locals("agent_id").(uuid.UUID); ok && id != want { reject }
+//
+// which is the idiom two files away at trust_score_handler.go:415. That shape
+// PERMITS when the assertion fails, and on the sdkAPI group the assertion fails
+// for every human caller: PQCAgentMiddleware hands off to the JWT middleware
+// whenever an Authorization header is present (pqc_agent_auth.go:39-41) or the
+// signature headers are absent (:50-52), and AuthMiddleware sets user_id /
+// organization_id / email / role and never agent_id (auth.go:132-135). Absence
+// of an agent principal is a rejection, not a reason to skip the check.
+//
+// Returning uuid.Nil rather than an ok flag is deliberate: LoadOwnedByAgent
+// refuses uuid.Nil before it touches the loader, so the fail-closed behaviour is
+// a property of the pair rather than of the caller remembering to check.
+func CallerAgentID(c fiber.Ctx) uuid.UUID {
+	if agentID, ok := c.Locals("agent_id").(uuid.UUID); ok {
+		return agentID
+	}
+	return uuid.Nil
+}
+
+// LoadOwnedByAgent is the agent-principal variant of LoadOwned: ownership is
+// established against the calling AGENT, not the calling organization.
+//
+// The sdkAPI group authenticates *an* agent; it does not establish that this
+// agent owns *this* resource. Organization scoping is not a substitute — two
+// agents in one organization are distinct principals, and the verification
+// events this guards are per-agent authorization records.
+//
+// Every failure path THIS HELPER takes — non-agent caller, loader error, missing
+// resource, row with no agent, different agent — writes the same 404 body and
+// returns nil, so the response cannot be used to test for the existence of
+// another agent's row. Same 404-not-403 rationale as LoadOwned; the caller must
+// `return nil`.
+//
+// Note the qualifier: a caller may emit a DIFFERENT 404 body later, after this
+// helper has already returned the resource (UpdateExecutionStatus does, when the
+// write itself affects no row). That is not an oracle — by then the caller has
+// been proven to own the row — but it does mean "every 404 from this route is
+// byte-identical" is false, and no code should rely on it.
+//
+// agentIDOf returns a *uuid.UUID because the owning column is nullable on the
+// domain types that need this (domain.VerificationEvent.AgentID is *uuid.UUID —
+// an event may target an MCP server instead of an agent). A nil owner is
+// refused rather than treated as a wildcard.
+func LoadOwnedByAgent[T any](
+	c fiber.Ctx,
+	loader func(uuid.UUID) (*T, error),
+	resourceID uuid.UUID,
+	callerAgentID uuid.UUID,
+	agentIDOf func(*T) *uuid.UUID,
+) *T {
+	// Defense-in-depth: a uuid.Nil caller is a non-agent principal (see
+	// CallerAgentID) or a middleware-chain bug. Refuse before the loader runs
+	// so no existence signal is produced. Matching uuid.Nil to uuid.Nil would
+	// let either case surface as ownership.
+	if callerAgentID == uuid.Nil || agentIDOf == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	resource, err := loader(resourceID)
+	if err != nil || resource == nil {
+		respondResourceNotFound(c)
+		return nil
+	}
+	ownerAgentID := agentIDOf(resource)
+	if ownerAgentID == nil || *ownerAgentID == uuid.Nil || *ownerAgentID != callerAgentID {
+		respondResourceNotFound(c)
+		return nil
+	}
+	return resource
+}
+
 func respondResourceNotFound(c fiber.Ctx) {
 	_ = c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 		"error": "not found",

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler.go
@@ -1149,83 +1149,54 @@ func (h *VerificationHandler) writeVerificationResponse(c fiber.Ctx, event *doma
 	return c.Status(fiber.StatusOK).JSON(response)
 }
 
-// SubmitVerificationResult handles verification result submission
-// @Summary Submit verification result
-// @Description Submit the result of a verification request (success/failure)
+// SubmitVerificationResult refuses every caller.
+//
+// SECURITY: `result` and
+// `status` are the authorization-decision channel. Their only legitimate writers
+// are CreateVerification, ApproveVerification, DenyVerification and the expiry
+// job. This endpoint was the execution-outcome channel writing into that column
+// pair, so an agent reporting its own action as "success" set result='verified',
+// which writeVerificationResponse projects to the SDK as status:"approved",
+// approvedBy:"system" (:1126-1131) and the SDK executes on. The party whose
+// action is pending approval is handed the verification ID by CreateVerification
+// itself, so this was self-approval.
+//
+// Authentication does not fix that: in the primary scenario the attacker IS the
+// owning agent and holds its own signing key, so a correctly-signed request from
+// the legitimate owner must still be refused. Both chiefs independently ruled
+// that the guarantee must hold BY CONSTRUCTION rather than by evaluation — the
+// call to UpdateVerificationResult is deleted from this handler, not guarded, so
+// `grep -n 'UpdateVerificationResult(' verification_handler.go` proves it in one
+// command instead of a reviewer having to reason about guard coverage across two
+// authentication middlewares and a future mount.
+//
+// The execution outcome gets its own CHECK-constrained columns in Stage 2
+// (the execution-outcome follow-up, which adds them by migration).
+// Until then this endpoint accepts nothing from anyone. Losing the telemetry is
+// a net improvement, not a regression: every caller reaches this route after the
+// authorization decision and after execution, and what it currently records is
+// an overwrite of that decision.
+//
+// 403 with a distinct machine-readable code, deliberately NOT 404: 404 collides
+// with the "Verification not found or update failed" body this handler used to
+// emit, which would make a refusal indistinguishable from the pre-fix behaviour
+// and hide the degradation. There is no existence oracle to protect because no
+// lookup happens. CISO argued for 410; the divergence and both positions are
+// recorded with the change. 403 is used because the follow-up restores a write
+// channel here, and 410 asserts a condition "likely to be permanent".
+//
+// @Summary Submit verification result (withdrawn)
+// @Description Withdrawn in Stage 1. Returns 403 for every caller; the execution-outcome channel moves to its own columns in Stage 2.
 // @Tags verifications
-// @Accept json
 // @Produce json
 // @Param id path string true "Verification ID (UUID)"
-// @Param result body object true "Verification result"
-// @Success 200 {object} map[string]interface{} "Result recorded"
-// @Failure 400 {object} ErrorResponse "Invalid request"
-// @Failure 404 {object} ErrorResponse "Verification not found"
-// @Failure 500 {object} ErrorResponse "Internal server error"
-// @Router /api/v1/verifications/{id}/result [post]
+// @Failure 403 {object} ErrorResponse "Endpoint withdrawn"
+// @Router /api/v1/sdk-api/verifications/{id}/result [post]
 func (h *VerificationHandler) SubmitVerificationResult(c fiber.Ctx) error {
-	// 📍 LOG 2: HANDLER ENTRY
-	// requestID := c.Locals("request_id")
-	verificationID := c.Params("id")
-	if verificationID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "verificationId is required",
-		})
-	}
-
-	var req struct {
-		Result   string                 `json:"result"` // "success", "failure"
-		Reason   string                 `json:"reason,omitempty"`
-		Metadata map[string]interface{} `json:"metadata,omitempty"`
-	}
-
-	if err := c.Bind().JSON(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid request body",
-		})
-	}
-
-	// Parse UUID
-	vid, err := uuid.Parse(verificationID)
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid verificationId format",
-		})
-	}
-
-	// Validate result value
-	if req.Result != "success" && req.Result != "failure" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "result must be either 'success' or 'failure'",
-		})
-	}
-
-	// Map result string to VerificationResult type
-	var result domain.VerificationResult
-	if req.Result == "success" {
-		result = domain.VerificationResultVerified
-	} else {
-		result = domain.VerificationResultDenied
-	}
-
-	// Prepare reason pointer
-	var reasonPtr *string
-	if req.Reason != "" {
-		reasonPtr = &req.Reason
-	}
-
-	// Update verification event in database
-	err = h.getVerificationEventService().UpdateVerificationResult(c.Context(), vid, result, reasonPtr, req.Metadata)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
-			"error": "Verification not found or update failed",
-		})
-	}
-
-	// Return success response
-	return c.Status(fiber.StatusOK).JSON(fiber.Map{
-		"id":     vid.String(),
-		"status": "result_recorded",
-		"result": req.Result,
+	return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+		"error": "verification result reporting is not accepted on this endpoint; " +
+			"result and status are the authorization-decision channel",
+		"code": "executionOutcomeNotAccepted",
 	})
 }
 
@@ -1766,10 +1737,38 @@ func (h *VerificationHandler) DenyVerification(c fiber.Ctx) error {
 // Allows the SDK to report whether a function was actually executed after verification
 // ============================================================================
 
-// UpdateExecutionStatusRequest represents the request body for reporting execution status
+// UpdateExecutionStatusRequest represents the request body for reporting execution status.
+//
+// SECURITY: there is deliberately no StrictMode field. Strict mode is OUR
+// configuration, not the reporting agent's to assert. An agent supplying
+// {"executed":false,"strictMode":true} stored the inputs from which
+// apps/web/components/alerts/alert-detail-panel.tsx derives its enforcement
+// text, including the string "Action BLOCKED (strict mode enforced)".
+//
+// Measured, so the record is accurate rather than dramatic: those four columns
+// are WRITE-ONLY in this backend today. No SELECT in
+// verification_event_repository.go lists them and nothing populates
+// domain.VerificationEvent.Executed, so the panel's `executed !== undefined`
+// guard never passes and the forged text does not currently reach an operator.
+// The forgery is stored and latent, not rendered: it renders the moment anyone
+// adds these columns to a read query, which is a one-line change with no reason
+// to look dangerous. That is why this is fixed at the write rather than left to
+// the reader.
+//
+// It is now derived server-side from the event's organization. Do not
+// reintroduce the field; UpdateExecutionStatus ignores anything sent under that
+// name and a guard test pins its absence.
+//
+// CAVEAT, recorded rather than silently absorbed: migration 053 documents
+// strict_mode as "whether the SDK was in strict mode when verification was
+// requested". This now stores the ORGANIZATION's mode at report time. Those can
+// differ — sdk/python/aim_sdk/decorators.py lets AIM_STRICT_MODE override the
+// backend mode locally — and rows written before this change carry the old,
+// agent-asserted meaning with no discriminator column to tell them apart.
+// Reconciling the column comment and labelling rows by provenance belongs to the
+// execution-outcome unit that adds the dedicated columns.
 type UpdateExecutionStatusRequest struct {
 	Executed       bool    `json:"executed"`                 // Whether the function was executed
-	StrictMode     bool    `json:"strictMode"`               // Whether SDK was in strict mode
 	ExecutedAt     string  `json:"executedAt"`               // Timestamp of execution (RFC3339)
 	ExecutionError *string `json:"executionError,omitempty"` // Error message if execution failed
 }
@@ -1788,19 +1787,34 @@ type UpdateExecutionStatusRequest struct {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /api/v1/sdk-api/verifications/{id}/execution-status [post]
 func (h *VerificationHandler) UpdateExecutionStatus(c fiber.Ctx) error {
-	verificationID := c.Params("id")
-	if verificationID == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "verificationId is required",
-		})
+	// SECURITY: the sdkAPI group authenticates *an* agent — and, through its JWT
+	// fall-through (pqc_agent_auth.go:39-41, :50-52), a human user of any
+	// organization. Neither establishes that this caller owns this event. The
+	// principal gate fires before any database read so a non-agent caller gets no
+	// existence signal for an ID it guessed.
+	callerAgentID := CallerAgentID(c)
+	if callerAgentID == uuid.Nil {
+		respondResourceNotFound(c)
+		return nil
 	}
 
-	// Parse UUID
-	vid, err := uuid.Parse(verificationID)
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid verificationId format",
-		})
+	vid, ok := parseVerificationIDParam(c)
+	if !ok {
+		return nil // helper already wrote the 400
+	}
+
+	// Ownership: mirrors GetVerificationSDK:1050-1053. 404 on every failure path,
+	// never 403, so "exists but not yours" is indistinguishable from "does not
+	// exist" and the route cannot be used to enumerate other agents' events.
+	event := LoadOwnedByAgent(c,
+		func(id uuid.UUID) (*domain.VerificationEvent, error) {
+			return h.getVerificationEventService().GetVerificationEvent(c.Context(), id)
+		},
+		vid, callerAgentID,
+		func(e *domain.VerificationEvent) *uuid.UUID { return e.AgentID },
+	)
+	if event == nil {
+		return nil // helper already wrote the 404
 	}
 
 	// Parse request body
@@ -1811,9 +1825,42 @@ func (h *VerificationHandler) UpdateExecutionStatus(c fiber.Ctx) error {
 		})
 	}
 
+	// SECURITY: strict mode is derived from the event's organization, never from
+	// the request body. The reporting agent is the party being audited; letting it
+	// assert what our enforcement configuration was let it forge the operator-facing
+	// "Action BLOCKED (strict mode enforced)" string. Same lookup as
+	// writeVerificationResponse:1083-1088. Caveat: this reflects the organization's
+	// mode at report time, not at decision time.
+	//
+	// If the mode cannot be established we record NOTHING, rather than defaulting.
+	// strict_mode is rendered to an operator as a statement about OUR configuration,
+	// so an unknown must not be coerced into one of the two labels: writing `false`
+	// on a lookup failure would print "enforcement mode: monitoring" for what may
+	// have been a strict organization, which is the same class of false claim this
+	// change exists to remove — merely in the quieter direction. Losing one
+	// post-execution telemetry row is the cheaper error. writeVerificationResponse
+	// defaults to "monitoring" on the same failure, but that value is transient
+	// response data, not a persisted record an incident is later reconstructed from.
+	orgRepo := h.getOrgRepo()
+	if orgRepo == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "cannot determine organization enforcement mode; execution status not recorded",
+			"code":  "enforcementModeUnavailable",
+		})
+	}
+	org, err := orgRepo.GetByID(event.OrganizationID)
+	if err != nil || org == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "cannot determine organization enforcement mode; execution status not recorded",
+			"code":  "enforcementModeUnavailable",
+		})
+	}
+	strictMode := org.EnforcementMode == domain.EnforcementModeStrict
+
 	// Parse execution timestamp
 	var executedAt time.Time
 	if req.ExecutedAt != "" {
+		var err error
 		executedAt, err = time.Parse(time.RFC3339, req.ExecutedAt)
 		if err != nil {
 			// Try parsing without timezone
@@ -1826,12 +1873,13 @@ func (h *VerificationHandler) UpdateExecutionStatus(c fiber.Ctx) error {
 		executedAt = time.Now()
 	}
 
-	// Update execution status in database
+	// Update execution status in database. The repository write is append-once
+	// (AND executed IS NULL), so a report cannot be overwritten by a later one.
 	err = h.getVerificationEventService().UpdateExecutionStatus(
 		c.Context(),
 		vid,
 		req.Executed,
-		req.StrictMode,
+		strictMode,
 		executedAt,
 		req.ExecutionError,
 	)
@@ -1845,7 +1893,7 @@ func (h *VerificationHandler) UpdateExecutionStatus(c fiber.Ctx) error {
 		"id":         vid.String(),
 		"status":     "execution_status_recorded",
 		"executed":   req.Executed,
-		"strictMode": req.StrictMode,
+		"strictMode": strictMode,
 		"executedAt": executedAt.Format(time.RFC3339),
 	})
 }

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler_integration_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler_integration_test.go
@@ -26,6 +26,13 @@ import (
 // value for their mock event.OrganizationID.
 var testJWTOrgID = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 
+// testSDKAgentID is the agent principal injected by setupVerificationTestApp on
+// the sdkAPI write routes, standing in for Ed25519AgentMiddleware's
+// c.Locals("agent_id"). Tests that expect UpdateExecutionStatus to succeed must
+// give their mock event this AgentID, because the handler now refuses any event
+// the calling agent does not own.
+var testSDKAgentID = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
 // ===========================
 // VerificationHandler Integration Tests
 // ===========================
@@ -40,11 +47,29 @@ func setupVerificationTestApp(handler *VerificationHandler) *fiber.App {
 		return c.Next()
 	})
 	jwtGroup.Get("/:id", handler.GetVerification)
-	jwtGroup.Post("/:id/result", handler.SubmitVerificationResult)
+	// NOTE: `jwtGroup.Post("/:id/result", ...)` is deliberately absent. That mount
+	// was removed from cmd/server/main.go — it authenticated a JWT user but the
+	// handler had no ownership check, so any user of any organization could
+	// rewrite any verification by UUID. Mirroring production here is the point:
+	// a harness that keeps a deleted route alive is how a test suite stays green
+	// over a route nobody serves.
 
-	// SDK API routes (signature-authed)
+	// SDK API routes (signature-authed). GetVerificationSDK verifies its own
+	// X-AIM-* headers and reads no locals, so it stays on the bare mount.
 	app.Get("/api/v1/sdk-api/verifications/:id", handler.GetVerificationSDK)
-	app.Post("/api/v1/sdk-api/verifications/:id/execution-status", handler.UpdateExecutionStatus)
+
+	// The two write routes now live behind the sdkAPI group. testSDKAgentID
+	// stands in for what Ed25519AgentMiddleware leaves in Locals; tests that need
+	// a different principal build their own app (see verification_sdk_write_auth_test.go).
+	sdkGroup := app.Group("/api/v1/sdk-api")
+	sdkGroup.Use(func(c fiber.Ctx) error {
+		c.Locals("agent_id", testSDKAgentID)
+		c.Locals("organization_id", testJWTOrgID)
+		c.Locals("authenticated_via", "ed25519")
+		return c.Next()
+	})
+	sdkGroup.Post("/verifications/:id/result", handler.SubmitVerificationResult)
+	sdkGroup.Post("/verifications/:id/execution-status", handler.UpdateExecutionStatus)
 
 	// Admin routes - require organization context
 	adminGroup := app.Group("/api/v1/admin")
@@ -596,12 +621,23 @@ func TestVerificationHandler_GetVerificationSDK_Valid_200(t *testing.T) {
 // SubmitVerificationResult Tests
 // ===========================
 
+// The four tests below previously asserted that POST .../result recorded a
+// result: 200 {"status":"result_recorded"} for "success", 400 for a malformed
+// body, 404 when the row was missing. They were green for the entire life of the
+// defect, because they asserted the contract the defect implemented.
+//
+// The endpoint is withdrawn. They now assert the
+// contract that replaced it, and each keeps its original name so that anyone
+// searching for "does /result record a success?" lands on the answer rather than
+// on a test of a route that no longer behaves that way.
+
 func TestVerificationHandler_SubmitVerificationResult_Success(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
 
+	writes := 0
 	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
 		UpdateVerificationResultFunc: func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error {
+			writes++
 			return nil
 		},
 	}
@@ -616,38 +652,34 @@ func TestVerificationHandler_SubmitVerificationResult_Success(t *testing.T) {
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
+	bodyBytes, _ := json.Marshal(map[string]interface{}{
 		"result":   "success",
 		"reason":   "Action completed",
 		"metadata": map[string]interface{}{"key": "value"},
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	})
 
-	// Act
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode,
+		"a well-formed success report is refused: result/status are the authorization-decision channel")
 
 	var response map[string]interface{}
 	body, _ := io.ReadAll(resp.Body)
-	err = json.Unmarshal(body, &response)
-	require.NoError(t, err)
-
-	assert.Equal(t, verificationID.String(), response["id"])
-	assert.Equal(t, "result_recorded", response["status"])
-	assert.Equal(t, "success", response["result"])
+	require.NoError(t, json.Unmarshal(body, &response))
+	assert.Equal(t, "executionOutcomeNotAccepted", response["code"])
+	assert.Zero(t, writes, "no store write may occur on the withdrawn endpoint")
 }
 
 func TestVerificationHandler_SubmitVerificationResult_Failure(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
 
+	writes := 0
 	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
 		UpdateVerificationResultFunc: func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error {
+			writes++
 			return nil
 		},
 	}
@@ -662,24 +694,22 @@ func TestVerificationHandler_SubmitVerificationResult_Failure(t *testing.T) {
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
+	bodyBytes, _ := json.Marshal(map[string]interface{}{
 		"result": "failure",
-		"reason": "Action failed due to error",
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+		"reason": "Action failed",
+	})
 
-	// Act
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode,
+		"a failure report is refused too: it wrote result='denied', which is equally the decision channel")
+	assert.Zero(t, writes)
 }
 
 func TestVerificationHandler_SubmitVerificationResult_InvalidResultWithMocks(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
 
 	handler := NewVerificationHandlerWithInterfaces(
@@ -692,28 +722,29 @@ func TestVerificationHandler_SubmitVerificationResult_InvalidResultWithMocks(t *
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
-		"result": "invalid",
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"result": "invalid"})
 
-	// Act
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode,
+		"a malformed body gets the SAME refusal as a well-formed one: no input-dependent branch survives, "+
+			"so the response cannot be used to probe what the endpoint would have accepted")
 }
 
 func TestVerificationHandler_SubmitVerificationResult_NotFound(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
 
 	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
+		GetVerificationEventFunc: func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error) {
+			t.Fatal("the withdrawn endpoint must not look the event up; a lookup is an existence oracle")
+			return nil, nil
+		},
 		UpdateVerificationResultFunc: func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error {
-			return fmt.Errorf("not found")
+			t.Fatal("the withdrawn endpoint must not write")
+			return nil
 		},
 	}
 
@@ -727,19 +758,15 @@ func TestVerificationHandler_SubmitVerificationResult_NotFound(t *testing.T) {
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
-		"result": "success",
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"result": "success"})
 
-	// Act
-	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode,
+		"an unknown id is refused identically to a known one, and is never looked up")
 }
 
 // ===========================
@@ -1134,135 +1161,149 @@ func TestVerificationHandler_DenyVerification_NotFound(t *testing.T) {
 // UpdateExecutionStatus Tests
 // ===========================
 
-func TestVerificationHandler_UpdateExecutionStatus_Success(t *testing.T) {
-	// Arrange
-	verificationID := uuid.New()
+// ownedEventFor builds an event the injected sdkAPI principal actually owns, so
+// these tests exercise the success path rather than the ownership refusal. An
+// event whose AgentID is not testSDKAgentID now 404s, which is what
+// verification_sdk_write_auth_test.go pins.
+func ownedEventFor(id uuid.UUID) *domain.VerificationEvent {
+	agentID := testSDKAgentID
+	return &domain.VerificationEvent{
+		ID:             id,
+		OrganizationID: testJWTOrgID,
+		AgentID:        &agentID,
+		Status:         domain.VerificationEventStatusPending,
+		CreatedAt:      time.Now().Add(-time.Minute),
+	}
+}
 
-	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
+func execStatusServiceFor(event *domain.VerificationEvent, onWrite func(executed, strictMode bool, executedAt time.Time)) *MockVerificationEventServiceForVerificationImpl {
+	return &MockVerificationEventServiceForVerificationImpl{
+		GetVerificationEventFunc: func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error) {
+			if event == nil || event.ID != id {
+				return nil, fmt.Errorf("verification event not found")
+			}
+			return event, nil
+		},
 		UpdateExecutionStatusFunc: func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
-			assert.Equal(t, verificationID, id)
-			assert.True(t, executed)
-			assert.True(t, strictMode)
+			if onWrite != nil {
+				onWrite(executed, strictMode, executedAt)
+			}
 			return nil
 		},
 	}
+}
 
+func TestVerificationHandler_UpdateExecutionStatus_Success(t *testing.T) {
+	verificationID := uuid.New()
+	event := ownedEventFor(verificationID)
+
+	var gotExecuted, gotStrict bool
 	handler := NewVerificationHandlerWithInterfaces(
 		&MockAgentServiceForVerificationImpl{},
 		&MockAuditServiceForVerificationImpl{},
 		&MockAlertServiceForVerificationImpl{},
-		mockVerifEventService,
+		execStatusServiceFor(event, func(executed, strictMode bool, _ time.Time) {
+			gotExecuted, gotStrict = executed, strictMode
+		}),
+		// Default mock organization is EnforcementModeMonitoring.
 		&MockOrganizationRepositoryerImpl{},
 	)
 
 	app := setupVerificationTestApp(handler)
 
 	now := time.Now().Format(time.RFC3339)
-	reqBody := map[string]interface{}{
+	bodyBytes, _ := json.Marshal(map[string]interface{}{
 		"executed":   true,
-		"strictMode": true,
+		"strictMode": true, // ignored: strict mode is server-derived
 		"executedAt": now,
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	})
 
-	// Act
 	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 
 	var response map[string]interface{}
 	body, _ := io.ReadAll(resp.Body)
-	err = json.Unmarshal(body, &response)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &response))
 
 	assert.Equal(t, verificationID.String(), response["id"])
 	assert.Equal(t, "execution_status_recorded", response["status"])
 	assert.Equal(t, true, response["executed"])
-	assert.Equal(t, true, response["strictMode"])
+	assert.True(t, gotExecuted)
+	assert.False(t, gotStrict,
+		"the organization is in monitoring mode, so strict_mode is false however the agent labelled its report")
+	assert.Equal(t, false, response["strictMode"])
 }
 
 func TestVerificationHandler_UpdateExecutionStatus_NotExecuted(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
+	event := ownedEventFor(verificationID)
 
-	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
-		UpdateExecutionStatusFunc: func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
-			assert.False(t, executed)
-			assert.NotNil(t, executionError)
-			return nil
-		},
-	}
-
+	var gotExecuted bool
 	handler := NewVerificationHandlerWithInterfaces(
 		&MockAgentServiceForVerificationImpl{},
 		&MockAuditServiceForVerificationImpl{},
 		&MockAlertServiceForVerificationImpl{},
-		mockVerifEventService,
+		execStatusServiceFor(event, func(executed, _ bool, _ time.Time) { gotExecuted = executed }),
 		&MockOrganizationRepositoryerImpl{},
 	)
 
 	app := setupVerificationTestApp(handler)
 
-	execError := "Permission denied"
-	reqBody := map[string]interface{}{
-		"executed":       false,
-		"strictMode":     true,
-		"executionError": execError,
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"executed": false})
 
-	// Act
 	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.False(t, gotExecuted)
 }
 
+// TestVerificationHandler_UpdateExecutionStatus_NotFound pins the not-found path
+// specifically. It must fail for the reason its name says: the event does not
+// exist. Ownership refusal also returns 404, so the mock here OWNS nothing at
+// all and the assertion below checks the write was never attempted, which
+// distinguishes "no such row" from "row belongs to someone else" at the seam
+// rather than at the status code.
 func TestVerificationHandler_UpdateExecutionStatus_NotFound(t *testing.T) {
-	// Arrange
 	verificationID := uuid.New()
 
-	mockVerifEventService := &MockVerificationEventServiceForVerificationImpl{
-		UpdateExecutionStatusFunc: func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
-			return fmt.Errorf("not found")
-		},
-	}
-
+	writes := 0
 	handler := NewVerificationHandlerWithInterfaces(
 		&MockAgentServiceForVerificationImpl{},
 		&MockAuditServiceForVerificationImpl{},
 		&MockAlertServiceForVerificationImpl{},
-		mockVerifEventService,
+		&MockVerificationEventServiceForVerificationImpl{
+			GetVerificationEventFunc: func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error) {
+				return nil, fmt.Errorf("verification event not found")
+			},
+			UpdateExecutionStatusFunc: func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
+				writes++
+				return nil
+			},
+		},
 		&MockOrganizationRepositoryerImpl{},
 	)
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
-		"executed":   true,
-		"strictMode": true,
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"executed": true})
 
-	// Act
 	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", verificationID.String()), bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+	assert.Zero(t, writes, "an unresolvable event must not reach the write")
 }
 
 func TestVerificationHandler_UpdateExecutionStatus_InvalidIDWithMocks(t *testing.T) {
-	// Arrange
 	handler := NewVerificationHandlerWithInterfaces(
 		&MockAgentServiceForVerificationImpl{},
 		&MockAuditServiceForVerificationImpl{},
@@ -1273,20 +1314,16 @@ func TestVerificationHandler_UpdateExecutionStatus_InvalidIDWithMocks(t *testing
 
 	app := setupVerificationTestApp(handler)
 
-	reqBody := map[string]interface{}{
-		"executed":   true,
-		"strictMode": true,
-	}
-	bodyBytes, _ := json.Marshal(reqBody)
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"executed": true})
 
-	// Act
 	req := httptest.NewRequest("POST", "/api/v1/sdk-api/verifications/invalid-uuid/execution-status", bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req)
 
-	// Assert
 	require.NoError(t, err)
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode,
+		"a malformed id is still a 400 for an authenticated agent; the principal gate runs first, so this "+
+			"also proves the gate admitted the agent rather than short-circuiting everything to 404")
 }
 
 // ===========================

--- a/apps/backend/internal/interfaces/http/handlers/verification_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_handler_test.go
@@ -142,6 +142,12 @@ func TestVerificationHandler_GetVerification_InvalidID(t *testing.T) {
 // VerificationHandler.SubmitVerificationResult Tests
 // ===========================
 
+// These three named the inputs the handler used to branch on. It no longer
+// branches: every caller and every body gets the same refusal. Keeping the names
+// and asserting the identical outcome is the point — it documents that no
+// input-dependent path survived, which is what makes the endpoint useless as a
+// probe.
+
 func TestVerificationHandler_SubmitVerificationResult_InvalidID(t *testing.T) {
 	handler := &VerificationHandler{}
 	app := fiber.New()
@@ -155,7 +161,7 @@ func TestVerificationHandler_SubmitVerificationResult_InvalidID(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
 func TestVerificationHandler_SubmitVerificationResult_InvalidJSON(t *testing.T) {
@@ -170,7 +176,7 @@ func TestVerificationHandler_SubmitVerificationResult_InvalidJSON(t *testing.T) 
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
 func TestVerificationHandler_SubmitVerificationResult_InvalidResult(t *testing.T) {
@@ -186,7 +192,25 @@ func TestVerificationHandler_SubmitVerificationResult_InvalidResult(t *testing.T
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
+// A nil-service handler proves the refusal needs no dependencies: if any code
+// path here touched a store, this would panic rather than fail.
+func TestVerificationHandler_SubmitVerificationResult_TouchesNoDependencies(t *testing.T) {
+	handler := &VerificationHandler{}
+	app := fiber.New()
+	app.Post("/verifications/:id/result", handler.SubmitVerificationResult)
+
+	req := httptest.NewRequest("POST", "/verifications/"+uuid.New().String()+"/result",
+		strings.NewReader(`{"result":"success"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
 // ===========================
@@ -280,6 +304,12 @@ func TestVerificationHandler_DenyVerification_EmptyReason(t *testing.T) {
 // VerificationHandler.UpdateExecutionStatus Tests
 // ===========================
 
+// UpdateExecutionStatus now refuses before it parses, when the caller is not an
+// agent. These mount with NO agent principal, which is exactly what the sdkAPI
+// group produces for a JWT or cookie caller, so 404 — not 400 — is the correct
+// assertion. The 400-on-malformed-id path is still covered, for an authenticated
+// agent, by TestVerificationHandler_UpdateExecutionStatus_InvalidIDWithMocks.
+
 func TestVerificationHandler_UpdateExecutionStatus_InvalidID(t *testing.T) {
 	handler := &VerificationHandler{}
 	app := fiber.New()
@@ -293,7 +323,8 @@ func TestVerificationHandler_UpdateExecutionStatus_InvalidID(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"no agent principal: refused before the id is even parsed, so a non-agent learns nothing about the id")
 }
 
 func TestVerificationHandler_UpdateExecutionStatus_InvalidJSON(t *testing.T) {
@@ -308,7 +339,8 @@ func TestVerificationHandler_UpdateExecutionStatus_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"no agent principal: refused before the body is bound")
 }
 
 // ===========================
@@ -536,7 +568,8 @@ func TestVerificationHandler_SubmitVerificationResult_EmptyID(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode,
+		"an absent id is refused like every other shape: the endpoint is withdrawn, not validating")
 }
 
 // ===========================
@@ -557,7 +590,8 @@ func TestVerificationHandler_UpdateExecutionStatus_EmptyID(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode,
+		"no agent principal: the principal gate fires before the id check")
 }
 
 // ===========================
@@ -703,17 +737,21 @@ func TestDenyVerificationRequest_Struct(t *testing.T) {
 	assert.Equal(t, "Agent not authorized for this action", req.Reason)
 }
 
+// StrictMode was removed from this struct: it is derived server-side from the
+// event's organization, because the reporting agent is the party being audited
+// and must not be able to assert what our enforcement configuration was. See
+// TestUpdateExecutionStatus_StrictModeIsServerDerived and
+// TestUpdateExecutionStatusRequest_HasNoStrictModeField in
+// verification_sdk_write_auth_test.go for the behaviour that replaced it.
 func TestUpdateExecutionStatusRequest_Struct(t *testing.T) {
 	errorMsg := "Connection timeout"
 	req := UpdateExecutionStatusRequest{
 		Executed:       false,
-		StrictMode:     true,
 		ExecutedAt:     "2024-01-01T12:00:00Z",
 		ExecutionError: &errorMsg,
 	}
 
 	assert.False(t, req.Executed)
-	assert.True(t, req.StrictMode)
 	assert.Equal(t, "2024-01-01T12:00:00Z", req.ExecutedAt)
 	assert.NotNil(t, req.ExecutionError)
 	assert.Equal(t, "Connection timeout", *req.ExecutionError)
@@ -722,13 +760,11 @@ func TestUpdateExecutionStatusRequest_Struct(t *testing.T) {
 func TestUpdateExecutionStatusRequest_Successful(t *testing.T) {
 	req := UpdateExecutionStatusRequest{
 		Executed:       true,
-		StrictMode:     false,
 		ExecutedAt:     "2024-01-01T12:00:00Z",
 		ExecutionError: nil,
 	}
 
 	assert.True(t, req.Executed)
-	assert.False(t, req.StrictMode)
 	assert.Nil(t, req.ExecutionError)
 }
 

--- a/apps/backend/internal/interfaces/http/handlers/verification_sdk_write_auth_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/verification_sdk_write_auth_test.go
@@ -1,0 +1,611 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Containment stage of the verification write-path fix.
+//
+// WHAT THESE TESTS ARE FOR, and what they deliberately are NOT.
+//
+// The defect these guard was not "an unsigned request was accepted". It was that
+// POST /api/v1/sdk-api/verifications/:id/result wrote the AUTHORIZATION DECISION
+// from a body the agent controls, and the agent whose action is pending approval
+// is handed the verification ID by CreateVerification itself. Authentication
+// cannot fix that, because in the primary scenario the attacker IS the owning
+// agent and holds its own signing key.
+//
+// So the test that matters here is
+// TestSubmitVerificationResult_OwningAgentCannotApprovePendingEvent: a caller
+// that has passed every authentication control and genuinely owns the event
+// still cannot move it from pending to approved. A suite that only proved
+// "unauthenticated is rejected" would be green over a live bypass — the exact
+// shape both chiefs named as the most likely way this fix fails.
+//
+// This file is cloud-only by construction. The sync from the public repo copies
+// files that exist there over cloud's copies; a file with no public counterpart
+// is never overwritten, and only apps/backend/{schema,scripts,seed,tests}/ are
+// delete-mirrored. So if a future sync restores the vulnerable handler, these go
+// red in pr-check.yml rather than shipping.
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// writeSpy records whether the handlers reached a store. Absence of a write is
+// the real assertion; a status code alone would pass even if the row changed.
+type writeSpy struct {
+	updateResultCalls    int
+	updateExecCalls      int
+	lastExecStrictMode   bool
+	lastExecExecuted     bool
+	lastExecutionErrorIn *string
+}
+
+func (s *writeSpy) service(event *domain.VerificationEvent) *MockVerificationEventServiceForVerificationImpl {
+	return &MockVerificationEventServiceForVerificationImpl{
+		GetVerificationEventFunc: func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error) {
+			if event == nil || event.ID != id {
+				return nil, fmt.Errorf("verification event not found")
+			}
+			return event, nil
+		},
+		UpdateVerificationResultFunc: func(ctx context.Context, id uuid.UUID, result domain.VerificationResult, reason *string, metadata map[string]interface{}) error {
+			s.updateResultCalls++
+			return nil
+		},
+		UpdateExecutionStatusFunc: func(ctx context.Context, id uuid.UUID, executed bool, strictMode bool, executedAt time.Time, executionError *string) error {
+			s.updateExecCalls++
+			s.lastExecExecuted = executed
+			s.lastExecStrictMode = strictMode
+			s.lastExecutionErrorIn = executionError
+			return nil
+		},
+	}
+}
+
+// principal is what a middleware chain leaves in Locals. The sdkAPI group can
+// produce any of these: PQCAgentMiddleware sets agent_id + organization_id
+// (pqc_agent_auth.go:162-163), and its JWT fall-through (:39-41, :50-52)
+// reaches AuthMiddleware, which sets organization_id/user_id and never agent_id
+// (auth.go:132-135).
+type principal struct {
+	name    string
+	agentID *uuid.UUID // nil => no agent principal, i.e. a JWT/cookie caller
+	orgID   *uuid.UUID
+	userID  *uuid.UUID
+}
+
+func agentPrincipal(name string, agentID, orgID uuid.UUID) principal {
+	return principal{name: name, agentID: &agentID, orgID: &orgID}
+}
+
+func jwtPrincipal(name string, orgID uuid.UUID) principal {
+	userID := uuid.New()
+	return principal{name: name, orgID: &orgID, userID: &userID}
+}
+
+func anonymousPrincipal() principal { return principal{name: "unauthenticated"} }
+
+// sdkWriteApp mounts the two write handlers behind a middleware that injects the
+// given principal, mirroring what the real sdkAPI group leaves in Locals. The
+// paths match cmd/server/main.go's group registrations.
+func sdkWriteApp(handler *VerificationHandler, p principal) *fiber.App {
+	app := fiber.New()
+	group := app.Group("/api/v1/sdk-api")
+	group.Use(func(c fiber.Ctx) error {
+		if p.agentID != nil {
+			c.Locals("agent_id", *p.agentID)
+			c.Locals("authenticated_via", "ed25519")
+			c.Locals("auth_method", "ed25519")
+		}
+		if p.orgID != nil {
+			c.Locals("organization_id", *p.orgID)
+		}
+		if p.userID != nil {
+			c.Locals("user_id", *p.userID)
+		}
+		return c.Next()
+	})
+	group.Post("/verifications/:id/result", handler.SubmitVerificationResult)
+	group.Post("/verifications/:id/execution-status", handler.UpdateExecutionStatus)
+	return app
+}
+
+func newHandlerFor(svc VerificationEventServicerForVerification, orgRepo OrganizationRepositoryer) *VerificationHandler {
+	return NewVerificationHandlerWithInterfaces(
+		&MockAgentServiceForVerificationImpl{},
+		&MockAuditServiceForVerificationImpl{},
+		&MockAlertServiceForVerificationImpl{},
+		svc,
+		orgRepo,
+	)
+}
+
+// pendingEvent is the state the whole defect turns on: a strict-mode JIT request
+// that CreateVerification wrote with Result nil (verification_handler.go:457-469)
+// and that the SDK is polling, reading "pending".
+func pendingEvent(agentID, orgID uuid.UUID) *domain.VerificationEvent {
+	return &domain.VerificationEvent{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		AgentID:        &agentID,
+		Status:         domain.VerificationEventStatusPending,
+		Result:         nil,
+		CreatedAt:      time.Now().Add(-time.Minute),
+	}
+}
+
+func postJSON(t *testing.T, app *fiber.App, path string, body map[string]interface{}) (*fiber.Ctx, int, map[string]interface{}) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest("POST", path, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	var decoded map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	return nil, resp.StatusCode, decoded
+}
+
+// ---------------------------------------------------------------------------
+// R1: the test that matters
+// ---------------------------------------------------------------------------
+
+// TestSubmitVerificationResult_OwningAgentCannotApprovePendingEvent is CISO R1's
+// acceptance test. The caller here is not an attacker who stole anything: it has
+// passed the group's Ed25519 signature check, the ±30s window and the revocation
+// gate, and it is the agent the event actually belongs to. It must still be
+// unable to turn its own pending authorization request into an approval.
+//
+// RED-PROOF: on pre-fix code this fails on both assertions — the handler returned
+// 200 {"status":"result_recorded"} and called UpdateVerificationResult, which
+// sets result='verified', status='success', which the SDK reads back as
+// status:"approved", approvedBy:"system" and executes on.
+func TestSubmitVerificationResult_OwningAgentCannotApprovePendingEvent(t *testing.T) {
+	agentID, orgID := uuid.New(), uuid.New()
+	event := pendingEvent(agentID, orgID)
+
+	spy := &writeSpy{}
+	handler := newHandlerFor(spy.service(event), &MockOrganizationRepositoryerImpl{})
+	app := sdkWriteApp(handler, agentPrincipal("owning agent", agentID, orgID))
+
+	_, status, body := postJSON(t, app,
+		fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", event.ID),
+		map[string]interface{}{"result": "success", "reason": "done"})
+
+	assert.Equal(t, fiber.StatusForbidden, status,
+		"a correctly-authenticated OWNING agent must still be refused; authentication is not the control here")
+	assert.Equal(t, "executionOutcomeNotAccepted", body["code"],
+		"the refusal must be machine-readable and distinct from the group's auth failure, so a degraded SDK is visibly degraded")
+
+	// The load-bearing assertion. A 403 with a completed write would pass a
+	// status-code-only test and still be the live bypass.
+	assert.Zero(t, spy.updateResultCalls,
+		"the authorization-decision write must not be reached at all; R1 is satisfied by construction, not by a guard")
+	assert.Nil(t, event.Result, "the pending event must remain pending")
+}
+
+// TestSubmitVerificationResult_RefusesEveryPrincipal pins that the refusal is not
+// scoped to agents. Keeping the route open for JWT callers would re-create the
+// cross-tenant write the ledger already recorded (the second mount at
+// main.go:2101), now with an ownership test passing beside it.
+func TestSubmitVerificationResult_RefusesEveryPrincipal(t *testing.T) {
+	agentID, orgID := uuid.New(), uuid.New()
+	event := pendingEvent(agentID, orgID)
+
+	for _, p := range []principal{
+		agentPrincipal("owning agent", agentID, orgID),
+		agentPrincipal("other agent, same org", uuid.New(), orgID),
+		agentPrincipal("other agent, other org", uuid.New(), uuid.New()),
+		jwtPrincipal("jwt user, same org", orgID),
+		jwtPrincipal("jwt user, other org", uuid.New()),
+		anonymousPrincipal(),
+	} {
+		t.Run(p.name, func(t *testing.T) {
+			spy := &writeSpy{}
+			handler := newHandlerFor(spy.service(event), &MockOrganizationRepositoryerImpl{})
+			app := sdkWriteApp(handler, p)
+
+			_, status, _ := postJSON(t, app,
+				fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", event.ID),
+				map[string]interface{}{"result": "success"})
+
+			assert.Equal(t, fiber.StatusForbidden, status)
+			assert.Zero(t, spy.updateResultCalls, "no principal may reach the decision write")
+		})
+	}
+}
+
+// TestSubmitVerificationResult_RefusesBeforeAnyLookup pins that the handler is
+// terminal rather than merely guarded: it must not read the store even to decide
+// whom to refuse, so the route cannot be used as an existence oracle for a
+// guessed UUID.
+func TestSubmitVerificationResult_RefusesBeforeAnyLookup(t *testing.T) {
+	reads := 0
+	svc := &MockVerificationEventServiceForVerificationImpl{
+		GetVerificationEventFunc: func(ctx context.Context, id uuid.UUID) (*domain.VerificationEvent, error) {
+			reads++
+			return nil, fmt.Errorf("must not be called")
+		},
+	}
+	handler := newHandlerFor(svc, &MockOrganizationRepositoryerImpl{})
+	app := sdkWriteApp(handler, agentPrincipal("owning agent", uuid.New(), uuid.New()))
+
+	// A malformed ID would previously have produced a distinguishable 400.
+	for _, id := range []string{uuid.New().String(), "not-a-uuid", ""} {
+		_, status, _ := postJSON(t, app,
+			fmt.Sprintf("/api/v1/sdk-api/verifications/%s/result", id),
+			map[string]interface{}{"result": "success"})
+		if id == "" {
+			continue // routes to a different path; nothing to assert
+		}
+		assert.Equal(t, fiber.StatusForbidden, status,
+			"every id shape gets the same refusal, so the response carries no information about the row")
+	}
+	assert.Zero(t, reads, "the withdrawn endpoint must perform no lookup")
+}
+
+// ---------------------------------------------------------------------------
+// /execution-status: ownership, and the JWT fall-through
+// ---------------------------------------------------------------------------
+
+// TestUpdateExecutionStatus_OwningAgentSucceeds is the POSITIVE control. Without
+// it the negative tests below could all pass because the route is broken for
+// everyone, which would be a different defect wearing this fix's clothes.
+func TestUpdateExecutionStatus_OwningAgentSucceeds(t *testing.T) {
+	agentID, orgID := uuid.New(), uuid.New()
+	event := pendingEvent(agentID, orgID)
+
+	spy := &writeSpy{}
+	handler := newHandlerFor(spy.service(event), &MockOrganizationRepositoryerImpl{})
+	app := sdkWriteApp(handler, agentPrincipal("owning agent", agentID, orgID))
+
+	_, status, body := postJSON(t, app,
+		fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", event.ID),
+		map[string]interface{}{"executed": true, "executedAt": time.Now().Format(time.RFC3339)})
+
+	require.Equal(t, fiber.StatusOK, status, "the owning agent must still be able to report execution")
+	assert.Equal(t, "execution_status_recorded", body["status"])
+	assert.Equal(t, 1, spy.updateExecCalls)
+	assert.True(t, spy.lastExecExecuted)
+}
+
+// TestUpdateExecutionStatus_RejectsNonOwners covers the cases the group move
+// alone does NOT close. The JWT rows are the important ones: the group's
+// Ed25519 middleware hands off to the JWT middleware whenever an Authorization
+// header is present, so after the move a human user of any organization reaches
+// this handler with no agent_id at all. An ownership check written as
+// `if id, ok := ...; ok && id != owner { reject }` — the idiom at
+// trust_score_handler.go:415 — never fires for them and converts an
+// unauthenticated forgery into an authenticated cross-tenant one.
+//
+// RED-PROOF: every row fails on pre-fix code, which returned 200 and wrote.
+func TestUpdateExecutionStatus_RejectsNonOwners(t *testing.T) {
+	agentID, orgID := uuid.New(), uuid.New()
+
+	for _, tc := range []struct {
+		p     principal
+		event *domain.VerificationEvent
+	}{
+		{agentPrincipal("other agent, same org", uuid.New(), orgID), pendingEvent(agentID, orgID)},
+		{agentPrincipal("other agent, other org", uuid.New(), uuid.New()), pendingEvent(agentID, orgID)},
+		{jwtPrincipal("jwt user, same org as event", orgID), pendingEvent(agentID, orgID)},
+		{jwtPrincipal("jwt user, unrelated org", uuid.New()), pendingEvent(agentID, orgID)},
+		{anonymousPrincipal(), pendingEvent(agentID, orgID)},
+	} {
+		t.Run(tc.p.name, func(t *testing.T) {
+			spy := &writeSpy{}
+			handler := newHandlerFor(spy.service(tc.event), &MockOrganizationRepositoryerImpl{})
+			app := sdkWriteApp(handler, tc.p)
+
+			_, status, body := postJSON(t, app,
+				fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", tc.event.ID),
+				map[string]interface{}{"executed": false})
+
+			assert.Equal(t, fiber.StatusNotFound, status,
+				"404 not 403: the response must not distinguish 'exists but not yours' from 'does not exist'")
+			assert.Equal(t, "not found", body["error"],
+				"the body must be identical to a genuine miss, or it is an existence oracle")
+			assert.Zero(t, spy.updateExecCalls, "a non-owner must not reach the write")
+		})
+	}
+}
+
+// TestUpdateExecutionStatus_EventWithNoAgentIsNotOwnable: a verification event
+// may target an MCP server instead of an agent, leaving AgentID nil. A nil owner
+// must be refused, never treated as a wildcard that any caller matches.
+func TestUpdateExecutionStatus_EventWithNoAgentIsNotOwnable(t *testing.T) {
+	orgID := uuid.New()
+	event := pendingEvent(uuid.New(), orgID)
+	event.AgentID = nil
+
+	spy := &writeSpy{}
+	handler := newHandlerFor(spy.service(event), &MockOrganizationRepositoryerImpl{})
+	app := sdkWriteApp(handler, agentPrincipal("some agent", uuid.New(), orgID))
+
+	_, status, _ := postJSON(t, app,
+		fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", event.ID),
+		map[string]interface{}{"executed": true})
+
+	assert.Equal(t, fiber.StatusNotFound, status)
+	assert.Zero(t, spy.updateExecCalls)
+}
+
+// TestUpdateExecutionStatus_UnknownEventDoesNotDistinguish pins that a genuine
+// miss and a cross-agent hit produce byte-identical responses.
+func TestUpdateExecutionStatus_UnknownEventDoesNotDistinguish(t *testing.T) {
+	agentID, orgID := uuid.New(), uuid.New()
+	realEvent := pendingEvent(agentID, orgID)
+
+	spy := &writeSpy{}
+	handler := newHandlerFor(spy.service(realEvent), &MockOrganizationRepositoryerImpl{})
+
+	// Same caller, two ids: one that exists but belongs to another agent, one
+	// that does not exist at all.
+	app := sdkWriteApp(handler, agentPrincipal("stranger", uuid.New(), orgID))
+
+	_, statusExisting, bodyExisting := postJSON(t, app,
+		fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", realEvent.ID),
+		map[string]interface{}{"executed": true})
+	_, statusMissing, bodyMissing := postJSON(t, app,
+		fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", uuid.New()),
+		map[string]interface{}{"executed": true})
+
+	assert.Equal(t, statusMissing, statusExisting)
+	assert.Equal(t, bodyMissing, bodyExisting,
+		"an attacker must not be able to tell a real other-agent event from a guess")
+	assert.Zero(t, spy.updateExecCalls)
+}
+
+// ---------------------------------------------------------------------------
+// strict_mode is ours, not the agent's
+// ---------------------------------------------------------------------------
+
+// TestUpdateExecutionStatus_StrictModeIsServerDerived is the D-B half. The alert
+// detail panel renders "Action BLOCKED (strict mode enforced)" from executed +
+// strictMode. While strictMode came off the request body, the agent being
+// audited could assert what OUR enforcement configuration was.
+//
+// RED-PROOF: the monitoring case fails on pre-fix code, which stored the
+// body-supplied true.
+func TestUpdateExecutionStatus_StrictModeIsServerDerived(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		orgMode  domain.EnforcementMode
+		bodySays bool
+		want     bool
+	}{
+		{"monitoring org cannot be made to look strict", domain.EnforcementModeMonitoring, true, false},
+		{"strict org is recorded strict even if the agent denies it", domain.EnforcementModeStrict, false, true},
+		{"agreement is still server-sourced", domain.EnforcementModeStrict, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID, orgID := uuid.New(), uuid.New()
+			event := pendingEvent(agentID, orgID)
+
+			spy := &writeSpy{}
+			orgRepo := &MockOrganizationRepositoryerImpl{
+				GetByIDFunc: func(id uuid.UUID) (*domain.Organization, error) {
+					return &domain.Organization{ID: id, EnforcementMode: tc.orgMode}, nil
+				},
+			}
+			handler := newHandlerFor(spy.service(event), orgRepo)
+			app := sdkWriteApp(handler, agentPrincipal("owning agent", agentID, orgID))
+
+			_, status, body := postJSON(t, app,
+				fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", event.ID),
+				map[string]interface{}{"executed": false, "strictMode": tc.bodySays})
+
+			require.Equal(t, fiber.StatusOK, status)
+			assert.Equal(t, tc.want, spy.lastExecStrictMode,
+				"strict_mode stored must come from the organization, not the request body")
+			assert.Equal(t, tc.want, body["strictMode"],
+				"the echoed value must be the server-derived one, or a caller learns its input was ignored only from the database")
+		})
+	}
+}
+
+// TestUpdateExecutionStatus_UnknownEnforcementModeRecordsNothing pins the
+// unknown case. strict_mode is persisted and later rendered to an operator as a
+// statement about OUR configuration, so when the organization cannot be read the
+// handler must decline to write rather than pick a label. Defaulting to false
+// would print "enforcement mode: monitoring" for what may have been a strict
+// organization — a smaller false claim, but the same kind this change removes.
+func TestUpdateExecutionStatus_UnknownEnforcementModeRecordsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		orgRepo OrganizationRepositoryer
+	}{
+		{"lookup errors", &MockOrganizationRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Organization, error) {
+				return nil, fmt.Errorf("connection reset")
+			},
+		}},
+		{"organization missing", &MockOrganizationRepositoryerImpl{
+			GetByIDFunc: func(id uuid.UUID) (*domain.Organization, error) {
+				return nil, nil
+			},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID, orgID := uuid.New(), uuid.New()
+			event := pendingEvent(agentID, orgID)
+
+			spy := &writeSpy{}
+			handler := newHandlerFor(spy.service(event), tc.orgRepo)
+			app := sdkWriteApp(handler, agentPrincipal("owning agent", agentID, orgID))
+
+			_, status, body := postJSON(t, app,
+				fmt.Sprintf("/api/v1/sdk-api/verifications/%s/execution-status", event.ID),
+				map[string]interface{}{"executed": false})
+
+			assert.Equal(t, fiber.StatusServiceUnavailable, status,
+				"an unknown enforcement mode must not be coerced into a persisted label")
+			assert.Equal(t, "enforcementModeUnavailable", body["code"])
+			assert.Zero(t, spy.updateExecCalls,
+				"nothing may be written when the mode cannot be established")
+		})
+	}
+}
+
+// TestUpdateExecutionStatusRequest_HasNoStrictModeField stops the field being
+// quietly reintroduced. Deleting the assignment is reversible in one line; a
+// struct with no such field makes the reintroduction a compile-visible change.
+func TestUpdateExecutionStatusRequest_HasNoStrictModeField(t *testing.T) {
+	typ := reflect.TypeOf(UpdateExecutionStatusRequest{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		// Normalise away the spellings a reintroduction could hide behind:
+		// StrictMode, strictMode, strict_mode, strict-mode all collapse to the
+		// same token. Checking only "strictmode" would miss `json:"strict_mode"`.
+		norm := func(s string) string {
+			s = strings.ToLower(s)
+			for _, sep := range []string{"_", "-", " "} {
+				s = strings.ReplaceAll(s, sep, "")
+			}
+			return s
+		}
+		tagName, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		assert.NotContains(t, norm(f.Name), "strictmode",
+			"strict mode must be server-derived; it must not be bindable from the request body")
+		assert.NotContains(t, norm(tagName), "strictmode",
+			"no json tag may bind strict mode from the request body (any spelling)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Class guards — these outlive the two handlers
+// ---------------------------------------------------------------------------
+
+// TestUpdateVerificationResultHasOnlyPermittedCallSites is the class guard. The
+// point of Stage 1 is not that these two handlers were fixed; it is that
+// result/status have a closed set of writers. This fails if any handler in the
+// file re-opens the authorization-decision write, including a new one nobody
+// thought to review.
+//
+// Permitted writers:
+// the lazy-expiry path, ApproveVerification, DenyVerification. Deliberately
+// enumerated by ENCLOSING FUNCTION rather than by line number, so the guard
+// survives edits above it and names what it is protecting.
+//
+// KNOWN LIMITS of this guard, stated so nobody mistakes it for the whole class:
+// it parses verification_handler.go only, and matches the selector name
+// UpdateVerificationResult. It does NOT see a direct call to the repository's
+// UpdateResult, a writer added in a different handler file, the raw-SQL expiry
+// job in cmd/server/main.go, or any INSERT path. In particular
+// VerificationEventHandler.CreateVerificationEvent inserts a row with a
+// caller-chosen status and result for a caller-supplied agentId — a fifth
+// writer of these columns that this guard cannot reach. It is pre-existing and
+// recorded in the roadmap rather than fixed here; do not read a green run of
+// this test as "result/status have exactly three writers".
+func TestUpdateVerificationResultHasOnlyPermittedCallSites(t *testing.T) {
+	permitted := map[string]bool{
+		"writeVerificationResponse": true, // lazy expiry of an elapsed event
+		"ApproveVerification":       true, // the human approval path
+		"DenyVerification":          true, // the human denial path
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	target := filepath.Join(filepath.Dir(thisFile), "verification_handler.go")
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, 0)
+	require.NoError(t, err, "parse verification_handler.go")
+
+	var offenders []string
+	for _, decl := range file.Decls {
+		fn, isFn := decl.(*ast.FuncDecl)
+		if !isFn {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			call, isCall := n.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			sel, isSel := call.Fun.(*ast.SelectorExpr)
+			if !isSel || sel.Sel.Name != "UpdateVerificationResult" {
+				return true
+			}
+			if !permitted[fn.Name.Name] {
+				offenders = append(offenders, fmt.Sprintf("%s (%s)",
+					fn.Name.Name, fset.Position(call.Pos())))
+			}
+			return true
+		})
+	}
+
+	assert.Empty(t, offenders,
+		"result/status are the authorization-decision channel. Only the approval, denial and "+
+			"expiry paths may write them. A new writer here is the Stage 1 defect reopening: an "+
+			"agent-reported outcome reaching UpdateVerificationResult sets result='verified', which "+
+			"the SDK reads back as approved. If a new writer is genuinely correct, change this "+
+			"guard deliberately and say why in the commit that does it.")
+}
+
+// TestSDKWriteRoutesAreNotRegisteredOnBareApp guards the wiring from inside the
+// handlers package as well as from cmd/server, because the two failure modes are
+// different: cmd/server's guard dies if main.go is restructured, this one dies
+// if the file moves. Fiber matches in registration order, so a bare app.Post
+// registered above the group keeps winning and an "add to the group" change that
+// forgets the delete is a no-op that reviews as done.
+func TestSDKWriteRoutesAreNotRegisteredOnBareApp(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	mainPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..",
+		"cmd", "server", "main.go")
+	src, err := os.ReadFile(filepath.Clean(mainPath))
+	require.NoError(t, err, "locate cmd/server/main.go")
+
+	// Only executable lines count. A comment naming a removed registration — and
+	// main.go now carries one, explaining why the JWT mount was deleted — is
+	// documentation, not a route. Matching it would make the guard fire on its
+	// own explanation and push the next person to delete the explanation.
+	var code []string
+	for _, line := range strings.Split(string(src), "\n") {
+		if trimmed := strings.TrimSpace(line); !strings.HasPrefix(trimmed, "//") {
+			code = append(code, line)
+		}
+	}
+	executable := strings.Join(code, "\n")
+
+	for _, forbidden := range []string{
+		`app.Post("/api/v1/sdk-api/verifications/:id/result"`,
+		`app.Post("/api/v1/sdk-api/verifications/:id/execution-status"`,
+		`verifications.Post("/:id/result"`,
+	} {
+		assert.NotContains(t, executable, forbidden,
+			"route registration %s must not exist: the bare app mount bypasses the sdkAPI group's "+
+				"authentication entirely, and the JWT mount had no ownership check", forbidden)
+	}
+	for _, required := range []string{
+		`sdkAPI.Post("/verifications/:id/result"`,
+		`sdkAPI.Post("/verifications/:id/execution-status"`,
+	} {
+		assert.Contains(t, executable, required,
+			"route %s must be registered on the authenticated sdkAPI group", required)
+	}
+}

--- a/apps/backend/tests/integration/verification_test.go
+++ b/apps/backend/tests/integration/verification_test.go
@@ -45,7 +45,21 @@ func TestGetVerificationInvalidUUID(t *testing.T) {
 	assert.True(t, resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized)
 }
 
-// TestSubmitVerificationResultUnauthorized verifies POST result requires authentication
+// TestSubmitVerificationResultUnauthorized was named "verifies POST result
+// requires authentication" and targeted /api/v1/verifications/:id/result — the
+// JWT-group mount. The route that was actually serving unauthenticated writes
+// was /api/v1/SDK-API/verifications/:id/result, three lines away in main.go and
+// never covered here. Anyone searching "is this route authed?" found a green
+// test with the right name exercising a different route.
+//
+// It now targets the sdk-api route, which is the one that mattered. The JWT
+// mount no longer exists at all.
+//
+// DURABILITY CAVEAT: apps/backend/tests/ is rsync --delete mirrored from the
+// public repo by scripts/sync-to-cloud.sh, so this correction is reverted by the
+// next sync. The durable fix belongs in the public tree, which is frozen pending
+// Abdel's disclosure decision. Recorded in the roadmap unit as not-done rather
+// than left to look done.
 func TestSubmitVerificationResultUnauthorized(t *testing.T) {
 	ensureAIMBackendRunning(t) // Skip if AIM backend not running
 	baseURL := getBaseURL()
@@ -57,11 +71,43 @@ func TestSubmitVerificationResultUnauthorized(t *testing.T) {
 	}
 
 	body, _ := json.Marshal(resultData)
-	resp, err := http.Post(baseURL+"/api/v1/verifications/"+verificationID+"/result", "application/json", bytes.NewBuffer(body))
+	resp, err := http.Post(baseURL+"/api/v1/sdk-api/verifications/"+verificationID+"/result", "application/json", bytes.NewBuffer(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "Should return 401 without auth token")
+	// 401 from the sdkAPI group middleware. Explicitly NOT 404: a 404 here would
+	// mean the handler ran and the UPDATE executed with no credentials, which is
+	// exactly what this endpoint did before the fix.
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"unauthenticated POST to the sdk-api result route must be rejected by the group middleware; "+
+			"404 would mean the handler ran and the write executed")
+}
+
+// TestSubmitVerificationResultNeverReportsSuccess sends NO credentials, and is
+// named for what it actually asserts rather than for what would be nice to
+// assert. The stronger property — that a correctly-signed request from the
+// OWNING agent is also refused — needs a registered agent and a private key,
+// which this suite has no fixture for; it is covered instead by
+// TestSubmitVerificationResult_OwningAgentCannotApprovePendingEvent in the
+// handlers package, red-proofed against pre-fix code.
+//
+// Naming a test for a stronger property than it tests is the specific failure
+// this file already committed once: TestSubmitVerificationResultUnauthorized
+// was named for this defect and pointed at a different route for months.
+func TestSubmitVerificationResultNeverReportsSuccess(t *testing.T) {
+	ensureAIMBackendRunning(t) // Skip if AIM backend not running
+	baseURL := getBaseURL()
+
+	verificationID := "00000000-0000-0000-0000-000000000000"
+	body, _ := json.Marshal(map[string]interface{}{"result": "success"})
+	resp, err := http.Post(baseURL+"/api/v1/sdk-api/verifications/"+verificationID+"/result", "application/json", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"the result endpoint is withdrawn; a 200 on any path means the decision channel is writable again")
+	assert.NotEqual(t, http.StatusNotFound, resp.StatusCode,
+		"404 was the pre-fix signature of the handler running and the UPDATE affecting zero rows")
 }
 
 // TestSubmitVerificationResultInvalidData verifies validation on result submission

--- a/apps/web/components/alerts/alert-detail-panel.tsx
+++ b/apps/web/components/alerts/alert-detail-panel.tsx
@@ -519,36 +519,53 @@ export function AlertDetailPanel({
                           </p>
                         )}
 
-                        {/* Execution Status - Shows what actually happened after verification */}
+                        {/*
+                          Execution status: what the AGENT SAID happened after verification.
+
+                          These fields (executed, strictMode, executedAt, executionError)
+                          have exactly one writer in the backend — the agent's own SDK, via
+                          POST /sdk-api/verifications/:id/execution-status. AIM holds no
+                          independent record of whether the action ran, so this block must
+                          be attributed to its source and must never assert that AIM
+                          enforced anything.
+
+                          It previously rendered "Action BLOCKED (strict mode enforced)",
+                          which read as a claim about our control while being derived
+                          entirely from the self-report of the party being audited. strictMode
+                          is now server-derived from the organization's enforcement mode, so
+                          the mode shown here is ours; `executed` is still the agent's word.
+                          Labelling these columns by provenance belongs to the
+                          execution-outcome follow-up.
+                        */}
                         {event.executed !== undefined && (
                           <div className={`mt-2 p-2 rounded text-xs ${
                             event.executed
-                              ? event.strictMode
-                                ? "bg-green-50 border border-green-200 text-green-700"
-                                : isDenied
-                                  ? "bg-yellow-50 border border-yellow-200 text-yellow-700"
-                                  : "bg-green-50 border border-green-200 text-green-700"
-                              : "bg-red-50 border border-red-200 text-red-700"
+                              ? isDenied
+                                ? "bg-yellow-50 border border-yellow-200 text-yellow-700"
+                                : "bg-green-50 border border-green-200 text-green-700"
+                              : "bg-gray-50 border border-gray-200 text-gray-700"
                           }`}>
                             <span className="font-medium">
                               {event.executed ? (
-                                event.strictMode ? (
-                                  "✓ Action executed (strict mode)"
-                                ) : isDenied ? (
-                                  "⚠ Action executed despite denial (monitoring mode)"
+                                isDenied ? (
+                                  "Agent reported: action executed despite denial"
                                 ) : (
-                                  "✓ Action executed successfully"
+                                  "Agent reported: action executed"
                                 )
                               ) : (
-                                event.strictMode ? (
-                                  "✗ Action BLOCKED (strict mode enforced)"
-                                ) : (
-                                  "✗ Action not executed"
-                                )
+                                "Agent reported: action not executed"
                               )}
                             </span>
+                            <p className="mt-1 text-gray-500">
+                              Self-reported by the agent. AIM does not independently observe
+                              execution, so this is not a record of enforcement.
+                              {event.strictMode !== undefined && (
+                                <> Organization enforcement mode at report time:{" "}
+                                  {event.strictMode ? "strict" : "monitoring"}.</>
+                              )}
+                            </p>
                             {event.executionError && (
-                              <p className="mt-1 text-red-600">Error: {event.executionError}</p>
+                              <p className="mt-1 text-red-600">Reported error: {event.executionError}</p>
                             )}
                           </div>
                         )}

--- a/apps/web/lib/api-documentation.ts
+++ b/apps/web/lib/api-documentation.ts
@@ -3378,53 +3378,6 @@ export const apiDocumentation: EndpointCategory[] = [
         },
         example: "No request body required",
       },
-      {
-        method: "POST",
-        path: "/api/v1/verifications/:id/result",
-        description: "Submit verification result (approve or reject). Called by authorized users to approve/reject agent action verification requests.",
-        summary: "Submit verification result",
-        auth: "Bearer Token (JWT)",
-        requiresAuth: true,
-        roleRequired: "manager",
-        tags: ["verifications", "security"],
-        requestSchema: {
-          type: "object",
-          properties: {
-            status: {
-              type: "string",
-              description: "Verification result: 'approved' or 'rejected'",
-              required: true,
-            },
-            comments: {
-              type: "string",
-              description: "Optional comments about the decision",
-              required: false,
-            },
-            conditions: {
-              type: "array",
-              description: "Optional conditions for approval (e.g., time windows, monitoring requirements)",
-              required: false,
-            },
-          },
-        },
-        responseSchema: {
-          type: "object",
-          properties: {
-            verification_id: { type: "string", description: "Verification ID" },
-            status: { type: "string", description: "Updated status" },
-            reviewed_at: { type: "string", description: "Review timestamp" },
-            reviewed_by: { type: "string", description: "Reviewer user ID" },
-          },
-        },
-        example: `{
-  "status": "approved",
-  "comments": "Approved with monitoring",
-  "conditions": [
-    "rollback_plan_required",
-    "monitoring_enabled"
-  ]
-}`,
-      },
     ],
   },
 ];


### PR DESCRIPTION
Two `POST` routes under `/api/v1/sdk-api/verifications/` were registered on the bare app, above the
`sdkAPI` group, with a rate limiter as their only middleware. A rate limiter authenticates nothing,
and the global chain ahead of them is recovery / security headers / logger / Prometheus / analytics
/ CORS. Neither handler read `c.Locals` at all, so both served **unauthenticated writes**.

`:id/result` is the worse half. It routed to `UpdateResult`, whose SQL is keyed `WHERE id = $5` with
no organization, no agent and no state precondition, and which derives `status` from `result`
internally. So `{"result":"success"}` set `result='verified'`, which `writeVerificationResponse`
projects to the SDK as `status:"approved"`, `approvedBy:"system"` — which the SDK accepts as
approval and executes on. `CreateVerification` hands the verification ID to the agent whose action
is pending, so this is **self-approval**, not a lateral attack. The same row feeds three trust
factors totalling 55% of the weight, and a flipped event leaves the human approval queue rather
than appearing in it as approved.

## What changed

- **Both POSTs move onto the `sdkAPI` group**, which supplies a body-bound canonical message, a
  ±30s window and revocation enforcement. The bare registrations are **deleted, not duplicated**:
  Fiber matches in registration order, so leaving them would have kept the unauthenticated path
  winning while the diff read as done.
- **Handler-level agent ownership**, because the group authenticates *an* agent and also falls
  through to JWT for human callers, who arrive with no `agent_id` at all. A missing or non-UUID
  `agent_id` is a rejection, never a reason to skip the check. Every failure path returns **404,
  never 403**, so "not yours" is indistinguishable from "does not exist".
- `/result` is **withheld entirely** — 403 for every caller — pending the redesign that separates
  the execution outcome from the authorization decision. The endpoint's problem is not only who may
  call it but that reporting a result should never have written the decision.
- Append-once enforcement on the execution report at the repository layer.
- `routes_gate_test.go` now requires every app-level `sdk-api/verifications` registration to be
  listed with the control that justifies it, and asserts the group's middleware is registered
  before the routes it guards. That is the recurrence guard: the defect was a registration-order
  property, so the test asserts registration order.
- The misnamed integration test is retargeted. `TestSubmitVerificationResultUnauthorized` claimed
  to verify "POST result requires authentication" but exercised the JWT-group mount three lines
  away, so anyone asking "is this route authed?" found a green test with the right name testing a
  different route.
- `api-documentation.ts` drops the `/verifications/:id/result` entry, which advertised a
  `roleRequired: "manager"` contract the handler never implemented.

## Hosted product

Not affected. The equivalent fix shipped to the hosted product on 2026-08-10 and production returns
`401` for an unauthenticated call to this route; verified again immediately before opening this PR.

## Verification

`go build ./...` and `go vet ./...` clean. 26 of the backend test packages pass.

`apps/backend/tests/integration` fails **identically on `main` and on this branch** —
`403 Member access required (viewers cannot perform this action)` on the `TestAgentCreation` group —
which reproduces from accumulated state in a long-lived local Postgres, not from this change. CI
boots a clean Postgres service and is the arbiter for that package.