### PR TITLE
Make the backend CI filter match the Dockerfile's actual inputs

### DIFF
--- a/.docker-verify-exempt-paths
+++ b/.docker-verify-exempt-paths
@@ -1,0 +1,29 @@
+# Paths exempt from the local build-and-swap docker verification gate.
+#
+# One path prefix or glob per line. `**` is the only recursive form; a single
+# `*` does not cross a `/`.
+#
+# This is NOT a list of paths that stay out of the image. It is a list of paths
+# that reach the image without reaching the RUNNING SERVICE, so a build-and-swap
+# run cannot observe any difference a change to them makes.
+#
+# The gate still applies unless EVERY changed file in the diff matches, and a
+# diff that touches this file is never exempt -- an exemption must not be able
+# to widen itself in the same merge that relies on it.
+#
+# GitHub CI is a separate matter and is NOT relaxed here: `.github/workflows/ci.yml`
+# includes `sdk/**` in the `backend` filter, so the backend build and the
+# container scan do run on these changes.
+
+# infrastructure/docker/Dockerfile.backend does `COPY sdk ./sdk` in the final
+# stage, so sdk changes do change the image. Nothing in the Go backend reads
+# /app/sdk at runtime and nothing embeds it -- measured 2026-08-20, no runtime
+# reference and no go:embed -- so those files ship as inert payload for
+# consumers to read out of the image, never as code the service executes.
+#
+# If that ever stops being true -- the server starts serving, parsing or
+# executing anything under /app/sdk -- delete this line. The claim it rests on
+# is checked by:
+#   grep -rn --include='*.go' -e '"./sdk' -e '/app/sdk' -e 'go:embed.*sdk' apps/backend
+# which must return nothing.
+sdk/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,16 @@ jobs:
             # Root package.json/package-lock.json feed apps/web via npm
             # workspaces (apps/web has no lockfile of its own) — a root dep
             # bump that skipped the frontend build would merge unvalidated.
+            # `sdk/**` is here because the backend IMAGE contains it:
+            # infrastructure/docker/Dockerfile.backend does `COPY sdk ./sdk` in
+            # its final stage. The filter listed only apps/backend/**, so every
+            # sdk-only change skipped the backend job AND the container scan for
+            # an image whose contents that change had just altered. The filter
+            # has to match the Dockerfile's inputs, and the Dockerfile's inputs
+            # are exactly apps/backend/** and sdk/**.
             backend:
               - 'apps/backend/**'
+              - 'sdk/**'
               - '.golangci.yml'
               - '.github/workflows/ci.yml'
             frontend:


### PR DESCRIPTION
Closes #389.

`infrastructure/docker/Dockerfile.backend:54` does `COPY sdk ./sdk` in its final stage, so every sdk-only change changes the backend image. The paths-filter listed only `apps/backend/**`, `.golangci.yml` and the workflow itself, so those changes skipped **both** the backend job and the container scan — for an image whose contents they had just altered. A skipped job satisfies a required status check, so the PR reads green with the container never built. #393 is a live example.

The filter now lists exactly what the Dockerfile reads: `apps/backend/**` and `sdk/**`. This makes CI **stricter**, not looser.

## `.docker-verify-exempt-paths`

Also adds the declaration the local build-and-swap gate consults (Abdel's call, 2026-08-20). It is not a list of paths that stay out of the image — it is a list of paths that reach the image without reaching the **running service**, so a build-and-swap run cannot observe any difference a change to them makes.

The claim for `sdk/**`, re-checked in this PR:

```
grep -rn --include='*.go' -e '"./sdk' -e '/app/sdk' -e 'go:embed.*sdk' apps/backend
```

returns nothing — no runtime reference, no `go:embed`. Those files ship as inert payload for consumers to read out of the image, never as code the service executes. The file carries that grep so the next reader can re-run it, and says to delete the line if it ever stops returning nothing.

Three properties keep this an exemption rather than a bypass, each with a test in `claude-hooks`:

1. **Every** changed file must match. One unmatched file and the gate applies.
2. A diff touching `.docker-verify-exempt-paths` is **never** exempt, so it cannot widen itself in the same merge that relies on it.
3. It **fails closed** — if the diff cannot be listed, no exemption.

A first draft of the matcher was over-broad: shell `case` globbing does not respect `/`, so `docs/*.md` matched `docs/nested/deep.md`, quietly covering a whole subtree. Caught by the test before it shipped; `**` is now the only recursive form.

## Verification

This PR's diff cannot change the backend image — the Dockerfile's only inputs are `apps/backend/**` and `sdk/**`, and this touches neither. Docker verification was still run against the compose stack rather than argued away.