### PR TITLE
Make ARP report the version npm published

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,22 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@opena2a/aim-sdk/arp` now reports the version npm published.** Its
+  `VERSION` export was a second hand-maintained literal that read `0.2.0` from
+  the day the module landed and was never bumped, so 1.0.0 through 1.2.0 all
+  reported the same ARP version while the root export reported the real one.
+  Both subpaths now export one value.
+
+  This constant goes on the wire. The two telemetry channels send it as
+  `User-Agent: OpenA2A-ARP/<VERSION>`, which is the only build signal the
+  registry records for a submission, so every ARP request it has ever logged
+  looks like it came from the same sensor build. If you parse that header,
+  expect the package version from this release on and `0.2.0` before it.
+
+## [1.2.0] - 2026-08-21
+
 ### Changed — read this before upgrading
 
 **Structural signature telemetry is now OFF by default.** It previously ran
@@ -56,10 +72,6 @@ unless the operator finds the switch is inconsistent with both.
   `arp telemetry opt-in` now distinguish them.
 - The first-run disclosure text no longer says "ON by default" and now names how
   to turn the channel on as well as off.
-
-## [1.2.0] - 2026-08-11
-
-### Fixed
 
 - **A server-side denial is now reported as a denial, not as an opaque 500.**
   `parseAPIError` maps HTTP 403 to `AuthorizationError`, but the express

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -1,10 +1,26 @@
 /**
- * ARP engine version. This tracks the ARP protocol/engine lineage and is
- * INTENTIONALLY independent of the `@opena2a/aim-sdk` package version (the
- * package may be 1.x while the engine is 0.2.x). Read the package version from
- * `require('@opena2a/aim-sdk/package.json').version` if you need that instead.
+ * The version this ARP build reports -- the package version, deliberately.
+ *
+ * This used to be a separate literal tracking an "ARP engine lineage"
+ * independent of `@opena2a/aim-sdk`. It read `0.2.0` from the day the module
+ * landed and no release ever moved it, so five published package versions
+ * (1.0.0 through 1.2.0) all reported the same engine version. The independence
+ * was asserted by a comment, never exercised by a bump.
+ *
+ * That is not cosmetic, because this constant goes on the wire: both telemetry
+ * channels send it as `User-Agent: OpenA2A-ARP/<VERSION>`, and it is the only
+ * build signal the registry records for a submission. Every ARP request the
+ * registry has ever logged carries `OpenA2A-ARP/0.2.0`, so no ingested
+ * signature can be attributed to the sensor build that produced it.
+ *
+ * There is one npm package, so there is one version line. A second
+ * hand-maintained version literal is the defect `SDK_VERSION` hit at 1.2.0
+ * (package.json said 1.2.0, the export still said 1.1.0), and a comment asking
+ * a human to remember is not a mechanism. `version.test.ts` beside this file is.
  */
-export const VERSION = '0.2.0';
+import { SDK_VERSION } from '../version';
+
+export const VERSION = SDK_VERSION;
 
 // Re-export types
 export type {

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -17,6 +17,16 @@
  * hand-maintained version literal is the defect `SDK_VERSION` hit at 1.2.0
  * (package.json said 1.2.0, the export still said 1.1.0), and a comment asking
  * a human to remember is not a mechanism. `version.test.ts` beside this file is.
+ *
+ * Before changing this back: the `0.2.0` was not arbitrary. ARP shipped as its
+ * own npm package, `arp-guard`, and that package is still published -- at
+ * 0.3.0, last released 2026-03-23. So `0.2.0` was a fossil of a standalone
+ * lineage that this copy left behind. It matched neither the package it ships
+ * in (1.2.0) nor the standalone engine's current version (0.3.0), and the code
+ * here has moved a long way past what `arp-guard` 0.3.0 contains. There is no
+ * reading under which a frozen `0.2.0` was the right answer, and tracking
+ * `arp-guard` instead would report a version describing different bytes than
+ * the ones the caller installed.
  */
 import { SDK_VERSION } from '../version';
 

--- a/sdk/typescript/src/arp/version.test.ts
+++ b/sdk/typescript/src/arp/version.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { VERSION as ARP_VERSION } from './index';
+import { VERSION as ROOT_VERSION } from '../index';
+
+/**
+ * `@opena2a/aim-sdk/arp` exports `VERSION`, and so does `@opena2a/aim-sdk`.
+ * Same export name, two subpaths of one npm package. They used to disagree:
+ * the root read the package version while ARP read a hand-maintained `0.2.0`
+ * that no release ever bumped, so 1.0.0 through 1.2.0 all reported the same
+ * ARP version.
+ *
+ * The value is not decoration. Both telemetry channels put it on the wire as
+ * `User-Agent: OpenA2A-ARP/<VERSION>`, which is the only build signal the
+ * registry records for a submission, so a frozen literal makes every ingested
+ * signature look like it came from the same sensor build.
+ *
+ * `src/version.test.ts` holds the root export to package.json. These hold the
+ * ARP export to the same line, and hold the wire header to the constant rather
+ * than to a literal someone typed.
+ */
+describe('the version ARP reports is the version npm published', () => {
+  const pkg = JSON.parse(
+    readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'),
+  ) as { version: string };
+
+  it('the ARP subpath export equals package.json version', () => {
+    expect(ARP_VERSION).toBe(pkg.version);
+  });
+
+  it('and the root subpath export agrees with it', () => {
+    // One package cannot have two version lines; the two subpaths are how it
+    // grew one.
+    expect(ARP_VERSION).toBe(ROOT_VERSION);
+  });
+
+  it('and package.json actually carries a version, so this is not vacuous', () => {
+    // Guards the oracle: a silently-undefined read would make the assertions
+    // above compare undefined to undefined.
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('the ARP User-Agent is built from that constant, not from a literal', () => {
+  /** Every `.ts` under src/, excluding tests -- the class, not the two known sites. */
+  function sourceFiles(dir: string, found: string[] = []): string[] {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        sourceFiles(full, found);
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        found.push(full);
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Code lines only. Docstrings quote the frozen `OpenA2A-ARP/0.2.0` on purpose
+   * -- this file and `arp/index.ts` both explain the defect by naming it -- and
+   * a guard that cannot tell prose from a header would force the explanation
+   * out. Comment detection is line-granular: a whole-line `//`, `/*` or ` *`.
+   * A header hidden inside a multi-line template on a line that opens with `*`
+   * would slip through, which is not a shape a refactor produces.
+   */
+  function codeOf(file: string): string {
+    return readFileSync(file, 'utf-8')
+      .split('\n')
+      .filter((line) => {
+        const t = line.trimStart();
+        return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+      })
+      .join('\n');
+  }
+
+  const src = join(__dirname, '..');
+  const files = sourceFiles(src);
+
+  it('scans a non-empty set of source files, so this is not vacuous', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('finds the header in code, so the pattern still matches how it is written', () => {
+    const withHeader = files.filter((f) => codeOf(f).includes('OpenA2A-ARP/'));
+    // Both telemetry channels send it: the GTIN channel and the signature
+    // emitter. If a refactor renames the product token, or the comment filter
+    // starts eating code, this goes red rather than silently guarding nothing.
+    expect(withHeader.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never hardcodes a version after the product token', () => {
+    // Matches `OpenA2A-ARP/0`..`OpenA2A-ARP/9`; the legitimate form is
+    // `OpenA2A-ARP/${VERSION}`, which starts with `$`.
+    const offenders = files
+      .filter((f) => /OpenA2A-ARP\/\d/.test(codeOf(f)))
+      .map((f) => f.slice(src.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #397.

`@opena2a/aim-sdk/arp` exported its own `VERSION` literal, asserted by a comment to track a separate "ARP engine lineage". No release ever bumped it — it read `0.2.0` from the day the module landed through five published package versions, while `@opena2a/aim-sdk` exported the real version under the same export name. Both subpaths now export one value.

## Why it is not cosmetic

The constant goes on the wire. Both telemetry channels send it as `User-Agent: OpenA2A-ARP/<VERSION>`, and that header is the only build signal recorded for a submission. Every ARP request logged carries `OpenA2A-ARP/0.2.0` — one distinct value across the whole history of the channel — so no ingested signature can be attributed to the build that produced it.

## Three corrections to the issue, found by checking the shipped object

- **Two wire sites, not one.** #397 names `telemetry/gtin.ts:281`; `telemetry/signature/emitter.ts:178` is the second, and it is the channel that actually matters.
- **The CLI bullet describes an unreachable surface.** `src/arp/cli/index.ts` is not a `tsup` entry and `package.json` has no `bin`, so no installed user can see `arp-guard v0.2.0`. Filed separately as #400.
- **`0.2.0` was a fossil, not an arbitrary number.** ARP shipped as its own npm package, `arp-guard`, still published at 0.3.0 (last released 2026-03-23). That rescues nothing — `0.2.0` matched neither the package it ships in nor the standalone engine's current version, and this copy has moved well past what arp-guard 0.3.0 contains. Recorded in the docstring so the change is not reverted by someone who finds arp-guard later.

Option (1) of the two in the issue. Option (2) — keep an independent version and start bumping it — is defensible only if the module is really versioned separately in practice, and five releases of evidence say it is not.

## Tests, and proof they are not vacuous

`src/arp/version.test.ts` pins three properties: the ARP export equals `package.json`, the two subpath exports equal each other, and the wire header is built from the constant rather than any literal a person typed.

- **Red-proof** against the real base revision (extracted with `git archive origin/main`, not a hand-edit): 2 tests fail with `expected '0.2.0' to be '1.2.0'`.
- **Mutations**, each killed by the intended assertion: hardcoding `'OpenA2A-ARP/0.3.0'` in `gtin.ts` fails the offender list naming that file; restoring `VERSION = '0.2.0'` fails both version assertions.
- **Non-vacuity controls** are real, not decorative: a file-count guard and a header-presence guard. The offender scan originally fired on this file's own docstring, which is how it was scoped to code lines rather than prose — it can demonstrably fail.

The sibling defect this mirrors (`SDK_VERSION` stale at 1.1.0 while `package.json` said 1.2.0) existed precisely because a comment asked a human to remember.

## Also in this branch

1.2.0 is on npm and its headline change is that structural signature telemetry became opt-in. The published tarball's CHANGELOG files that change under `## [Unreleased]`, while its `## [1.2.0]` entry describes only the earlier denial-reporting work under a date ten days before the publish — so a user upgrading to get the telemetry fix reads the 1.2.0 entry and does not find it. Verified against the published artifact on a clean `HOME` before moving anything (default posture `false`, `AIM_TELEMETRY=1` `true`, `OPENA2A_TELEMETRY=off` wins over it), so this is a correction rather than a rewrite.

## Behaviour change to note

`VERSION` jumps `0.2.0` → the package version. Nothing server-side parses the header, so no parser breaks, but it is called out in the CHANGELOG for anyone external who does. In TypeScript the declared literal type changes with it, so a consumer comparing `=== '0.2.0'` now gets a compile error rather than a silent false.

Build, 1093 tests, typecheck and lint all green; consumer install of the packed tarball on a clean `HOME` reports 1.2.0 from all three of `arp`, root and `package.json`, with the telemetry default still off.