### PR TITLE
Make the SDK report the version npm actually published

### DIFF
--- a/sdk/typescript/src/version.test.ts
+++ b/sdk/typescript/src/version.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { SDK_VERSION } from './version';
+
+/**
+ * `SDK_VERSION` is what `require('@opena2a/aim-sdk').VERSION` returns, and
+ * `package.json` is what npm publishes under. When they disagree, the installed
+ * package reports a version that was never released -- provenance a caller reads
+ * as fact about the artifact in their hand.
+ *
+ * `version.ts` is a hand-maintained literal whose own docstring says to keep it
+ * in sync on every release. That instruction was followed for 1.1.0 and missed
+ * for 1.2.0: package.json said 1.2.0 while the export still said 1.1.0, and the
+ * 1.2.0 release test caught it in the pre-flight rather than after publish.
+ *
+ * A comment asking a human to remember is not a mechanism. This is.
+ */
+describe('the version the SDK reports is the version npm published', () => {
+  const pkg = JSON.parse(
+    readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
+  ) as { version: string };
+
+  it('SDK_VERSION equals package.json version', () => {
+    expect(SDK_VERSION).toBe(pkg.version);
+  });
+
+  it('and package.json actually carries a version, so this is not vacuous', () => {
+    // Guards the oracle: if the read silently produced undefined, the assertion
+    // above would compare undefined to undefined on a broken build.
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -5,5 +5,11 @@
  * (`npm version <patch|minor|major>` updates package.json; update this file in
  * the same commit). It is a standalone leaf module so any part of the SDK can
  * import it without a circular dependency on the barrel `index.ts`.
+ *
+ * `version.test.ts` asserts that equality, because this comment asking a human
+ * to remember is not a mechanism and 1.2.0 is where it stopped being remembered:
+ * package.json read 1.2.0 while this file still read 1.1.0, so the package would
+ * have published reporting a version it was not. The test fails the build
+ * instead.
  */
-export const SDK_VERSION = '1.1.0';
+export const SDK_VERSION = '1.2.0';


### PR DESCRIPTION
Found by the 1.2.0 release test's pre-flight, **before** the tag. This blocks `sdk-ts-v1.2.0`.

`package.json` reads `1.2.0` while `src/version.ts` still reads `1.1.0`, so `require('@opena2a/aim-sdk').VERSION` on a published 1.2.0 would return `1.1.0` — a version the artifact in the caller's hand is not.

| | published 1.1.0 | 1.2.0 candidate (before this fix) |
|---|---|---|
| `package.json` | 1.1.0 | 1.2.0 |
| `VERSION` export | 1.1.0 — agrees | **1.1.0 — stale** |

That makes it a **regression**, not a carried defect: the two agree on published latest and diverge only because `package.json` moved and this literal did not.

## Why a test and not a better comment

`version.ts`'s docstring already said to keep it in sync on every release. That instruction was followed for 1.1.0 and missed here. A comment asking a human to remember is not a mechanism.

`version.test.ts` asserts the equality and was confirmed red against the stale literal. It carries a second assertion that `package.json` actually parses a version, so the comparison cannot pass by comparing `undefined` to `undefined` on a broken build.

## Carried, not fixed here

`src/arp/index.ts` exports its own `VERSION = '0.2.0'` for the ARP module. It reaches user-visible output (`arp-guard v0.2.0`) and the `OpenA2A-ARP/0.2.0` User-Agent on the GTIN channel. It reproduces identically on published 1.1.0 and contradicts no claim this release makes, so folding it into a release whose subject is something else would be scope creep. Worth its own issue.

## Verification

Packed the tarball and installed it fresh: `package.json 1.2.0`, `VERSION 1.2.0`, agrees. Full suite 1087 pass, `tsc` clean.