### PR TITLE
ci(pr-review): share the model call; fix the prior-review fetch and the `-` filename hole

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,21 @@
 name: PR Review
-# Runs on every PR to main — calls Claude API for security-focused code review
-# v2: Full file context + verification mandate + re-review awareness
+# Runs on every PR to main — calls the Claude API for a security-focused code review.
+#
+# The gate fails CLOSED. There are three verdicts: APPROVE passes,
+# REQUEST_CHANGES fails, INCONCLUSIVE fails. Inconclusive covers a missing key,
+# a non-200, empty content, an unparseable verdict, a missing verdict and a
+# request that does not fit the model's context window. Unknown is a third
+# state and it is not a pass.
+#
+# THE MODEL CALL IS NOT IN THIS FILE. It lives in a SHA-pinned composite action
+# shared across the org. Three defects were found in this gate and all three
+# lived in the call: an `anthropic-version` the API rejected outright, an
+# extraction reading only `.content[0].text`, and a 120,000-BYTE cap standing in
+# for a token budget. This repo carried one of the three: the byte cap. Its
+# anthropic-version was already valid and its extraction already read every text
+# block. Copy-paste is how one defect became nine, so the call is shared. What stays here is what legitimately differs per repo: diff gathering,
+# the system prompt, posting, and the verdict enforcement that sets the job
+# conclusion.
 
 on:
   pull_request:
@@ -24,7 +39,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # fetch-depth: 0 is load-bearing, not hygiene: the 406 fallback below
+          # builds the diff locally from `origin/$BASE_REF...HEAD`, which needs
+          # the base branch present.
           fetch-depth: 0
+          # Do not leave this job's GITHUB_TOKEN in .git/config as an
+          # http.extraheader for the rest of the job. The only git operations
+          # after checkout are local reads against refs already fetched, and
+          # `gh` uses GH_TOKEN from the step env, so a credential left at rest
+          # buys nothing and this job holds `pull-requests: write`.
+          persist-credentials: false
 
       - name: Gather review context
         id: context
@@ -45,30 +69,33 @@ jobs:
           gh pr view "$PR_NUMBER" --json title -q '.title' > /tmp/pr_title.txt
           gh pr view "$PR_NUMBER" --json body -q '.body' | head -c 2000 > /tmp/pr_body.txt
 
+          # The diff is passed WHOLE. There was a 120,000-byte cap here that
+          # stood in for a token budget, and over it the gate wrote INCONCLUSIVE
+          # without ever calling the API. Bytes are the wrong instrument:
+          # measured on real diffs at 2.8-3.2 bytes per token it refused at
+          # roughly 38-43K tokens — about a fifth of the window, on exactly the
+          # large, security-relevant changes an automated opinion is worth most
+          # on. The shared action measures the request that will actually be
+          # sent with count_tokens and refuses on that. Truncating here as well
+          # would hand the model a cut-down diff behind a token count that
+          # passes, which is the worst of both.
           DIFF_BYTES=$(wc -c < /tmp/pr_diff.txt | tr -d ' ')
           echo "$DIFF_BYTES" > /tmp/diff_size.txt
           FILE_COUNT=$(wc -l < /tmp/changed_files.txt | tr -d ' ')
           echo "$FILE_COUNT" > /tmp/file_count.txt
 
-          # Truncate diff at 120KB. Truncation is recorded, not hidden: a review
-          # of the first 120KB describes a slice of the change while reporting
-          # on the PR, so the next step turns this into INCONCLUSIVE rather than
-          # letting a partial read produce a verdict.
-          if [ "$DIFF_BYTES" -gt 120000 ]; then
-            head -c 120000 /tmp/pr_diff.txt > /tmp/pr_diff_trunc.txt
-            printf '\n\n[DIFF TRUNCATED — original was %s bytes]\n' "$DIFF_BYTES" >> /tmp/pr_diff_trunc.txt
-            mv /tmp/pr_diff_trunc.txt /tmp/pr_diff.txt
-            echo "truncated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "truncated=false" >> "$GITHUB_OUTPUT"
-          fi
-          echo "diff_bytes=$DIFF_BYTES" >> "$GITHUB_OUTPUT"
-
           # Full source file context (line-numbered) for mitigation verification
           echo "" > /tmp/full_files.txt
           TOTAL_SIZE=0
           MAX_FULL_SIZE=200000
