### PR TITLE
Derive the docker paths filter from the Dockerfiles instead of beside them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,21 @@ jobs:
       - name: .sync-protect is honoured by every sync path
         run: ./scripts/test-sync-protect.sh
 
+  # The `docker` paths filter in security.yml decides whether Container Scan
+  # runs. It was maintained beside the Dockerfiles rather than derived from
+  # them and drifted twice (#389, #398), each time letting a change to the
+  # image's own contents skip the scan of that image. Unconditional, because
+  # the drift it catches is a change to a Dockerfile OR to the filter, and
+  # gating this check behind a filter would reintroduce the class it exists
+  # to close.
+  docker-paths-filter:
+    name: Docker paths filter follows the Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Every COPY source is covered by the docker filter
+        run: ./scripts/lint-docker-paths-filter.sh
+
   # A BLOCKING audit of the SDK's shipped dependency tree.
   #
   # Why this exists, and why it is separate from security.yml's "Dependency Audit":
@@ -509,6 +524,7 @@ jobs:
         tenant-scoping-lint,
         workflow-lint,
         sync-protect-guard,
+        docker-paths-filter,
         sdk-dependency-audit,
         changes,
         backend,
@@ -526,6 +542,7 @@ jobs:
           tl='${{ needs.tenant-scoping-lint.result }}'
           wl='${{ needs.workflow-lint.result }}'
           sp='${{ needs.sync-protect-guard.result }}'
+          dp='${{ needs.docker-paths-filter.result }}'
           sa='${{ needs.sdk-dependency-audit.result }}'
           ch='${{ needs.changes.result }}'
           be='${{ needs.backend.result }}'
@@ -533,11 +550,11 @@ jobs:
           ax='${{ needs.atx-conformance.result }}'
           fe='${{ needs.frontend.result }}'
           ee='${{ needs.e2e-empty-state.result }}'
-          echo "secrets-lint=$sl tenant-scoping-lint=$tl workflow-lint=$wl sync-protect-guard=$sp sdk-dependency-audit=$sa changes=$ch"
+          echo "secrets-lint=$sl tenant-scoping-lint=$tl workflow-lint=$wl sync-protect-guard=$sp docker-paths-filter=$dp sdk-dependency-audit=$sa changes=$ch"
           echo "backend=$be integration=$it atx-conformance=$ax frontend=$fe e2e-empty-state=$ee"
           fail=0
           # Unconditional jobs must succeed outright.
-          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "workflow-lint:$wl" "sync-protect-guard:$sp" "sdk-dependency-audit:$sa" "changes:$ch"; do
+          for pair in "secrets-lint:$sl" "tenant-scoping-lint:$tl" "workflow-lint:$wl" "sync-protect-guard:$sp" "docker-paths-filter:$dp" "sdk-dependency-audit:$sa" "changes:$ch"; do
             if [ "${pair#*:}" != "success" ]; then
               echo "::error::${pair%%:*} did not succeed (${pair#*:}); failing closed."
               fail=1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,12 +43,22 @@ jobs:
               - 'apps/backend/**'
             frontend:
               - 'apps/web/**'
+            # Derived from what the Dockerfiles COPY, not maintained beside
+            # them. `scripts/lint-docker-paths-filter.sh` fails CI if a COPY
+            # source stops being covered, because maintaining this list by hand
+            # drifted twice: #389 (ci.yml missed sdk/**) and #398 (this filter
+            # missed sdk/**, apps/backend/** and apps/web/**). Both were
+            # invisible in review, since a skipped job satisfies a required
+            # status check and the PR reads green with the image never scanned.
+            #
+            # Dockerfile.backend  COPY: apps/backend/, apps/backend/go.mod,
+            #                           apps/backend/migrations, sdk
+            # Dockerfile.frontend COPY: apps/web/, apps/web/package.json
             docker:
               - 'infrastructure/docker/**'
-              - 'apps/backend/go.mod'
-              - 'apps/backend/go.sum'
-              - 'apps/web/package.json'
-              - 'apps/web/package-lock.json'
+              - 'apps/backend/**'
+              - 'apps/web/**'
+              - 'sdk/**'
             deps:
               - 'apps/backend/go.mod'
               - 'apps/backend/go.sum'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,11 +54,18 @@ jobs:
             # Dockerfile.backend  COPY: apps/backend/, apps/backend/go.mod,
             #                           apps/backend/migrations, sdk
             # Dockerfile.frontend COPY: apps/web/, apps/web/package.json
+            #
+            # security.yml is in its own filter for the reason ci.yml states for
+            # ci.yml: a PR that edits this filter must run the container scan
+            # UNDER the edited filter, not under the old one. Without it, the
+            # change that widens or narrows this list is the one change the list
+            # never governs.
             docker:
               - 'infrastructure/docker/**'
               - 'apps/backend/**'
               - 'apps/web/**'
               - 'sdk/**'
+              - '.github/workflows/security.yml'
             deps:
               - 'apps/backend/go.mod'
               - 'apps/backend/go.sum'

