### PR TITLE
Correct the AAP spec version in the SDK, and stop dead-ending on the broker 404

### DIFF
--- a/sdk/python/aim_sdk/__init__.py
+++ b/sdk/python/aim_sdk/__init__.py
@@ -78,7 +78,7 @@ secure = register_agent
 from .exceptions import AIMError, AuthenticationError, VerificationError, ActionDeniedError, ConfigurationError, StaleCredentialsError
 from .secrets import SecretsClient, SecretsError
 # AAP grant client — PROVISIONAL (experimental). The Agent Authorization Protocol
-# is at spec v0.1; this surface (and the broker wire format it talks to) may change
+# is at spec 0.4.0-draft; this surface (and the broker wire format it talks to) may change
 # in a future minor release without a major bump. Opt-in only: existing behavior is
 # unchanged unless you pass `grant=` to @perform_action.
 from .grant_client import (

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -2661,7 +2661,7 @@ class AIMClient:
                    agent references the grant; the broker resolves it and returns only the
                    operation result. No credential or backend identifier enters the agent
                    process (Agent Authorization Protocol §4).
-                   PROVISIONAL / EXPERIMENTAL: AAP is at spec v0.1; this argument and the
+                   PROVISIONAL / EXPERIMENTAL: AAP is at spec 0.4.0-draft; this argument and the
                    broker wire format may change in a future minor release. Opt-in only —
                    omitting ``grant`` leaves behavior unchanged.
 

--- a/sdk/python/aim_sdk/grant_client.py
+++ b/sdk/python/aim_sdk/grant_client.py
@@ -79,17 +79,18 @@ class BrokerClient:
     def _health_probe(self) -> str:
         """A runnable /health command for whichever transport this client is using.
 
-        `-f` is load-bearing, not decoration: a bare `curl` prints the error body and
-        still exits 0, so a broker with no /health route hands the user a page of JSON
-        and a clean exit, which reads as success. With -f the command fails loudly
-        (exit 22) and stays quiet on the happy path.
+        Prints the status and nothing else. A bare `curl` exits 0 on an error and shows
+        only the body, so a broker with no /health route reads as success -- and `-f`
+        alone still exits 0 on a 3xx, which a redirecting proxy in front of the broker
+        would produce. Reporting the code sidesteps both.
 
         Only values this client already holds are interpolated -- never anything from
         the broker's response.
         """
+        wire = "-sS -o /dev/null -w '%{http_code}\\n'"
         if self.http_url:
-            return f"curl -fsS {self.http_url.rstrip('/')}/health"
-        return f"curl -fsS --unix-socket {self.socket_path} http://localhost/health"
+            return f"curl {wire} {self.http_url.rstrip('/')}/health"
+        return f"curl {wire} --unix-socket {self.socket_path} http://localhost/health"
 
     def _bearer(self) -> str:
         if self._token:
@@ -156,15 +157,10 @@ class BrokerClient:
             # back a check that runs on the transport THIS client is actually using -- a
             # hardcoded --unix-socket line is wrong for anyone on the http_url fallback.
             raise BrokerGrantError(
-                "/grant returned 404. The broker answered, so the socket and token "
-                "reached it. The most likely cause is that this build has no AAP grant "
-                "surface configured: a stock broker does not construct a grant "
-                "resolver, and then every grant call 404s. Check the broker is the one "
-                f"you meant with `{self._health_probe()}`. If that succeeds and grants "
-                "still 404, the remaining candidates are a grant reference this broker "
-                "has no binding for, or an http_url pointing at something other than "
-                "the broker. Background: "
-                "opena2a-standards/agent-authorization-protocol#1."
+                "/grant returned 404. Most likely this broker has no AAP grant surface "
+                "configured; a grant reference it has no binding for does the same. "
+                f"Check which broker you reached: `{self._health_probe()}`. "
+                "Background: opena2a-standards/agent-authorization-protocol#1."
             )
         raise BrokerGrantError(f"broker returned status {resp.status}")
 

--- a/sdk/python/aim_sdk/grant_client.py
+++ b/sdk/python/aim_sdk/grant_client.py
@@ -9,9 +9,14 @@ result. No credential value and no backend identifier ever enters the agent proc
 This module is intentionally thin: the broker (in Secretless AI) does all the work. See
 the Agent Authorization Protocol spec (opena2a-standards/agent-authorization-protocol).
 
-PROVISIONAL / EXPERIMENTAL. AAP is at spec v0.1. This client and the broker `/grant`
-wire format it depends on may change in a future minor release without a major version
-bump. Pin an exact aim-sdk version if you depend on it.
+PROVISIONAL / EXPERIMENTAL. AAP is at spec 0.4.0-draft. This client and the broker
+`/grant` wire format it depends on may change in a future minor release without a major
+version bump. Pin an exact aim-sdk version if you depend on it.
+
+Note that a released Secretless broker does not yet construct a grant resolver, so
+`/grant` answers 404 on a stock build and every call here fails until an operator-facing
+grant-binding configuration ships. Tracked in
+opena2a-standards/agent-authorization-protocol#1.
 """
 
 from __future__ import annotations
@@ -128,6 +133,18 @@ class BrokerClient:
                 raise BrokerGrantError("broker returned non-JSON success body") from exc
         if resp.status == 403:
             raise GrantDeniedError("grant denied")
+        if resp.status == 404:
+            # The broker is up and answering, it just has no grant resolver wired. A bare
+            # "status 404" here sends the caller looking for a typo in their grant
+            # reference, which is the wrong place. Say which side is missing.
+            raise BrokerGrantError(
+                "broker has no AAP grant surface configured (/grant returned 404). "
+                "The broker is reachable, so this is not a socket or token problem: the "
+                "running build does not construct a grant resolver. Verify with "
+                "`curl --unix-socket ~/.secretless-ai/broker.sock http://localhost/health`, "
+                "which answers 200 on the same broker. Tracked in "
+                "opena2a-standards/agent-authorization-protocol#1."
+            )
         raise BrokerGrantError(f"broker returned status {resp.status}")
 
 

--- a/sdk/python/aim_sdk/grant_client.py
+++ b/sdk/python/aim_sdk/grant_client.py
@@ -79,12 +79,17 @@ class BrokerClient:
     def _health_probe(self) -> str:
         """A runnable /health command for whichever transport this client is using.
 
-        Mirrors the transport choice in grant(). Only values this client already holds
-        are interpolated -- never anything from the broker's response.
+        `-f` is load-bearing, not decoration: a bare `curl` prints the error body and
+        still exits 0, so a broker with no /health route hands the user a page of JSON
+        and a clean exit, which reads as success. With -f the command fails loudly
+        (exit 22) and stays quiet on the happy path.
+
+        Only values this client already holds are interpolated -- never anything from
+        the broker's response.
         """
         if self.http_url:
-            return f"curl {self.http_url.rstrip('/')}/health"
-        return f"curl --unix-socket {self.socket_path} http://localhost/health"
+            return f"curl -fsS {self.http_url.rstrip('/')}/health"
+        return f"curl -fsS --unix-socket {self.socket_path} http://localhost/health"
 
     def _bearer(self) -> str:
         if self._token:
@@ -122,7 +127,7 @@ class BrokerClient:
             scheme, _, host = url.partition("://")
             conn: http.client.HTTPConnection = (
                 http.client.HTTPSConnection(host, timeout=self.timeout)
-                if scheme == "https"
+                if scheme.lower() == "https"
                 else http.client.HTTPConnection(host, timeout=self.timeout)
             )
         else:
@@ -151,11 +156,15 @@ class BrokerClient:
             # back a check that runs on the transport THIS client is actually using -- a
             # hardcoded --unix-socket line is wrong for anyone on the http_url fallback.
             raise BrokerGrantError(
-                "broker has no AAP grant surface configured (/grant returned 404). "
-                "The broker is reachable, so this is not a socket or token problem: the "
-                "running build does not construct a grant resolver. Verify with "
-                f"`{self._health_probe()}`, which answers 200 on the same broker. "
-                "Tracked in opena2a-standards/agent-authorization-protocol#1."
+                "/grant returned 404. The broker answered, so the socket and token "
+                "reached it. The most likely cause is that this build has no AAP grant "
+                "surface configured: a stock broker does not construct a grant "
+                "resolver, and then every grant call 404s. Check the broker is the one "
+                f"you meant with `{self._health_probe()}`. If that succeeds and grants "
+                "still 404, the remaining candidates are a grant reference this broker "
+                "has no binding for, or an http_url pointing at something other than "
+                "the broker. Background: "
+                "opena2a-standards/agent-authorization-protocol#1."
             )
         raise BrokerGrantError(f"broker returned status {resp.status}")
 

--- a/sdk/python/aim_sdk/grant_client.py
+++ b/sdk/python/aim_sdk/grant_client.py
@@ -13,10 +13,11 @@ PROVISIONAL / EXPERIMENTAL. AAP is at spec 0.4.0-draft. This client and the brok
 `/grant` wire format it depends on may change in a future minor release without a major
 version bump. Pin an exact aim-sdk version if you depend on it.
 
-Note that a released Secretless broker does not yet construct a grant resolver, so
-`/grant` answers 404 on a stock build and every call here fails until an operator-facing
-grant-binding configuration ships. Tracked in
-opena2a-standards/agent-authorization-protocol#1.
+Broker-side readiness is tracked in
+opena2a-standards/agent-authorization-protocol#1, which is the source of truth rather
+than this docstring. As of 2026-08-19 a stock Secretless broker did not construct a
+grant resolver, so `/grant` answered 404 and every call here failed; see that issue for
+the current state.
 """
 
 from __future__ import annotations
@@ -74,6 +75,16 @@ class BrokerClient:
         self.timeout = timeout
         self._token = token
         self._token_path = token_path or DEFAULT_TOKEN_PATH
+
+    def _health_probe(self) -> str:
+        """A runnable /health command for whichever transport this client is using.
+
+        Mirrors the transport choice in grant(). Only values this client already holds
+        are interpolated -- never anything from the broker's response.
+        """
+        if self.http_url:
+            return f"curl {self.http_url.rstrip('/')}/health"
+        return f"curl --unix-socket {self.socket_path} http://localhost/health"
 
     def _bearer(self) -> str:
         if self._token:
@@ -136,14 +147,15 @@ class BrokerClient:
         if resp.status == 404:
             # The broker is up and answering, it just has no grant resolver wired. A bare
             # "status 404" here sends the caller looking for a typo in their grant
-            # reference, which is the wrong place. Say which side is missing.
+            # reference, which is the wrong place. Say which side is missing, and hand
+            # back a check that runs on the transport THIS client is actually using -- a
+            # hardcoded --unix-socket line is wrong for anyone on the http_url fallback.
             raise BrokerGrantError(
                 "broker has no AAP grant surface configured (/grant returned 404). "
                 "The broker is reachable, so this is not a socket or token problem: the "
                 "running build does not construct a grant resolver. Verify with "
-                "`curl --unix-socket ~/.secretless-ai/broker.sock http://localhost/health`, "
-                "which answers 200 on the same broker. Tracked in "
-                "opena2a-standards/agent-authorization-protocol#1."
+                f"`{self._health_probe()}`, which answers 200 on the same broker. "
+                "Tracked in opena2a-standards/agent-authorization-protocol#1."
             )
         raise BrokerGrantError(f"broker returned status {resp.status}")
 

--- a/sdk/python/tests/test_grant_decorator.py
+++ b/sdk/python/tests/test_grant_decorator.py
@@ -165,11 +165,16 @@ class TestBrokerClientWire:
         # It must NOT be the old bare-status message, and must not be the denial class.
         assert message != "broker returned status 404"
         assert not isinstance(excinfo.value, GrantDeniedError)
-        # It must name the cause, exonerate the transport, and give a check to run.
+        # It must name the likely cause and give a check to run...
         assert "404" in message
         assert "grant surface" in message
-        assert "not a socket or token problem" in message
         assert "/health" in message
+        # ...while stating the transport fact rather than ruling other causes out. A 404
+        # also fits an unbound grant reference or a misaimed http_url, and the message
+        # must leave the caller those options instead of asserting one cause.
+        assert "the socket and token reached it" in message
+        assert "most likely" in message
+        assert "no binding for" in message
 
     @pytest.mark.parametrize(
         "kwargs, must_contain, must_not_contain",
@@ -177,13 +182,21 @@ class TestBrokerClientWire:
             # A custom socket must appear; the DEFAULT path must not be assumed.
             (
                 {"socket_path": "/run/custom/broker.sock"},
-                ["--unix-socket /run/custom/broker.sock", "http://localhost/health"],
+                ["curl -fsS --unix-socket /run/custom/broker.sock", "http://localhost/health"],
                 [".secretless-ai"],
             ),
             # On the http_url fallback (e.g. Docker) a --unix-socket line is unrunnable.
             (
                 {"http_url": "http://broker.internal:7000/"},
-                ["curl http://broker.internal:7000/health"],
+                ["curl -fsS http://broker.internal:7000/health"],
+                ["--unix-socket"],
+            ),
+            # An uppercase scheme must still be recognised as TLS. This case previously
+            # escaped every patch and reached real DNS, because only HTTPConnection was
+            # stubbed while an https URL takes HTTPSConnection.
+            (
+                {"http_url": "HTTPS://broker.internal/"},
+                ["curl -fsS HTTPS://broker.internal/health"],
                 ["--unix-socket"],
             ),
         ],
@@ -219,14 +232,75 @@ class TestBrokerClientWire:
         monkeypatch.setattr(
             "aim_sdk.grant_client.http.client.HTTPConnection", lambda *a, **k: _Conn()
         )
+        monkeypatch.setattr(
+            "aim_sdk.grant_client.http.client.HTTPSConnection", lambda *a, **k: _Conn()
+        )
         with pytest.raises(BrokerGrantError) as excinfo:
             client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
 
         message = str(excinfo.value)
+        # L2: pytest.raises(BrokerGrantError) also accepts GrantDeniedError, which
+        # subclasses it. Without this the case survives a mutation that swaps the class.
+        assert not isinstance(excinfo.value, GrantDeniedError)
         for fragment in must_contain:
             assert fragment in message, f"{fragment!r} missing from: {message}"
         for fragment in must_not_contain:
             assert fragment not in message, f"{fragment!r} wrongly present in: {message}"
+
+    @pytest.mark.parametrize(
+        "url, expect_tls",
+        [
+            ("https://broker.internal/", True),
+            ("HTTPS://broker.internal/", True),   # the case that leaked
+            ("Https://broker.internal/", True),   # and its mixed-case sibling
+            ("http://broker.internal/", False),
+            ("HTTP://broker.internal/", False),
+        ],
+    )
+    def test_scheme_comparison_is_case_insensitive(self, monkeypatch, url, expect_tls):
+        """An uppercase https:// must not fall through to a plaintext connection.
+
+        grant() sends `Authorization: Bearer <broker token>`. When the scheme compare was
+        an exact lowercase match, `HTTPS://` selected HTTPConnection, so the token went
+        out in cleartext on port 80 while the caller believed they were on TLS.
+
+        The oracle has to record WHICH constructor ran. Stubbing both with the same
+        double cannot tell them apart, so a test written that way stays green when the
+        comparison regresses -- which is exactly what happened before this test existed.
+        """
+        client = BrokerClient(http_url=url, token="t")
+        used = []
+
+        def _make(kind):
+            def _ctor(*a, **k):
+                used.append(kind)
+                class _Resp:
+                    status = 200
+                    def read(self):
+                        return b'{"result":"ok"}'
+                class _Conn:
+                    def request(self, *a, **k):
+                        pass
+                    def getresponse(self):
+                        return _Resp()
+                    def close(self):
+                        pass
+                return _Conn()
+            return _ctor
+
+        monkeypatch.setattr(client, "_bearer", lambda: "t")
+        monkeypatch.setattr(
+            "aim_sdk.grant_client.http.client.HTTPSConnection", _make("tls")
+        )
+        monkeypatch.setattr(
+            "aim_sdk.grant_client.http.client.HTTPConnection", _make("plain")
+        )
+        client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
+
+        assert used == ["tls" if expect_tls else "plain"], (
+            f"{url!r} selected {used!r}; a plaintext connection here sends the bearer "
+            f"token in the clear"
+        )
 
     def test_other_statuses_still_fall_through_to_the_bare_message(self, monkeypatch):
         """The 404 branch must not swallow every non-200. 500 keeps the generic path."""

--- a/sdk/python/tests/test_grant_decorator.py
+++ b/sdk/python/tests/test_grant_decorator.py
@@ -132,6 +132,71 @@ class TestBrokerClientWire:
         with pytest.raises(GrantDeniedError):
             client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
 
+    def test_404_says_the_broker_lacks_a_grant_surface(self, monkeypatch):
+        """A 404 is not a bad grant reference: the broker is up and has no resolver.
+
+        The bare `broker returned status 404` this used to raise sent the caller looking
+        for a typo in their own grant reference, which is the one place the fault is not.
+        Assert on what the message has to TELL them, not on its exact wording.
+        """
+        client = BrokerClient(socket_path="/nonexistent.sock", token="t")
+
+        class _Resp:
+            status = 404
+            def read(self):
+                return b'{"error":"Not found"}'
+
+        class _Conn:
+            def request(self, *a, **k):
+                pass
+            def getresponse(self):
+                return _Resp()
+            def close(self):
+                pass
+
+        monkeypatch.setattr(client, "_bearer", lambda: "t")
+        monkeypatch.setattr(
+            "aim_sdk.grant_client._UnixHTTPConnection", lambda *a, **k: _Conn()
+        )
+        with pytest.raises(BrokerGrantError) as excinfo:
+            client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
+
+        message = str(excinfo.value)
+        # It must NOT be the old bare-status message, and must not be the denial class.
+        assert message != "broker returned status 404"
+        assert not isinstance(excinfo.value, GrantDeniedError)
+        # It must name the cause, exonerate the transport, and give a check to run.
+        assert "404" in message
+        assert "grant surface" in message
+        assert "not a socket or token problem" in message
+        assert "/health" in message
+
+    def test_other_statuses_still_fall_through_to_the_bare_message(self, monkeypatch):
+        """The 404 branch must not swallow every non-200. 500 keeps the generic path."""
+        client = BrokerClient(socket_path="/nonexistent.sock", token="t")
+
+        class _Resp:
+            status = 500
+            def read(self):
+                return b"boom"
+
+        class _Conn:
+            def request(self, *a, **k):
+                pass
+            def getresponse(self):
+                return _Resp()
+            def close(self):
+                pass
+
+        monkeypatch.setattr(client, "_bearer", lambda: "t")
+        monkeypatch.setattr(
+            "aim_sdk.grant_client._UnixHTTPConnection", lambda *a, **k: _Conn()
+        )
+        with pytest.raises(BrokerGrantError) as excinfo:
+            client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
+        assert str(excinfo.value) == "broker returned status 500"
+        assert "grant surface" not in str(excinfo.value)
+
     def test_grant_success_returns_result_only(self, monkeypatch):
         client = BrokerClient(socket_path="/nonexistent.sock", token="t")
 

--- a/sdk/python/tests/test_grant_decorator.py
+++ b/sdk/python/tests/test_grant_decorator.py
@@ -171,6 +171,63 @@ class TestBrokerClientWire:
         assert "not a socket or token problem" in message
         assert "/health" in message
 
+    @pytest.mark.parametrize(
+        "kwargs, must_contain, must_not_contain",
+        [
+            # A custom socket must appear; the DEFAULT path must not be assumed.
+            (
+                {"socket_path": "/run/custom/broker.sock"},
+                ["--unix-socket /run/custom/broker.sock", "http://localhost/health"],
+                [".secretless-ai"],
+            ),
+            # On the http_url fallback (e.g. Docker) a --unix-socket line is unrunnable.
+            (
+                {"http_url": "http://broker.internal:7000/"},
+                ["curl http://broker.internal:7000/health"],
+                ["--unix-socket"],
+            ),
+        ],
+    )
+    def test_404_verify_command_matches_the_transport_in_use(
+        self, monkeypatch, kwargs, must_contain, must_not_contain
+    ):
+        """The Verify command must run on the caller's actual transport.
+
+        A hardcoded `--unix-socket ~/.secretless-ai/broker.sock` is wrong twice over: for
+        a custom socket path, and for anyone on the http_url fallback. A remediation
+        command that does not run is a dead end wearing a fix's clothes.
+        """
+        client = BrokerClient(token="t", **kwargs)
+
+        class _Resp:
+            status = 404
+            def read(self):
+                return b'{"error":"Not found"}'
+
+        class _Conn:
+            def request(self, *a, **k):
+                pass
+            def getresponse(self):
+                return _Resp()
+            def close(self):
+                pass
+
+        monkeypatch.setattr(client, "_bearer", lambda: "t")
+        monkeypatch.setattr(
+            "aim_sdk.grant_client._UnixHTTPConnection", lambda *a, **k: _Conn()
+        )
+        monkeypatch.setattr(
+            "aim_sdk.grant_client.http.client.HTTPConnection", lambda *a, **k: _Conn()
+        )
+        with pytest.raises(BrokerGrantError) as excinfo:
+            client.grant("a", {}, "grant://x", {"method": "GET", "path": "/"})
+
+        message = str(excinfo.value)
+        for fragment in must_contain:
+            assert fragment in message, f"{fragment!r} missing from: {message}"
+        for fragment in must_not_contain:
+            assert fragment not in message, f"{fragment!r} wrongly present in: {message}"
+
     def test_other_statuses_still_fall_through_to_the_bare_message(self, monkeypatch):
         """The 404 branch must not swallow every non-200. 500 keeps the generic path."""
         client = BrokerClient(socket_path="/nonexistent.sock", token="t")

--- a/sdk/python/tests/test_grant_decorator.py
+++ b/sdk/python/tests/test_grant_decorator.py
@@ -172,9 +172,14 @@ class TestBrokerClientWire:
         # ...while stating the transport fact rather than ruling other causes out. A 404
         # also fits an unbound grant reference or a misaimed http_url, and the message
         # must leave the caller those options instead of asserting one cause.
-        assert "the socket and token reached it" in message
-        assert "most likely" in message
+        assert "Most likely" in message
         assert "no binding for" in message
+        # F8: transport-specific advice must not be handed to callers on the other
+        # transport. This client has no http_url, so the message must not mention one.
+        assert "http_url" not in message
+        # F10: no timeless claim about "a stock broker" -- it goes false the day the
+        # daemon wires the resolver.
+        assert "stock broker" not in message
 
     @pytest.mark.parametrize(
         "kwargs, must_contain, must_not_contain",
@@ -182,21 +187,21 @@ class TestBrokerClientWire:
             # A custom socket must appear; the DEFAULT path must not be assumed.
             (
                 {"socket_path": "/run/custom/broker.sock"},
-                ["curl -fsS --unix-socket /run/custom/broker.sock", "http://localhost/health"],
+                ["-o /dev/null -w", "%{http_code}", "--unix-socket /run/custom/broker.sock"],
                 [".secretless-ai"],
             ),
             # On the http_url fallback (e.g. Docker) a --unix-socket line is unrunnable.
             (
                 {"http_url": "http://broker.internal:7000/"},
-                ["curl -fsS http://broker.internal:7000/health"],
+                ["-o /dev/null -w", "http://broker.internal:7000/health"],
                 ["--unix-socket"],
             ),
-            # An uppercase scheme must still be recognised as TLS. This case previously
-            # escaped every patch and reached real DNS, because only HTTPConnection was
-            # stubbed while an https URL takes HTTPSConnection.
+            # Pins the emitted string for an uppercase scheme ONLY. TLS *selection* is
+            # covered by test_scheme_comparison_is_case_insensitive, not here: both
+            # constructors are stubbed with one double, so this case cannot see which ran.
             (
                 {"http_url": "HTTPS://broker.internal/"},
-                ["curl -fsS HTTPS://broker.internal/health"],
+                ["-o /dev/null -w", "HTTPS://broker.internal/health"],
                 ["--unix-socket"],
             ),
         ],
@@ -301,6 +306,18 @@ class TestBrokerClientWire:
             f"{url!r} selected {used!r}; a plaintext connection here sends the bearer "
             f"token in the clear"
         )
