### PR TITLE
Stop reporting a trust score nobody measured, and drop emoji from output

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Closes both defects 2.0.0 carried as known issues. `VERSION` is deliberately not
+bumped here: the release tag is what publishes, so cutting the version is a
+separate decision from landing the fix.
+
+### Fixed
+
+- **The registration panel no longer reports a trust score the server did not
+  send** ([#390](https://github.com/opena2a-org/agent-identity-management/issues/390)).
+  Three defects sat on this one path, each of which independently put a number on
+  screen that nothing measured:
+  - `client.py` defaulted to `0.85`, so an unscored agent was announced as
+    `Trust Score: 85%` in the same form as a real reading.
+  - The same line used `or` rather than a presence test, so a genuine server-sent
+    `0` — a real, maximally-untrusted score — is falsy and fell through to that
+    same fabricated 85%. Verified before fixing: a payload of
+    `{"trust_score": 0}` printed `Trust: 85%`.
+  - `AIMConsole._normalize_trust_score` mapped `None` to `0.0`, which rendered an
+    unknown score as a measured, alarming red `0%` — and, because callers
+    normalize before formatting, made the `N/A` branch in both formatters
+    unreachable. That branch existed and looked like a control; nothing could
+    reach it.
+
+  An absent score now stays absent and prints `N/A`. A genuine `0` still prints
+  `0%` and remains distinguishable from unknown.
+
+- **Emoji removed from user-facing output**
+  ([#391](https://github.com/opena2a-org/agent-identity-management/issues/391)).
+  U+23F3 hourglass becomes U+25CB, the mark this console already uses for
+  pending; U+26A0 warning sign (usually carrying U+FE0F, which forces colour
+  emoji presentation) becomes the word `Warning:`, which most of those lines
+  already carried; U+2139 is dropped, since the label states what it is. U+2713,
+  U+2717 and U+25CB are the house style and are unchanged.
+
+  Characters are named by codepoint here rather than shown, because the
+  regression guard below scans this file too.
+
+  The sweep went wider than the issue's table, which listed three codepoints.
+  The same standard was being broken by U+2705 heavy check mark (23 uses), U+274C
+  cross mark (12) and sixteen pictographs in the same files — fixing only the
+  tabled three would have shipped a panel with house-style U+2713 and emoji
+  U+2705 on adjacent lines. U+2705 and U+274C map to U+2713 and U+2717; the
+  pictographs are dropped.
+
+  Correction to the issue's framing: `docs/*.md` are described there as shipped.
+  They are not — `MANIFEST.in` ships `VERSION`, `README.md`, `CHANGELOG.md`,
+  `LICENSE` and `aim_sdk/*.py` only. They are swept anyway because they are
+  public on GitHub, but no pip user was receiving them.
+
+### Added
+
+- A regression guard that enumerates the package and the prose from disk and
+  fails on any emoji, rather than checking the sites that were once wrong.
+  Checking only known-bad sites is how this class returns. The guard is
+  property-based for the same reason: the first pass at this fix used a
+  hand-written list of pictographs to strip, and the list was the defect — it
+  missed ten others sitting in the same documents.
+
 ## [2.0.0] - 2026-08-11
 
 **On the deprecation window.** `docs/VERSIONING.md` documents a mandatory N+1 minor
@@ -358,7 +415,7 @@ this release also carries the 1.22.0 changes listed below.
   added in `tests/test_register_agent.py`.
 - **`aim-sdk login` callback pages now render UTF-8 correctly.** The local OAuth
   callback responses sent `Content-Type: text/html` with no charset, so browsers
-  decoded the page as Latin-1 and the `✅` showed up as `âœ…`. Both the success
+  decoded the page as Latin-1 and the `✓` showed up as `âœ…`. Both the success
   and error responses now send `text/html; charset=utf-8`.
 
 ## [1.22.0] - 2026-05-25
@@ -650,8 +707,8 @@ This release positions AIM as an MCP supply chain security platform:
 
 | Version | Status | Support Level | End of Support |
 |---------|--------|---------------|----------------|
-| 1.0.x   | ✅ Current | Full support | N/A |
-| 0.9.x   | ⚠️ Pre-release | No support | Immediately |
+| 1.0.x   | ✓ Current | Full support | N/A |
+| 0.9.x   | Warning: Pre-release | No support | Immediately |
 
 ## Migration Guides
 
@@ -674,7 +731,7 @@ def query_users():
 # Critical actions with JIT access - requires admin approval
 @agent.perform_action(risk_level="critical", jit_access=True, resource="database:users")
 def delete_all_users():
-    return db.execute("DELETE FROM users")  # ⏸️ Pauses until admin approves
+    return db.execute("DELETE FROM users")  # ○ Pauses until admin approves
 
 # Alternative: use @require_approval for critical actions
 @agent.require_approval(risk_level="critical", resource="database:users")
@@ -683,8 +740,8 @@ def purge_data():
 ```
 
 **Action Required**:
-- ✅ No immediate action required - 0.9.x code continues to work
-- ⚠️ Update decorators to new style before v2.0.0 (recommended)
+- ✓ No immediate action required - 0.9.x code continues to work
+- Warning: Update decorators to new style before v2.0.0 (recommended)
 
 ---
 

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -2810,8 +2810,8 @@ class AIMClient:
 
             # SECURITY: Never print private keys - they're saved to secure file storage
             # Credentials are stored in ~/.aim/agents/{name}.json with 0600 permissions
-            print(f"✅ Created agent: {new_agent['id']}")
-            print(f"🔐 Credentials saved to: ~/.aim/agents/{name}.json")
+            print(f"✓ Created agent: {new_agent['id']}")
+            print(f"Credentials saved to: ~/.aim/agents/{name}.json")
 
         Raises:
             ConfigurationError: If name is missing or invalid
@@ -4556,7 +4556,7 @@ def register_agent(
     if capabilities:
         registration_data["capabilities"] = capabilities
     if tags:
-        registration_data["tagIds"] = tags  # ✅ Tags applied during registration
+        registration_data["tagIds"] = tags  # ✓ Tags applied during registration
 
     # 5. Register agent (mode-specific endpoint)
     try:
@@ -5393,7 +5393,14 @@ def _print_registration_success(
     agent_id = credentials.get("agent_id") or credentials.get("id", "")
     agent_type = credentials.get("agentType") or credentials.get("agent_type", "ai_agent")
     version = credentials.get("version", "1.0.0")
-    trust_score = credentials.get("trust_score") or credentials.get("trustScore", 0.85)
+    # An absent trust score stays absent. Two things were wrong here: the 0.85
+    # default announced an unscored agent as "Trust Score: 85%", and `or` made a
+    # genuine server-sent 0 -- a real, maximally-untrusted score -- falsy, so it
+    # fell through to that same fabricated 85%. Test both spellings explicitly
+    # for presence, not truthiness.
+    trust_score = credentials.get("trust_score")
+    if trust_score is None:
+        trust_score = credentials.get("trustScore")
     status = credentials.get("status", "active")
 
     console.agent_registered(

--- a/sdk/python/aim_sdk/console.py
+++ b/sdk/python/aim_sdk/console.py
@@ -45,15 +45,22 @@ class AIMConsole:
             print(message)
 
     @staticmethod
-    def _normalize_trust_score(score: float) -> float:
-        """Normalize trust score to a 0-1 float.
+    def _normalize_trust_score(score: Optional[float]) -> Optional[float]:
+        """Normalize trust score to a 0-1 float, preserving "unknown".
 
         The server may return trust scores as either a 0-1 float (e.g. 0.55)
         or a 0-100 integer (e.g. 55). Python's :.0% format expects 0-1, so
         values > 1 are divided by 100 to normalize.
+
+        ``None`` means the server sent no score and propagates as ``None``. It
+        previously became ``0.0``, which is a different and worse claim: it
+        announced an unscored agent as measured at an alarming red 0%, and
+        because callers normalize before formatting, it also made the ``N/A``
+        branch in both formatters unreachable. A genuine server-sent ``0``
+        still normalizes to ``0.0`` and stays distinguishable from unknown.
         """
         if score is None:
-            return 0.0
+            return None
         if score > 1:
             return score / 100.0
         return float(score)
@@ -144,7 +151,9 @@ class AIMConsole:
         print(f"│  Type:        {agent_type:<32} │")
         print(f"│  Version:     {version:<32} │")
         print(f"│  Status:      {status:<32} │")
-        print(f"│  Trust Score: {trust_score:.0%}{'':>28} │")
+        # None means the server sent no score; print that rather than a number.
+        trust_display = "N/A" if trust_score is None else f"{trust_score:.0%}"
+        print(f"│  Trust Score: {trust_display}{'':>28} │")
         if capabilities:
             cap_str = ", ".join(capabilities[:3])
             if len(capabilities) > 3:
@@ -295,7 +304,7 @@ class AIMConsole:
                 f"[bold]Risk Level:[/] [red]{risk_level.upper()}[/]\n"
                 f"[bold]Timeout:[/] {timeout}s\n\n"
                 f"[dim]Approve in dashboard: [link]{url}[/link][/]",
-                title="[bold yellow]⏳ Awaiting Admin Approval[/]",
+                title="[bold yellow]○ Awaiting Admin Approval[/]",
                 title_align="left",
                 border_style="yellow",
                 padding=(1, 2)
@@ -304,7 +313,7 @@ class AIMConsole:
         else:
             print()
             print("╭─────────────────────────────────────────────────╮")
-            print("│  ⏳ Awaiting Admin Approval                     │")
+            print("│  ○ Awaiting Admin Approval                      │")
             print("├─────────────────────────────────────────────────┤")
             print(f"│  Capability:  {capability:<32} │")
             print(f"│  Risk Level:  {risk_level.upper():<32} │")
@@ -411,16 +420,16 @@ class AIMConsole:
     def warning(self, message: str):
         """Display warning message."""
         if RICH_AVAILABLE:
-            self.console.print(f"[yellow]⚠ Warning:[/] {message}")
+            self.console.print(f"[yellow]Warning:[/] {message}")
         else:
-            print(f"⚠ Warning: {message}")
+            print(f"Warning: {message}")
 
     def info(self, message: str):
         """Display info message."""
         if RICH_AVAILABLE:
-            self.console.print(f"[blue]ℹ[/] {message}")
+            self.console.print(f"{message}")
         else:
-            print(f"ℹ {message}")
+            print(f"{message}")
 
     # ═══════════════════════════════════════════════════════════════════════════
     # PROGRESS INDICATORS
@@ -449,9 +458,9 @@ class AIMConsole:
         if self.quiet or not os.environ.get("AIM_DEBUG"):
             return
         if RICH_AVAILABLE:
-            self.console.print(f"[dim]🔍 {message}[/]")
+            self.console.print(f"[dim]{message}[/]")
         else:
-            print(f"🔍 {message}")
+            print(f"{message}")
 
 
 # Global console instance for the SDK

--- a/sdk/python/aim_sdk/credentials.py
+++ b/sdk/python/aim_sdk/credentials.py
@@ -224,7 +224,7 @@ def save_sdk_credentials(credentials: Dict[str, Any]) -> bool:
             success=False,
             error=str(e)
         )
-        print(f"⚠️  Failed to save SDK credentials: {e}")
+        print(f"Warning: Failed to save SDK credentials: {e}")
         return False
 
 
@@ -306,7 +306,7 @@ def _migrate_sdk_credentials(credentials: Dict[str, Any]) -> None:
     """Migrate SDK credentials from legacy to new location."""
     try:
         save_sdk_credentials(credentials)
-        print(f"✅ SDK credentials migrated to {SDK_CREDENTIALS_FILE}")
+        print(f"✓ SDK credentials migrated to {SDK_CREDENTIALS_FILE}")
     except Exception:
         pass
 
@@ -443,7 +443,7 @@ def save_agent_credentials(agent_name: str, credentials: Dict[str, Any]) -> bool
             success=False,
             error=str(e)
         )
-        print(f"⚠️  Failed to save agent credentials: {e}")
+        print(f"Warning: Failed to save agent credentials: {e}")
         return False
 
 
@@ -499,16 +499,16 @@ def _migrate_legacy_agent_credentials(data: Dict[str, Any]) -> None:
         for key, value in data.items():
             if isinstance(value, dict) and ("agent_id" in value or "private_key" in value):
                 save_agent_credentials(key, value)
-                print(f"✅ Agent '{key}' credentials migrated to {AGENTS_DIR}")
+                print(f"✓ Agent '{key}' credentials migrated to {AGENTS_DIR}")
 
         # Check for flat format with name field
         if "agent_id" in data or "private_key" in data:
             name = data.get("name") or data.get("agent_name") or "default"
             save_agent_credentials(name, data)
-            print(f"✅ Agent '{name}' credentials migrated to {AGENTS_DIR}")
+            print(f"✓ Agent '{name}' credentials migrated to {AGENTS_DIR}")
 
     except Exception as e:
-        print(f"⚠️  Failed to migrate agent credentials: {e}")
+        print(f"Warning: Failed to migrate agent credentials: {e}")
 
 
 # =============================================================================
@@ -519,7 +519,7 @@ def print_sdk_credentials_not_found_error(aim_url: str = "http://localhost:8080"
     """Print a clear error message when SDK credentials are not found."""
     print()
     print("=" * 72)
-    print("❌ SDK CREDENTIALS NOT FOUND")
+    print("✗ SDK CREDENTIALS NOT FOUND")
     print("=" * 72)
     print()
     print("No SDK authentication credentials found.")
@@ -542,7 +542,7 @@ def print_wrong_credential_type_error(found_type: str, agent_name: str = None, a
     """Print a clear error message when wrong credential type is found."""
     print()
     print("=" * 72)
-    print("⚠️  WRONG CREDENTIAL TYPE")
+    print("Warning: WRONG CREDENTIAL TYPE")
     print("=" * 72)
     print()
 
@@ -579,7 +579,7 @@ def print_token_expired_error(aim_url: str = "http://localhost:8080") -> None:
     """
     print()
     print("=" * 72)
-    print("⚠️  SDK REFRESH TOKEN REJECTED")
+    print("Warning: SDK REFRESH TOKEN REJECTED")
     print("=" * 72)
     print()
     print(f"The AIM server rejected the refresh token at {SDK_CREDENTIALS_FILE}.")

--- a/sdk/python/aim_sdk/integrations/crewai/callbacks.py
+++ b/sdk/python/aim_sdk/integrations/crewai/callbacks.py
@@ -72,7 +72,7 @@ class AIMTaskCallback:
 
         if self.verbose:
             task_desc = getattr(task, 'description', 'unknown task')
-            print(f"🔧 AIM: Task started - {task_desc[:50]}")
+            print(f"AIM: Task started - {task_desc[:50]}")
 
     def on_task_complete(self, output: Any) -> None:
         """
@@ -84,7 +84,7 @@ class AIMTaskCallback:
             output: Task output/result
         """
         if self.verbose:
-            print(f"✅ AIM: Task completed")
+            print(f"✓ AIM: Task completed")
 
         # Log to AIM
         try:
@@ -109,11 +109,11 @@ class AIMTaskCallback:
             )
 
             if self.verbose:
-                print("✅ AIM: Task completion logged")
+                print("✓ AIM: Task completion logged")
 
         except Exception as e:
             if self.verbose:
-                print(f"⚠️  AIM logging error: {e}")
+                print(f"Warning: AIM logging error: {e}")
 
     def on_task_error(self, error: Exception, task: Optional[Any] = None) -> None:
         """
@@ -127,7 +127,7 @@ class AIMTaskCallback:
             task_desc = "unknown task"
             if task:
                 task_desc = getattr(task, 'description', 'unknown task')
-            print(f"❌ AIM: Task failed - {task_desc[:50]}: {error}")
+            print(f"✗ AIM: Task failed - {task_desc[:50]}: {error}")
 
         # Log error to AIM
         try:
@@ -144,8 +144,8 @@ class AIMTaskCallback:
             )
 
             if self.verbose:
-                print("✅ AIM: Task failure logged")
+                print("✓ AIM: Task failure logged")
 
         except Exception as e:
             if self.verbose:
-                print(f"⚠️  AIM logging error: {e}")
+                print(f"Warning: AIM logging error: {e}")

--- a/sdk/python/aim_sdk/integrations/crewai/decorators.py
+++ b/sdk/python/aim_sdk/integrations/crewai/decorators.py
@@ -58,7 +58,7 @@ def aim_verified_task(
                     _agent = AIMClient.from_credentials(auto_load_agent)
                 except FileNotFoundError:
                     print(
-                        f"⚠️  Warning: No AIM agent configured for task '{func.__name__}', "
+                        f"Warning: No AIM agent configured for task '{func.__name__}', "
                         f"running without verification"
                     )
                     # Run without verification if no agent available
@@ -109,7 +109,7 @@ def aim_verified_task(
                         )
                     except Exception as e:
                         # Don't fail the task if logging fails
-                        print(f"⚠️  Warning: AIM result logging failed: {e}")
+                        print(f"Warning: AIM result logging failed: {e}")
 
                 return result
 
@@ -123,7 +123,7 @@ def aim_verified_task(
                             error_message=str(e)
                         )
                     except Exception as log_error:
-                        print(f"⚠️  Warning: AIM error logging failed: {log_error}")
+                        print(f"Warning: AIM error logging failed: {log_error}")
 
                 # Re-raise the original exception
                 raise

--- a/sdk/python/aim_sdk/integrations/crewai/wrapper.py
+++ b/sdk/python/aim_sdk/integrations/crewai/wrapper.py
@@ -113,7 +113,7 @@ class AIMCrewWrapper:
             PermissionError: If AIM verification fails
         """
         if self.verbose:
-            print(f"🔧 AIM: Verifying crew execution (risk: {self.risk_level})")
+            print(f"AIM: Verifying crew execution (risk: {self.risk_level})")
 
         # Prepare resource for verification
         resource = ""
@@ -135,13 +135,13 @@ class AIMCrewWrapper:
             )
         except Exception as e:
             if self.verbose:
-                print(f"⚠️  AIM verification error: {e}")
+                print(f"Warning: AIM verification error: {e}")
             raise PermissionError(f"AIM verification failed for crew execution: {e}")
 
         verification_id = verification_result.get("verification_id")
 
         if self.verbose:
-            print(f"✅ AIM: Crew execution verified (id: {verification_id})")
+            print(f"✓ AIM: Crew execution verified (id: {verification_id})")
 
         # Execute crew
         try:
@@ -161,10 +161,10 @@ class AIMCrewWrapper:
                     )
                 except Exception as e:
                     if self.verbose:
-                        print(f"⚠️  AIM result logging error: {e}")
+                        print(f"Warning: AIM result logging error: {e}")
 
             if self.verbose:
-                print("✅ AIM: Crew execution completed and logged")
+                print("✓ AIM: Crew execution completed and logged")
 
             return result
 
@@ -179,10 +179,10 @@ class AIMCrewWrapper:
                     )
                 except Exception as log_error:
                     if self.verbose:
-                        print(f"⚠️  AIM result logging error: {log_error}")
+                        print(f"Warning: AIM result logging error: {log_error}")
 
             if self.verbose:
-                print(f"❌ AIM: Crew execution failed: {e}")
+                print(f"✗ AIM: Crew execution failed: {e}")
 
             raise
 
@@ -200,7 +200,7 @@ class AIMCrewWrapper:
             PermissionError: If AIM verification fails
         """
         if self.verbose:
-            print(f"🔧 AIM: Verifying async crew execution (risk: {self.risk_level})")
+            print(f"AIM: Verifying async crew execution (risk: {self.risk_level})")
 
         # Prepare resource for verification
         resource = ""
@@ -223,13 +223,13 @@ class AIMCrewWrapper:
             )
         except Exception as e:
             if self.verbose:
-                print(f"⚠️  AIM verification error: {e}")
+                print(f"Warning: AIM verification error: {e}")
             raise PermissionError(f"AIM verification failed for async crew execution: {e}")
 
         verification_id = verification_result.get("verification_id")
 
         if self.verbose:
-            print(f"✅ AIM: Async crew execution verified (id: {verification_id})")
+            print(f"✓ AIM: Async crew execution verified (id: {verification_id})")
 
         # Execute crew asynchronously
         try:
@@ -249,10 +249,10 @@ class AIMCrewWrapper:
                     )
                 except Exception as e:
                     if self.verbose:
-                        print(f"⚠️  AIM result logging error: {e}")
+                        print(f"Warning: AIM result logging error: {e}")
 
             if self.verbose:
-                print("✅ AIM: Async crew execution completed and logged")
+                print("✓ AIM: Async crew execution completed and logged")
 
             return result
 
@@ -267,10 +267,10 @@ class AIMCrewWrapper:
                     )
                 except Exception as log_error:
                     if self.verbose:
-                        print(f"⚠️  AIM result logging error: {log_error}")
+                        print(f"Warning: AIM result logging error: {log_error}")
 
             if self.verbose:
-                print(f"❌ AIM: Async crew execution failed: {e}")
+                print(f"✗ AIM: Async crew execution failed: {e}")
 
             raise
 

--- a/sdk/python/aim_sdk/integrations/langchain/callback.py
+++ b/sdk/python/aim_sdk/integrations/langchain/callback.py
@@ -96,7 +96,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         for run_id in stale_ids:
             if self.verbose:
                 tool_name = self._active_tools[run_id].get("tool_name", "unknown")
-                print(f"🧹 AIM: Cleaning up stale tool entry - {tool_name} (run_id: {run_id})")
+                print(f"AIM: Cleaning up stale tool entry - {tool_name} (run_id: {run_id})")
             del self._active_tools[run_id]
 
     def on_tool_start(
@@ -117,7 +117,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         tool_name = serialized.get("name", "unknown_tool")
 
         if self.verbose:
-            print(f"🔧 AIM: Tool started - {tool_name}")
+            print(f"AIM: Tool started - {tool_name}")
 
         # Store tool invocation details for later logging
         self._active_tools[run_id] = {
@@ -140,14 +140,14 @@ class AIMCallbackHandler(BaseCallbackHandler):
         """Called when a tool finishes successfully"""
         if run_id not in self._active_tools:
             if self.verbose:
-                print(f"⚠️  AIM: Tool end event for unknown run_id: {run_id}")
+                print(f"Warning: AIM: Tool end event for unknown run_id: {run_id}")
             return
 
         tool_data = self._active_tools.pop(run_id)
         tool_name = tool_data["tool_name"]
 
         if self.verbose:
-            print(f"✅ AIM: Tool completed - {tool_name}")
+            print(f"✓ AIM: Tool completed - {tool_name}")
 
         # Log successful tool execution to AIM
         try:
@@ -175,7 +175,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
 
         except Exception as e:
             if self.log_errors and self.verbose:
-                print(f"⚠️  AIM logging error: {e}")
+                print(f"Warning: AIM logging error: {e}")
 
     def on_tool_error(
         self,
@@ -192,7 +192,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         tool_name = tool_data["tool_name"]
 
         if self.verbose:
-            print(f"❌ AIM: Tool failed - {tool_name}: {str(error)[:100]}")
+            print(f"✗ AIM: Tool failed - {tool_name}: {str(error)[:100]}")
 
         # Log error to AIM
         if self.log_errors:
@@ -220,7 +220,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
 
             except Exception as e:
                 if self.verbose:
-                    print(f"⚠️  AIM logging error: {e}")
+                    print(f"Warning: AIM logging error: {e}")
 
     def on_chain_start(
         self,
@@ -233,7 +233,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         """Called when a chain starts (optional - for chain-level logging)"""
         if self.verbose:
             chain_name = serialized.get("name", "unknown_chain")
-            print(f"🔗 AIM: Chain started - {chain_name}")
+            print(f"AIM: Chain started - {chain_name}")
 
     def on_chain_end(
         self,
@@ -244,7 +244,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Called when a chain ends (optional - for chain-level logging)"""
         if self.verbose:
-            print(f"✅ AIM: Chain completed")
+            print(f"✓ AIM: Chain completed")
 
     def on_chain_error(
         self,
@@ -255,4 +255,4 @@ class AIMCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Called when a chain fails (optional - for chain-level logging)"""
         if self.verbose:
-            print(f"❌ AIM: Chain failed - {str(error)[:100]}")
+            print(f"✗ AIM: Chain failed - {str(error)[:100]}")

--- a/sdk/python/aim_sdk/integrations/langchain/decorators.py
+++ b/sdk/python/aim_sdk/integrations/langchain/decorators.py
@@ -79,7 +79,7 @@ def aim_verify(
                     _agent = AIMClient.from_credentials(auto_load_agent)
                 except FileNotFoundError:
                     # No AIM agent configured - run without verification (graceful degradation)
-                    print(f"⚠️  Warning: No AIM agent configured for {func.__name__}, running without verification")
+                    print(f"Warning: No AIM agent configured for {func.__name__}, running without verification")
                     return func(*args, **kwargs)
 
             # Determine action name

--- a/sdk/python/aim_sdk/integrations/mcp/registration.py
+++ b/sdk/python/aim_sdk/integrations/mcp/registration.py
@@ -561,12 +561,12 @@ def attest_mcp_server(
         # Import discovery module (lazy import to avoid overhead when not used)
         from aim_sdk.integrations.mcp.discovery import discover_capabilities
 
-        print(f"🔍 Auto-discovering capabilities from MCP server: {mcp_url}")
+        print(f"Auto-discovering capabilities from MCP server: {mcp_url}")
         discovery_result = discover_capabilities(mcp_url, timeout_seconds=discovery_timeout)
 
         if discovery_result.error:
             if capabilities_found:
-                print(f"⚠️  Auto-discovery failed ({discovery_result.error}), using provided capabilities")
+                print(f"Warning: Auto-discovery failed ({discovery_result.error}), using provided capabilities")
             else:
                 raise ValueError(
                     f"Auto-discovery failed and no capabilities_found provided: {discovery_result.error}"
@@ -575,7 +575,7 @@ def attest_mcp_server(
             # Use discovered capabilities
             capabilities_found = discovery_result.tool_names
             connection_latency_ms = discovery_result.connection_latency_ms
-            print(f"✅ Discovered {len(capabilities_found)} tools: {capabilities_found}")
+            print(f"✓ Discovered {len(capabilities_found)} tools: {capabilities_found}")
 
     # Validate capabilities are provided
     if not capabilities_found:
@@ -590,9 +590,9 @@ def attest_mcp_server(
         try:
             challenge_response = get_attestation_challenge(aim_client, server_id)
             challenge = challenge_response.get("challenge")
-            print(f"🔐 Obtained attestation challenge (expires: {challenge_response.get('expiresAt')})")
+            print(f"Obtained attestation challenge (expires: {challenge_response.get('expiresAt')})")
         except Exception as e:
-            print(f"⚠️  Warning: Could not get challenge, proceeding without: {e}")
+            print(f"Warning: Could not get challenge, proceeding without: {e}")
             # Continue without challenge for backward compatibility
 
     # Step 2: Build attestation payload (including challenge for proof of key possession)
@@ -642,9 +642,9 @@ def attest_mcp_server(
     )
 
     if challenge:
-        print(f"✅ Attestation submitted with proof of key possession")
+        print(f"✓ Attestation submitted with proof of key possession")
     else:
-        print(f"✅ Attestation submitted (legacy mode, no challenge)")
+        print(f"✓ Attestation submitted (legacy mode, no challenge)")
 
     # Add discovery information to response if auto_discover was used
     if discovery_result and not discovery_result.error:

--- a/sdk/python/aim_sdk/integrations/mcp/verification.py
+++ b/sdk/python/aim_sdk/integrations/mcp/verification.py
@@ -142,7 +142,7 @@ def log_mcp_action_result(
         return True
     except Exception as e:
         # Don't fail if result logging fails
-        print(f"⚠️  Warning: MCP action result logging error: {e}")
+        print(f"Warning: MCP action result logging error: {e}")
         return False
 
 
@@ -215,7 +215,7 @@ class MCPActionWrapper:
         _risk_level = risk_level or self.default_risk_level
 
         if self.verbose:
-            print(f"🔧 AIM: Verifying MCP tool '{tool_name}' (risk: {_risk_level})")
+            print(f"AIM: Verifying MCP tool '{tool_name}' (risk: {_risk_level})")
 
         # Verify with AIM
         try:
@@ -229,11 +229,11 @@ class MCPActionWrapper:
             verification_id = verification.get("verification_id")
 
             if self.verbose:
-                print(f"✅ AIM: Tool verified (id: {verification_id})")
+                print(f"✓ AIM: Tool verified (id: {verification_id})")
 
         except Exception as e:
             if self.verbose:
-                print(f"❌ AIM: Verification failed: {e}")
+                print(f"✗ AIM: Verification failed: {e}")
             raise
 
         # Execute tool
@@ -250,7 +250,7 @@ class MCPActionWrapper:
                 )
 
             if self.verbose:
-                print(f"✅ AIM: Tool execution completed and logged")
+                print(f"✓ AIM: Tool execution completed and logged")
 
             return result
 
@@ -265,6 +265,6 @@ class MCPActionWrapper:
                 )
 
             if self.verbose:
-                print(f"❌ AIM: Tool execution failed: {e}")
+                print(f"✗ AIM: Tool execution failed: {e}")
 
             raise

--- a/sdk/python/aim_sdk/oauth.py
+++ b/sdk/python/aim_sdk/oauth.py
@@ -41,7 +41,7 @@ try:
 except ImportError as e:
     SECURE_STORAGE_AVAILABLE = False
     SECURE_STORAGE_WARNING = (
-        "⚠️  SECURITY WARNING: Secure storage packages not installed.\n"
+        "SECURITY WARNING: Secure storage packages not installed.\n"
         "   Credentials will be stored in PLAINTEXT without encryption.\n"
         "   For encrypted storage, install: pip install cryptography keyring\n"
     )
@@ -95,10 +95,10 @@ def decode_jwt_claims(token: str) -> Optional[Dict[str, Any]]:
 
     except jwt.exceptions.DecodeError as e:
         # Token is malformed (not a valid JWT)
-        print(f"⚠️  Warning: Failed to decode JWT: {e}")
+        print(f"Warning: Failed to decode JWT: {e}")
         return None
     except Exception as e:
-        print(f"⚠️  Warning: Unexpected error decoding JWT: {e}")
+        print(f"Warning: Unexpected error decoding JWT: {e}")
         return None
 
 
@@ -187,14 +187,14 @@ class OAuthTokenManager:
                     # credentials we still need.
                     _save_sdk_credentials_to_module(creds)
                     print(
-                        f"🔄 Migrated credentials from encrypted shadow file to JSON "
+                        f"Migrated credentials from encrypted shadow file to JSON "
                         f"single source of truth at {self.credentials_path}."
                     )
                     migrated = True
             except Exception as e:
                 decrypt_failed = True
                 print(
-                    f"⚠️  Could not migrate legacy encrypted credentials at "
+                    f"Warning: Could not migrate legacy encrypted credentials at "
                     f"{encrypted_path} ({e}); leaving the file in place."
                 )
 
@@ -209,7 +209,7 @@ class OAuthTokenManager:
                 encrypted_path.unlink()
                 if not migrated:
                     print(
-                        f"🧹 Removed deprecated encrypted credentials file at "
+                        f"Removed deprecated encrypted credentials file at "
                         f"{encrypted_path} (single-source-of-truth migration, audit #12)."
                     )
             except Exception:
@@ -238,7 +238,7 @@ class OAuthTokenManager:
                 return True
             return False
         except Exception as e:
-            print(f"⚠️  Warning: Failed to load credentials: {e}")
+            print(f"Warning: Failed to load credentials: {e}")
             return False
 
     def save_credentials(self, credentials: Dict[str, Any]) -> bool:
@@ -259,7 +259,7 @@ class OAuthTokenManager:
             self.credentials = credentials
             return True
         except Exception as e:
-            print(f"⚠️  Warning: Failed to save credentials: {e}")
+            print(f"Warning: Failed to save credentials: {e}")
             return False
 
     def has_credentials(self) -> bool:
@@ -340,7 +340,7 @@ class OAuthTokenManager:
                         details={"token_id": token_id, "attempting_recovery": True}
                     )
                     if not suppress_errors:
-                        print("🔄 Token was revoked - attempting automatic recovery...")
+                        print("Token was revoked - attempting automatic recovery...")
 
                     # Try token recovery endpoint (new feature - zero downtime!)
                     recovery_url = f"{aim_url.rstrip('/')}/api/v1/auth/sdk/recover"
@@ -368,8 +368,8 @@ class OAuthTokenManager:
                                         self.credentials['sdkTokenId'] = new_token_id
 
                                 self.save_credentials(self.credentials)
-                                print("✅ Token recovered automatically! SDK credentials updated.")
-                                print("💡 No need to re-download the SDK - everything just works!")
+                                print("✓ Token recovered automatically! SDK credentials updated.")
+                                print("No need to re-download the SDK - everything just works!")
 
                                 # Decode new access token expiry using PyJWT
                                 payload = decode_jwt_claims(self.access_token)
@@ -412,7 +412,7 @@ class OAuthTokenManager:
                         details={"token_id": token_id, "http_status": response.status_code}
                     )
                     if not suppress_errors:
-                        print(f"⚠️  Token refresh failed with status {response.status_code}: {error_msg}")
+                        print(f"Warning: Token refresh failed with status {response.status_code}: {error_msg}")
 
                 return None
 
@@ -447,7 +447,7 @@ class OAuthTokenManager:
                 # server-side so the user understands why an out-of-band copy
                 # (other machine, another venv, bundled SDK) would stop working.
                 print(
-                    "🔄 Token rotated successfully \u2014 old refresh token revoked "
+                    "Token rotated successfully \u2014 old refresh token revoked "
                     f"(new id: {new_token_id_full[:8] + '...' if new_token_id_full else 'unknown'})"
                 )
 
@@ -478,7 +478,7 @@ class OAuthTokenManager:
                 details={"token_id": local_token_id}
             )
             if not suppress_errors:
-                print(f"⚠️  Warning: Token refresh failed: {e}")
+                print(f"Warning: Token refresh failed: {e}")
             return None
 
     def get_auth_header(self) -> Dict[str, str]:
@@ -527,11 +527,11 @@ class OAuthTokenManager:
             self.access_token = None
             self.access_token_expiry = None
 
-            print("✅ Token revoked and credentials deleted")
+            print("✓ Token revoked and credentials deleted")
             return True
 
         except Exception as e:
-            print(f"⚠️  Warning: Token revocation failed: {e}")
+            print(f"Warning: Token revocation failed: {e}")
             # Still delete local credentials for safety
             if self.credentials_path.exists():
                 self.credentials_path.unlink()

--- a/sdk/python/aim_sdk/secure_storage.py
+++ b/sdk/python/aim_sdk/secure_storage.py
@@ -60,7 +60,7 @@ class SecureCredentialStorage:
                 missing.append("keyring")
 
             raise RuntimeError(
-                f"❌ SECURITY ERROR: Required packages not installed: {', '.join(missing)}\n"
+                f"✗ SECURITY ERROR: Required packages not installed: {', '.join(missing)}\n"
                 f"   AIM SDK REQUIRES secure credential storage.\n"
                 f"   Install with: pip install {' '.join(missing)}\n"
                 f"   We do NOT support insecure plaintext storage."
@@ -92,13 +92,13 @@ class SecureCredentialStorage:
                 # Generate new key and store in keyring
                 key = Fernet.generate_key().decode('utf-8')
                 keyring.set_password(self.SERVICE_NAME, self.KEY_NAME, key)
-                print("🔐 Generated new encryption key and stored in system keyring")
+                print("Generated new encryption key and stored in system keyring")
 
             return Fernet(key.encode('utf-8'))
 
         except Exception as e:
             raise RuntimeError(
-                f"❌ SECURITY ERROR: Failed to access system keyring: {e}\n"
+                f"✗ SECURITY ERROR: Failed to access system keyring: {e}\n"
                 f"   AIM SDK requires secure credential storage.\n"
                 f"   Please check your system keyring configuration."
             )
@@ -146,7 +146,7 @@ class SecureCredentialStorage:
                 return credentials
             except Exception as e:
                 raise RuntimeError(
-                    f"❌ SECURITY ERROR: Failed to decrypt credentials: {e}\n"
+                    f"✗ SECURITY ERROR: Failed to decrypt credentials: {e}\n"
                     f"   Credentials may be corrupted or encryption key changed.\n"
                     f"   You may need to re-register with AIM."
                 )
@@ -158,19 +158,19 @@ class SecureCredentialStorage:
                 with open(self.credentials_path, 'r') as f:
                     credentials = json.load(f)
 
-                print(f"🔐 Auto-migrating plaintext credentials to encrypted storage...")
+                print(f"Auto-migrating plaintext credentials to encrypted storage...")
 
                 # Save as encrypted (this also sets self.credentials)
                 self.save_credentials(credentials)
 
                 # Plaintext file already deleted by save_credentials()
-                print(f"✅ Credentials migrated successfully to encrypted storage.")
+                print(f"✓ Credentials migrated successfully to encrypted storage.")
 
                 return credentials
 
             except Exception as e:
                 # If migration fails, try to read plaintext if it still exists
-                print(f"⚠️  Warning: Failed to migrate credentials to encrypted storage: {e}")
+                print(f"Warning: Failed to migrate credentials to encrypted storage: {e}")
                 print(f"   Attempting to use plaintext credentials as fallback...")
 
                 try:
@@ -191,11 +191,11 @@ class SecureCredentialStorage:
         """Delete stored credentials (both encrypted and plaintext)."""
         if self.encrypted_path.exists():
             self.encrypted_path.unlink()
-            print(f"🗑️  Deleted encrypted credentials at {self.encrypted_path}")
+            print(f"Deleted encrypted credentials at {self.encrypted_path}")
 
         if self.credentials_path.exists():
             self.credentials_path.unlink()
-            print(f"🗑️  Deleted plaintext credentials at {self.credentials_path}")
+            print(f"Deleted plaintext credentials at {self.credentials_path}")
 
     def credentials_exist(self) -> bool:
         """Check if credentials file exists (encrypted or plaintext)."""
@@ -209,11 +209,11 @@ class SecureCredentialStorage:
             True if migration successful, False otherwise
         """
         if not self.cipher:
-            print("⚠️  Encryption not available, cannot migrate")
+            print("Warning: Encryption not available, cannot migrate")
             return False
 
         if not self.credentials_path.exists():
-            print("⚠️  No plaintext credentials found to migrate")
+            print("Warning: No plaintext credentials found to migrate")
             return False
 
         try:
@@ -223,11 +223,11 @@ class SecureCredentialStorage:
             # Save encrypted
             self.save_credentials(credentials)
 
-            print("✅ Successfully migrated credentials to encrypted storage")
+            print("✓ Successfully migrated credentials to encrypted storage")
             return True
 
         except Exception as e:
-            print(f"❌ Failed to migrate credentials: {e}")
+            print(f"✗ Failed to migrate credentials: {e}")
             return False
 
 

--- a/sdk/python/docs/CREWAI_INTEGRATION.md
+++ b/sdk/python/docs/CREWAI_INTEGRATION.md
@@ -1,27 +1,27 @@
-# 🤖 AIM + CrewAI Integration Guide
+# AIM + CrewAI Integration Guide
 
-**Status**: ✅ **PRODUCTION-READY** - Fully tested and verified
+**Status**: ✓ **PRODUCTION-READY** - Fully tested and verified
 **Last Updated**: October 8, 2025
-**Test Results**: 4/4 passing ✅
+**Test Results**: 4/4 passing ✓
 
 ---
 
-## 🎯 Overview
+## Overview
 
 Seamless integration between **AIM (Agent Identity Management)** and **CrewAI** for automatic verification and audit logging of multi-agent AI systems.
 
 ### What This Enables
 
-- ✅ **Crew-level verification** of multi-agent system executions
-- ✅ **Task-level verification** for individual agent tasks
-- ✅ **Automatic logging** of all crew and task executions
-- ✅ **Audit trail** for compliance (SOC 2, HIPAA, GDPR)
-- ✅ **Trust scoring** for AI agent crews
-- ✅ **Zero-friction** developer experience
+- ✓ **Crew-level verification** of multi-agent system executions
+- ✓ **Task-level verification** for individual agent tasks
+- ✓ **Automatic logging** of all crew and task executions
+- ✓ **Audit trail** for compliance (SOC 2, HIPAA, GDPR)
+- ✓ **Trust scoring** for AI agent crews
+- ✓ **Zero-friction** developer experience
 
 ---
 
-## 🚀 Quick Start (3 Options)
+## Quick Start (3 Options)
 
 ### Option 1: Crew Wrapper (Simplest)
 
@@ -77,10 +77,10 @@ result = verified_crew.kickoff(inputs={"topic": "AI safety"})
 ```
 
 **Benefits**:
-- ✅ Zero changes to existing crew code
-- ✅ Automatic verification of all executions
-- ✅ Works with sync and async kickoff
-- ✅ Minimal performance overhead
+- ✓ Zero changes to existing crew code
+- ✓ Automatic verification of all executions
+- ✓ Works with sync and async kickoff
+- ✓ Minimal performance overhead
 
 ---
 
@@ -103,8 +103,8 @@ agent = secure(
 @aim_verified_task(agent=aim_client, risk_level="high")
 def analyze_sensitive_data(data: str) -> str:
     '''Analyze sensitive financial data'''
-    # ✅ AIM verification happens BEFORE this code runs
-    # ❌ Raises PermissionError if verification fails
+    # ✓ AIM verification happens BEFORE this code runs
+    # ✗ Raises PermissionError if verification fails
     return perform_analysis(data)
 
 # Medium-risk task
@@ -172,14 +172,14 @@ crew.kickoff()
 ```
 
 **Benefits**:
-- ✅ Automatic logging of all task completions
-- ✅ Error logging for failed tasks
-- ✅ Minimal code changes
-- ✅ Works with existing tasks
+- ✓ Automatic logging of all task completions
+- ✓ Error logging for failed tasks
+- ✓ Minimal code changes
+- ✓ Works with existing tasks
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 # Install AIM SDK with CrewAI support
@@ -195,7 +195,7 @@ pip3 install crewai crewai-tools
 
 ---
 
-## 🔧 API Reference
+## API Reference
 
 ### AIMCrewWrapper
 
@@ -287,7 +287,7 @@ task = Task(
 
 ---
 
-## 🧪 Testing
+## Testing
 
 Run the integration tests to verify everything works:
 
@@ -300,19 +300,19 @@ python3 sdks/python/test_crewai_integration.py
 ======================================================================
 TEST SUMMARY
 ======================================================================
-✅ PASSED: AIMCrewWrapper
-✅ PASSED: @aim_verified_task decorator
-✅ PASSED: AIMTaskCallback
-✅ PASSED: Graceful degradation
+✓ PASSED: AIMCrewWrapper
+✓ PASSED: @aim_verified_task decorator
+✓ PASSED: AIMTaskCallback
+✓ PASSED: Graceful degradation
 
 Total: 4/4 tests passed
 
-🎉 ALL TESTS PASSED - CrewAI integration working perfectly!
+ALL TESTS PASSED - CrewAI integration working perfectly!
 ```
 
 ---
 
-## 📊 What Gets Logged to AIM
+## What Gets Logged to AIM
 
 ### For Each Crew Execution
 
@@ -333,17 +333,17 @@ Total: 4/4 tests passed
 
 ### Available in AIM Dashboard
 
-- ✅ **Crew composition** (number of agents and tasks)
-- ✅ **Execution inputs** (first 100 chars)
-- ✅ **Execution outputs** (first 500 chars)
-- ✅ **Execution time** and **status**
-- ✅ **Success/failure** tracking
-- ✅ **Error messages** (if failed)
-- ✅ **Risk level** and **verification ID**
+- ✓ **Crew composition** (number of agents and tasks)
+- ✓ **Execution inputs** (first 100 chars)
+- ✓ **Execution outputs** (first 500 chars)
+- ✓ **Execution time** and **status**
+- ✓ **Success/failure** tracking
+- ✓ **Error messages** (if failed)
+- ✓ **Risk level** and **verification ID**
 
 ---
 
-## 🔒 Security Best Practices
+## Security Best Practices
 
 ### 1. Use Risk Levels Appropriately
 
@@ -383,7 +383,7 @@ chmod 600 ~/.aim/credentials.json
 
 ---
 
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### "No AIM agent configured" Warning
 
@@ -436,7 +436,7 @@ os.environ["OPENAI_API_KEY"] = "sk-..."
 
 ---
 
-## 📈 Performance
+## Performance
 
 ### Benchmarks (Measured)
 
@@ -447,11 +447,11 @@ os.environ["OPENAI_API_KEY"] = "sk-..."
 | **Callback logging** | <1ms | Async, non-blocking |
 | **Total overhead** | **~15-20ms** | Per crew execution |
 
-**Conclusion**: Minimal performance impact (<50ms target achieved ✅)
+**Conclusion**: Minimal performance impact (<50ms target achieved ✓)
 
 ---
 
-## 🎯 Real-World Examples
+## Real-World Examples
 
 ### Example 1: Research & Writing Crew
 
@@ -539,7 +539,7 @@ result = verified_crew.kickoff(inputs={"quarter": "Q4 2025"})
 
 ---
 
-## 🚀 Next Steps
+## Next Steps
 
 1. **Install CrewAI**: `pip3 install crewai crewai-tools`
 2. **Register AIM Agent**: `python3 -c "from aim_sdk import secure; secure('crewai-agent')"`
@@ -549,7 +549,7 @@ result = verified_crew.kickoff(inputs={"quarter": "Q4 2025"})
 
 ---
 
-## 📚 Additional Resources
+## Additional Resources
 
 - **AIM Documentation**: [Main README](../../README.md)
 - **CrewAI Docs**: https://docs.crewai.com/
@@ -558,7 +558,7 @@ result = verified_crew.kickoff(inputs={"quarter": "Q4 2025"})
 
 ---
 
-**Integration Status**: ✅ **PRODUCTION-READY**
+**Integration Status**: ✓ **PRODUCTION-READY**
 **Last Tested**: October 8, 2025
 **Test Results**: 4/4 passing
 **CrewAI Version**: 0.201.1
@@ -566,4 +566,4 @@ result = verified_crew.kickoff(inputs={"quarter": "Q4 2025"})
 
 ---
 
-**Happy Building with AIM + CrewAI! 🤖✨**
+**Happy Building with AIM + CrewAI! **

--- a/sdk/python/docs/ENV_CONFIG.md
+++ b/sdk/python/docs/ENV_CONFIG.md
@@ -2,7 +2,7 @@
 
 The AIM Python SDK supports automatic configuration through environment variables, enabling zero-configuration deployments and seamless CI/CD integration.
 
-## 📋 Quick Start
+## Quick Start
 
 ```bash
 # Minimal configuration (agent auto-registers if not found)
@@ -24,7 +24,7 @@ def my_function():
 
 ---
 
-## 🔑 Environment Variables Reference
+## Environment Variables Reference
 
 ### Core Configuration
 
@@ -90,7 +90,7 @@ Settings → Security → Policies)
 
 ---
 
-## 🚀 Usage Examples
+## Usage Examples
 
 ### Example 1: Development Environment
 
@@ -265,14 +265,14 @@ jobs:
 
 ---
 
-## 🔒 Security Best Practices
+## Security Best Practices
 
 ### 1. Never Commit Credentials
 ```bash
-# ❌ WRONG - Don't put credentials in .env files
+# ✗ WRONG - Don't put credentials in .env files
 AIM_PRIVATE_KEY=ed25519_private_key_abc123...
 
-# ✅ CORRECT - Use credential file with restricted permissions
+# ✓ CORRECT - Use credential file with restricted permissions
 chmod 600 ~/.aim/credentials.json
 export AIM_CREDENTIALS_PATH=~/.aim/credentials.json
 ```
@@ -308,7 +308,7 @@ chown myuser:mygroup ~/.aim/credentials.json
 
 ---
 
-## 📦 Integration with Popular Tools
+## Integration with Popular Tools
 
 ### Django
 ```python
@@ -368,7 +368,7 @@ chain = LLMChain(llm=llm, callbacks=[handler])
 
 ---
 
-## 🐳 Docker Compose Example
+## Docker Compose Example
 
 ```yaml
 # docker-compose.yml
@@ -398,7 +398,7 @@ services:
 
 ---
 
-## 🧪 Testing with Environment Variables
+## Testing with Environment Variables
 
 ```python
 # test_with_env.py
@@ -422,7 +422,7 @@ def test_aim_auto_init():
 
 ---
 
-## ❓ Troubleshooting
+## Troubleshooting
 
 ### Error: "AIM client not provided and auto_init failed"
 **Cause**: `AIM_AGENT_NAME` environment variable not set
@@ -455,7 +455,7 @@ python -c "from aim_sdk import secure; secure('my-agent')"
 
 ---
 
-## 📚 See Also
+## See Also
 
 - [AIM SDK Documentation](../README.md)
 - [Authentication Guide](./AUTHENTICATION.md)

--- a/sdk/python/docs/LANGCHAIN_INTEGRATION.md
+++ b/sdk/python/docs/LANGCHAIN_INTEGRATION.md
@@ -1,27 +1,27 @@
-# 🦜 AIM + LangChain Integration Guide
+# AIM + LangChain Integration Guide
 
-**Status**: ✅ **PRODUCTION-READY** - Fully tested and verified
+**Status**: ✓ **PRODUCTION-READY** - Fully tested and verified
 **Last Updated**: October 8, 2025
-**Test Results**: 4/4 passing ✅
+**Test Results**: 4/4 passing ✓
 
 ---
 
-## 🎯 Overview
+## Overview
 
 Seamless integration between **AIM (Agent Identity Management)** and **LangChain** for automatic tool verification and audit logging.
 
 ### What This Enables
 
-- ✅ **Automatic logging** of all LangChain tool invocations
-- ✅ **Explicit verification** before tool execution
-- ✅ **Wrap existing tools** with zero code changes
-- ✅ **Audit trail** for compliance (SOC 2, HIPAA, GDPR)
-- ✅ **Trust scoring** for AI agent actions
-- ✅ **Zero-friction** developer experience
+- ✓ **Automatic logging** of all LangChain tool invocations
+- ✓ **Explicit verification** before tool execution
+- ✓ **Wrap existing tools** with zero code changes
+- ✓ **Audit trail** for compliance (SOC 2, HIPAA, GDPR)
+- ✓ **Trust scoring** for AI agent actions
+- ✓ **Zero-friction** developer experience
 
 ---
 
-## 🚀 Quick Start (3 Options)
+## Quick Start (3 Options)
 
 ### Option 1: Automatic Logging (Simplest)
 
@@ -63,10 +63,10 @@ agent.invoke({"input": "Find user john@example.com and send them an email"})
 ```
 
 **Benefits**:
-- ✅ Zero changes to existing tools
-- ✅ Automatic logging of all tool calls
-- ✅ Tracks successes and failures
-- ✅ Minimal performance overhead (<50ms)
+- ✓ Zero changes to existing tools
+- ✓ Automatic logging of all tool calls
+- ✓ Tracks successes and failures
+- ✓ Minimal performance overhead (<50ms)
 
 ---
 
@@ -87,8 +87,8 @@ agent = secure("langchain-agent")
 @aim_verify(agent=agent, risk_level="high")
 def delete_user(user_id: str) -> str:
     '''Delete a user from the database'''
-    # ✅ AIM verification happens BEFORE this code runs
-    # ❌ Raises PermissionError if verification fails
+    # ✓ AIM verification happens BEFORE this code runs
+    # ✗ Raises PermissionError if verification fails
     return f"Deleted user {user_id}"
 
 # Medium-risk tool
@@ -156,14 +156,14 @@ agent = create_react_agent(
 ```
 
 **Benefits**:
-- ✅ No code changes to existing tools
-- ✅ Batch wrap multiple tools at once
-- ✅ Consistent verification across all tools
-- ✅ Easy to add/remove verification
+- ✓ No code changes to existing tools
+- ✓ Batch wrap multiple tools at once
+- ✓ Consistent verification across all tools
+- ✓ Easy to add/remove verification
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 # Install AIM SDK with LangChain support
@@ -179,7 +179,7 @@ pip install langchain langchain-core langchain-openai
 
 ---
 
-## 🔧 API Reference
+## API Reference
 
 ### AIMCallbackHandler
 
@@ -265,7 +265,7 @@ verified_tools = wrap_tools_with_aim(
 
 ---
 
-## 🧪 Testing
+## Testing
 
 Run the integration tests to verify everything works:
 
@@ -278,19 +278,19 @@ python test_langchain_integration.py
 ======================================================================
 TEST SUMMARY
 ======================================================================
-✅ PASSED: AIMCallbackHandler
-✅ PASSED: @aim_verify decorator
-✅ PASSED: AIMToolWrapper
-✅ PASSED: Graceful degradation
+✓ PASSED: AIMCallbackHandler
+✓ PASSED: @aim_verify decorator
+✓ PASSED: AIMToolWrapper
+✓ PASSED: Graceful degradation
 
 Total: 4/4 tests passed
 
-🎉 ALL TESTS PASSED - LangChain integration working perfectly!
+ALL TESTS PASSED - LangChain integration working perfectly!
 ```
 
 ---
 
-## 📊 What Gets Logged to AIM
+## What Gets Logged to AIM
 
 ### For Each Tool Invocation
 
@@ -312,18 +312,18 @@ Total: 4/4 tests passed
 
 ### Available in AIM Dashboard
 
-- ✅ **Tool name** and **description**
-- ✅ **Input** (first 100 chars)
-- ✅ **Output** (first 500 chars)
-- ✅ **Execution time**
-- ✅ **Success/failure status**
-- ✅ **Error messages** (if failed)
-- ✅ **Run ID** (for tracing)
-- ✅ **Tags** and **metadata**
+- ✓ **Tool name** and **description**
+- ✓ **Input** (first 100 chars)
+- ✓ **Output** (first 500 chars)
+- ✓ **Execution time**
+- ✓ **Success/failure status**
+- ✓ **Error messages** (if failed)
+- ✓ **Run ID** (for tracing)
+- ✓ **Tags** and **metadata**
 
 ---
 
-## 🔒 Security Best Practices
+## Security Best Practices
 
 ### 1. Use Risk Levels Appropriately
 
@@ -362,7 +362,7 @@ chmod 600 ~/.aim/credentials.json
 
 ---
 
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### "No AIM agent configured" Warning
 
@@ -411,7 +411,7 @@ except PermissionError as e:
 
 ---
 
-## 📈 Performance
+## Performance
 
 ### Benchmarks (Measured)
 
@@ -422,11 +422,11 @@ except PermissionError as e:
 | **Tool wrapping** | <1ms | One-time overhead |
 | **Total overhead** | **~10-15ms** | Per tool invocation |
 
-**Conclusion**: Minimal performance impact (<50ms target achieved ✅)
+**Conclusion**: Minimal performance impact (<50ms target achieved ✓)
 
 ---
 
-## 🎯 Real-World Examples
+## Real-World Examples
 
 ### Example 1: Customer Support Agent
 
@@ -487,7 +487,7 @@ def drop_table(table_name: str) -> str:
 
 ---
 
-## 🚀 Next Steps
+## Next Steps
 
 1. **Install LangChain**: `pip install langchain langchain-core`
 2. **Register AIM Agent**: `python -c "from aim_sdk import secure; secure('langchain-agent')"`
@@ -497,7 +497,7 @@ def drop_table(table_name: str) -> str:
 
 ---
 
-## 📚 Additional Resources
+## Additional Resources
 
 - **AIM Documentation**: [Main README](../../README.md)
 - **LangChain Docs**: https://python.langchain.com/docs/
@@ -506,7 +506,7 @@ def drop_table(table_name: str) -> str:
 
 ---
 
-**Integration Status**: ✅ **PRODUCTION-READY**
+**Integration Status**: ✓ **PRODUCTION-READY**
 **Last Tested**: October 8, 2025
 **Test Results**: 4/4 passing
 **LangChain Version**: 0.3.78
@@ -514,4 +514,4 @@ def drop_table(table_name: str) -> str:
 
 ---
 
-**Happy Building with AIM + LangChain! 🦜✨**
+**Happy Building with AIM + LangChain! **

--- a/sdk/python/docs/MCP_INTEGRATION.md
+++ b/sdk/python/docs/MCP_INTEGRATION.md
@@ -1,29 +1,29 @@
-# 🔌 AIM + MCP (Model Context Protocol) Integration Guide
+# AIM + MCP (Model Context Protocol) Integration Guide
 
-**Status**: ✅ **SDK IMPLEMENTATION COMPLETE** - Backend endpoints exist, SDK ready
+**Status**: ✓ **SDK IMPLEMENTATION COMPLETE** - Backend endpoints exist, SDK ready
 **Last Updated**: December 10, 2025
 **Note**: Integration testing requires authentication setup
 
 ---
 
-## 🎯 Overview
+## Overview
 
 Seamless integration between **AIM (Agent Identity Management)** and **MCP (Model Context Protocol)** for registration, verification, and audit logging of MCP servers and their actions.
 
 ### What This Enables
 
-- ✅ **MCP Server Registration** with cryptographic verification
-- ✅ **Dynamic Capability Discovery** - Automatically queries MCP servers for their tools
-- ✅ **Auto-Attestation** - Agents automatically attest to MCP capabilities on registration
-- ✅ **Action Verification** for MCP tools, resources, and prompts
-- ✅ **Trust Scoring** for MCP servers based on usage history
-- ✅ **Audit Trail** for all MCP server interactions
-- ✅ **Centralized Registry** of trusted MCP servers
-- ✅ **Security Verification** before tool/resource access
+- ✓ **MCP Server Registration** with cryptographic verification
+- ✓ **Dynamic Capability Discovery** - Automatically queries MCP servers for their tools
+- ✓ **Auto-Attestation** - Agents automatically attest to MCP capabilities on registration
+- ✓ **Action Verification** for MCP tools, resources, and prompts
+- ✓ **Trust Scoring** for MCP servers based on usage history
+- ✓ **Audit Trail** for all MCP server interactions
+- ✓ **Centralized Registry** of trusted MCP servers
+- ✓ **Security Verification** before tool/resource access
 
 ---
 
-## 📦 What is MCP?
+## What is MCP?
 
 **Model Context Protocol (MCP)** is an open standard introduced by Anthropic in November 2024 that enables AI systems (like LLMs) to integrate with external data sources and tools.
 
@@ -46,7 +46,7 @@ Seamless integration between **AIM (Agent Identity Management)** and **MCP (Mode
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Step 1: Register an MCP Server
 
@@ -68,7 +68,7 @@ server_info = register_mcp_server(
     version="1.0.0"
 )
 
-print(f"✅ Server registered: {server_info['id']}")
+print(f"✓ Server registered: {server_info['id']}")
 print(f"   Status: {server_info['status']}")
 print(f"   Trust Score: {server_info['trust_score']}")
 ```
@@ -99,7 +99,7 @@ verification = verify_mcp_action(
     risk_level="low"
 )
 
-print(f"✅ Action verified: {verification['verification_id']}")
+print(f"✓ Action verified: {verification['verification_id']}")
 
 # Execute MCP tool (your implementation)
 results = mcp_server.tools.web_search(query="AI safety")
@@ -142,14 +142,14 @@ print(f"Results: {result}")
 ```
 
 **Benefits**:
-- ✅ Automatic verification before execution
-- ✅ Automatic result logging after completion
-- ✅ Error handling and logging
-- ✅ Clean, simple API
+- ✓ Automatic verification before execution
+- ✓ Automatic result logging after completion
+- ✓ Error handling and logging
+- ✓ Clean, simple API
 
 ---
 
-## 🔍 Dynamic Capability Discovery
+## Dynamic Capability Discovery
 
 The SDK automatically discovers MCP server capabilities by querying each server using the official MCP protocol. **No hardcoded capability lists** - capabilities are discovered at runtime directly from the servers.
 
@@ -205,11 +205,11 @@ agent = secure(
 
 | Without Dynamic Discovery | With Dynamic Discovery |
 |---------------------------|------------------------|
-| ❌ Hardcoded capability lists | ✅ Real capabilities from servers |
-| ❌ Lists become outdated | ✅ Always up-to-date |
-| ❌ Manual maintenance | ✅ Zero maintenance |
-| ❌ Limited to known servers | ✅ Works with any MCP server |
-| ❌ Users must list all tools | ✅ Automatic - just provide server names |
+| ✗ Hardcoded capability lists | ✓ Real capabilities from servers |
+| ✗ Lists become outdated | ✓ Always up-to-date |
+| ✗ Manual maintenance | ✓ Zero maintenance |
+| ✗ Limited to known servers | ✓ Works with any MCP server |
+| ✗ Users must list all tools | ✓ Automatic - just provide server names |
 
 ### Advanced: Full Detection with Tools
 
@@ -227,7 +227,7 @@ for d in detections:
 
 ---
 
-## 🔐 Smart Attestation System
+## Smart Attestation System
 
 The SDK provides **smart attestation** - intelligent, automatic attestation that builds trust in MCP servers through cryptographic verification while minimizing overhead.
 
@@ -277,7 +277,7 @@ The SDK automatically detects when MCP servers change their capabilities:
 
 ```python
 # If capability drift is detected, you'll see:
-# ⚠️ Capability drift detected (severity: medium): +2 added, -1 removed
+# Warning: Capability drift detected (severity: medium): +2 added, -1 removed
 
 # Drift severity levels:
 # - low: New tools added (expansion)
@@ -299,8 +299,8 @@ agent = secure(
 )
 
 # Console output:
-# ✅ Registered MCP server: filesystem
-# ✅ Auto-attested MCP server 'filesystem' with 14 capabilities
+# ✓ Registered MCP server: filesystem
+# ✓ Auto-attested MCP server 'filesystem' with 14 capabilities
 ```
 
 ### Manual Attestation
@@ -336,7 +336,7 @@ result = agent.use_mcp_tool(
 
 ---
 
-## 📊 Supply Chain Analytics
+## Supply Chain Analytics
 
 The SDK tracks MCP tool usage for supply chain visibility, enabling:
 
@@ -397,7 +397,7 @@ if decision["shouldAttest"]:
 
 ---
 
-## 🔧 API Reference
+## API Reference
 
 ### register_mcp_server()
 
@@ -634,7 +634,7 @@ report = cache.get_supply_chain_report()
 
 ---
 
-## 📊 What Gets Logged to AIM
+## What Gets Logged to AIM
 
 ### MCP Server Registration
 
@@ -673,7 +673,7 @@ report = cache.get_supply_chain_report()
 
 ---
 
-## 🔒 Security Best Practices
+## Security Best Practices
 
 ### 1. Verify All High-Risk MCP Actions
 
@@ -715,7 +715,7 @@ admin_server = register_mcp_server(
 server = get_mcp_server(aim_client, server_id)
 
 if server['trust_score'] < 60.0:
-    print(f"⚠️  Warning: Low trust score for {server['name']}")
+    print(f"Warning: Warning: Low trust score for {server['name']}")
     # Consider suspending or reviewing server
 ```
 
@@ -733,7 +733,7 @@ for server in servers:
 
 ---
 
-## 🎯 Real-World Examples
+## Real-World Examples
 
 ### Example 1: Research Assistant MCP Server
 
@@ -812,26 +812,26 @@ try:
         context={"user_id": "user123", "reason": "account closure"}
     )
 except PermissionError as e:
-    print(f"❌ Operation denied: {e}")
+    print(f"✗ Operation denied: {e}")
     # Handle denial (notify admin, log incident, etc.)
 ```
 
 ---
 
-## 📈 MCP vs AIM Integration Benefits
+## MCP vs AIM Integration Benefits
 
 | Without AIM | With AIM Integration |
 |-------------|---------------------|
-| ❌ No central registry of MCP servers | ✅ Centralized MCP server registry |
-| ❌ No verification before tool execution | ✅ Cryptographic verification required |
-| ❌ No audit trail of MCP actions | ✅ Complete audit trail of all actions |
-| ❌ No trust scoring for servers | ✅ ML-powered trust scoring |
-| ❌ Manual security reviews | ✅ Automatic security verification |
-| ❌ No compliance reporting | ✅ Exportable audit record for compliance reporting |
+| ✗ No central registry of MCP servers | ✓ Centralized MCP server registry |
+| ✗ No verification before tool execution | ✓ Cryptographic verification required |
+| ✗ No audit trail of MCP actions | ✓ Complete audit trail of all actions |
+| ✗ No trust scoring for servers | ✓ ML-powered trust scoring |
+| ✗ Manual security reviews | ✓ Automatic security verification |
+| ✗ No compliance reporting | ✓ Exportable audit record for compliance reporting |
 
 ---
 
-## 🐛 Troubleshooting
+## Troubleshooting
 
 ### "Authentication failed" Error
 
@@ -876,7 +876,7 @@ public_key_b64 = base64.b64encode(public_key_bytes).decode()
 
 ---
 
-## 🚀 Next Steps
+## Next Steps
 
 1. **Register Your MCP Server**: Use `register_mcp_server()` to add your server
 2. **Test Verification**: Try `verify_mcp_action()` with a sample action
@@ -886,7 +886,7 @@ public_key_b64 = base64.b64encode(public_key_bytes).decode()
 
 ---
 
-## 📚 Additional Resources
+## Additional Resources
 
 - **MCP Specification**: https://modelcontextprotocol.io/specification/2025-06-18
 - **AIM Documentation**: [Main README](../../README.md)
@@ -895,11 +895,11 @@ public_key_b64 = base64.b64encode(public_key_bytes).decode()
 
 ---
 
-**Integration Status**: ✅ **SDK IMPLEMENTATION COMPLETE**
-**Backend Status**: ✅ **ENDPOINTS IMPLEMENTED**
+**Integration Status**: ✓ **SDK IMPLEMENTATION COMPLETE**
+**Backend Status**: ✓ **ENDPOINTS IMPLEMENTED**
 **Last Updated**: December 10, 2025
 **AIM SDK Version**: 1.8.0
 
 ---
 
-**Secure Your MCP Servers with AIM! 🔌🔒**
+**Secure Your MCP Servers with AIM! **

--- a/sdk/python/docs/README.md
+++ b/sdk/python/docs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains comprehensive integration guides and configuration documentation for the AIM Python SDK.
 
-## 📚 Integration Guides
+## Integration Guides
 
 ### Framework Integrations
 
@@ -24,7 +24,7 @@ This directory contains comprehensive integration guides and configuration docum
   - Server lifecycle management
   - Real-time verification
 
-## ⚙️ Configuration
+## Configuration
 
 - **[ENV_CONFIG.md](./ENV_CONFIG.md)** - Environment variables and configuration options
   - Authentication settings
@@ -39,19 +39,19 @@ This directory contains comprehensive integration guides and configuration docum
   - Upgrade guides
   - Support policy
 
-## 🚀 Quick Start
+## Quick Start
 
 For basic usage and getting started, see the main [README.md](../README.md) in the SDK root directory.
 
 For working code examples, check the [examples/](../examples/) directory.
 
-## 📖 Additional Resources
+## Additional Resources
 
 - **[Main SDK README](../README.md)** - Installation, quick start, and basic usage
 - **[Examples](../examples/)** - Working code examples
 - **[Tests](../tests/)** - Comprehensive test suite demonstrating SDK functionality
 
-## 🤝 Contributing
+## Contributing
 
 When adding new integration guides:
 1. Follow the existing document structure

--- a/sdk/python/docs/VERSIONING.md
+++ b/sdk/python/docs/VERSIONING.md
@@ -130,10 +130,10 @@ pytest tests/ -v --cov=aim_sdk --cov-report=html
 ```
 
 **Required**:
-- ✅ 100% of unit tests pass
-- ✅ Integration tests with backend pass
-- ✅ Decorator tests pass
-- ✅ Cryptographic signing tests pass
+- ✓ 100% of unit tests pass
+- ✓ Integration tests with backend pass
+- ✓ Decorator tests pass
+- ✓ Cryptographic signing tests pass
 
 ### 4. Build
 
@@ -223,8 +223,8 @@ python -c "import aim_sdk; print(aim_sdk.__version__)"
 - `@agent.perform_action()` now supports `jit_access=True` for admin approval flows
 
 **Action Required**:
-- ✅ No breaking changes
-- ⚠️ Migrate from `track_action()` to `perform_action()` (recommended)
+- ✓ No breaking changes
+- Warning: Migrate from `track_action()` to `perform_action()` (recommended)
 
 **Migration**:
 ```python

--- a/sdk/python/tests/test_console_trust_score.py
+++ b/sdk/python/tests/test_console_trust_score.py
@@ -21,8 +21,11 @@ class TestTrustScoreNormalization:
     def test_hundred_normalized(self):
         assert AIMConsole._normalize_trust_score(100) == 1.0
 
-    def test_none_returns_zero(self):
-        assert AIMConsole._normalize_trust_score(None) == 0.0
+    def test_none_stays_none(self):
+        # Was `== 0.0`, which asserted the #390 defect: an agent the server sent
+        # no score for was normalized into a measured, alarming red 0%. Unknown
+        # and zero are different claims and must stay distinguishable.
+        assert AIMConsole._normalize_trust_score(None) is None
 
     def test_high_float_normalized(self):
         # 85 from server should become 0.85

--- a/sdk/python/tests/test_no_emoji_in_console_output.py
+++ b/sdk/python/tests/test_no_emoji_in_console_output.py
@@ -1,0 +1,137 @@
+"""User-facing output carries no emoji-class characters (#391).
+
+Enumerates the shipped package from disk rather than checking known sites, so a
+NEW emoji added to a NEW file fails this test. Checking only the files that were
+once wrong is how the class comes back.
+
+Scope is the issue's: U+23F3, U+26A0 (bare and with the U+FE0F variation
+selector that forces colour-emoji presentation), U+2139. The house-style marks
+the issue explicitly exempts -- U+2713, U+2717, U+25CB, box drawing -- are
+asserted PRESENT below, so a future "sweep" cannot pass this file by deleting
+the whole visual vocabulary.
+"""
+
+import pathlib
+import unicodedata
+
+import pytest
+
+PKG = pathlib.Path(__file__).resolve().parent.parent / "aim_sdk"
+
+# In scope. Named, not derived from a property lookup, so the test states its
+# own contract rather than tracking whatever the local unicodedata says today.
+#
+# Written as escapes, never as literal glyphs. A bare U+FE0F is an INVISIBLE
+# character, and a file asserting "no invisible characters here" that contains
+# one is indistinguishable from the GlassWorm attack it guards against -- our own
+# scanner flagged an earlier draft of this file as CRITICAL for exactly that.
+# Escapes also keep the file greppable and reviewable in a plain diff.
+BANNED = {
+    "\u23F3": "HOURGLASS WITH FLOWING SAND",
+    "\u26A0": "WARNING SIGN",
+    "\u2139": "INFORMATION SOURCE",
+    "\uFE0F": "VARIATION SELECTOR-16 (forces emoji presentation)",
+}
+
+# Deliberately allowed: the house style, per the issue.
+HOUSE_STYLE = {
+    "\u2713": "CHECK MARK",
+    "\u2717": "BALLOT X",
+    "\u25CB": "WHITE CIRCLE",
+}
+
+
+def _python_files():
+    files = sorted(PKG.rglob("*.py"))
+    assert files, f"found no source under {PKG} -- the scan is blind"
+    return files
+
+
+def _text_surfaces():
+    """Python source plus the prose a reader actually meets.
+
+    CHANGELOG.md and README.md are in MANIFEST.in and therefore ship inside the
+    distribution; docs/*.md do not ship but are public on GitHub, and the
+    standard is about what a human reads, not about the packaging manifest.
+    """
+    root = PKG.parent
+    files = _python_files()
+    files += [p for p in (root / "CHANGELOG.md", root / "README.md") if p.exists()]
+    files += sorted((root / "docs").rglob("*.md"))
+    return files
+
+
+def _is_emoji(ch: str) -> bool:
+    """Property-based, so a pictograph nobody enumerated is still caught.
+
+    An earlier fix here used a hand-written list of emoji to strip, and the list
+    was the defect: it removed the ones someone had thought of and left ten
+    others (a bug, a plug, a handshake) sitting in the same documents. A rule
+    that needs a rule per spelling is not a rule.
+    """
+    if ch in HOUSE_STYLE:
+        return False
+    o = ord(ch)
+    return (
+        0x1F000 <= o <= 0x1FAFF
+        or 0x2600 <= o <= 0x27BF
+        or 0x2B00 <= o <= 0x2BFF
+        or o in (0xFE0F, 0x2139, 0x23F3, 0x23F8)
+    )
+
+
+def test_no_banned_emoji_class_characters_anywhere_in_the_package():
+    offenders = []
+    for f in _python_files():
+        for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for ch in set(line) & set(BANNED):
+                offenders.append(
+                    f"{f.relative_to(PKG.parent)}:{lineno}: U+{ord(ch):04X} {BANNED[ch]}"
+                )
+    assert not offenders, "emoji-class characters in shipped output:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_no_emoji_of_any_kind_in_source_or_prose():
+    """The whole class, not the three codepoints the issue happened to table."""
+    offenders = []
+    for f in _text_surfaces():
+        for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for ch in {c for c in line if _is_emoji(c)}:
+                offenders.append(
+                    f"{f.relative_to(PKG.parent)}:{lineno}: U+{ord(ch):04X} "
+                    f"{unicodedata.name(ch, '?')}"
+                )
+    assert not offenders, "emoji in source or prose:\n" + "\n".join(offenders[:40])
+
+
+@pytest.mark.parametrize("ch", sorted(HOUSE_STYLE))
+def test_house_style_marks_are_still_used(ch):
+    """Non-vacuity control, and a guard against over-correction.
+
+    If this fails, someone removed the plain-text vocabulary instead of the
+    emoji -- which would make the banned-character test above pass for the
+    wrong reason.
+    """
+    total = sum(f.read_text(encoding="utf-8").count(ch) for f in _python_files())
+    assert total > 0, f"U+{ord(ch):04X} {HOUSE_STYLE[ch]} vanished from the package"
+
+
+def test_the_scanner_can_actually_see_a_planted_offender(tmp_path):
+    """Proves the detection works, independent of the package's current state.
+
+    Without this, a scan that silently matched nothing would report the same
+    clean result as a scan that read every file and found nothing.
+    """
+    planted = tmp_path / "planted.py"
+    # Single-escaped on purpose: this source file stays pure ASCII, while the
+    # bytes written to the fixture are the real characters the scan must catch.
+    # Double-escaping here would write the literal text backslash-u-26A0, the scan would
+    # find nothing, and the test would report the detector broken when it is not.
+    planted.write_text('print("\u26A0\uFE0F  something")\n', encoding="utf-8")
+    found = [ch for ch in set(planted.read_text(encoding="utf-8")) if ch in BANNED]
+    assert found, "the scan cannot see a known-bad character"
+    # U+FE0F is unnamed in the UCD, so name() raises rather than returning "".
+    assert all(unicodedata.name(ch, "") is not None for ch in found)
+    assert _is_emoji("\u26A0"), "the property-based check disagrees with BANNED"

--- a/sdk/python/tests/test_trust_score_not_fabricated.py
+++ b/sdk/python/tests/test_trust_score_not_fabricated.py
@@ -1,0 +1,120 @@
+"""An unmeasured trust score must never be printed as if it were measured.
+
+Regression tests for #390. Three distinct defects sit on this path, and each of
+them independently produces a number the server never sent:
+
+1. ``client.py`` defaulted to ``0.85``, so an agent the server returned no score
+   for was announced to the operator as "Trust Score: 85%".
+2. The same line used ``or`` rather than an explicit ``is None`` test, so a
+   genuine server-sent ``0`` -- a real, meaningful, maximally-untrusted score --
+   is falsy and fell through to that same fabricated 85%.
+3. ``AIMConsole._normalize_trust_score`` mapped ``None`` to ``0.0``, which
+   rendered an unknown score as a measured, alarming red "0%" and made the
+   ``N/A`` branch in both formatters unreachable, because normalization runs
+   before them.
+
+A number on screen is a claim of measurement. Absent must render as absent.
+"""
+
+import pytest
+
+from aim_sdk.console import AIMConsole
+
+
+class TestNormalizeDoesNotInventAZero:
+    def test_none_stays_none(self):
+        # Was 0.0, which is a measurement claim about an agent nobody scored.
+        assert AIMConsole._normalize_trust_score(None) is None
+
+    def test_genuine_zero_is_preserved_and_is_not_none(self):
+        # 0 is a real score and must survive as one, distinct from "unknown".
+        assert AIMConsole._normalize_trust_score(0) == 0.0
+        assert AIMConsole._normalize_trust_score(0) is not None
+
+    def test_existing_normalization_still_holds(self):
+        assert AIMConsole._normalize_trust_score(0.55) == 0.55
+        assert AIMConsole._normalize_trust_score(55) == 0.55
+        assert AIMConsole._normalize_trust_score(100) == 1.0
+        assert AIMConsole._normalize_trust_score(1.0) == 1.0
+
+
+class TestFormattersDistinguishUnknownFromZero:
+    def test_inline_formatter_reports_unknown_not_zero_percent(self):
+        out = AIMConsole()._format_trust_score_inline(None)
+        assert "0%" not in out
+        assert "N/A" in out
+
+    def test_labelled_formatter_reports_unknown_not_zero_percent(self):
+        out = AIMConsole()._format_trust_score(None)
+        assert "0%" not in out
+        assert "N/A" in out
+
+    def test_a_genuine_zero_still_renders_as_zero(self):
+        # The complement: fixing "unknown" must not swallow a real 0.
+        assert "0%" in AIMConsole()._format_trust_score_inline(0)
+        assert "0%" in AIMConsole()._format_trust_score(0)
+
+
+class TestRegistrationPanelNeverReportsAScoreTheServerDidNotSend:
+    """The end-to-end shape of #390, driven through the public entry point.
+
+    These assert the VALUE the panel hands the renderer, not the rendered text.
+    That is deliberate: #390 is a defect in what the value is, and scraping
+    stdout here is not a sound oracle. ``AIMConsole`` binds rich's output stream
+    at construction and the module-global console is built at import time, so
+    whether ``capsys`` observes the panel depends on which test imported the
+    module first. An earlier draft of this file did scrape stdout, passed alone,
+    and failed in the full suite for exactly that reason.
+    """
+
+    @staticmethod
+    def _reported_score(monkeypatch, credentials):
+        from aim_sdk import client as client_mod
+
+        seen = {}
+
+        def spy(**kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr(client_mod.console, "agent_registered", spy)
+        client_mod._print_registration_success("probe-agent", credentials)
+        assert seen, "the panel never called agent_registered — oracle is blind"
+        return seen["trust_score"]
+
+    def test_absent_score_is_reported_as_unknown_not_as_85_percent(self, monkeypatch):
+        score = self._reported_score(monkeypatch, {"agent_id": "abcdef1234567890"})
+        assert score is None, f"fabricated {score!r} for an agent the server did not score"
+
+    def test_server_sent_zero_survives_as_zero(self, monkeypatch):
+        # The `or` bug: 0 is falsy, so it fell through to the 0.85 default.
+        score = self._reported_score(
+            monkeypatch, {"agent_id": "abcdef1234567890", "trust_score": 0}
+        )
+        assert score == 0, f"a genuine server-sent 0 was reported as {score!r}"
+
+    def test_server_sent_zero_camel_case_survives_as_zero(self, monkeypatch):
+        score = self._reported_score(
+            monkeypatch, {"agent_id": "abcdef1234567890", "trustScore": 0}
+        )
+        assert score == 0
+
+    def test_a_real_score_is_passed_through_unchanged(self, monkeypatch):
+        # Non-vacuity control: the assertions above must be able to observe a
+        # real score, or they would pass against a panel that reports nothing.
+        score = self._reported_score(
+            monkeypatch, {"agent_id": "abcdef1234567890", "trust_score": 0.85}
+        )
+        assert score == 0.85
+
+    def test_camel_case_real_score_is_passed_through(self, monkeypatch):
+        score = self._reported_score(
+            monkeypatch, {"agent_id": "abcdef1234567890", "trustScore": 0.42}
+        )
+        assert score == 0.42
+
+    def test_the_simple_renderer_accepts_an_unknown_score(self):
+        # The value fix pushes None into the renderer, where the non-rich path
+        # formatted with `:.0%` and would raise TypeError on None.
+        AIMConsole(quiet=False)._agent_registered_simple(
+            "probe-agent", "abcdef1234567890", "ai_agent", "1.0.0", None, "active"
+        )


### PR DESCRIPTION
Closes #390 and #391 — the two defects 2.0.0 shipped as documented known issues. Per the roadmap unit a second carry was allowed and a third barred, so these are fixed rather than carried again.

`VERSION` is deliberately **not** bumped. The tag is what publishes, so cutting 2.0.1 stays a separate decision; the entry sits under `## [Unreleased]`.

## #390 — a trust score nobody measured

Three defects sat on one path, each of which independently put a number on screen that nothing measured.

| | before | after |
|---|---|---|
| server sent no score | `Trust: 85%` | `Trust: N/A` |
| server sent a genuine `0` | `Trust: 85%` | `Trust: 0%` |
| server sent `0.85` | `Trust: 85%` | `Trust: 85%` |

1. `client.py` defaulted to `0.85`, so an unscored agent was announced in exactly the form of a real reading.
2. The same line used `or` rather than a presence test. `0` is falsy, so a real, maximally-untrusted score fell through to that same fabricated 85%. Confirmed before fixing: a `{"trust_score": 0}` payload printed `Trust: 85%`.
3. `AIMConsole._normalize_trust_score` mapped `None` to `0.0`, rendering an unknown score as a measured, alarming red `0%`. It also made the `N/A` branch in *both* formatters unreachable, because callers normalize before formatting — the branch existed and read like a control while nothing could reach it.

`tests/test_console_trust_score.py` asserted `_normalize_trust_score(None) == 0.0`. That test encoded the defect, so it changes with the code.

The new tests assert the **value** handed to the renderer rather than scraping stdout. An earlier draft did scrape, passed alone, and failed in the full suite: `AIMConsole` binds rich's output stream at construction and the module-global console is built at import, so whether `capsys` sees the panel depends on which test imported first. That is not a sound oracle for a defect about what a value *is*.

## #391 — emoji in user-facing output

U+23F3 becomes U+25CB (the mark this console already uses for pending); U+26A0, usually carrying U+FE0F which forces colour-emoji presentation, becomes the word `Warning:` that most of those lines already carried; U+2139 is dropped since the label states what it is.

**The sweep went wider than the issue's table of three codepoints,** because the same standard was being broken in the same files by U+2705 (23 uses), U+274C (12) and sixteen pictographs. Fixing only the tabled three would have shipped a panel with house-style U+2713 beside emoji U+2705. U+2705 and U+274C map to U+2713 and U+2717; pictographs are dropped. U+2713/U+2717/U+25CB are the house style and are untouched — a test asserts they are still **present**, so a later sweep cannot satisfy the guard by deleting the whole visual vocabulary.

**Correction to the issue:** it describes `docs/*.md` as shipped. They are not — `MANIFEST.in` ships `VERSION`, `README.md`, `CHANGELOG.md`, `LICENSE` and `aim_sdk/*.py` only. They are swept anyway because they are public on GitHub, but no pip user was receiving them.

## Two defects found in this work, by our own tooling

- **The first pass used a hand-written list of pictographs to strip, and the list was the defect.** It removed the ones someone had thought of and left a bug, a plug and a handshake in the same documents. The final sweep and the guard are both property-based.
- **`hackmyagent secure` flagged the new guard file CRITICAL** for an invisible codepoint: I had put a bare U+FE0F literal in its `BANNED` dict. A file asserting "no invisible characters here" that contains one is indistinguishable from the GlassWorm vector it guards against. The file is now pure ASCII — every character is a `\uXXXX` escape, and its planted-offender fixture writes the real bytes at runtime.

## Verification

Both regression tests confirmed failing against the pre-fix source before the fix landed (4 and 1 failures respectively). 880 pass. `ruff` is byte-identical to the base — 120 errors on both sides, F541 16 on both — so this introduces no new lint. `hackmyagent secure` 100/100.

**Recorded, not fixed:** the non-rich fallback box has misaligned columns. Measured against `origin/main`, it renders identically misaligned there, so it is pre-existing and out of scope for this change.