--- a/scripts/lint-docker-paths-filter.sh
+++ b/scripts/lint-docker-paths-filter.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# lint-docker-paths-filter.sh — the `docker` paths filter in security.yml must
+# cover every path the Dockerfiles actually read.
+#
+# Why this exists. The filter was maintained BESIDE the Dockerfiles instead of
+# derived FROM them, and drifted twice:
+#
+#   #389  ci.yml's `backend` filter listed apps/backend/** but not sdk/**, while
+#         Dockerfile.backend does `COPY sdk ./sdk`. An sdk-only change skipped
+#         the backend job entirely.
+#   #398  security.yml's `docker` filter listed infrastructure/docker/** and two
+#         lockfile pairs but neither sdk/** nor apps/backend/**, so Container
+#         Scan skipped on changes to an image that contains both.
+#
+# Both were invisible in review because a skipped job satisfies a required
+# status check: the PR reads green with the container never built. The class
+# does not close by fixing the list a third time, only by making the list
+# answerable from the Dockerfiles.
+#
+# What it checks: every `COPY <src>` in every Dockerfile resolves to a path
+# covered by at least one `docker:` filter pattern. Build-stage-internal copies
+# (`COPY --from=...`) are skipped: they move artifacts inside the build, not
+# from the repo.
+#
+# Usage:  ./scripts/lint-docker-paths-filter.sh
+# Exit:   0 pass, 1 an uncovered COPY source, 2 tool error.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+workflow=".github/workflows/security.yml"
+[ -r "$workflow" ] || { echo "lint-docker-paths-filter: cannot read $workflow" >&2; exit 2; }
+
+dockerfiles=(infrastructure/docker/Dockerfile.*)
+[ -e "${dockerfiles[0]}" ] || {
+  echo "lint-docker-paths-filter: found no Dockerfiles to derive from" >&2
+  exit 2
+}
+
+# The `docker:` block of the filter, as a list of bare patterns.
+patterns="$(awk '
+  /^[[:space:]]*docker:[[:space:]]*$/ { inblock=1; next }
+  inblock && /^[[:space:]]*-[[:space:]]*.[^"]*.[[:space:]]*$/ {
+    line=$0
+    gsub(/^[[:space:]]*-[[:space:]]*/, "", line)
+    gsub(/^['"'"'"]|['"'"'"][[:space:]]*$/, "", line)
+    print line
+    next
+  }
+  inblock && /^[[:space:]]*[a-zA-Z_-]+:[[:space:]]*$/ { inblock=0 }
+' "$workflow")"
+
+[ -n "$patterns" ] || {
+  echo "lint-docker-paths-filter: parsed ZERO patterns from the docker: block." >&2
+  echo "  The filter format changed and this check is now blind. Fix the parser," >&2
+  echo "  do not delete the check: a scan that matches nothing reports the same" >&2
+  echo "  clean result as a scan that read everything." >&2
+  exit 2
+}
+
+covered() {
+  local src="$1" pat prefix
+  while IFS= read -r pat; do
+    [ -n "$pat" ] || continue
+    prefix="${pat%/\*\*}"
+    [ "$src" = "$pat" ] && return 0
+    case "$src" in "$prefix"/*) return 0 ;; esac
+    case "$src" in "$prefix") return 0 ;; esac
+  done <<< "$patterns"
+  return 1
+}
+
+fail=0
+checked=0
+for df in "${dockerfiles[@]}"; do
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    case "$src" in --from=*) continue ;; esac   # intra-build, not a repo path
+    src="${src%/}"                              # `apps/backend/` -> `apps/backend`
+    checked=$((checked + 1))
+    if ! covered "$src"; then
+      echo "FAIL  $df copies '$src', which no docker: filter pattern covers." >&2
+      echo "      A change under $src alters the image and would skip Container Scan." >&2
+      fail=1
+    fi
+  done < <(grep -oE '^COPY[[:space:]]+[^[:space:]]+' "$df" | awk '{print $2}')
+done
+
+[ "$checked" -gt 0 ] || {
+  echo "lint-docker-paths-filter: parsed ZERO COPY lines. Parser is blind; fix it." >&2
+  exit 2
+}
+
+if [ "$fail" -eq 0 ]; then
+  echo "docker paths filter covers all $checked COPY source(s) across ${#dockerfiles[@]} Dockerfile(s)."
+fi
+exit "$fail"


### PR DESCRIPTION
Closes #398.

`security.yml`'s `docker` filter gates `Container Scan`. It listed `infrastructure/docker/**` and two lockfile pairs — but `Dockerfile.backend` does `COPY sdk ./sdk` and `COPY apps/backend/ ./`, and `Dockerfile.frontend` does `COPY apps/web/ ./`. So a change to `apps/backend/**`, `apps/web/**` or `sdk/**` altered the image and skipped the scan **of that image**.

Measured on #393, an sdk-only diff, after #389 landed:

| job | result |
|---|---|
| `Backend (Go)` | **pass** — the #389 fix working |
| `Container Scan` | **skipping** — this defect |

A skipped job satisfies a required status check, so the PR reads green with the container never scanned. That is why neither instance was visible in review.

## Why a script and not a third correction

Fixing the list again would not close the class. The list is now answerable from the Dockerfiles: `scripts/lint-docker-paths-filter.sh` parses every `COPY <src>` out of `infrastructure/docker/Dockerfile.*` and fails if any source is uncovered. `COPY --from=` is skipped — those move artifacts inside the build, not from the repo.

The guard found **more than #398 described**: `apps/web` was uncovered too, so the frontend image had the same defect. The issue only identified the backend half.

## Non-vacuity

- Confirmed **red** against the filter as it stood — 4 uncovered sources.
- Confirmed **red** again under a mutation removing only `sdk/**` (exit 1, checked without a pipe so the exit code is the script's and not the pipe's).
- Refuses to pass on a parse yielding zero patterns or zero COPY lines: a matcher that reads nothing reports the same clean result as one that read everything.

## Wired into the gate, not just added

`docker-paths-filter` is in the CI Gate's `needs[]` **and** its unconditional must-succeed loop. A job the gate does not aggregate is a job whose failure does not block — the same shape as the defect being fixed.

`actionlint` findings unchanged from base (2, both pre-existing, in an unrelated job).