### PR TITLE
Give verification a typed decision, and make a denial behave like one

### DIFF
--- a/sdk/python/LICENSE
+++ b/sdk/python/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 OpenA2A
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/python/MANIFEST.in
+++ b/sdk/python/MANIFEST.in
@@ -1,4 +1,8 @@
 include VERSION
 include README.md
+# The PyPI page is README.md, and it tells the reader to check their
+# enforcement mode before upgrading. CHANGELOG.md was in neither the sdist nor
+# the wheel, so that instruction reached no pip user at all.
+include CHANGELOG.md
 include LICENSE
 recursive-include aim_sdk *.py

--- a/sdk/python/aim_sdk/decision.py
+++ b/sdk/python/aim_sdk/decision.py
@@ -1,0 +1,256 @@
+"""
+AIM SDK - the typed three-state verification decision, and the enforcement-mode cache.
+
+Before 2.0.0 a verification result was a dict whose ``verified`` key meant two
+different things. ``verified: False`` was returned both when AIM DENIED the action
+and when AIM was never successfully asked -- a 404, a 429, a 500, a connection
+error. Callers could not tell those apart, so the SDK treated "we could not
+determine" exactly like "permitted, with a warning".
+
+This module replaces that bool with three states that cannot be confused:
+
+* ``ALLOW``   -- AIM answered and permitted the action.
+* ``DENY``    -- AIM answered and refused it.
+* ``UNKNOWN`` -- no decision was obtained.
+
+``UNKNOWN`` carries a second field, :class:`UnknownSource`, because the two ways to
+reach it are not equivalent and must not be enforced the same way:
+
+* ``TRANSPORT``     -- timeout, connection, DNS, TLS. We cannot tell whether AIM
+  exists. This is the ONLY class eligible for permissive handling, and the
+  allowlist is exhaustive by construction: it is populated from the transport
+  exception, never from a status code.
+* ``SERVER_ANSWER`` -- 400, 404, 409, 429, 500, 502, 503. The server answered; it
+  simply did not carry a decision. An answer is never permissive. Being lenient
+  here is what made 101 requests in a minute from the agent's own IP switch
+  verification off for that IP, with no credentials and no exploit.
+
+Enforcement mode resolution is strictly ordered: a fresh AIM answer, then a
+process-scoped in-memory last-known mode within TTL, then ``UNKNOWN``.
+
+**The cache is never persisted to disk.** A disk cache is forgeable in the lenient
+direction -- an adversary does not suppress the cached mode, they write
+``monitoring`` into it. Holding it in memory reduces forgery to "the adversary has
+code execution in the agent process", at which point every client-side control is
+already lost. Any persistence of this cache -- disk, keyring, cross-process --
+voids that reasoning and makes a signed, expiring mode assertion mandatory.
+"""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+# Unmeasured default. No production distribution of agent process lifetimes or of
+# enforcement-mode change frequency has been measured, so this number is a choice,
+# not a finding. It bounds how long a process keeps enforcing a mode the
+# organization may have already changed.
+DEFAULT_MODE_TTL_SECONDS = 300
+
+
+class Outcome(str, Enum):
+    """What AIM decided, or that it did not decide."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    UNKNOWN = "unknown"
+
+
+class UnknownSource(str, Enum):
+    """Why an UNKNOWN outcome is UNKNOWN. Meaningless on ALLOW and DENY."""
+
+    NONE = "none"
+    TRANSPORT = "transport"
+    SERVER_ANSWER = "server_answer"
+
+
+class EnforcementMode(str, Enum):
+    """The organization's enforcement mode, as resolved for this decision."""
+
+    STRICT = "strict"
+    MONITORING = "monitoring"
+    UNKNOWN = "unknown"
+
+
+class ModeSource(str, Enum):
+    """Where the enforcement mode came from. Ordered: RESPONSE, CACHE, then none."""
+
+    RESPONSE = "response"
+    CACHE = "cache"
+    ENV_OVERRIDE = "env_override"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class VerificationDecision:
+    """
+    One verification decision.
+
+    Deliberately NOT a Mapping. A dict-like shim would have to return something
+    for ``verified`` on an UNKNOWN outcome, and any value it picked would rebuild
+    the exact conflation this type exists to remove.
+    """
+
+    outcome: Outcome
+    mode: EnforcementMode
+    mode_source: ModeSource
+    verification_id: Optional[str] = None
+    status: Optional[str] = None
+    reason: Optional[str] = None
+    approved_by: Optional[str] = None
+    expires_at: Optional[str] = None
+    unknown_source: UnknownSource = UnknownSource.NONE
+
+    @property
+    def allowed(self) -> bool:
+        """True only on an explicit ALLOW. Never true on UNKNOWN."""
+        return self.outcome is Outcome.ALLOW
+
+    @property
+    def denied(self) -> bool:
+        return self.outcome is Outcome.DENY
+
+    @property
+    def undetermined(self) -> bool:
+        return self.outcome is Outcome.UNKNOWN
+
+    def to_legacy_dict(self) -> dict:
+        """
+        Project an ALLOW decision onto the dict `verify_capability` has always
+        returned, plus the two additive mode keys.
+
+        This is the ONLY place the legacy shape is constructed. 3.0.0 flips
+        `verify_capability` to return the decision itself by dropping this call --
+        if that flip ever needs more than one line, a caller has started
+        hand-building the dict somewhere else and that is the defect.
+
+        Only meaningful on ALLOW. DENY and UNKNOWN never return; they raise, so
+        there is no `verified: False` anywhere in the SDK left to conflate.
+        """
+        if self.outcome is not Outcome.ALLOW:
+            raise ValueError(
+                "to_legacy_dict() is only defined for an ALLOW outcome; "
+                f"got {self.outcome.value}. DENY and UNKNOWN raise instead of returning."
+            )
+        return {
+            "verified": True,
+            "verification_id": self.verification_id,
+            "approved_by": self.approved_by,
+            "expires_at": self.expires_at,
+            # Additive in 2.0.0. The organization's enforcement mode finally
+            # reaches the caller; before this it was read from a key no return
+            # site ever emitted.
+            "mode": self.mode.value,
+            "mode_source": self.mode_source.value,
+        }
+
+    @property
+    def permissive_eligible(self) -> bool:
+        """
+        Whether this outcome may be handled permissively at all.
+
+        True only for a transport failure. A server that answered is never
+        eligible, whatever it answered.
+        """
+        return (
+            self.outcome is Outcome.UNKNOWN
+            and self.unknown_source is UnknownSource.TRANSPORT
+        )
+
+
+def parse_enforcement_mode(raw: Optional[str]) -> EnforcementMode:
+    """
+    Map a wire value to an enforcement mode.
+
+    An absent, empty, or unrecognised value is UNKNOWN -- never MONITORING. A
+    degraded upstream must not be able to emit the healthy, lenient value by
+    saying nothing, which is how the backend's own failed organization lookup
+    used to produce "monitoring".
+    """
+    if raw is None:
+        return EnforcementMode.UNKNOWN
+    normalized = str(raw).strip().lower()
+    if normalized == "strict":
+        return EnforcementMode.STRICT
+    if normalized == "monitoring":
+        return EnforcementMode.MONITORING
+    return EnforcementMode.UNKNOWN
+
+
+@dataclass
+class _CacheEntry:
+    mode: EnforcementMode
+    stored_at: float
+
+
+class ModeCache:
+    """
+    Process-scoped, in-memory last-known enforcement mode, keyed by agent id.
+
+    Uses a monotonic clock, so a system clock change cannot extend or expire an
+    entry. Never written to disk, a keyring, or any cross-process store.
+    """
+
+    def __init__(self, ttl_seconds: int = DEFAULT_MODE_TTL_SECONDS):
+        self.ttl_seconds = ttl_seconds
+        self._entries = {}
+        self._lock = threading.Lock()
+
+    def put(self, agent_id: Optional[str], mode: EnforcementMode) -> None:
+        """Record a mode AIM actually stated. UNKNOWN is never cached."""
+        if not agent_id or mode is EnforcementMode.UNKNOWN:
+            return
+        with self._lock:
+            self._entries[agent_id] = _CacheEntry(mode=mode, stored_at=time.monotonic())
+
+    def get(self, agent_id: Optional[str]) -> Optional[EnforcementMode]:
+        """Return the cached mode if one is present and within TTL, else None."""
+        if not agent_id:
+            return None
+        with self._lock:
+            entry = self._entries.get(agent_id)
+            if entry is None:
+                return None
+            if time.monotonic() - entry.stored_at > self.ttl_seconds:
+                del self._entries[agent_id]
+                return None
+            return entry.mode
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+# The single process-wide cache. Module-level so two AIMClient instances for the
+# same agent in one process share a mode, and so it dies with the process.
+_MODE_CACHE = ModeCache()
+
+
+def get_mode_cache() -> ModeCache:
+    return _MODE_CACHE
+
+
+def resolve_mode(
+    response_mode: EnforcementMode,
+    agent_id: Optional[str],
+    cache: Optional[ModeCache] = None,
+) -> "tuple[EnforcementMode, ModeSource]":
+    """
+    Resolve the enforcement mode in the ruled order: fresh answer, then cache
+    within TTL, then UNKNOWN.
+
+    A fresh answer is also written back to the cache, so a later call that gets no
+    mode can still enforce the organization's real setting.
+    """
+    store = cache if cache is not None else _MODE_CACHE
+
+    if response_mode is not EnforcementMode.UNKNOWN:
+        store.put(agent_id, response_mode)
+        return response_mode, ModeSource.RESPONSE
+
+    cached = store.get(agent_id)
+    if cached is not None:
+        return cached, ModeSource.CACHE
+
+    return EnforcementMode.UNKNOWN, ModeSource.UNAVAILABLE

