### PR TITLE
Gate the SDK's shipped dependencies, and stop a green check that cannot fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,46 @@ jobs:
       - name: .sync-protect is honoured by every sync path
         run: ./scripts/test-sync-protect.sh
 
+  # A BLOCKING audit of the SDK's shipped dependency tree.
+  #
+  # Why this exists, and why it is separate from security.yml's "Dependency Audit":
+  # that job cannot fail. Both of its Trivy steps pass `exit-code: 0`, its npm audit
+  # ends in `|| true`, and it only looks at apps/web. It reported SUCCESS on every PR
+  # while sdk/typescript shipped js-yaml 4.3.0 (GHSA-5p4m-2wfm-xmqj, HIGH) — a green
+  # check that was structurally incapable of going red, over a directory it never read.
+  #
+  # The defect was eventually caught downstream, by aim-cloud's Trivy on a sync PR,
+  # which is the wrong place: by then the vulnerable floor was already being carried
+  # into the hosted product. This gate moves that catch to the source.
+  #
+  # Scope is deliberate and measured, not arbitrary:
+  #   --omit=dev      only dependencies that reach consumers of @opena2a/aim-sdk.
+  #                   Dev-only findings do not ship and must not be able to wedge an
+  #                   unrelated PR; they are tracked separately.
+  #   --package-lock-only
+  #                   installs nothing, so no dependency's install script executes on
+  #                   a fork's pull request.
+  #   sdk/typescript  measured clean (0 high, 0 critical) at 0b1f876. The repo ROOT
+  #                   tree is NOT gated here because it currently carries 4 prod highs
+  #                   (next, sharp, postcss, nanoid); adding it today would land a
+  #                   permanently-red gate, which teaches people to ignore it. Widen
+  #                   this to `.` once those are resolved — that is the intended end
+  #                   state, not a permanent exemption.
+  sdk-dependency-audit:
+    name: SDK dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: No high or critical advisories in the SDK's shipped dependencies
+        working-directory: sdk/typescript
+        run: |
+          set -uo pipefail
+          # No `|| true`, and no `exit-code: 0`. A finding here fails the gate.
+          npm audit --package-lock-only --omit=dev --audit-level=high
+
   # Detect which parts of the monorepo changed
   changes:
     name: Detect Changes
@@ -461,6 +501,7 @@ jobs:
         tenant-scoping-lint,
         workflow-lint,
         sync-protect-guard,
+        sdk-dependency-audit,
         changes,
         backend,
         integration,
@@ -477,17 +518,18 @@ jobs:
           tl='${{ needs.tenant-scoping-lint.result }}'
           wl='${{ needs.workflow-lint.result }}'
           sp='${{ needs.sync-protect-guard.result }}'
+          sa='${{ needs.sdk-dependency-audit.result }}'
           ch='${{ needs.changes.result }}'
           be='${{ needs.backend.result }}'
           it='${{ needs.integration.result }}'
           ax='${{ needs.atx-conformance.result }}'
           fe='${{ needs.frontend.result }}'
           ee='${{ needs.e2e-empty-state.result }}'
-          echo "secrets-lint=$sl tenant-scoping-lint=$tl workflow-lint=$wl sync-protect-guard=$sp changes=$ch"
+          echo "secrets-lint=$sl tenant-scoping-lint=$tl workflow-lint=$wl sync-protect-guard=$sp sdk-dependency-audit=$sa changes=$ch"
           echo "backend=$be integration=$it atx-conformance=$ax frontend=$fe e2e-empty-state=$ee"
           fail=0
           # Unconditional jobs must succeed outright.
-          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "workflow-lint:$wl" "sync-protect-guard:$sp" "changes:$ch"; do
+          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "workflow-lint:$wl" "sync-protect-guard:$sp" "sdk-dependency-audit:$sa" "changes:$ch"; do
             if [ "${pair#*:}" != "success" ]; then
               echo "::error::${pair%%:*} did not succeed (${pair#*:}); failing closed."
               fail=1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,6 +92,23 @@ jobs:
         #                          deletion landed.
         run: npx hackmyagent@latest secure . --ci --scan-depth quick --static-only --fail-below 90
 