-          while IFS= read -r file; do
+          # The loop reads the file list on fd 3 and nl reads through a stdin
+          # redirect: a changed file literally named '-' must not let any
+          # command in the body consume the list itself, because nl treats the
+          # operand '-' as stdin. With the previous form the '-' entry rendered
+          # the REMAINING file list as its own contents and the loop then ended
+          # at exit 0 — every later file dropped, with no truncation notice and
+          # nothing in the log to say so.
+          while IFS= read -r file <&3; do
             case "$file" in
               *_test.go | *.test.* | *.spec.* | package-lock.json | *.lock | go.sum) continue ;;
             esac
@@ -81,57 +108,66 @@ jobs:
             fi
             TOTAL_SIZE=$NEW_TOTAL
             printf '\n=== %s ===\n' "$file" >> /tmp/full_files.txt
-            nl -ba "$file" >> /tmp/full_files.txt
-          done < /tmp/changed_files.txt
+            nl -ba < "$file" >> /tmp/full_files.txt
+          done 3< /tmp/changed_files.txt
 
           # Previous review comments (for re-review awareness on synchronize).
-          # This job posts issue comments rather than pull request reviews, so
-          # the history lives on the comments endpoint.
-          gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --paginate \
-            --jq '[.[] | select(.body | test("Claude Code Review")) | .body] | last // ""' \
-            2>/dev/null | head -c 4000 > /tmp/previous_review.txt || echo "" > /tmp/previous_review.txt
+          #
+          # --paginate was already here, but WITHOUT --slurp and combined with
+          # --jq the filter runs once PER PAGE, so a thread spanning pages
+          # yielded one body per page concatenated together rather than the
+          # single latest review. --slurp yields one array of page-arrays,
+          # hence `.[][]`, and jq runs standalone because gh rejects --slurp
+          # combined with --jq.
+          #
+          # The login filter is the security half: any commenter who quotes
+          # "Claude Code Review" would otherwise be fed back to the model under
+          # a PREVIOUS REVIEW heading the system prompt instructs it to trust,
+          # as the gate's own prior verdict.
+          gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null \
+            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review")) | .body] | last // ""' \
+            | sed -e '/^## Claude Code Review/d' \
+                  -e '/^\*\*Verdict:.*\*\*[[:space:]]*$/d' \
+                  -e '/^\*Reviewed .*\*[[:space:]]*$/d' \
+                  -e '/^\*No review was produced\..*\*[[:space:]]*$/d' \
+            | head -c 4000 > /tmp/previous_review.txt || echo "" > /tmp/previous_review.txt
 
-      - name: Run Claude review
-        id: review
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The gate's OWN heading and footer are removed from what gets replayed.
+          # The comment a human reads states the verdict in its heading; that same
+          # comment is what this fetch selects, and the system prompt tells the
+          # model to trust the PREVIOUS REVIEW block and not re-raise against it.
+          # Feeding back a heading reading "— APPROVE" therefore hands the next
+          # review its own prior approval as trusted context: open a clean pull
+          # request, collect an APPROVE, then push the real change. What the model
+          # needs from a previous review is the FINDINGS, not the verdict word or
+          # the byte counts. The verdict is carried by the check conclusion, which
+          # is what actually gates the merge.
+          #
+          # The PRE-ADOPTION comment format is covered too, and that is not
+          # belt-and-braces: `pull_request` runs this workflow from the merge ref,
+          # so the moment adoption lands on main every already-open pull request
+          # runs the NEW workflow against a comment history that is still OLD. This
+          # repo's previous format emitted `**Verdict: $VERDICT**` on its own line
+          # and a footer without the `review path:` phrase, so a rule written only
+          # for the new shape would replay a legacy APPROVE on exactly the first
+          # re-review after adoption. The trailing `[[:space:]]*` before `$` is for
+          # the same reason a parser cannot govern transport: a CRLF body would
+          # otherwise slip past a bare `$` anchor.
+
+      - name: Build review prompt
+        # Kept local on purpose: AIM's tech stack and review focus are its own,
+        # and only the model call drifted. This step deliberately contains no
+        # workflow expressions, so it can be executed verbatim outside Actions
+        # when verifying this logic.
         run: |
           PR_TITLE=$(cat /tmp/pr_title.txt)
 