--- a/sdk/python/aim_sdk/enforcement.py
+++ b/sdk/python/aim_sdk/enforcement.py
@@ -1,0 +1,290 @@
+"""
+AIM SDK - the one enforcement rule.
+
+Every entry point that verifies before running user code routes through
+:func:`evaluate`. There are seven of them -- ``aim_verify`` and its four
+convenience wrappers, ``perform_action``, ``track_action``, ``require_approval``,
+and the separate ``aim_verify`` shipped for LangChain -- and before 2.0.0 they
+each carried their own ``if`` ladder. They disagreed with each other: on an
+explicit denial one raised, one returned a sentinel dict, one ran the function
+anyway, and one crashed with ``AttributeError`` before it ever asked.
+
+Direction agreement across entry points is a release gate. Keeping the rule in one
+pure function is what makes agreement structural rather than a coincidence that
+survives until the next edit.
+
+The rule
+--------
+
+Given a :class:`~aim_sdk.decision.VerificationDecision` and the state of the
+``AIM_STRICT_MODE`` ratchet:
+
+======================  ==========  ============  =============
+outcome                 strict      monitoring    mode unknown
+======================  ==========  ============  =============
+ALLOW                   run         run           run
+DENY                    BLOCK       BLOCK         BLOCK
+UNKNOWN, server answer  BLOCK       run + warn    BLOCK
+UNKNOWN, transport      BLOCK       run + warn    run + notice
+======================  ==========  ============  =============
+
+What monitoring mode governs
+----------------------------
+
+Monitoring mode governs what happens when AIM cannot give an answer, not what
+happens when AIM says no. A verification that could not be completed is logged
+and the action proceeds; an explicit denial blocks in every mode, because it is a
+decision AIM already made with your organization's enforcement mode in hand.
+
+That last clause is a backend fact, not an SDK preference. ``VerifyCapability``
+already applies monitoring mode server-side at every policy gate: under monitoring
+a policy refusal is converted to an approval before it is ever sent. What still
+arrives as a denial is the short list the server declines to override while
+holding the org row and knowing the mode -- agent not found, agent marked
+compromised (not mode-gated at all), capability lookup failed. The SDK used to
+override that a second time, on a copy of the mode it read off the same
+response. Measured consequence: an administrator pressing Deny in the JIT
+dashboard did not stop the action.
+
+Two cells still carry reasoning that is not obvious:
+
+**DENY under an unknown mode blocks** for the same reason it blocks under
+monitoring, plus one more: the mode is unknown exactly when AIM's organization
+lookup failed, and a degraded upstream must not be able to produce the lenient
+outcome by failing.
+
+**A server that answered is not treated like a transport failure.** A 429 or a
+5xx means AIM is reachable and the control is live; we simply did not get a
+decision. Treating that as permissive is what let 101 requests in a minute from
+the agent's own IP switch verification off for that IP, with no credentials and
+no exploit. It stays lenient under monitoring only because that is the one thing
+monitoring mode does mean -- an unanswered verification is logged and proceeds --
+and because blocking it unconditionally would hand an unauthenticated party a
+stop button, a 429 being reachable by making the agent's IP busy and firing by
+accident behind a NAT.
+
+**The cost of blocking DENY under monitoring, stated plainly.** An attacker who
+can induce a 429 can now suppress a denial for the default population: before
+this table a monitoring org had nothing to suppress. The bounded 429 retry in
+``client.py`` narrows the window; it does not close it. The fix is that the rate
+limiter must not sit in front of an authorization decision, and this table
+promotes that from hygiene to live exposure.
+
+**A TRANSPORT failure under an unknown mode runs in 2.0.0, and blocks in
+3.0.0.** Read the qualifier carefully: this warning window applies ONLY to the
+transport row. A server answer under an unknown mode blocks TODAY, in 2.0.0 --
+see the truth table, where those are two different rows. Conflating them would
+ship the 429 bypass under the banner of having fixed it.
+
+The transport-plus-unknown-mode cell is the only one where the SDK can tell
+neither whether AIM exists nor what the organization wants. Blocking it is ruled,
+and it is a behaviour flip that takes down cold-starting agents during an AIM
+outage -- including monitoring-mode organizations who chose leniency and have no
+way to tell us so. It ships as a major after a warning window. 2.0.0 is that
+window: the cell runs and says so.
+
+One caveat about how small that population is. It is tempting to say a process
+that ever received one good answer has a cached mode and never lands here. That
+is only true within the cache TTL (300 s by default, on a monotonic clock). An
+agent that verifies less often than the TTL is cold on EVERY call and lands in
+this cell every time. The TTL is not removed to shrink the population: a cache
+that never expires means an organization that flips monitoring to strict never
+takes effect in a long-lived process, which fails in the worse direction.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from aim_sdk.decision import (
+    EnforcementMode,
+    ModeSource,
+    Outcome,
+    UnknownSource,
+    VerificationDecision,
+)
+
+# Named so a caller can suppress exactly this one without suppressing the rest.
+class PendingEnforcementChange(FutureWarning):
+    """The unknown/unknown cell runs today and will block in 3.0.0."""
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What the caller must do. Exactly one of run / block."""
+
+    run: bool
+    effective_mode: EnforcementMode
+    mode_source: ModeSource
+    # Set when run is False. The caller raises it.
+    error: Optional[BaseException] = None
+    # Set when the caller should warn on the console before running.
+    warning: Optional[str] = None
+    # Set when the caller should emit PendingEnforcementChange before running.
+    pending_change: Optional[str] = None
+    # Whether the caller should report executed=True to AIM after running. False
+    # only when nothing was verified, so there is no event to attach a report to.
+    reportable: bool = True
+
+    @property
+    def blocked(self) -> bool:
+        return not self.run
+
+
+def _denial_message(
+    what: str, decision: VerificationDecision, mode: EnforcementMode
+) -> str:
+    """
+    The message a blocked developer reads.
+
+    It must not offer switching the organization to monitoring mode. That was the
+    remediation before this release and it no longer works -- an explicit denial
+    blocks in every mode -- so printing it would send a blocked developer to
+    change a setting, watch nothing happen, and have no next step. It also must
+    not assert the mode is strict, which was false for the default population the
+    moment denials started blocking under monitoring.
+    """
+    reason = decision.reason or "no reason given"
+    return (
+        f"AIM denied {what}: {reason}. "
+        f"The action was blocked and not executed. AIM denies an action after "
+        f"applying your organization's enforcement mode (currently "
+        f"{mode.value}), so a denial blocks in every mode -- monitoring mode "
+        f"governs verifications AIM could not answer, not ones it refused. "
+        f"To permit this capability, grant it to this agent in the AIM dashboard "
+        f"under Agents. If the agent should not be denied at all, check its status "
+        f"there: an agent marked compromised, suspended or unverified is refused "
+        f"regardless of its capabilities."
+    )
+
+
+def _unavailable_message(
+    what: str, decision: VerificationDecision, mode: EnforcementMode
+) -> str:
+    """
+    The message read when AIM never returned a decision and the action blocked.
+
+    ``mode`` is threaded through because this message is produced on two
+    different rows -- strict, and mode-unknown-with-a-server-answer -- and the
+    single sentence it used to print ("the enforcement mode is strict") was false
+    on the second one.
+    """
+    detail = decision.reason or "no detail available"
+    if decision.unknown_source is UnknownSource.SERVER_ANSWER:
+        cause = (
+            f"AIM answered but returned no decision ({detail}). The service is "
+            f"reachable, so this is not a network problem."
+        )
+    else:
+        cause = f"AIM could not be reached ({detail})."
+    if mode is EnforcementMode.STRICT:
+        why = (
+            "The organization's enforcement mode is strict, so the action was "
+            "blocked and not executed."
+        )
+    else:
+        why = (
+            "This process could not resolve the organization's enforcement mode, "
+            "so the action was blocked and not executed rather than assuming the "
+            "lenient setting."
+        )
+    return (
+        f"AIM could not verify {what}. {cause} {why} "
+        f"This is NOT a denial -- AIM never returned a decision. "
+        f"Catch VerificationUnavailableError to handle it separately from "
+        f"ActionDeniedError."
+    )
+
+
+def evaluate(
+    decision: VerificationDecision,
+    strict_override: bool = False,
+    what: str = "this action",
+) -> Verdict:
+    """
+    Apply the enforcement rule. Pure: no I/O, no environment access, no logging.
+
+    Args:
+        decision: the typed three-state decision.
+        strict_override: whether the ``AIM_STRICT_MODE`` ratchet is engaged.
+            Resolve it with :func:`aim_sdk.strict_mode.strict_mode_override`; this
+            function does not read the environment so it stays testable.
+        what: a short human label for the thing being verified, used in messages.
+
+    Returns:
+        A :class:`Verdict`. The caller runs the wrapped body iff ``verdict.run``,
+        and raises ``verdict.error`` otherwise.
+    """
+    # Lazy import: aim_sdk.exceptions is cheap, but keeping the import here makes
+    # this module importable from exceptions-adjacent code without a cycle.
+    from aim_sdk.exceptions import ActionDeniedError, VerificationUnavailableError
+
+    if strict_override:
+        mode = EnforcementMode.STRICT
+        mode_source = ModeSource.ENV_OVERRIDE
+    else:
+        mode = decision.mode
+        mode_source = decision.mode_source
+
+    if decision.outcome is Outcome.ALLOW:
+        return Verdict(run=True, effective_mode=mode, mode_source=mode_source)
+
+    monitoring = mode is EnforcementMode.MONITORING
+
+    # An explicit denial blocks in EVERY mode. Monitoring is not consulted here:
+    # the server already applied it before deciding, so honouring it a second time
+    # is the SDK overriding an answer AIM gave while holding the org row.
+    if decision.outcome is Outcome.DENY:
+        return Verdict(
+            run=False,
+            effective_mode=mode,
+            mode_source=mode_source,
+            error=ActionDeniedError(_denial_message(what, decision, mode)),
+        )
+
+    # Outcome.UNKNOWN from here down.
+    if monitoring:
+        return Verdict(
+            run=True,
+            effective_mode=mode,
+            mode_source=mode_source,
+            warning=(
+                f"AIM could not verify {what}: "
+                f"{decision.reason or 'no detail available'}. The organization's "
+                f"enforcement mode is monitoring, so the action was executed anyway."
+            ),
+            # Nothing was verified, so there is no verification event to report
+            # an execution against.
+            reportable=decision.verification_id is not None,
+        )
+
+    if mode is EnforcementMode.STRICT:
+        return Verdict(
+            run=False,
+            effective_mode=mode,
+            mode_source=mode_source,
+            error=VerificationUnavailableError(_unavailable_message(what, decision, mode)),
+        )
+
+    # Mode is UNKNOWN. A server that answered is still an answer and is never
+    # permissive; only a transport failure reaches the 2.0.0 warning window.
+    if not decision.permissive_eligible:
+        return Verdict(
+            run=False,
+            effective_mode=mode,
+            mode_source=mode_source,
+            error=VerificationUnavailableError(_unavailable_message(what, decision, mode)),
+        )
+
+    return Verdict(
+        run=True,
+        effective_mode=mode,
+        mode_source=mode_source,
+        pending_change=(
+            f"AIM could not be reached to verify {what} "
+            f"({decision.reason or 'no detail available'}), and this process has "
+            f"no cached enforcement mode for this agent, so the action was "
+            f"executed unverified. Starting in aim-sdk 3.0.0 this case will block "
+            f"instead. To get the blocking behaviour now, set AIM_STRICT_MODE=true."
+        ),
+        reportable=decision.verification_id is not None,
+    )

