### PR TITLE
Sanitise server-sent text before it can reach a terminal

### DIFF
--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -36,6 +36,7 @@ from .decision import (
     Outcome,
     UnknownSource,
     VerificationDecision,
+    _sanitize_reason,
     parse_enforcement_mode,
     resolve_mode,
 )
@@ -901,7 +902,10 @@ class AIMClient:
                     error_detail = response.json().get("error", "unknown error")
                 except:
                     error_detail = response.text
-                raise AuthenticationError(f"Authentication failed - invalid agent credentials: {error_detail}")
+                # Server text sanitised where it enters the message (#384 class).
+                raise AuthenticationError(
+                    f"Authentication failed - invalid agent credentials: {_sanitize_reason(error_detail)}"
+                )
 
             # Handle forbidden errors (denied action or agent status issue).
             # A 403 on this route is the server refusing the action -- the wire
@@ -925,7 +929,7 @@ class AIMClient:
                 if not isinstance(body, dict):
                     body = {}
 
-                error_detail = (
+                error_detail = _sanitize_reason(
                     body.get("denialReason")
                     or body.get("error")  # a proxy or gateway 403, not ours
                     or (response.text if not body else None)
@@ -994,10 +998,14 @@ class AIMClient:
             if response.status_code >= 400:
                 error_msg = f"HTTP {response.status_code} error"
                 try:
-                    error_detail = response.json().get("error", response.text)
+                    # Server text sanitised where it enters the string that both
+                    # the console warning and the decision reason are built from
+                    # (#384 class) — this print happens BEFORE the decision
+                    # exists, so construction-time sanitisation cannot cover it.
+                    error_detail = _sanitize_reason(response.json().get("error", response.text))
                     error_msg = f"{error_msg}: {error_detail}"
                 except Exception:
-                    error_msg = f"{error_msg}: {response.text[:200]}"
+                    error_msg = f"{error_msg}: {_sanitize_reason(response.text[:200])}"
 
                 console.warning(f"Verification request failed: {error_msg}")
                 return self._undetermined(error_msg, UnknownSource.SERVER_ANSWER)
@@ -1597,10 +1605,11 @@ class AIMClient:
                 if response.status_code >= 400:
                     error_msg = f"HTTP {response.status_code} error"
                     try:
-                        error_detail = response.json().get("error", response.text)
+                        # Server text sanitised at entry (#384 class).
+                        error_detail = _sanitize_reason(response.json().get("error", response.text))
                         error_msg = f"{error_msg}: {error_detail}"
                     except:
-                        error_msg = f"{error_msg}: {response.text[:200]}"
+                        error_msg = f"{error_msg}: {_sanitize_reason(response.text[:200])}"
                     # Continue polling on transient errors, but log the issue
                     console.warning(f"Error polling verification status: {error_msg}")
                     time.sleep(poll_interval)

--- a/sdk/python/aim_sdk/console.py
+++ b/sdk/python/aim_sdk/console.py
@@ -23,6 +23,22 @@ except ImportError:
 # Global console instance
 _console = Console() if RICH_AVAILABLE else None
 
+
+def _strip_control_bytes(text: str) -> str:
+    """
+    Defence in depth for the free-text output methods (#384 class): drop C0
+    control bytes other than newline and tab, DEL, and the C1 range, so a
+    message assembled from server text cannot drive the reader's terminal even
+    if a call site forgot to sanitise. No length cap here — legitimate console
+    content can be long; length bounds belong at the untrusted-value entry
+    sites (decision.py / client.py).
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    return "".join(
+        ch for ch in text if not ((ch < " " and ch not in "\n\t") or "\x7f" <= ch <= "\x9f")
+    )
+
 # AIM Brand Colors
 BRAND_BLUE = "#3B82F6"
 BRAND_TEAL = "#14B8A6"
@@ -366,7 +382,9 @@ class AIMConsole:
         if self.quiet:
             return
 
-        reason_str = f" - {reason}" if reason else ""
+        # Same sink defence as warning/error/info: today's callers pass a
+        # sanitised decision.reason, but a future caller may not.
+        reason_str = f" - {_strip_control_bytes(reason)}" if reason else ""
         if RICH_AVAILABLE:
             self.console.print(f"  [bold red]✗[/] [cyan]{capability}[/] [red]denied[/]{reason_str}")
         else:
@@ -408,6 +426,8 @@ class AIMConsole:
 
     def error(self, message: str, details: Optional[str] = None):
         """Display error message."""
+        message = _strip_control_bytes(message)
+        details = _strip_control_bytes(details) if details else details
         if RICH_AVAILABLE:
             self.console.print(f"[bold red]✗ Error:[/] {message}")
             if details:
@@ -419,6 +439,7 @@ class AIMConsole:
 
     def warning(self, message: str):
         """Display warning message."""
+        message = _strip_control_bytes(message)
         if RICH_AVAILABLE:
             self.console.print(f"[yellow]Warning:[/] {message}")
         else:
@@ -426,6 +447,7 @@ class AIMConsole:
 
     def info(self, message: str):
         """Display info message."""
+        message = _strip_control_bytes(message)
         if RICH_AVAILABLE:
             self.console.print(f"{message}")
         else:

--- a/sdk/python/aim_sdk/decision.py
+++ b/sdk/python/aim_sdk/decision.py
@@ -38,7 +38,7 @@ voids that reasoning and makes a signed, expiring mode assertion mandatory.
 
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
@@ -47,6 +47,40 @@ from typing import Optional
 # not a finding. It bounds how long a process keeps enforcing a mode the
 # organization may have already changed.
 DEFAULT_MODE_TTL_SECONDS = 300
+
+# A reason longer than this is truncated with an explicit marker. The server
+# accepts denial reasons up to its body limit; nothing a human wrote for a human
+# needs more than this on a terminal.
+REASON_MAX_CHARS = 500
+_TRUNCATION_MARKER = " [truncated]"
+
+
+def _sanitize_reason(raw: object) -> str:
+    """
+    Make a server-supplied string safe to place in an exception message or a
+    console line (#384).
+
+    Total over any input: a non-str value (a server sending ``{"reason": 123}``
+    or a JSON object) is coerced with ``str()`` first. Raising here would turn
+    an explicit DENY into UNKNOWN at construction time -- a fail-open -- so this
+    function must never raise.
+
+    C0 control bytes other than newline and tab, DEL, and the C1 range are
+    stripped: ESC and the single-byte CSI drive the reader's terminal instead of
+    being read, and carriage return overwrites the line the developer just saw.
+    Newline itself is kept (ordinary whitespace, per #384's acceptance) -- a
+    multi-line reason is an accepted residual, visible as indented continuation
+    text. Unicode bidi controls are deliberately NOT stripped -- legitimate RTL
+    text may carry them, and this value renders in contexts we do not control.
+    """
+    if not isinstance(raw, str):
+        raw = str(raw)
+    cleaned = "".join(
+        ch for ch in raw if not ((ch < " " and ch not in "\n\t") or "\x7f" <= ch <= "\x9f")
+    )
+    if len(cleaned) > REASON_MAX_CHARS:
+        cleaned = cleaned[:REASON_MAX_CHARS] + _TRUNCATION_MARKER
+    return cleaned
 
 
 class Outcome(str, Enum):
@@ -101,6 +135,17 @@ class VerificationDecision:
     approved_by: Optional[str] = None
     expires_at: Optional[str] = None
     unknown_source: UnknownSource = UnknownSource.NONE
+
+    def __post_init__(self):
+        # Sanitised at construction rather than at each message site, so a new
+        # message builder reading decision.reason cannot miss it (#384). This
+        # covers only DECISION-BORNE strings: client.py also prints server text
+        # directly (pre-decision console warnings, the 401 exception message)
+        # and sanitises those at their own entry sites, with a control-byte
+        # strip in AIMConsole as defence in depth. The other fields here are
+        # returned to callers as data, and rewriting an id would corrupt it.
+        if self.reason is not None:
+            object.__setattr__(self, "reason", _sanitize_reason(self.reason))
 
     @property
     def allowed(self) -> bool:

--- a/sdk/python/tests/test_denial_reason_sanitised.py
+++ b/sdk/python/tests/test_denial_reason_sanitised.py
@@ -1,0 +1,249 @@
+"""
+Issue #384: a server-supplied denial reason reaches the developer's terminal
+through exception messages and the monitoring-mode warning. Control bytes in it
+can rewrite what the developer sees; an unbounded one can scroll the real
+message away.
+
+The guarantee under test: the reason is sanitised where it enters the decision
+(VerificationDecision construction), not at each message site, so a new message
+builder cannot miss it.
+"""
+
+from aim_sdk.decision import (
+    EnforcementMode,
+    ModeSource,
+    Outcome,
+    UnknownSource,
+    VerificationDecision,
+)
+from aim_sdk.enforcement import _denial_message, _unavailable_message
+
+
+def _deny(reason):
+    return VerificationDecision(
+        outcome=Outcome.DENY,
+        mode=EnforcementMode.STRICT,
+        mode_source=ModeSource.RESPONSE,
+        reason=reason,
+    )
+
+def _unknown(reason):
+    return VerificationDecision(
+        outcome=Outcome.UNKNOWN,
+        mode=EnforcementMode.STRICT,
+        mode_source=ModeSource.RESPONSE,
+        reason=reason,
+        unknown_source=UnknownSource.SERVER_ANSWER,
+    )
+
+
+def _control_bytes_in(text):
+    """Every char that could drive a terminal rather than be read by a human."""
+    return [
+        ch
+        for ch in text
+        if (ch < " " and ch not in "\n\t") or "\x7f" <= ch <= "\x9f"
+    ]
+
+
+class TestControlBytesAreStripped:
+    def test_ansi_escape_sequence_is_inert(self):
+        # ESC[2K erases the line, ESC[1A moves the cursor up: together they
+        # overwrite what the developer just read.
+        decision = _deny("\x1b[2K\x1b[1Adenied \x1b[32mALLOWED\x1b[0m")
+        assert "\x1b" not in decision.reason
+        assert "denied" in decision.reason  # the text itself survives
+
+    def test_c1_csi_is_stripped(self):
+        # 0x9b is the single-byte CSI; it drives terminals with no ESC at all.
+        decision = _deny("bad\x9b31mactor")
+        assert _control_bytes_in(decision.reason) == []
+        assert "bad" in decision.reason and "actor" in decision.reason
+
+    def test_carriage_return_is_dropped(self):
+        # \r is the overwrite primitive: everything before it gets rewritten.
+        decision = _deny("real reason\rFAKE LINE")
+        assert "\r" not in decision.reason
+
+    def test_delete_byte_is_stripped(self):
+        decision = _deny("a\x7fb")
+        assert "\x7f" not in decision.reason
+
+    def test_newline_and_tab_survive(self):
+        decision = _deny("line one\n\tindented")
+        assert decision.reason == "line one\n\tindented"
+
+    def test_null_and_bell_are_stripped(self):
+        decision = _deny("a\x00b\x07c")
+        assert decision.reason == "abc"
+
+
+class TestNonStrReasonNeverCrashesConstruction:
+    """
+    A server sending {"reason": 123} or a JSON object must not make the
+    constructor raise: an exception here converts an explicit DENY into
+    UNKNOWN — a fail-open. Found by adversarial review of the first cut of
+    this fix, which crashed on exactly these inputs.
+    """
+
+    def test_int_reason_stays_deny(self):
+        decision = _deny(123)
+        assert decision.denied
+        assert decision.reason == "123"
+
+    def test_dict_reason_stays_deny(self):
+        decision = _deny({"code": "quota", "limit": 5})
+        assert decision.denied
+        assert isinstance(decision.reason, str)
+        assert "quota" in decision.reason
+
+    def test_list_reason_stays_deny(self):
+        decision = _deny(["a", "b"])
+        assert decision.denied
+        assert isinstance(decision.reason, str)
+
+    def test_hostile_non_str_is_still_sanitised(self):
+        decision = _deny({"k": "\x1b[2K" + "z" * 100_000})
+        assert _control_bytes_in(decision.reason) == []
+        assert len(decision.reason) == 512
+
+
+class TestLengthIsBounded:
+    def test_long_reason_is_truncated_with_marker(self):
+        decision = _deny("x" * 100_000)
+        # Exact bound, pinned from both sides: 500 kept chars + the 12-char
+        # marker. A cap that drifted anywhere in 500-588 passed the old
+        # <=600 assertion; only 512 passes this one.
+        assert len(decision.reason) == 512
+        assert decision.reason == "x" * 500 + " [truncated]"
+
+    def test_short_reason_is_untouched(self):
+        decision = _deny("insufficient capability grant")
+        assert decision.reason == "insufficient capability grant"
+
+    def test_reason_at_cap_gets_no_marker(self):
+        decision = _deny("y" * 500)
+        assert decision.reason == "y" * 500
+
+    def test_none_reason_stays_none(self):
+        decision = _deny(None)
+        assert decision.reason is None
+
+
+class TestMessagesBuiltFromHostileDecisionsAreInert:
+    def test_denial_message_carries_no_control_bytes(self):
+        decision = _deny("\x1b[2K\rspoof\x9b0m" + "z" * 100_000)
+        message = _denial_message("capability 'x' for agent 'a'", decision, decision.mode)
+        assert _control_bytes_in(message) == []
+        # Bounded by the reason cap plus the builder's fixed guidance text --
+        # not by the 100k input.
+        assert len(message) < 2_000
+
+    def test_unavailable_message_carries_no_control_bytes(self):
+        decision = _unknown("\x1b]0;owned\x07" + "w" * 100_000)
+        message = _unavailable_message("capability 'x' for agent 'a'", decision, decision.mode)
+        assert _control_bytes_in(message) == []
+        # Bounded by the reason cap plus the builder's fixed guidance text --
+        # not by the 100k input.
+        assert len(message) < 2_000
+
+    def test_monitoring_mode_warning_is_inert(self):
+        # The warning named in #384: monitoring mode runs the action and warns
+        # with the server's reason. Exercised through evaluate(), the real
+        # integration, not by formatting the string by hand.
+        from aim_sdk.enforcement import evaluate
+
+        decision = VerificationDecision(
+            outcome=Outcome.UNKNOWN,
+            mode=EnforcementMode.MONITORING,
+            mode_source=ModeSource.RESPONSE,
+            reason="\x1b[2K\rfake-all-clear\x9b0m" + "q" * 100_000,
+            unknown_source=UnknownSource.SERVER_ANSWER,
+        )
+        verdict = evaluate(decision, what="capability 'x' for agent 'a'")
+        assert verdict.run is True
+        assert verdict.warning is not None
+        assert _control_bytes_in(verdict.warning) == []
+        assert len(verdict.warning) < 2_000
+
+
+class TestClientSinksAreSanitised:
+    """
+    client.py prints or raises server text BEFORE any decision exists (found by
+    adversarial review of the first cut of this fix): the >=400 console
+    warning, the JIT poll warning, and the 401 exception message.
+    Construction-time sanitisation cannot reach them; each sanitises at its own
+    entry, driven here through the real _decide_capability with only
+    session.request stubbed (the shape test_enforcement_matrix.py established).
+    """
+
+    HOSTILE = "\x1b[2K\x1b[1A\rfake ALLOWED\x9b31m" + "s" * 100_000
+
+    def _client(self, status, payload):
+        import base64
+
+        from nacl.encoding import Base64Encoder
+        from nacl.signing import SigningKey
+
+        from aim_sdk.client import AIMClient
+
+        sk = SigningKey.generate()
+        client = AIMClient(
+            agent_id="agent-under-test",
+            public_key=sk.verify_key.encode(encoder=Base64Encoder).decode(),
+            private_key=base64.b64encode(bytes(sk)).decode(),
+            aim_url="http://aim.invalid",
+            sdk_token_id="test-token",
+            telemetry={"enabled": False},
+        )
+
+        class FakeResponse:
+            status_code = status
+            text = "raw body"
+            headers = {}
+
+            def json(self_inner):
+                return payload
+
+        def stub(method, url, **kwargs):
+            return FakeResponse()
+
+        client.session.request = stub
+        return client
+
+    def test_server_answer_console_warning_is_inert_and_bounded(self, capsys, monkeypatch):
+        import aim_sdk.client as client_module
+        from aim_sdk.decision import Outcome
+
+        monkeypatch.setattr(client_module, "RATE_LIMIT_RETRY_ATTEMPTS", 0)
+        client = self._client(429, {"error": self.HOSTILE})
+        decision = client._decide_capability("cap")
+        assert decision.outcome is Outcome.UNKNOWN
+        out = capsys.readouterr().out
+        # The branch under test printed — without this the control-byte assert
+        # would pass vacuously on empty output.
+        assert "Verification request failed" in out
+        assert _control_bytes_in(out.replace("\n", "")) == []
+        assert len(out) < 3_000  # bounded by the cap, not the 100k input
+
+    def test_401_exception_message_is_inert_and_bounded(self):
+        import pytest
+
+        from aim_sdk.exceptions import AuthenticationError
+
+        client = self._client(401, {"error": self.HOSTILE})
+        with pytest.raises(AuthenticationError) as excinfo:
+            client._decide_capability("cap")
+        message = str(excinfo.value)
+        assert _control_bytes_in(message) == []
+        assert len(message) < 2_000
+
+    def test_console_sink_strips_control_bytes(self, capsys):
+        # Defence in depth: even a call site that forgot to sanitise cannot
+        # push control bytes through the console's free-text methods.
+        from aim_sdk.console import AIMConsole
+
+        AIMConsole().warning("before\x1b[2K\x9b31m\rafter")
+        out = capsys.readouterr().out
+        assert _control_bytes_in(out.replace("\n", "")) == []
+        assert "before" in out and "after" in out


### PR DESCRIPTION
Closes #384.

A server-sent denial reason reached developer terminals through exception messages and the monitoring-mode warning with no control-byte stripping and no length bound: ANSI escapes could rewrite what a developer sees, and an unbounded reason scrolls the real message away.

Decision-borne strings are sanitised in `VerificationDecision.__post_init__` — client.py constructs decisions at eight sites, and a builder reading `decision.reason` cannot miss a field sanitised at construction. The sanitiser is total: non-str reasons are coerced, never raised on (raising would flip an explicit DENY to UNKNOWN — fail-open).

Adversarial review of the first cut showed construction-time sanitisation alone was a false guarantee: client.py prints server text before any decision exists. The ≥400 console warning, JIT poll warning, 401 exception message and 403 denial-detail parse now sanitise at their own entries, with a control-byte strip in `AIMConsole` free-text methods as defence in depth.

Strip set: C0 except \n \t, DEL, C1; cap 500 chars with an explicit truncation marker. Bidi controls kept (legitimate RTL text). Tests drive the real paths with only `session.request` stubbed; 8 of 12 original assertions fail pre-fix, and five named mutants (C1 range, truncation, CR, non-str coercion, site unsanitise) are each killed.