-          # An inconclusive review is a third state and it is not a pass. Each
-          # of these writes INCONCLUSIVE and exits 0; the "Enforce verdict" step
-          # turns that into a failing job.
-          inconclusive() {
-            echo "verdict=INCONCLUSIVE" >> "$GITHUB_OUTPUT"
-            echo "INCONCLUSIVE" > /tmp/verdict.txt
-            {
-              echo "SUMMARY: $1"
-              echo ""
-              echo "This pull request has NOT been reviewed. A human review is required."
-            } > /tmp/review_body.txt
-          }
-
-          if [ "${{ steps.context.outputs.truncated }}" = "true" ]; then
-            inconclusive "The diff is ${{ steps.context.outputs.diff_bytes }} bytes, over the 120000-byte review cap. Only part of it could be examined, so an automated verdict would describe a subset of the change."
-            exit 0
-          fi
-
-          if [ ! -s /tmp/pr_diff.txt ]; then
-            inconclusive "The pull request diff could not be retrieved (empty after both the API and the local fallback), so there was nothing to review."
-            exit 0
-          fi
-
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            inconclusive "Automated review did not run: ANTHROPIC_API_KEY is unavailable to this run."
-            exit 0
-          fi
-
-          # Per-run nonce. The verdict is read back as VERDICT-<nonce>, so the
-          # marker cannot be pre-placed in an attacker-authored diff: the value
-          # does not exist until this step runs.
-          NONCE=$(head -c 16 /dev/urandom | xxd -p)
-
-          # Build system prompt
+          # Build system prompt.
+          #
+          # The verdict-line block was appended with `printf` OUTSIDE the quoted
+          # heredoc so that $NONCE would expand. The nonce is no longer minted
+          # here, so that block moves inside the heredoc carrying the literal
+          # __NONCE__ placeholder. Verified byte-identical to the printf render.
           cat > /tmp/system_prompt.txt << 'SYSPROMPT'
           You are a senior security engineer reviewing a pull request for the Agent Identity Management (AIM) platform — an open-source non-human identity platform for AI agents.
 
@@ -187,18 +223,20 @@ jobs:
           - Only REQUEST_CHANGES for genuine, unmitigated security/correctness issues introduced in this PR
           - CI/config/docs-only changes: always APPROVE
           - Max 10 findings, most important first
-          SYSPROMPT
 