--- a/sdk/python/aim_sdk/exceptions.py
+++ b/sdk/python/aim_sdk/exceptions.py
@@ -18,8 +18,73 @@ class VerificationError(AIMError):
     pass
 
 
-class ActionDeniedError(AIMError):
-    """Raised when AIM denies permission to perform an action"""
+class _CarriesDecision:
+    """Mixin: an exception that carries the typed decision that produced it.
+
+    From 2.0.0 the three-state verification decision is the exception channel.
+    ``verify_capability`` returns only on ALLOW; DENY raises
+    :class:`ActionDeniedError` and an undetermined outcome raises
+    :class:`VerificationUnavailableError`. Both carry the decision, so a caller --
+    and every decorator in this SDK -- can read the organization's enforcement
+    mode on the paths where enforcement is actually decided.
+
+    Without this, the mode channel would exist only on the ALLOW path, which is
+    the one path that does not need it.
+    """
+
+    def __init__(self, message: str, decision=None):
+        super().__init__(message)
+        self.decision = decision
+
+    @property
+    def mode(self):
+        """The enforcement mode resolved for this decision, or None."""
+        return getattr(self.decision, "mode", None)
+
+    @property
+    def mode_source(self):
+        """Where that mode came from (response, cache, or unavailable)."""
+        return getattr(self.decision, "mode_source", None)
+
+
+class ActionDeniedError(_CarriesDecision, AIMError, PermissionError):
+    """Raised when AIM denies permission to perform an action.
+
+    AIM ANSWERED and refused. This is not "AIM could not be reached" -- that is
+    ``VerificationUnavailableError``, which is deliberately not catchable by a
+    handler written for this one.
+
+    ``PermissionError`` is a second base as a COMPATIBILITY measure, added in
+    2.0.0. ``README.md`` documents that strict mode raises ``PermissionError``,
+    and the decorators have always had an ``except PermissionError`` handler --
+    but this class did not inherit from it, so a denial fell through to the
+    generic ``except Exception`` fail-open branch and the action ran. Every
+    existing ``except PermissionError`` and ``except ActionDeniedError`` handler
+    keeps working.
+
+    The base is compatibility, not the mechanism: enforcement is decided by the
+    typed outcome in ``aim_sdk.decision``, never by an exception's base class.
+
+    Note one consequence of the base: ``PermissionError`` descends from
+    ``OSError``, so a denial now also satisfies ``except OSError`` (and its alias
+    ``IOError``). A wrapped function that catches ``OSError`` broadly will catch a
+    denial too.
+    """
+    pass
+
+
+class VerificationUnavailableError(_CarriesDecision, AIMError):
+    """Raised when no verification decision could be obtained.
+
+    AIM was never successfully asked, or answered without a decision: a timeout,
+    a connection or DNS or TLS failure, a 429, a 5xx, a 404.
+
+    This deliberately does NOT subclass ``VerificationError`` or
+    ``ActionDeniedError``. A handler written for "AIM said no" must not silently
+    absorb "AIM was never asked" -- before 2.0.0 a 5xx surfaced as
+    ``PermissionError: AIM verification failed ... HTTP 500``, which told a
+    developer they had been denied when AIM was merely down.
+    """
     pass
 
 