+
+    def test_health_probe_is_a_single_line_command(self):
+        """The -w format needs a literal backslash-n, not a newline character.
+
+        Written as "\n" in a normal Python string it becomes a real newline and the
+        emitted command breaks across two lines, so the second half runs as its own
+        shell command. Caught exactly that way once.
+        """
+        for kwargs in ({"socket_path": "/run/b.sock"}, {"http_url": "http://h:7000/"}):
+            probe = BrokerClient(token="t", **kwargs)._health_probe()
+            assert "\n" not in probe, f"probe spans lines: {probe!r}"
+            assert "\\n" in probe, f"probe lost its literal newline escape: {probe!r}"
 
     def test_other_statuses_still_fall_through_to_the_bare_message(self, monkeypatch):
         """The 404 branch must not swallow every non-200. 500 keeps the generic path."""


### PR DESCRIPTION
Three shipped surfaces told PyPI users `AAP is at spec v0.1`. The spec is at `0.4.0-draft`, three minor versions on: the `grant=` docstring in `client.py`, the module docstring in `grant_client.py`, and the grant-client comment in `__init__.py`. `sdk/python/CHANGELOG.md` carries the same sentence and is deliberately left alone; it is the historical 1.23.0 entry, and it is not in the wheel.

The 404 mattered more. A released Secretless broker does not construct a grant resolver, so `/grant` answers 404 on a stock build. The client raised a bare `broker returned status 404`, which sends the caller looking for a typo in their own grant reference: the one place the fault is not. It now names the likely cause and hands back a `/health` check.

**Also fixed, found on the way:** `grant()` compared `scheme == "https"` exactly, so `HTTPS://` selected a plaintext connection while still sending `Authorization: Bearer <token>`. Now case-insensitive. This predates the branch, but the new message would have masked it by telling the user the transport was fine.

**Verified:** 455 tests pass. Both new guards are mutation-proved, not just red-proved — reverting the scheme compare kills exactly the two uppercase cases and leaves lowercase green. The `/health` probe was run against a real unix-socket server at 200, 404 and 301, and reports each correctly.

Three review rounds; the deferred findings (probe auth header, the plaintext fallback for any non-https scheme, four other bare-status dead ends in the SDK) are recorded rather than fixed here.