-          # The verdict line goes first so it cannot be lost if the reply is cut
-          # short, and carries the per-run nonce so it cannot be forged from the
-          # diff. Appended outside the quoted heredoc so $NONCE expands.
-          {
-            printf '\n=== VERDICT LINE (required) ===\n'
-            printf 'Your reply MUST BEGIN with exactly one of these two lines, with nothing whatsoever before it:\n'
-            printf 'VERDICT-%s: APPROVE\n' "$NONCE"
-            printf 'VERDICT-%s: REQUEST_CHANGES\n' "$NONCE"
-            printf 'Write SUMMARY and FINDINGS on the lines after it.\n'
-          } >> /tmp/system_prompt.txt
+          === VERDICT LINE (required) ===
+          Your reply MUST BEGIN with exactly one of these two lines, with nothing whatsoever before it:
+          VERDICT-__NONCE__: APPROVE
+          VERDICT-__NONCE__: REQUEST_CHANGES
+          Write SUMMARY and FINDINGS on the lines after it.
+          SYSPROMPT
+          # The per-run nonce is NOT minted here. `__NONCE__` is a PLACEHOLDER:
+          # the shared action mints a nonce, substitutes it into a COPY of this
+          # prompt, and then requires the reply's first line to match exactly.
+          # The marker therefore does not exist until the review runs and cannot
+          # be pre-placed in an attacker-authored diff. There must be no local
+          # `sed` here — substituting first would consume the placeholder and the
+          # action would refuse the prompt for not carrying one.
 
           # Build user message with full context
           {
@@ -218,113 +256,129 @@ jobs:
             cat /tmp/previous_review.txt >> /tmp/user_msg.txt
           fi
 
-          # Call Anthropic API with extended thinking
-          HTTP_CODE=$(jq -n \
-            --rawfile system /tmp/system_prompt.txt \
-            --rawfile user /tmp/user_msg.txt \
-            '{
-              model: "claude-sonnet-4-5-20250929",
-              max_tokens: 16000,
-              thinking: { type: "enabled", budget_tokens: 10000 },
-              system: $system,
-              messages: [{ role: "user", content: $user }]
-            }' | curl -s -w '%{http_code}' -o /tmp/api_response.json \
-              -X POST "https://api.anthropic.com/v1/messages" \
-              -H "Content-Type: application/json" \
-              -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-              -H "anthropic-version: 2023-06-01" \
-              -d @-)
-
-          # Extract response text (skip thinking blocks), tolerate null .content
-          REVIEW_TEXT=""
-          if [ "$HTTP_CODE" = "200" ]; then
-            REVIEW_TEXT=$(jq -r '(.content // [])[] | select(.type == "text") | .text' /tmp/api_response.json 2>/dev/null || true)
-          fi
-
-          # Fallback: retry without thinking if first call failed
-          if [ -z "$REVIEW_TEXT" ]; then
-            echo "::notice::First API call returned HTTP $HTTP_CODE, retrying without extended thinking"
-            HTTP_CODE=$(jq -n \
-              --rawfile system /tmp/system_prompt.txt \
-              --rawfile user /tmp/user_msg.txt \
-              '{
-                model: "claude-sonnet-4-5-20250929",
-                max_tokens: 8192,
-                system: $system,
-                messages: [{ role: "user", content: $user }]
-              }' | curl -s -w '%{http_code}' -o /tmp/api_response.json \
-                -X POST "https://api.anthropic.com/v1/messages" \
-                -H "Content-Type: application/json" \
-                -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-                -H "anthropic-version: 2023-06-01" \
-                -d @-)
-
-            if [ "$HTTP_CODE" = "200" ]; then
-              REVIEW_TEXT=$(jq -r '(.content // [])[] | select(.type == "text") | .text' /tmp/api_response.json 2>/dev/null || true)
-            fi
-          fi
-
-          # If both calls failed the review did not happen. That is INCONCLUSIVE,
-          # not APPROVE: an unreachable reviewer has no opinion about this diff.
-          if [ -z "$REVIEW_TEXT" ]; then
-            ERROR=$(jq -r '.error.message // "Unknown API error"' /tmp/api_response.json 2>/dev/null || echo "No response")
-            echo "::error::Claude API unavailable (HTTP $HTTP_CODE: $ERROR)."
-            inconclusive "Automated review could not be completed — the Claude API returned HTTP $HTTP_CODE ($ERROR)."
-            exit 0
-          fi
-
-          # Strip the verdict line out of what gets posted, so the marker is
-          # never echoed into a comment where a later run could read it back.
-          printf '%s\n' "$REVIEW_TEXT" | grep -v "VERDICT-$NONCE:" > /tmp/review_body.txt || true
-
-          # Read the verdict from the FIRST line only, and require the nonce.
-          FIRST_LINE=$(printf '%s\n' "$REVIEW_TEXT" | sed -n '1p')
-          if [ "$FIRST_LINE" = "VERDICT-$NONCE: APPROVE" ]; then
-            echo "verdict=APPROVE" >> "$GITHUB_OUTPUT"
-            echo "APPROVE" > /tmp/verdict.txt
-          elif [ "$FIRST_LINE" = "VERDICT-$NONCE: REQUEST_CHANGES" ]; then
-            echo "verdict=REQUEST_CHANGES" >> "$GITHUB_OUTPUT"
-            echo "REQUEST_CHANGES" > /tmp/verdict.txt
-          else
-            # No parseable verdict is a third state, and it is not a pass.
-            BODY=$(cat /tmp/review_body.txt)
-            inconclusive "The verdict line could not be parsed, so the review outcome is unknown."
-            printf '\n%s\n' "$BODY" >> /tmp/review_body.txt
-          fi
+      - name: Run Claude review
+        id: review
+        # The model call is shared across the org. It held three defects at once
+        # — an anthropic-version the API rejected, an extraction that read only
+        # the first content block, and a byte cap standing in for a token budget
+        # — and copy-paste is how one defect became nine. Pinned to a SHA, never
+        # @main: @main would move every consuming repo, and this check is
+        # REQUIRED on this repo's main, the instant that file changed.
+        uses: opena2a-org/.github/actions/claude-review@d278bf3b88f8822a8c3b020aac3f824db33a18e2
+        with:
+          # A composite action cannot read `secrets`, so the caller passes it in.
+          # A step `env:` is the boundary GitHub actually enforces: this key
+          # exists in exactly one step. That step does read the diff — that is
+          # its job — but no PR-authored text is ever substituted into its script
+          # SOURCE, which is the exposure a `${{ }}` in a `run:` would create.
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          system-prompt-file: /tmp/system_prompt.txt
+          user-message-file: /tmp/user_msg.txt
+          # All three are AIM's existing settings. The action defaults to
+          # thinking OFF at 4096 output tokens, so omitting them would silently
+          # downgrade every review while the check stayed green.
+          thinking-budget: "10000"
+          max-tokens: "16000"
+          fallback-max-tokens: "8192"
 
       - name: Post review
-        if: always() && steps.review.outcome != 'skipped'
         # Posting is best effort and must never decide the outcome. A run that
         # cannot comment — a read-only token, a rate limit — is a delivery
         # problem, not a review result. The conclusion is set by the next step.
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bound through `env:` rather than substituted into the shell source
+          # with `${{ }}`. An output interpolated directly into `run:` becomes
+          # part of the script text before bash ever sees it.
+          VERDICT: ${{ steps.review.outputs.verdict }}
+          REVIEW_FILE: ${{ steps.review.outputs.review-file }}
+          REVIEW_PATH: ${{ steps.review.outputs.review-path }}
+          INPUT_TOKENS: ${{ steps.review.outputs.input-tokens }}
         run: |
-          # A missing verdict file means the review step did not reach a verdict.
-          # Unknown is not a pass.
-          VERDICT=$(cat /tmp/verdict.txt 2>/dev/null || echo "INCONCLUSIVE")
-          [ -n "$VERDICT" ] || VERDICT="INCONCLUSIVE"
-          DIFF_SIZE=$(cat /tmp/diff_size.txt 2>/dev/null || echo "0")
-          FILE_COUNT=$(cat /tmp/file_count.txt 2>/dev/null || echo "0")
-          REVIEW_BODY=$(cat /tmp/review_body.txt 2>/dev/null || echo "SUMMARY: The review step did not produce a result. This pull request has NOT been reviewed.")
+          # An absent verdict means the review step never reached a decision —
+          # including the case where the action itself failed to run at all.
+          VERDICT="${VERDICT:-INCONCLUSIVE}"
+          case "$VERDICT" in
+            APPROVE|REQUEST_CHANGES|INCONCLUSIVE) ;;
+            *) VERDICT="INCONCLUSIVE" ;;
+          esac
+
+          DIFF_SIZE=$(cat /tmp/diff_size.txt 2>/dev/null || echo "unknown")
+          FILE_COUNT=$(cat /tmp/file_count.txt 2>/dev/null || echo "unknown")
+
+          # Guard: if the review body is missing, say so. Do not manufacture one
+          # that reads as an approval.
+          if [ -z "$REVIEW_FILE" ] || [ ! -f "$REVIEW_FILE" ]; then
+            REVIEW_FILE=/tmp/review_body_missing.txt
+            printf 'SUMMARY: Automated review could not be completed and produced no review body. A human review is required.\n' > "$REVIEW_FILE"
+          elif [ ! -s "$REVIEW_FILE" ]; then
+            # A reply consisting of nothing but the nonce-bound marker line leaves
+            # a ZERO-BYTE body once the marker is stripped, under a verdict that is
+            # legitimately APPROVE. State the absence instead of publishing a
+            # verdict header over empty space.
+            REVIEW_FILE=/tmp/review_body_empty.txt
+            printf 'SUMMARY: The review returned a verdict with no accompanying commentary.\n' > "$REVIEW_FILE"
+          fi
+
+          # FOUR states, not two and not three. `verdict` and `review-path` are
+          # orthogonal: INCONCLUSIVE + primary is reachable and means the model
+          # answered but its first line did not carry this run's marker, and the
+          # action deliberately preserves those findings. The path answers "which
+          # request produced this text", never "was there a review".
+          #
+          # `none` and empty are DIFFERENT and the difference is the only thing a
+          # blocked author needs: `none` means requests were sent and none
+          # answered, so re-running may work; empty means no request was ever
+          # sent, so re-running changes nothing.
+          case "$REVIEW_PATH" in
+            primary)
+              PATH_NOTE="review path: primary."
+              ;;
+            fallback)
+              PATH_NOTE="review path: FALLBACK — the primary request failed and this verdict came from the retry, without extended thinking. See the run log."
+              ;;
+            none)
+              PATH_NOTE="review path: none — requests were sent and none of them produced a review. Re-running the job may succeed."
+              ;;
+            *)
+              # Catch-all for nine distinct action exits plus the case where the
+              # review step never ran at all. The action writes the true cause,
+              # with its HTTP code, into the review body directly above this line;
+              # the footer's job is to not contradict it.
+              PATH_NOTE="review path: no request produced a review, and the reason is stated above."
+              ;;
+          esac
+
+          # The "Reviewed N files" sentence is a factual claim about work that
+          # happened, so it is emitted ONLY when a request produced a review. On
+          # `none` and on empty the machine verdict is correctly INCONCLUSIVE,
+          # but a footer asserting N files were reviewed would leave the artifact
+          # a human reads failing OPEN.
+          case "$REVIEW_PATH" in
+            primary|fallback)
+              FOOTER="*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes, ${INPUT_TOKENS:-unmeasured} input tokens) — ${PATH_NOTE}*"
+              ;;
+            *)
+              FOOTER="*No review was produced. The change measured ${FILE_COUNT} files (${DIFF_SIZE} bytes) — ${PATH_NOTE}*"
+              ;;
+          esac
 
           {
-            echo "## Claude Code Review"
+            echo "## Claude Code Review — $VERDICT"
             echo ""
-            echo "**Verdict: $VERDICT**"
-            echo ""
-            echo "$REVIEW_BODY"
+            cat "$REVIEW_FILE"
             echo ""
             echo "---"
-            echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+            echo "$FOOTER"
           } > /tmp/full_review.txt
 
           BODY=$(cat /tmp/full_review.txt)
 