+  # ADVISORY ONLY — this job cannot fail, by construction. Both Trivy steps pass
+  # `exit-code: 0` and the npm audit ends in `|| true`, so a green "Dependency Audit"
+  # on a pull request means "the job ran", NOT "no advisories were found". Read the
+  # step logs; do not read the check mark.
+  #
+  # This is not hypothetical. It reported SUCCESS on every PR for the whole period in
+  # which sdk/typescript shipped js-yaml 4.3.0 (GHSA-5p4m-2wfm-xmqj, HIGH) — which it
+  # would not have caught in any case, because it only scans apps/web and never reads
+  # sdk/. The advisory was eventually found downstream by aim-cloud's Trivy on a sync
+  # pull request, after the vulnerable floor was already being carried into the hosted
+  # product.
+  #
+  # The BLOCKING counterpart is `sdk-dependency-audit` in ci.yml, wired into CI Gate.
+  # Leaving this job advisory is deliberate — making its steps blocking today would
+  # turn main red on 4 pre-existing production highs in the root tree (next, sharp,
+  # postcss, nanoid) plus dev-only findings in apps/web. Resolve those, then promote
+  # these steps rather than adding more advisory ones.
   dependency-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

`sdk/typescript` shipped `js-yaml` 4.3.0 — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)
(HIGH, CVE-2026-59870) — and no check in this repo objected. It was found **downstream**, by
aim-cloud's Trivy on a sync PR, after the vulnerable floor was already being carried toward the
hosted product. Fixed in #374; this is the control so the next one is caught here instead.

**The reason nothing objected is the more interesting half.** `security.yml`'s `Dependency Audit`
job *cannot fail*: both Trivy steps pass `exit-code: 0`, the npm audit ends in `|| true`, and it
scans `apps/web` only — it never reads `sdk/`. It reported SUCCESS on every PR throughout. A check
that is structurally incapable of going red is not a weaker check than one that can; it is an
absence of a check wearing a green tick.

## What

1. **New BLOCKING `sdk-dependency-audit` job** in `ci.yml`, wired into `CI Gate`'s `needs` and its
   unconditional-success loop:

   ```
   npm audit --package-lock-only --omit=dev --audit-level=high
   ```

   `--omit=dev` — only dependencies that reach consumers of `@opena2a/aim-sdk`; dev-only findings
   must not be able to wedge an unrelated PR. `--package-lock-only` — installs nothing, so no
   dependency's install script runs on a fork's PR.

2. **A comment on the advisory job** recording that its green means "the job ran", not "no
   advisories found", so the next reader does not trust the tick.

## Scope is measured, not guessed

`sdk/typescript` is clean today (0 high, 0 critical). The repo **root** tree is deliberately not
gated — it currently carries four production highs (`next`, `sharp`, `postcss`, `nanoid`), so
gating it today would land a permanently-red check, which is how a gate becomes something people
learn to ignore. Widening to `.` once those are resolved is the intended end state and is written
into the job's comment rather than left implicit.

Those four are reported separately; they are a dependency bump and therefore a human-review
decision, not something to smuggle into a CI change.

## Proven non-vacuous, both directions

Given this replaces a check that could not fail, "it's green" is not evidence:

| probe | result |
|---|---|
| gate command on the **pre-fix** lockfile (js-yaml 4.3.0) | **exit 1** — would have caught the real defect |
| gate command on the current tree | exit 0 |
| `CI Gate` simulated, job = `success` | pass |
| `CI Gate` simulated, job = `failure` / `skipped` / `cancelled` | **fail**, with a named error |
| `actionlint` on both workflows | clean |

The `skipped` case matters: a job that silently stops running fails the gate rather than vanishing
from it — the same failure mode this PR exists to close.