--- a/sdk/python/aim_sdk/strict_mode.py
+++ b/sdk/python/aim_sdk/strict_mode.py
@@ -1,0 +1,120 @@
+"""
+AIM SDK - the AIM_STRICT_MODE ratchet.
+
+ONE parser, used by the SDK and by `demo_agent.py`. Before 2.0.0 there were two:
+`decorators.py` accepted only the literal string ``"true"`` while `demo_agent.py`
+accepted ``("true", "1", "yes")`` -- so ``AIM_STRICT_MODE=1`` executed a denied
+action while our own demo printed "Strict Mode: ENABLED".
+
+The variable is a RATCHET. It may only make enforcement stricter:
+
+* a recognised true value forces strict mode, whatever the organization's
+  enforcement mode says;
+* a recognised false value is IGNORED with a warning -- it cannot relax an
+  organization that is in strict mode;
+* anything else is ignored with a warning.
+
+A false value is a warning rather than a hard error on purpose: before 2.0.0 the
+downward override was measurably a no-op (the organization's mode never reached
+the decorator at all), so refusing to start would take agents down over a stale
+`.env` while removing nothing anyone actually depended on.
+"""
+
+import os
+import threading
+from typing import Mapping, Optional
+
+# Recognised spellings, compared case-insensitively after stripping whitespace.
+TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
+FALSE_VALUES = frozenset({"false", "0", "no", "off"})
+
+ENV_VAR = "AIM_STRICT_MODE"
+
+# Warn once per distinct rejected value per process. A decorator resolves the
+# ratchet on every wrapped call; without this a misconfigured agent would emit a
+# warning per action for the life of the process.
+_warned_values = set()
+_warned_lock = threading.Lock()
+
+
+def _warn_once(value: str, message: str) -> None:
+    with _warned_lock:
+        if value in _warned_values:
+            return
+        _warned_values.add(value)
+    # Imported lazily: aim_sdk.console pulls in formatting machinery that the
+    # parser itself does not need, and this module is imported at decoration time.
+    from aim_sdk.console import console
+    console.warning(message)
+
+
+def parse_strict_mode(raw: Optional[str]) -> Optional[bool]:
+    """
+    Parse one raw AIM_STRICT_MODE value.
+
+    Returns True for a recognised true value, False for a recognised false
+    value, and None when the variable is unset, empty, or unrecognised.
+
+    This is the pure form with no warnings and no environment access, so a test
+    can assert the accepted spellings without capturing output.
+    """
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if not normalized:
+        return None
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    return None
+
+
+def strict_mode_override(env: Optional[Mapping[str, str]] = None) -> bool:
+    """
+    Resolve the ratchet.
+
+    Returns True only when AIM_STRICT_MODE names a recognised true value. Every
+    other case returns False, meaning "the ratchet does not apply" -- NOT
+    "enforcement is off". The caller keeps the organization's enforcement mode
+    when this returns False.
+
+    A recognised false value and an unrecognised value each warn once per
+    process, naming the accepted spellings.
+    """
+    source = os.environ if env is None else env
+    raw = source.get(ENV_VAR)
+    if raw is None:
+        return False
+
+    parsed = parse_strict_mode(raw)
+    if parsed is True:
+        return True
+
+    stripped = raw.strip()
+    if not stripped:
+        return False
+
+    accepted = ", ".join(sorted(TRUE_VALUES))
+    if parsed is False:
+        _warn_once(
+            stripped.lower(),
+            f"{ENV_VAR}={stripped} is ignored. {ENV_VAR} can only raise enforcement, "
+            f"never lower it -- it cannot put a strict-mode organization into "
+            f"monitoring mode. Unset the variable to use the organization's "
+            f"enforcement mode. To force strict mode set one of: {accepted}.",
+        )
+    else:
+        _warn_once(
+            stripped.lower(),
+            f"{ENV_VAR}={stripped} is not a recognised value and is ignored. "
+            f"To force strict mode set one of: {accepted}. Unset the variable to "
+            f"use the organization's enforcement mode.",
+        )
+    return False
+
+
+def reset_warning_state() -> None:
+    """Clear the warn-once memory. For tests only."""
+    with _warned_lock:
+        _warned_values.clear()