-          # The summary is written first, so the review is readable even when
+          # The job summary is written first, so the review is readable even if
           # the comment cannot be delivered.
-          cat /tmp/full_review.txt >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
 
           # Comment only. This job does not submit pull request reviews: an
           # approving review from GITHUB_TOKEN counts toward a required-approval
@@ -336,11 +390,14 @@ jobs:
       - name: Enforce verdict
         # The job conclusion IS the policy decision, and it is decided here so
         # that nothing upstream can turn a REQUEST_CHANGES or an INCONCLUSIVE
-        # into a green check by succeeding at something unrelated.
+        # into a green check by succeeding at something unrelated. `always()`
+        # means a crashed or skipped review step still lands here with no verdict
+        # at all, which is INCONCLUSIVE, which is not a pass.
+        if: always()
+        env:
+          VERDICT: ${{ steps.review.outputs.verdict }}
         run: |
-          VERDICT=$(cat /tmp/verdict.txt 2>/dev/null || echo "INCONCLUSIVE")
-          [ -n "$VERDICT" ] || VERDICT="INCONCLUSIVE"
-          case "$VERDICT" in
+          case "${VERDICT:-INCONCLUSIVE}" in
             APPROVE)
               echo "Automated review approved."
               ;;
@@ -349,7 +406,7 @@ jobs:
               exit 1
               ;;
             *)
