### PR TITLE
Raise the js-yaml floor to the patched version, and unstale the lockfile

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opena2a/aim-sdk",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/atx-verify": "0.3.0",
         "fastify-plugin": "^6.0.0",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.3.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -3461,9 +3461,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -79,7 +79,7 @@
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/atx-verify": "0.3.0",
     "fastify-plugin": "^6.0.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.3.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## What

`sdk/typescript` declared `js-yaml: ^4.1.1` with the lockfile resolving **4.3.0**. 4.3.0 is
affected by [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (HIGH,
CVE-2026-59870) — quadratic CPU consumption in `!!omap` resolution. The first patched 4.x is
**4.3.1**.

Two lines of substance: the floor moves to `^4.3.1`, and the lockfile is regenerated. Nothing
else moved — the lock diff is 12 lines, all js-yaml or the package's own version field.

## How it surfaced

Not from a scheduled audit. aim-cloud already carried `^4.3.1` with 4.3.1 locked, so the sync
from this repo into cloud proposed a **downgrade of the hosted product onto the vulnerable
version**. aim-cloud's Trivy scan caught it on the regenerated sync PR:

```
js-yaml | GHSA-5p4m-2wfm-xmqj | HIGH | fixed | 4.3.0 | 4.3.1, 3.15.1
```

The direction of travel was public → cloud, and public was the weaker of the two. Pinning the
file on cloud's side would have silenced the symptom and manufactured permanent drift; raising
the floor here converges both trees on the patched version and leaves nothing to protect.

## Measured effect

| tree | before | after |
|---|---|---|
| production deps (what consumers install) | **1 HIGH — js-yaml** | **0** |
| all deps incl. dev | 14 HIGH / 1 CRITICAL | 13 HIGH / 1 CRITICAL |

`npm audit` reports js-yaml vulnerable over `4.0.0 - 4.3.0`; it is flagged on the base commit
and absent on this one, with no other package's status changing.

Scope note on consumer exposure: a fresh `npm install @opena2a/aim-sdk` resolved `^4.1.1` to
4.3.1 already, so published-package consumers were most likely never exposed. The exposure was
to anything installing from **this lockfile** — this repo's CI, and aim-cloud's build once the
sync landed.

## Verification

- `npm ci` installs js-yaml 4.3.1; lockfile integrity hash matches the npm registry's published
  hash for 4.3.1 exactly; canonical registry tarball; unchanged maintainer.
- `tsc --noEmit` clean, `npm run build` clean, **1026 tests pass / 36 skipped / 0 fail**.
- `dist/index.js` loads with 102 exports; YAML parsing works on 4.3.1.
- Honest negative: I wrote a direct `!!omap` timing probe to reproduce the DoS and it **did not
  reproduce** — 4.3.0 and 4.3.1 timed the same, so the fixture never reached the vulnerable
  branch. It is recorded as a non-reproduction and contributes no evidence. The basis for this
  change is the advisory plus two independent scanners (npm audit, Trivy), not that probe.

## Not fixed here, deliberately

13 HIGH + 1 CRITICAL remain in **devDependencies** (typescript-eslint chain, vitest/vite,
postcss, minimatch, brace-expansion, nanoid, fastify/find-my-way/fast-uri). All pre-existing,
none reaching the published package — the production tree is clean. Bundling unrelated
dependency bumps into a security fix is how a release stops ending; these belong in their own
reviewed change.

## Merge posture

**Auto-merge deliberately not armed.** The CISO charter requires human review on every
dependency bump, no auto-merge. Flagging for review rather than landing it.