### PR TITLE
Record the two carried defects in the 2.0.0 CHANGELOG

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -235,6 +235,29 @@ compromised agent still routing through the SDK is blocked, and the AIM console
 stops implying enforcement it never performed. It does **not** enforce anything
 against a hostile operator.
 
+### Known issues
+
+Two defects found by this release's fresh-user walkthrough are **not** fixed here.
+Both reproduce identically on 1.24.1, so neither is introduced by 2.0.0 and
+upgrading does not expose you to anything you were not already exposed to. Both
+are scheduled for **2.0.1**. They are recorded here rather than left silent
+because this release's own subject matter is the SDK reporting things that were
+not true.
+
+- **The registration panel prints `Trust Score: 85%` when the server sent no trust
+  score at all** ([#390](https://github.com/opena2a-org/agent-identity-management/issues/390)).
+  `client.py` reads `credentials.get("trust_score") or credentials.get("trustScore", 0.85)`,
+  so an absent field renders as `85%` in the same form as a measured value, on the
+  first thing a new user sees. The `or` also means a real server-sent score of `0`
+  displays as `85%`. The SDK's own stored record is correct — `~/.aim/agents/<name>.json`
+  holds `"trust_score": null` for the same registration — so the display contradicts
+  the file. Treat the trust score shown at registration as unverified; read it from
+  the dashboard instead.
+- **Emoji-class characters in console output**
+  ([#391](https://github.com/opena2a-org/agent-identity-management/issues/391)).
+  U+23F3 in the `@require_approval` panel, U+26A0 on warning lines, and U+2139 on
+  the API-key mode line. Cosmetic; no behavioural effect.
+
 ## [1.24.1] - 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
Adds a `Known issues` section to the 2.0.0 CHANGELOG entry for two defects the release-test walkthrough found and this release does not fix. Documentation only — no code changes, no behaviour change.

## Why this blocks the 2.0.0 tag

The release gate permits shipping a P1 that already exists on the published version, but only if it is disclosed in the same document that announces the fixes, carries a tracking issue, and is scheduled to a named version. Without this block the two defects would ship undisclosed. Filed as #390 and #391, both scheduled for 2.0.1.

## The two defects, and why neither holds the release

Both were measured against published `aim-sdk==1.24.1`, not asserted:

| Defect | 1.24.1 | 2.0.0 | Verdict |
|---|---|---|---|
| Hardcoded `85%` trust score (#390) | `client.py:4931` | `client.py:5396` | byte-identical line, same `console.py:147` renderer |
| Emoji-class characters (#391) | U+23F3 / U+26A0 / U+2139 in 1 / 11 / 1 files | same 1 / 11 / 1 files | identical; `ℹ API Key Mode` observed in live 1.24.1 output |

Neither is introduced by 2.0.0, and holding 2.0.0 over them would leave users on a version that executes denied actions, crashes `@require_approval` on every call, never sends execution reports, and turns verification off on a 429. The published artifact is not safer on any axis.

#390 is the more serious of the two and is the reason this is written down rather than left silent: an absent trust score renders as `85%` in the same form as a measured value, and the `or` in that line also renders a genuine server-sent `0` as `85%`. Verified against a stub sending no trust-score field — the panel printed `Trust Score: 85%` while the SDK's own `~/.aim/agents/<name>.json` stored `"trust_score": null`.

The codepoints are written as `U+` rather than rendered, so documenting the defect does not add it to a file that ships in the sdist.

## Verification

- `pytest`: 862 passed, 34 skipped, 26 deselected (exit 0)
- Diff touches no `.py`; the pre-existing ruff findings are unchanged by it
- Both issue links resolve OPEN
- 8-phase pre-push gate PASS