### PR DESCRIPTION
First of four. **Adds primitives only — nothing imports them yet**, so behaviour on `main` is unchanged by this PR alone and the suite is the same 455 it is today. The wire-up that makes them live is #next in the stack.

## What this adds

`decision.py` models a verification result as three states rather than a bool: ALLOW, DENY, and undetermined. A bool cannot distinguish *the organization said no* from *we never got an answer*, and those two must not be enforced the same way. It also records where the enforcement mode came from (`response`, `cache`, `env_override`, `unavailable`), so a mode that arrived from a degraded path is never mistaken for one the server stated.

`enforcement.py` turns a decision plus a mode into a `Verdict`. An absent or unrecognised mode resolves to `unknown`, never to `monitoring` — a degraded upstream must not be able to select the lenient value by failing.

`strict_mode.py` parses `AIM_STRICT_MODE` and warns once rather than per call on a value it cannot read.

`exceptions.py` is the change with teeth. `ActionDeniedError` was a plain `AIMError`, and the decorators' only two handlers are `except PermissionError` and `except Exception` — so every denial fell into the fail-open branch. It now subclasses `PermissionError`, which is the contract the README has always documented. Both it and the new `VerificationUnavailableError` carry the decision through a `_CarriesDecision` mixin, so the enforcement mode is readable on the paths where enforcement is actually decided rather than only on ALLOW — the one path that does not need it.

Note that `PermissionError` descends from `OSError`, so a denial now also satisfies `except OSError`.

## Verification

- 455 passed on this tree.
- Split this way because the full change is 256,783 bytes against a 120,000-byte review cap. This PR is 43,134.

## Stack

1. **#this** — primitives (no behaviour change)
2. wire-up + docs — the actual fix
3. regression suite — must land immediately after the wire-up
4. TypeScript middlewares — independent, off `main`