### PR TITLE
Make ARP signature telemetry opt-in, and honor the opt-out the privacy policy documents

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -20,6 +20,17 @@ you turn it on:
 If you were relying on this channel, it stops on upgrade and you must opt in to
 restore it. If you had already opted out, nothing changes for you.
 
+**`OPENA2A_TELEMETRY=off` now works in this SDK.** That is the spelling
+[opena2a.org/privacy](https://opena2a.org/privacy) documents and the one it
+tells you to put in your shell profile, but no released version of this package
+ever read it: 1.0.0 through 1.1.0 read only `OPENA2A_TELEMETRY_OPTOUT` and
+`ARP_TELEMETRY_DISABLED`, neither of which appears in the policy. A user who did
+exactly what the policy said was still emitting. `off`, `0`, `false` and `no`
+are accepted, matching the CLIs. It is honored in the off direction only —
+`OPENA2A_TELEMETRY=on` does not turn the channel on, because an ecosystem-wide
+CLI setting should not start a network channel inside a library embedded in your
+process.
+
 An opt-out still beats an opt-in, so `OPENA2A_TELEMETRY_OPTOUT=1`,
 `ARP_TELEMETRY_DISABLED=1`, `signatureTelemetry.enabled: false` and the
 `~/.opena2a/telemetry-optout` marker all continue to work and now take

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to `@opena2a/aim-sdk` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed — read this before upgrading
+
+**Structural signature telemetry is now OFF by default.** It previously ran
+unless you opted out, sending the structural shape of anomalous runtime events
+to `https://api.oa2a.org` from inside your process. It now sends nothing until
+you turn it on:
+
+- `AIM_TELEMETRY=1` in the environment, or
+- `signatureTelemetry: { enabled: true }` in your ARP config.
+
+If you were relying on this channel, it stops on upgrade and you must opt in to
+restore it. If you had already opted out, nothing changes for you.
+
+An opt-out still beats an opt-in, so `OPENA2A_TELEMETRY_OPTOUT=1`,
+`ARP_TELEMETRY_DISABLED=1`, `signatureTelemetry.enabled: false` and the
+`~/.opena2a/telemetry-optout` marker all continue to work and now take
+precedence over either opt-in above. Clearing an opt-out no longer starts the
+channel by itself — refusing and never choosing are now distinct states, and
+only an explicit opt-in starts it.
+
+This SDK ships as a library inside other people's production processes, and
+AIM's claim is that identity and audit stay on disk. A channel that phones home
+unless the operator finds the switch is inconsistent with both.
+
+### Fixed
+
+- **The default config no longer enables the channel.** `defaultConfig()`
+  carried `signatureTelemetry: { enabled: true }`, so every `AgentRuntimeProtection`
+  built from defaults — which is every one that does not pass an explicit config
+  — turned the channel on. That value is now absent rather than `false`:
+  an explicit `false` is an opt-out, and because an opt-out beats an opt-in it
+  would have made `AIM_TELEMETRY=1` silently do nothing.
+- **`arp telemetry status` no longer reports "OFF (opted out)" when nobody opted
+  out.** Off-because-refused and off-because-never-enabled are different states
+  and only one of them has a reason to report; the status output and
+  `arp telemetry opt-in` now distinguish them.
+- The first-run disclosure text no longer says "ON by default" and now names how
+  to turn the channel on as well as off.
+
 ## [1.2.0] - 2026-08-11
 
 ### Fixed

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -398,8 +398,8 @@ Turn it off again — an opt-out always wins over an opt-in — with any one of:
   `~/.opena2a/telemetry-optout` across processes.
 
 Any one of these is the runtime-protection module's master switch: it disables
-every telemetry channel the module can produce (structural signatures and the
-opt-in legacy GTIN runtime channel). The causal-denial channel above is
+every telemetry channel the module can produce - structural signatures, the
+opt-in legacy GTIN runtime channel, and fleet behavioral gradients. The causal-denial channel above is
 controlled solely by its own `telemetry` client config and is off unless you
 enabled it. To also delete signatures this sensor already shared, call
 `purgeRemoteSignatures()` (right-to-delete; best-effort, never blocks the

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -255,8 +255,8 @@ fact), the classified intent, and the injection cause (both inferences). The
 full **correlated record** is authoritative and stays on the machine; only an
 anonymized **shared indicator** is ever uploaded. This section covers the
 causal-denial channel only — the runtime-protection module ships a separate
-structural-signature channel that is **on by default**; see the Runtime
-Protection section for its scope and opt-out.
+structural-signature channel that is also **off by default**; see the Runtime
+Protection section for its scope and how to turn it on.
 
 The causal-denial channel is **off by default** and gated by two independent
 opt-ins:
@@ -371,9 +371,9 @@ to "no classification" — it never fabricates a label and never blocks.
 detection outputs flow through the `telemetry.detection` seam into the
 correlated record; they never enter `verifyAction`'s allow/deny decision.
 
-**Structural signature telemetry (on by default, opt-out).** Unlike the
-opt-in causal-denial channel above, the ARP engine shares **structural attack
-signatures** by default: when a detection fires, the structural shape of the
+**Structural signature telemetry (off by default, opt-in).** Like the
+causal-denial channel above, the ARP engine shares nothing unless you turn it
+on. When enabled, and when a detection fires, the structural shape of the
 event sequence — technique identifier, event-type sequence, severity, and a
 one-way hash of structural tokens — is signed and reported to the OpenA2A
 registry (`https://api.oa2a.org`), so an attack shape first seen at one
@@ -382,7 +382,14 @@ contents or paths, command lines, environment values, secrets, IP addresses,
 hostnames, and account, tool, agent, and model names are never shared. A
 one-time disclosure is printed before first collection, and every payload is
 appended to a local audit log (`~/.opena2a/telemetry-audit.log`, JSONL) before
-it is sent. Opt out with any one of:
+it is sent.
+
+Turn it on with either of:
+
+- `AIM_TELEMETRY=1` in the environment, or
+- `signatureTelemetry: { enabled: true }` in your ARP config.
+
+Turn it off again — an opt-out always wins over an opt-in — with any one of:
 
 - `OPENA2A_TELEMETRY_OPTOUT=1` (or `ARP_TELEMETRY_DISABLED=1`) in the
   environment,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -391,6 +391,12 @@ Turn it on with either of:
 
 Turn it off again — an opt-out always wins over an opt-in — with any one of:
 
+- `OPENA2A_TELEMETRY=off` in the environment. This is the ecosystem-wide switch
+  documented at [opena2a.org/privacy](https://opena2a.org/privacy), and it works
+  here the same way it works on the CLIs (`off`, `0`, `false` and `no` are all
+  accepted). It is read in the off direction only: `OPENA2A_TELEMETRY=on` will
+  not turn this channel on, because a library running inside your process should
+  not start a network channel on the strength of an ecosystem-wide CLI setting.
 - `OPENA2A_TELEMETRY_OPTOUT=1` (or `ARP_TELEMETRY_DISABLED=1`) in the
   environment,
 - `signatureTelemetry: { enabled: false }` in your ARP config, or

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -287,7 +287,7 @@ async function telemetryCommand(): Promise<void> {
       // remote purge below is best-effort cleanup of already-sent data and must
       // never block or undo the opt-out (fail OPEN).
       const p = writeOptOutMarker();
-      console.log('\n  OpenA2A telemetry DISABLED (both signature and GTIN channels).');
+      console.log('\n  OpenA2A telemetry DISABLED (signature, GTIN and fleet-gradient channels).');
       console.log(`  Marker: ${p}`);
 
       if (args.includes('--no-purge')) {

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -314,8 +314,13 @@ async function telemetryCommand(): Promise<void> {
         console.log('  NOTE: telemetry is still disabled by an env var or config');
         console.log('  (OPENA2A_TELEMETRY_OPTOUT / ARP_TELEMETRY_DISABLED, or');
         console.log('  signatureTelemetry.enabled: false). Clear those to re-enable.\n');
+      } else if (signatureTelemetryEnabled(tcfg)) {
+        console.log('  Structural signature telemetry is ON.\n');
       } else {
-        console.log('  Structural signature telemetry is ON (default).\n');
+        // Clearing a refusal is not consent. Say so rather than implying the
+        // channel just started.
+        console.log('  This channel stays OFF until you turn it on:');
+        console.log('    AIM_TELEMETRY=1  (or signatureTelemetry.enabled: true)\n');
       }
       break;
     }
@@ -331,10 +336,11 @@ async function telemetryCommand(): Promise<void> {
     disclosure    Print the full install-time disclosure
     opt-out       Disable ALL OpenA2A telemetry (also deletes already-sent
                   signatures from the registry; use --no-purge to skip that)
-    opt-in        Remove the local opt-out marker
+    opt-in        Remove the local opt-out marker (does not turn the channel on)
     purge         Ask the registry to delete already-sent signatures (right-to-delete)
 
-  Structural signatures are DEFAULT-ON. Only the SHAPE of an anomalous
+  Structural signatures are OFF unless you turn them on with AIM_TELEMETRY=1
+  or signatureTelemetry.enabled: true. Only the SHAPE of an anomalous
   behavior is shared, never payloads. Every byte sent is recorded locally
   first — review it with: arp telemetry log
 `);
@@ -422,15 +428,22 @@ async function telemetryLog(): Promise<void> {
 
 async function telemetryStatus(tcfg?: import('../types').SignatureTelemetryConfig): Promise<void> {
   const enabled = signatureTelemetryEnabled(tcfg);
+  const optedOut = isOptedOut(tcfg);
   const records = await readAuditRecords(100000);
   const counts: Record<string, number> = {};
   for (const r of records) counts[r.phase] = (counts[r.phase] ?? 0) + 1;
 
   console.log('\n  OpenA2A structural signature telemetry');
   console.log('  ─────────────────────────────────────');
-  console.log(`  State:        ${enabled ? 'ON (default-on)' : 'OFF (opted out)'}`);
-  if (!enabled) {
+  // Off-because-refused and off-because-never-enabled are different states and
+  // must not be collapsed: only one of them has a reason to report.
+  console.log(
+    `  State:        ${enabled ? 'ON' : optedOut ? 'OFF (opted out)' : 'OFF (not turned on)'}`,
+  );
+  if (optedOut) {
     console.log(`  Opted out by: ${optOutReason(tcfg)}`);
+  } else if (!enabled) {
+    console.log('  Turn on with: AIM_TELEMETRY=1 (or signatureTelemetry.enabled: true)');
   }
   console.log(`  Registry:     ${resolveRegistryUrl(tcfg)}`);
   try {
@@ -453,7 +466,9 @@ async function telemetryStatus(tcfg?: import('../types').SignatureTelemetryConfi
   console.log('  Dropped:      ' + (counts['dropped'] ?? 0));
   console.log('\n  Review payloads: arp telemetry log');
   console.log('  Disclosure:      arp telemetry disclosure');
-  console.log(`  ${enabled ? 'Opt out:         arp telemetry opt-out' : 'Opt back in:     arp telemetry opt-in'}\n`);
+  console.log(
+    `  ${enabled ? 'Opt out:         arp telemetry opt-out' : optedOut ? 'Opt back in:     arp telemetry opt-in' : 'Turn on:         AIM_TELEMETRY=1'}\n`,
+  );
 }
 
 function optOutReason(tcfg?: import('../types').SignatureTelemetryConfig): string {

--- a/sdk/typescript/src/arp/config/loader.ts
+++ b/sdk/typescript/src/arp/config/loader.ts
@@ -96,10 +96,11 @@ export function defaultConfig(): ARPConfig {
       enableBatching: true,
       batchWindowMs: 300000,
     },
-    // Structural signature telemetry is DEFAULT-ON (opt-out). It emits only the
-    // structural shape of anomalous behaviors and writes every byte sent to a
-    // local audit log first. Opt out with OPENA2A_TELEMETRY_OPTOUT=1, `arp
-    // telemetry opt-out`, or `signatureTelemetry.enabled: false`.
-    signatureTelemetry: { enabled: true },
+    // Structural signature telemetry is OFF unless the operator turns it on
+    // (AIM_TELEMETRY=1, or signatureTelemetry.enabled: true). Deliberately
+    // ABSENT here rather than `{ enabled: false }`: an explicit false is an
+    // opt-OUT, and an opt-out beats an opt-in, so writing one here would make
+    // AIM_TELEMETRY=1 silently do nothing. Absent means "nobody has chosen",
+    // which is the only value that leaves both switches working.
   };
 }

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -324,11 +324,16 @@ export class AgentRuntimeProtection {
       this.monitors.push(new A2AProtocolInterceptor(this.engine, al.a2a.trustedAgents));
     }
 
-    // The single master opt-out (env / marker file / config) disables ALL
-    // OpenA2A telemetry, so a customer who opts out is never surprised by
-    // another channel. Resolved once here and applied to both channels below;
-    // the third channel (fleet gradients) applies it in RuntimeTwin itself,
-    // both at construction and again before each send.
+    // The master opt-out (env / marker file / config) disables every channel
+    // THIS module produces, so a customer who opts out is not surprised by a
+    // second one. Resolved once here and applied to both channels below; the
+    // third (fleet gradients) applies it in RuntimeTwin itself, at construction
+    // and again before each send.
+    //
+    // It does NOT govern src/telemetry/relay.ts, which is the AIM client's
+    // causal-denial channel with its own switch, default off. That exclusion is
+    // deliberate and documented in README.md; telemetry-egress-census.test.ts
+    // pins the whole set so a new channel cannot join it silently.
     const optedOut = isOptedOut(this.config.signatureTelemetry);
 
     // Create GTIN forwarder if opted in AND not globally opted out. GTIN remains

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -212,7 +212,7 @@ export class AgentRuntimeProtection {
   private readonly monitors: Monitor[] = [];
   private gtinForwarder: GTINForwarder | null = null;
   /**
-   * Structural signature producer (G2/G4/G5/G7). DEFAULT-ON, opt-out — distinct
+   * Structural signature producer (G2/G4/G5/G7). OFF by default, opt-in — distinct
    * from the legacy opt-in GTIN runtime channel. Null only when the customer has
    * opted out (the single master opt-out, which also gates GTIN below).
    */
@@ -346,7 +346,8 @@ export class AgentRuntimeProtection {
       });
     }
 
-    // Create the structural signature emitter unless opted out (DEFAULT-ON).
+    // Create the structural signature emitter only if explicitly opted in
+    // (OFF by default; see telemetry/signature/config.ts).
     if (signatureTelemetryEnabled(this.config.signatureTelemetry)) {
       this.signatureEmitter = new SignatureEmitter({
         registryUrl: resolveRegistryUrl(this.config.signatureTelemetry),
@@ -381,7 +382,7 @@ export class AgentRuntimeProtection {
     }
 
     // Start the structural signature emitter and, on first run only, print the
-    // plain install-time disclosure (G7) so a default-on customer knows exactly
+    // plain first-run disclosure (G7) so a customer who turned this on knows exactly
     // what is shared and how to opt out.
     if (this.signatureEmitter) {
       maybeShowDisclosure(undefined, this.config.signatureTelemetry);

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -325,8 +325,10 @@ export class AgentRuntimeProtection {
     }
 
     // The single master opt-out (env / marker file / config) disables ALL
-    // OpenA2A telemetry, so a customer who opts out is never surprised by a
-    // second channel. Resolved once here and applied to both channels below.
+    // OpenA2A telemetry, so a customer who opts out is never surprised by
+    // another channel. Resolved once here and applied to both channels below;
+    // the third channel (fleet gradients) applies it in RuntimeTwin itself,
+    // both at construction and again before each send.
     const optedOut = isOptedOut(this.config.signatureTelemetry);
 
     // Create GTIN forwarder if opted in AND not globally opted out. GTIN remains

--- a/sdk/typescript/src/arp/intelligence/runtime-twin.optout.test.ts
+++ b/sdk/typescript/src/arp/intelligence/runtime-twin.optout.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RuntimeTwin } from './runtime-twin';
+import { EventEngine } from '../engine/event-engine';
+import { writeOptOutMarker } from '../telemetry/signature/config';
+import type { ARPEvent, ARPConfig } from '../types';
+
+/**
+ * The fleet-gradient channel and the master opt-out.
+ *
+ * `arp telemetry opt-out`, the first-run disclosure and the TypeScript README all
+ * tell the operator that opting out disables every telemetry channel this module
+ * produces. The fleet gradient is one of those channels: it POSTs to
+ * api.oa2a.org from inside the customer's process. Before this file, nothing
+ * asserted the opt-out reached it, and it did not.
+ *
+ * The first test is the positive control and it matters more than the rest: a
+ * suite that only proves "nothing was sent" passes just as well against a
+ * channel that never sends at all, which would make every other assertion here
+ * vacuous.
+ */
+
+const testConfig: ARPConfig = { rules: [], monitors: [], interceptors: [] };
+
+const GRADIENT_URL = 'https://api.oa2a.org/api/v1/telemetry/behavioral-gradient';
+
+let home: string;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'arp-twin-optout-'));
+  process.env.OPENA2A_HOME = home;
+  delete process.env.OPENA2A_TELEMETRY_OPTOUT;
+  delete process.env.ARP_TELEMETRY_DISABLED;
+
+  fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.OPENA2A_HOME;
+  delete process.env.OPENA2A_TELEMETRY_OPTOUT;
+  delete process.env.ARP_TELEMETRY_DISABLED;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function emitTestEvent(engine: EventEngine): Promise<ARPEvent> {
+  return engine.emit({
+    source: 'test-monitor',
+    category: 'normal',
+    severity: 'info',
+    description: 'Test event',
+    data: { source: 'process', capability: 'db:read' },
+  });
+}
+
+/** Feed the twin real events, then force the flush that shutdown() performs. */
+async function runAndFlush(twin: RuntimeTwin, engine: EventEngine, events = 5) {
+  twin.attach(engine);
+  for (let i = 0; i < events; i++) await emitTestEvent(engine);
+  await new Promise(r => setTimeout(r, 50));
+  await twin.shutdown();
+  await new Promise(r => setTimeout(r, 20));
+}
+
+function gradientPosts() {
+  return fetchSpy.mock.calls.filter(c => String(c[0]) === GRADIENT_URL);
+}
+
+describe('fleet gradients honor the master opt-out', () => {
+  it('POSITIVE CONTROL: transmits when fleet is on and nobody has opted out', async () => {
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('control-agent', { fleetEnabled: true });
+
+    await runAndFlush(twin, engine);
+
+    // If this ever goes to 0, every assertion below is proving nothing.
+    expect(gradientPosts().length).toBeGreaterThan(0);
+  });
+
+  it('sends nothing when OPENA2A_TELEMETRY_OPTOUT is set', async () => {
+    process.env.OPENA2A_TELEMETRY_OPTOUT = '1';
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('env-optout-agent', { fleetEnabled: true });
+
+    await runAndFlush(twin, engine);
+
+    expect(gradientPosts()).toHaveLength(0);
+  });
+
+  it('sends nothing when ARP_TELEMETRY_DISABLED is set', async () => {
+    process.env.ARP_TELEMETRY_DISABLED = 'true';
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('env2-optout-agent', { fleetEnabled: true });
+
+    await runAndFlush(twin, engine);
+
+    expect(gradientPosts()).toHaveLength(0);
+  });
+
+  it('sends nothing when the opt-out marker file exists', async () => {
+    writeOptOutMarker();
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('marker-optout-agent', { fleetEnabled: true });
+
+    await runAndFlush(twin, engine);
+
+    expect(gradientPosts()).toHaveLength(0);
+  });
+
+  it('honors an opt-out written AFTER the twin was constructed', async () => {
+    // Pins the pre-send re-check specifically. The constructor gate cannot
+    // catch this case: fleet was legitimately enabled when the process started
+    // and the refusal arrived while it was running.
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('late-optout-agent', { fleetEnabled: true });
+
+    twin.attach(engine);
+    for (let i = 0; i < 5; i++) await emitTestEvent(engine);
+    await new Promise(r => setTimeout(r, 50));
+
+    writeOptOutMarker();
+
+    await twin.shutdown();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(gradientPosts()).toHaveLength(0);
+  });
+
+  it('stays off when fleet was never enabled, opt-out or not', async () => {
+    const engine = new EventEngine(testConfig);
+    const twin = new RuntimeTwin('default-agent');
+
+    await runAndFlush(twin, engine);
+
+    expect(gradientPosts()).toHaveLength(0);
+  });
+});

--- a/sdk/typescript/src/arp/intelligence/runtime-twin.ts
+++ b/sdk/typescript/src/arp/intelligence/runtime-twin.ts
@@ -33,6 +33,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { isOptedOut } from '../telemetry/signature/config';
 import type { ARPEvent } from '../types';
 import type { EventEngine } from '../engine/event-engine';
 
@@ -117,7 +118,10 @@ export class RuntimeTwin {
     this.agentId = agentId;
     this.sessionId = crypto.randomUUID();
     this.enabled = config?.enabled ?? true;
-    this.fleetEnabled = config?.fleetEnabled ?? false; // opt-in only
+    // Opt-in only, and an opt-out beats the opt-in. Resolved once here so the
+    // per-event accumulation path costs no syscall; flushGradient re-checks
+    // before sending so an opt-out written after startup is still honored.
+    this.fleetEnabled = (config?.fleetEnabled ?? false) && !isOptedOut();
     this.agentCategory = config?.agentCategory ?? 'general';
     this.eventLogPath = path.join(os.homedir(), '.opena2a', 'arp', 'events.jsonl');
 
@@ -450,6 +454,17 @@ export class RuntimeTwin {
    */
   private async flushGradient(): Promise<void> {
     if (this.gradientEventCount === 0) return;
+
+    // Pre-send re-check of the master opt-out. This is the only point at which
+    // fleet gradients leave the process, so it is the point that has to honor
+    // "opting out disables all OpenA2A telemetry". Accumulators are reset on the
+    // way out so a refusal does not turn this into a per-event check.
+    if (isOptedOut()) {
+      this.gradientAccumulator = new Array(GRADIENT_DIMS).fill(0);
+      this.gradientEventCount = 0;
+      this.gradientLossSum = 0;
+      return;
+    }
 
     // Normalize gradient by event count
     const normalized = this.gradientAccumulator.map(

--- a/sdk/typescript/src/arp/telemetry/signature/audit-log.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/audit-log.ts
@@ -1,11 +1,11 @@
 /**
- * Local customer audit log (G2) — the trust counterweight for default-on.
+ * Local customer audit log (G2) — the trust counterweight for any sending at all.
  *
  * BEFORE any payload is transmitted, the producer appends to this local,
  * append-only JSONL log EXACTLY the bytes it will send. A customer can therefore
  * verify with their own eyes (via `arp telemetry log`) that no payload, prompt,
- * argument, path, secret, or PII ever leaves the device — which is what makes a
- * default-on / opt-out posture defensible.
+ * argument, path, secret, or PII ever leaves the device — the evidence behind
+ * the claim, rather than a promise to be taken on trust.
  *
  * The log write is best-effort and FAILS OPEN: a logging failure never blocks or
  * crashes the agent. Writes happen on the emitter's flush path, off the agent's

--- a/sdk/typescript/src/arp/telemetry/signature/config.test.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.test.ts
@@ -16,6 +16,7 @@ let home: string;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'arp-cfg-'));
   process.env.OPENA2A_HOME = home;
+  delete process.env.OPENA2A_TELEMETRY;
   delete process.env.OPENA2A_TELEMETRY_OPTOUT;
   delete process.env.ARP_TELEMETRY_DISABLED;
   delete process.env.OPENA2A_REGISTRY_URL;
@@ -23,6 +24,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   delete process.env.OPENA2A_HOME;
+  delete process.env.OPENA2A_TELEMETRY;
   delete process.env.OPENA2A_TELEMETRY_OPTOUT;
   delete process.env.ARP_TELEMETRY_DISABLED;
   delete process.env.OPENA2A_REGISTRY_URL;
@@ -66,6 +68,57 @@ describe('the channel is OFF unless explicitly turned on', () => {
 
   it('config enabled:true turns it on', () => {
     expect(signatureTelemetryEnabled({ enabled: true })).toBe(true);
+  });
+});
+
+describe('OPENA2A_TELEMETRY — the spelling the published privacy policy documents', () => {
+  // opena2a.org/privacy tells users verbatim: "Set the environment variable
+  // OPENA2A_TELEMETRY=off in your shell profile", and opena2a.org/telemetry
+  // repeats it as working "on every OpenA2A CLI". Every published version of
+  // this SDK (1.0.0 through 1.1.0) read only OPENA2A_TELEMETRY_OPTOUT and
+  // ARP_TELEMETRY_DISABLED, so a user who did exactly what the policy said was
+  // still emitting. These tests fail on that code.
+  //
+  // Value semantics are the ecosystem's, not this file's older truthy-name
+  // convention: the canonical predicate is
+  // opena2a/packages/telemetry/src/config.ts envOptOut(), which opts out on
+  // off/0/false/no after a trim. A name-truthy test would read
+  // OPENA2A_TELEMETRY=off as "not set" and fail open.
+
+  it.each(['off', '0', 'false', 'no', 'OFF', 'False', ' off ', 'off\n'])(
+    'OPENA2A_TELEMETRY=%j opts out',
+    (v) => {
+      process.env.OPENA2A_TELEMETRY = v;
+      expect(isOptedOut()).toBe(true);
+      expect(signatureTelemetryEnabled()).toBe(false);
+    },
+  );
+
+  it('beats an explicit opt-in, like every other opt-out source', () => {
+    process.env.AIM_TELEMETRY = '1';
+    process.env.OPENA2A_TELEMETRY = 'off';
+    expect(signatureTelemetryEnabled()).toBe(false);
+    expect(signatureTelemetryEnabled({ enabled: true })).toBe(false);
+  });
+
+  it('does NOT opt in when set to an on value — the switch only moves the safe way', () => {
+    // Deliberate asymmetry. OPENA2A_TELEMETRY is an ecosystem-wide CLI switch;
+    // this SDK is a library running inside someone else's production process.
+    // Someone who exported OPENA2A_TELEMETRY=on for the CLIs must not thereby
+    // start a network channel inside their agent. Opting IN stays explicit and
+    // AIM-specific (AIM_TELEMETRY / signatureTelemetry.enabled).
+    for (const v of ['on', '1', 'true', 'yes']) {
+      process.env.OPENA2A_TELEMETRY = v;
+      expect(isOptedIn()).toBe(false);
+      expect(signatureTelemetryEnabled()).toBe(false);
+    }
+  });
+
+  it('unset or empty is not a refusal', () => {
+    delete process.env.OPENA2A_TELEMETRY;
+    expect(isOptedOut()).toBe(false);
+    process.env.OPENA2A_TELEMETRY = '';
+    expect(isOptedOut()).toBe(false);
   });
 });
 

--- a/sdk/typescript/src/arp/telemetry/signature/config.test.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   isOptedOut,
+  isOptedIn,
   signatureTelemetryEnabled,
   resolveRegistryUrl,
   writeOptOutMarker,
@@ -18,24 +19,101 @@ beforeEach(() => {
   delete process.env.OPENA2A_TELEMETRY_OPTOUT;
   delete process.env.ARP_TELEMETRY_DISABLED;
   delete process.env.OPENA2A_REGISTRY_URL;
+  delete process.env.AIM_TELEMETRY;
 });
 afterEach(() => {
   delete process.env.OPENA2A_HOME;
   delete process.env.OPENA2A_TELEMETRY_OPTOUT;
   delete process.env.ARP_TELEMETRY_DISABLED;
   delete process.env.OPENA2A_REGISTRY_URL;
+  delete process.env.AIM_TELEMETRY;
   rmSync(home, { recursive: true, force: true });
 });
 
-describe('master opt-out — default-on', () => {
-  it('is ON by default (no opt-out source active)', () => {
+describe('the channel is OFF unless explicitly turned on', () => {
+  it('does NOT run when nothing is configured — taking no action shares nothing', () => {
+    expect(signatureTelemetryEnabled()).toBe(false);
+  });
+
+  it('doing nothing is not the same as refusing: nobody opted in, nobody opted out', () => {
+    // Guards the invariant that broke the old design, where these were each
+    // other's negation and "no action" therefore read as consent.
+    expect(isOptedIn()).toBe(false);
     expect(isOptedOut()).toBe(false);
+  });
+
+  it('AIM_TELEMETRY turns it on', () => {
+    process.env.AIM_TELEMETRY = '1';
+    expect(isOptedIn()).toBe(true);
     expect(signatureTelemetryEnabled()).toBe(true);
   });
 
+  it.each(['1', 'true', 'yes', 'on', 'TRUE', ' On '])(
+    'AIM_TELEMETRY=%j is a recognised truthy opt-in',
+    (v) => {
+      process.env.AIM_TELEMETRY = v;
+      expect(signatureTelemetryEnabled()).toBe(true);
+    },
+  );
+
+  it.each(['0', 'false', 'no', 'off', '', 'maybe'])(
+    'AIM_TELEMETRY=%j does NOT turn it on',
+    (v) => {
+      process.env.AIM_TELEMETRY = v;
+      expect(signatureTelemetryEnabled()).toBe(false);
+    },
+  );
+
+  it('config enabled:true turns it on', () => {
+    expect(signatureTelemetryEnabled({ enabled: true })).toBe(true);
+  });
+});
+
+describe('the shipped default config does not turn the channel on', () => {
+  // This is the hazard that made the opt-in flip vacuous once already:
+  // defaultConfig() carried `signatureTelemetry: { enabled: true }`, which the
+  // opt-in check reads as an explicit choice, so every ARP built from defaults
+  // ran the channel. Asserted against the REAL loader, not a copy of its shape.
+  it('defaultConfig() does not opt in', async () => {
+    const { defaultConfig } = await import('../../config/loader');
+    expect(signatureTelemetryEnabled(defaultConfig().signatureTelemetry)).toBe(false);
+  });
+
+  it('defaultConfig() does not opt OUT either — AIM_TELEMETRY must still work', async () => {
+    // A `{ enabled: false }` default would also make this test's sibling pass
+    // while permanently disabling the env var, so pin both directions.
+    const { defaultConfig } = await import('../../config/loader');
+    process.env.AIM_TELEMETRY = '1';
+    expect(signatureTelemetryEnabled(defaultConfig().signatureTelemetry)).toBe(true);
+  });
+});
+
+describe('an opt-out always beats an opt-in', () => {
+  it('config enabled:false wins over AIM_TELEMETRY=1', () => {
+    process.env.AIM_TELEMETRY = '1';
+    expect(signatureTelemetryEnabled({ enabled: false })).toBe(false);
+  });
+
+  it('OPENA2A_TELEMETRY_OPTOUT wins over config enabled:true', () => {
+    process.env.OPENA2A_TELEMETRY_OPTOUT = '1';
+    expect(signatureTelemetryEnabled({ enabled: true })).toBe(false);
+  });
+
+  it('ARP_TELEMETRY_DISABLED wins over config enabled:true', () => {
+    process.env.ARP_TELEMETRY_DISABLED = 'true';
+    expect(signatureTelemetryEnabled({ enabled: true })).toBe(false);
+  });
+
+  it('the marker file wins over AIM_TELEMETRY=1', () => {
+    process.env.AIM_TELEMETRY = '1';
+    writeOptOutMarker();
+    expect(signatureTelemetryEnabled()).toBe(false);
+  });
+});
+
+describe('master opt-out — unchanged semantics (still gates GTIN and the pre-send re-check)', () => {
   it('config enabled:false opts out', () => {
     expect(isOptedOut({ enabled: false })).toBe(true);
-    expect(signatureTelemetryEnabled({ enabled: false })).toBe(false);
   });
 
   it('OPENA2A_TELEMETRY_OPTOUT opts out', () => {
@@ -48,7 +126,7 @@ describe('master opt-out — default-on', () => {
     expect(isOptedOut()).toBe(true);
   });
 
-  it('the marker file opts out, and clearing it re-enables', () => {
+  it('the marker file opts out, and clearing it lifts the refusal', () => {
     expect(optOutMarkerExists()).toBe(false);
     writeOptOutMarker();
     expect(optOutMarkerExists()).toBe(true);
@@ -56,6 +134,8 @@ describe('master opt-out — default-on', () => {
     clearOptOutMarker();
     expect(optOutMarkerExists()).toBe(false);
     expect(isOptedOut()).toBe(false);
+    // Clearing a refusal must NOT itself start the channel.
+    expect(signatureTelemetryEnabled()).toBe(false);
   });
 });
 

--- a/sdk/typescript/src/arp/telemetry/signature/config.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.ts
@@ -1,14 +1,34 @@
 /**
- * Signature telemetry configuration + the single master opt-out.
+ * Signature telemetry configuration, the explicit opt-in, and the master opt-out.
  *
- * Ratified posture (project_telemetry_consent_design): structural signatures are
- * DEFAULT-ON, opt-out. The opt-out is a SINGLE master switch — when a customer
- * opts out, BOTH this signature channel and the legacy GTIN runtime channel are
- * disabled, so there is never a surprise second channel. Opt-out is honored from
- * three independent sources (any one disables):
+ * Posture: OPT-IN. The channel is disabled by default and starts only when the
+ * operator turns it on explicitly. This supersedes the earlier default-on,
+ * opt-out ratification (`project_telemetry_consent_design`) for this SDK
+ * surface, per the 2026-08-11 ruling in `todo/COUNCIL_LEDGER.md`: AIM telemetry
+ * is opt-in by explicit configuration only, is never prompted for, and is
+ * disabled by default in every distribution channel.
+ *
+ * Why the reversal: this SDK ships as a library inside other people's
+ * production processes, and AIM's product claim is that identity and audit stay
+ * on disk. A channel that phones home unless you find the switch is
+ * inconsistent with both.
+ *
+ * Turning it ON requires one of (either is explicit and operator-chosen):
+ *   1. Environment: AIM_TELEMETRY truthy.
+ *   2. Config: `signatureTelemetry.enabled === true`.
+ *
+ * Turning it OFF is honored from three independent sources, and an opt-out
+ * ALWAYS beats an opt-in — the switch only ever moves in the safe direction, so
+ * a stale env var cannot re-enable a channel someone deliberately disabled:
  *   1. Environment: OPENA2A_TELEMETRY_OPTOUT / ARP_TELEMETRY_DISABLED truthy.
  *   2. A marker file at ~/.opena2a/telemetry-optout (written by `arp telemetry opt-out`).
  *   3. Config: `signatureTelemetry.enabled === false`.
+ *
+ * `isOptedOut` deliberately keeps its original meaning — "has someone actively
+ * refused?" — because it is ALSO the master switch gating the separate GTIN
+ * runtime channel (see `arp/index.ts`) and the emitter's own pre-send re-check.
+ * Ask `signatureTelemetryEnabled` for "should this channel run?"; the two are no
+ * longer each other's negation.
  */
 
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
@@ -32,8 +52,13 @@ export function optOutMarkerExists(): boolean {
 }
 
 /**
- * The single master opt-out decision. True if ANY opt-out source is active. This
- * is consulted both for the signature channel AND (in index.ts) to gate GTIN.
+ * The master opt-out decision: has someone ACTIVELY refused telemetry? True if
+ * any opt-out source is active. Consulted by the signature channel, by the
+ * emitter's pre-send re-check, and (in index.ts) to gate the GTIN channel.
+ *
+ * Note this is NOT the negation of `signatureTelemetryEnabled`. Taking no action
+ * at all leaves this false (nobody refused) while the channel still does not run
+ * (nobody opted in).
  */
 export function isOptedOut(config?: SignatureTelemetryConfig): boolean {
   if (config?.enabled === false) return true;
@@ -42,9 +67,23 @@ export function isOptedOut(config?: SignatureTelemetryConfig): boolean {
   return false;
 }
 
-/** Whether the signature channel should run (default-on unless opted out). */
+/**
+ * Whether the operator has explicitly asked for the signature channel. Does not
+ * consider opt-outs; `signatureTelemetryEnabled` applies those on top.
+ */
+export function isOptedIn(config?: SignatureTelemetryConfig): boolean {
+  if (config?.enabled === true) return true;
+  if (envTruthy('AIM_TELEMETRY')) return true;
+  return false;
+}
+
+/**
+ * Whether the signature channel should run. OFF unless explicitly enabled, and
+ * an opt-out always wins over an opt-in.
+ */
 export function signatureTelemetryEnabled(config?: SignatureTelemetryConfig): boolean {
-  return !isOptedOut(config);
+  if (isOptedOut(config)) return false;
+  return isOptedIn(config);
 }
 
 /** Resolve the registry base URL for ingestion. */

--- a/sdk/typescript/src/arp/telemetry/signature/config.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.ts
@@ -45,6 +45,31 @@ function envTruthy(name: string): boolean {
   return s === '1' || s === 'true' || s === 'yes' || s === 'on';
 }
 
+/**
+ * The ecosystem-wide opt-out, read in the OFF direction only.
+ *
+ * `opena2a.org/privacy` tells users verbatim to "Set the environment variable
+ * OPENA2A_TELEMETRY=off in your shell profile", and `opena2a.org/telemetry`
+ * repeats it as working on every OpenA2A surface. This is a VALUE predicate,
+ * not a truthy-name one: the name being present means nothing, the value
+ * off/0/false/no is the refusal. Reading it with `envTruthy` would treat
+ * `OPENA2A_TELEMETRY=off` as unset and fail open on the one spelling we
+ * publish. Kept byte-compatible with the canonical implementation in
+ * `opena2a/packages/telemetry/src/config.ts` (`envOptOut`), trim included —
+ * trailing whitespace is routine in .env files, docker-compose YAML and
+ * command substitution, and an opt-out must never fail open over a stray space.
+ *
+ * Deliberately one-directional: `OPENA2A_TELEMETRY=on` does NOT opt in here.
+ * That variable is an ecosystem CLI switch, while this SDK is a library inside
+ * someone else's production process; opting in stays explicit and AIM-specific.
+ */
+function ecosystemOptOut(): boolean {
+  const v = process.env.OPENA2A_TELEMETRY;
+  if (v === undefined) return false;
+  const s = v.trim().toLowerCase();
+  return s === 'off' || s === '0' || s === 'false' || s === 'no';
+}
+
 /** True if the opt-out marker file is present. */
 export function optOutMarkerExists(): boolean {
   return existsSync(homePath(OPTOUT_MARKER_FILE));
@@ -62,6 +87,7 @@ export function optOutMarkerExists(): boolean {
 export function isOptedOut(config?: SignatureTelemetryConfig): boolean {
   if (config?.enabled === false) return true;
   if (envTruthy('OPENA2A_TELEMETRY_OPTOUT') || envTruthy('ARP_TELEMETRY_DISABLED')) return true;
+  if (ecosystemOptOut()) return true;
   if (optOutMarkerExists()) return true;
   return false;
 }

--- a/sdk/typescript/src/arp/telemetry/signature/config.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.ts
@@ -2,11 +2,10 @@
  * Signature telemetry configuration, the explicit opt-in, and the master opt-out.
  *
  * Posture: OPT-IN. The channel is disabled by default and starts only when the
- * operator turns it on explicitly. This supersedes the earlier default-on,
- * opt-out ratification (`project_telemetry_consent_design`) for this SDK
- * surface, per the 2026-08-11 ruling in `todo/COUNCIL_LEDGER.md`: AIM telemetry
- * is opt-in by explicit configuration only, is never prompted for, and is
- * disabled by default in every distribution channel.
+ * operator turns it on explicitly. This reverses an earlier default-on,
+ * opt-out posture for this SDK surface. Telemetry here is opt-in by explicit
+ * configuration only, is never prompted for, and is disabled by default in
+ * every distribution channel.
  *
  * Why the reversal: this SDK ships as a library inside other people's
  * production processes, and AIM's product claim is that identity and audit stay

--- a/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
@@ -55,8 +55,13 @@ export function disclosureText(config?: SignatureTelemetryConfig): string {
     '  - set OPENA2A_TELEMETRY_OPTOUT=1 (or ARP_TELEMETRY_DISABLED=1)',
     '  - signatureTelemetry.enabled: false in your ARP config',
     '  - run `arp telemetry opt-out` (hackmyagent CLI)',
-    'An opt-out always wins over an opt-in. Opting out disables ALL OpenA2A',
-    'telemetry and purges shared signatures on the registry (right-to-delete).',
+    'An opt-out always wins over an opt-in. It disables every channel this',
+    'runtime-protection module produces: structural signatures, the legacy GTIN',
+    'channel, and fleet behavioral gradients. It also purges signatures this',
+    'sensor already shared with the registry (right-to-delete). Fleet gradients',
+    'carry no identifier, so there is nothing about them to purge.',
+    'The AIM client has a separate causal-denial relay with its own switch,',
+    'off unless you enabled it; this opt-out does not govern it.',
   ].join('\n');
 }
 

--- a/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/disclosure.ts
@@ -1,24 +1,28 @@
 /**
- * Install-time disclosure (G7).
+ * First-run disclosure (G7).
  *
- * A default-on / opt-out posture is only ethical if the customer is told plainly,
- * at first run, exactly what is shared, why, and how to turn it off. This text is
- * intentionally plain and non-marketing (CPO/legal voice). It is shown once (a
- * marker is written after the first show) and is always available on demand via
- * `disclosureText()` (or `arp telemetry disclosure` for hackmyagent CLI users).
+ * The channel is opt-in, so this text is shown to someone who has already turned
+ * it on: it confirms plainly what that choice shares, what it never shares, and
+ * how to reverse it. Intentionally plain and non-marketing (CPO/legal voice).
+ * Shown once (a marker is written after the first show) and always available on
+ * demand via `disclosureText()` (or `arp telemetry disclosure` for hackmyagent
+ * CLI users).
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { opena2aHome, homePath, DISCLOSURE_MARKER_FILE } from './paths';
 import { auditLogPath } from './audit-log';
-import { isOptedOut, type SignatureTelemetryConfig } from './config';
+import { isOptedOut, signatureTelemetryEnabled, type SignatureTelemetryConfig } from './config';
 
-/** Build the disclosure text. Reflects the CURRENT opt-out state for honesty. */
+/** Build the disclosure text. Reflects the CURRENT channel state for honesty. */
 export function disclosureText(config?: SignatureTelemetryConfig): string {
   const optedOut = isOptedOut(config);
+  const enabled = signatureTelemetryEnabled(config);
   const status = optedOut
     ? 'Status: OFF. You have opted out; nothing is shared.'
-    : 'Status: ON by default. Structural signatures are shared (see below).';
+    : enabled
+      ? 'Status: ON. You turned this on; structural signatures are shared (see below).'
+      : 'Status: OFF. This channel is off unless you turn it on; nothing is shared.';
 
   return [
     'OpenA2A community threat intelligence',
@@ -35,7 +39,7 @@ export function disclosureText(config?: SignatureTelemetryConfig): string {
     'hostnames, account ids, or the names of your tools, agents, or models.',
     '',
     'Why: shared structural signatures let an attack first seen at one deployment',
-    'protect every other deployment. Collection is off until you have visibility:',
+    'protect every other deployment. Nothing is sent until you have visibility:',
     'every payload is written to a local audit log BEFORE it is sent, so you can',
     'verify exactly what left your machine.',
     '',
@@ -43,12 +47,16 @@ export function disclosureText(config?: SignatureTelemetryConfig): string {
     'Review it:  read the audit log file above. If you installed the hackmyagent',
     '            CLI you can also run `arp telemetry log` / `arp telemetry status`.',
     '',
-    'How to turn it off (any one):',
+    'This channel is OFF unless you turn it on (either one):',
+    '  - set AIM_TELEMETRY=1',
+    '  - signatureTelemetry.enabled: true in your ARP config',
+    '',
+    'How to turn it off again (any one):',
     '  - set OPENA2A_TELEMETRY_OPTOUT=1 (or ARP_TELEMETRY_DISABLED=1)',
     '  - signatureTelemetry.enabled: false in your ARP config',
     '  - run `arp telemetry opt-out` (hackmyagent CLI)',
-    'Opting out disables ALL OpenA2A telemetry and purges shared signatures',
-    'on the registry (right-to-delete).',
+    'An opt-out always wins over an opt-in. Opting out disables ALL OpenA2A',
+    'telemetry and purges shared signatures on the registry (right-to-delete).',
   ].join('\n');
 }
 

--- a/sdk/typescript/src/arp/telemetry/signature/index.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/index.ts
@@ -62,6 +62,7 @@ export type { AuditRecord, AuditPhase } from './audit-log';
 
 export {
   isOptedOut,
+  isOptedIn,
   optOutMarkerExists,
   signatureTelemetryEnabled,
   resolveRegistryUrl,

--- a/sdk/typescript/src/arp/telemetry/signature/redaction.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/redaction.ts
@@ -4,7 +4,7 @@
  * This is the privacy chokepoint of the producer. It reduces a runtime ARP
  * observation to a CLOSED SET of allowlisted structural tokens — the SHAPE of a
  * behavior — and nothing else. It is deliberately small and readable so that a
- * customer can audit it before trusting the default-on channel.
+ * customer can audit it before trusting the channel.
  *
  * Hard invariants (see opena2a-registry/docs/telemetry-behavioral-hash-spec.md):
  *   - Every output token comes from a fixed enum in THIS file. No value is ever

--- a/sdk/typescript/src/arp/types.ts
+++ b/sdk/typescript/src/arp/types.ts
@@ -74,17 +74,22 @@ export interface ARPConfig {
   /** GTIN (Global Threat Intelligence Network) opt-in configuration */
   gtin?: GTINConfig;
   /**
-   * Structural signature telemetry (DEFAULT-ON, opt-out). Distinct from GTIN.
+   * Structural signature telemetry (OFF by default, opt-in). Distinct from GTIN.
    * Emits only the structural shape of anomalous behaviors, with a local audit
-   * log of every byte sent. Set `enabled: false` (or OPENA2A_TELEMETRY_OPTOUT,
-   * or `arp telemetry opt-out`) to disable ALL OpenA2A telemetry.
+   * log of every byte sent. Turn on with `enabled: true` or AIM_TELEMETRY=1.
+   * Set `enabled: false` (or OPENA2A_TELEMETRY_OPTOUT, or `arp telemetry
+   * opt-out`) to disable ALL OpenA2A telemetry.
    */
   signatureTelemetry?: SignatureTelemetryConfig;
 }
 
 /** Structural signature telemetry configuration (see telemetry/signature). */
 export interface SignatureTelemetryConfig {
-  /** Master enable. Default true (default-on). false opts out of ALL telemetry. */
+  /**
+   * Master switch. Undefined (the default) means nobody has chosen and the
+   * channel does NOT run. true opts in; false opts out of ALL telemetry and
+   * beats any opt-in.
+   */
   enabled?: boolean;
   /** Registry base URL override (default OPENA2A_REGISTRY_URL or https://api.oa2a.org). */
   registryUrl?: string;

--- a/sdk/typescript/src/telemetry-egress-census.test.ts
+++ b/sdk/typescript/src/telemetry-egress-census.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Every module that sends data to the OpenA2A registry, and whether the master
+ * opt-out reaches it.
+ *
+ * This pins the CLASS, not an instance. Two consent defects in this SDK were the
+ * same shape: a channel was added, it POSTed to the registry, and nobody wired it
+ * to the opt-out — while the user-facing text kept promising the opt-out covered
+ * everything. Per-channel tests cannot catch that, because the failure is a
+ * channel nobody wrote a test for. The only thing that catches it is enumerating
+ * the channels from the source and asserting the set.
+ *
+ * The sweep that found the third channel missed the fourth by scoping its grep to
+ * `src/arp/`. This test reads the whole of `src/` for that reason.
+ *
+ * If this test fails because you added a channel: wire it to `isOptedOut()`, or
+ * add it to EXCLUDED with the reason and the user-facing text that discloses it.
+ * Do not widen the matcher.
+ */
+
+const SRC = join(__dirname);
+const REGISTRY_HOST = 'api.oa2a.org';
+
+/**
+ * Channels deliberately outside the ARP master opt-out.
+ *
+ * Listing one here is a claim that its exclusion is disclosed to the user. Both
+ * README.md and the first-run disclosure state that the causal-denial relay has
+ * its own switch and is not governed by this opt-out.
+ */
+const EXCLUDED: Record<string, string> = {
+  'telemetry/relay.ts':
+    'AIM client causal-denial relay. Own switch (telemetry.enabled + relay.enabled), ' +
+    'default off. Exclusion is stated in README.md and in the first-run disclosure. ' +
+    'Tracked for review as a joint DPO/CA question.',
+};
+
+/**
+ * Channels whose gate lives at the construction site rather than inside the
+ * module. Listing one here is not an exemption: the guard named below is
+ * asserted to still exist, so deleting it fails this test.
+ */
+const GATED_AT_CALLSITE: Record<string, { site: string; guard: RegExp }> = {
+  'arp/telemetry/gtin.ts': {
+    site: 'arp/index.ts',
+    // The forwarder is never constructed while opted out.
+    guard: /this\.config\.gtin\?\.enabled\s*&&\s*!optedOut/,
+  },
+};
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist') continue;
+      walk(p, out);
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * Strip comments before looking for senders. `src/index.ts` documents Express and
+ * Fastify integration with `app.post(...)` examples in JSDoc; counting those as
+ * telemetry egress made the census report a module that transmits nothing.
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * Any call that puts bytes on the wire, including an injected or aliased sender.
+ *
+ * `telemetry/relay.ts` transmits via `this.fetchImpl(...)`, so a matcher looking
+ * only for a literal `fetch(` does not see it — and a channel is invisible to
+ * this census exactly when it is hardest to notice by hand. Match any
+ * fetch-shaped identifier, bare or as a member call.
+ */
+const SENDER = /(^|[^A-Za-z0-9_$.])fetch[A-Za-z0-9_$]*\s*\(|\.\s*fetch[A-Za-z0-9_$]*\s*\(|\baxios\.|\bhttps?\.request\s*\(/;
+
+/** Modules that actually transmit to the registry, as opposed to naming its URL. */
+function egressModules(): string[] {
+  const hits: string[] = [];
+  for (const file of walk(SRC)) {
+    const code = stripComments(readFileSync(file, 'utf-8'));
+    const sends = SENDER.test(code);
+    if (!sends) continue;
+    const reachesRegistry =
+      code.includes(REGISTRY_HOST) ||
+      /registryUrl|REGISTRY_URL|this\.endpoint/.test(code);
+    if (reachesRegistry) hits.push(relative(SRC, file));
+  }
+  return hits.sort();
+}
+
+describe('telemetry egress census', () => {
+  it('finds the channels at all — the census is not silently empty', () => {
+    // Without this, every assertion below passes vacuously if walk() or the
+    // matcher breaks and the census returns nothing.
+    const mods = egressModules();
+    expect(mods.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('every registry egress module consults the master opt-out, or is a disclosed exclusion', () => {
+    const offenders: string[] = [];
+
+    for (const mod of egressModules()) {
+      if (mod in EXCLUDED) continue;
+      if (mod in GATED_AT_CALLSITE) continue; // its guard is asserted separately below
+      const src = readFileSync(join(SRC, mod), 'utf-8');
+      if (!src.includes('isOptedOut')) offenders.push(mod);
+    }
+
+    expect(
+      offenders,
+      `These modules send to ${REGISTRY_HOST} without consulting isOptedOut():\n` +
+        offenders.map(o => `  - ${o}`).join('\n') +
+        '\n\nWire each to isOptedOut(), or add it to EXCLUDED with the reason and ' +
+        'the user-facing text that discloses it.',
+    ).toEqual([]);
+  });
+
+  it('call-site gates still exist — a channel listed as gated elsewhere really is', () => {
+    for (const [mod, { site, guard }] of Object.entries(GATED_AT_CALLSITE)) {
+      const siteSrc = readFileSync(join(SRC, site), 'utf-8');
+      expect(
+        guard.test(siteSrc),
+        `${mod} is recorded as gated at ${site}, but that guard is gone. ` +
+          `Either restore it, or wire ${mod} to isOptedOut() directly.`,
+      ).toBe(true);
+    }
+  });
+
+  it('the known ARP channels are present and gated — guards against a matcher that stops matching', () => {
+    const mods = egressModules();
+    // Positive control: if these three ever drop out of the census, the matcher
+    // has broken and the assertion above is no longer measuring anything.
+    for (const expected of [
+      'arp/intelligence/runtime-twin.ts',
+      'arp/telemetry/gtin.ts',
+      'arp/telemetry/signature/emitter.ts',
+    ]) {
+      expect(mods, `${expected} fell out of the census`).toContain(expected);
+    }
+  });
+
+  it('every EXCLUDED entry still exists and still sends — stale exemptions do not linger', () => {
+    const mods = egressModules();
+    for (const mod of Object.keys(EXCLUDED)) {
+      expect(
+        mods,
+        `${mod} is exempted but no longer sends to the registry. Remove the exemption.`,
+      ).toContain(mod);
+    }
+  });
+});


### PR DESCRIPTION
Structural signature telemetry in this SDK ran by default and sent the structural shape of anomalous runtime events to `https://api.oa2a.org` from inside the consuming process. This turns it off unless the operator explicitly asks for it, and makes the opt-out that our privacy policy actually documents work.

## The measurement that set the scope

Probed against the artifacts on npm — not the source tree — with a clean `HOME`:

| version | published | default posture | `OPENA2A_TELEMETRY=off` honored |
|---|---|---|---|
| 1.0.0 | 2026-07-06 | **ON** | no |
| 1.0.1 | 2026-07-06 | **ON** | no |
| 1.0.2 | 2026-07-06 | **ON** | no |
| 1.0.3 | 2026-07-16 | **ON** | no |
| 1.1.0 | 2026-07-16 | **ON** | no |

Every version ever published. `opena2a.org/privacy` tells users verbatim to "Set the environment variable `OPENA2A_TELEMETRY=off` in your shell profile", and `opena2a.org/telemetry` repeats it as working across OpenA2A surfaces — but this SDK read only `OPENA2A_TELEMETRY_OPTOUT` and `ARP_TELEMETRY_DISABLED`, neither of which appears in the policy. A user who followed the published instruction exactly was still emitting.

**A measurement trap worth naming:** the first probes all reported "not default-on", which would have supported the opposite conclusion. Cause was a `~/.opena2a/telemetry-optout` marker on the machine doing the measuring — it was reading the operator's own opt-out, not the package. Every default-posture probe of this SDK has to run with a clean `HOME`.

## What changes

**Posture is now opt-in.** The channel starts only on `AIM_TELEMETRY=1` or `signatureTelemetry: { enabled: true }`. `defaultConfig()` previously carried `signatureTelemetry: { enabled: true }`, so every runtime built from defaults turned it on; that key is now absent rather than `false`, because an explicit `false` is an opt-out and an opt-out beats an opt-in, which would have made `AIM_TELEMETRY=1` silently do nothing.

**`OPENA2A_TELEMETRY` is honored**, as a value predicate (`off`/`0`/`false`/`no`, trimmed), kept byte-compatible with the canonical `envOptOut` in `opena2a/packages/telemetry`. Reading it with the neighbouring `envTruthy` helper would have treated `off` as unset and failed open on the one spelling we publish.

It is deliberately **one-directional**: `OPENA2A_TELEMETRY=on` does not opt in. That variable is an ecosystem-wide CLI switch, while this SDK is a library inside someone else's production process — an operator who exported it for the CLIs must not thereby start a network channel inside their agent.

**Refusing and never choosing are now distinct states.** `isOptedOut` keeps its original meaning ("has someone actively refused?") because it also gates the GTIN channel; ask `signatureTelemetryEnabled` for "should this run?". They are no longer each other's negation, so taking no action no longer reads as consent. `arp telemetry status` stops reporting "OFF (opted out)" when nobody opted out.

## Reach

The fix sits in `isOptedOut`, so one change covers all three ARP registry channels. Verified behaviourally against the built artifact, not by reading:

| channel | opted in, no opt-out | + `OPENA2A_TELEMETRY=off` |
|---|---|---|
| `signatureEmitter` | constructed | **not constructed** |
| `gtinForwarder` | constructed | **not constructed** |
| fleet gradients (`fleetEnabled`) | on | **off** |

Identical to the established `OPENA2A_TELEMETRY_OPTOUT=1` in every case, which is the actual claim: the documented spelling now behaves exactly like the one that already worked.

`src/telemetry/relay.ts` (the AIM client causal-denial channel) keeps its own switch and stays default-off. That exclusion is disclosed in `README.md` and pinned by `telemetry-egress-census.test.ts`, which enumerates senders from source so a fourth channel cannot join the set silently.

## Tests

`config.test.ts` gains the documented-spelling cases; red-proofed at 9 failures against the pre-fix code. Four mutations, all killed: dropping the call (9 fail), dropping `.trim()` (2 fail), making it bidirectional (1 fail — the asymmetry has teeth), narrowing to only `off` (4 fail).

Full suite 1085 passed / 36 skipped, `tsc --noEmit` clean, HackMyAgent 100/100.

## Not covered here

- **This does not remedy anyone by itself.** The fix reaches users only when a fixed version is published; until then `main` has the fix and npm has the defect.
- The website still says "Deploy on your infrastructure. Your data never leaves your environment." on the AIM page. Separate repo, separate change.
- No phase exercised `arp telemetry status` as a user would — this package ships no `bin`, so that surface is reachable through `hackmyagent`, not from here.