-              echo "::error::Automated review was inconclusive ($VERDICT). Unknown is not a pass; this pull request has not been reviewed."
+              echo "::error::Automated review was inconclusive (${VERDICT:-no verdict recorded}). Treated as not passing; a human review is required."
               exit 1
               ;;
           esac


### PR DESCRIPTION
Adopts the org's SHA-pinned `claude-review` composite action, and fixes the two context-gathering defects in the same change rather than leaving a second pull request against the same file.

Full reasoning is in the commit message. Summary of what changes:

- the model call moves to `opena2a-org/.github/actions/claude-review@d278bf3b`
- the 120,000-byte diff cap and its INCONCLUSIVE-on-truncation branch are deleted; the action measures the real request with `count_tokens` against a 180,000-token budget
- `thinking-budget`, `max-tokens` and `fallback-max-tokens` are passed explicitly, because the action defaults to thinking off at 4096
- the prior-review fetch passed `--paginate` together with `--jq` but **without** `--slurp`, so the filter ran once per PAGE and a multi-page thread concatenated one body per page. It now slurps, and gains a `github-actions[bot]` author filter
- the `-` filename hole is closed with an fd-3 loop and `nl -ba < "$file"`
- the posted comment gains the four-state footer, and no longer claims files were reviewed when no request produced a review

**This repo's 406 fallback is preserved unchanged**, and it is worth naming: `agent-identity-management` and `hackmyagent` are the only two of the nine gate copies that fall back to a local `git diff origin/$BASE_REF...HEAD` when `gh pr diff` returns 406 above ~20,000 changed lines. The other seven abort the gathering step before any size guard runs. `fetch-depth: 0` is what makes that work, and is now documented as load-bearing rather than hygiene.

## What was verified before this was pushed

Three checks, all run against this branch's actual file:

- **The rendered system prompt is byte-identical** across the heredoc rewrite. Both sides were
  rendered and the nonce substituted to a fixed value before comparing.
- **9/9 composed cases**, running this file's real `Gather review context` / `Build review prompt`
  steps against the real composite action at the pinned SHA, with `gh` and `curl` stubbed. The stub
  reads the per-run nonce back out of the request it is handed and answers with it, so the binding is
  exercised rather than assumed. Cases cover the happy path, `REQUEST_CHANGES`, a thinking block
  arriving first, primary-fails-to-fallback, both-fail, a forged nonce, no API key, a verdict that is
  not on the first line, and a request over the token budget.
- **14/14 caller mutants caught**, with the baseline green and the file restored byte-exact. A green
  harness proves nothing until it goes red on purpose. The mutants include an input-name typo, a
  dropped `max-tokens`, a silently downgraded `max-tokens`, thinking disabled, the pin moved to
  `@main`, a misspelled output, `review-path` no longer surfaced, `none` collapsed into the empty
  arm, the count line emitted when no request produced a review, and `INCONCLUSIVE` or
  `REQUEST_CHANGES` treated as a pass.

The mutant that matters most here is "thinking disabled": the action defaults to thinking OFF at
4096 output tokens, so a caller that omits `thinking-budget` / `max-tokens` gets a silently
downgraded review behind a green check. That is exactly what the harness caught in an early draft of
the registry file, where the values had been left as a placeholder.

## What to look for on this PR's own run

This PR is reviewed by the workflow it changes, so the run log is the acceptance test:

- the check is named exactly `Claude Code Review`
- `Measured request size: N input tokens (budget 180000)`
- `Review produced by the primary request.` — a fallback on an ordinary PR is the old defect
- the job step list contains `Build review prompt` and not the old key-loading step, which is what
  proves this PR's own new workflow reviewed it rather than the base version
- the posted comment carries a real verdict, `review path: primary.`, and no 32-hex nonce

## Review notes

An adversarial review of this diff found one regression it had introduced and several false
statements in its own comments; all are fixed in the commit. The details are in the commit message
rather than here, because the commit is what survives.
