### PR TITLE
Attribute an opt-out to the source actually in effect

### DIFF
--- a/sdk/typescript/src/arp/cli/telemetry-status-readonly.test.ts
+++ b/sdk/typescript/src/arp/cli/telemetry-status-readonly.test.ts
@@ -96,3 +96,67 @@ describe('opt-out and purge do not mint identity on a machine that never sent', 
     expect(lines.join('\n')).toContain('nothing to purge');
   });
 });
+
+describe('opt-out attribution names the source that is actually in effect', () => {
+  // The 1.3.0 release walkthrough found OPENA2A_TELEMETRY=off attributed to a
+  // "local opt-out marker" with `opt-in` cited as the fix — a dead end, since
+  // opt-in cannot clear an env var.
+  function statusOutput(): Promise<string> {
+    const lines: string[] = [];
+    vi.mocked(console.log).mockImplementation((...a: unknown[]) => {
+      lines.push(a.join(' '));
+    });
+    return import('./telemetry').then((t) => t.telemetryStatus(undefined)).then(() => lines.join('\n'));
+  }
+
+  it('OPENA2A_TELEMETRY=off is attributed to the env var, not the marker', async () => {
+    process.env.OPENA2A_TELEMETRY = 'off';
+    try {
+      const out = await statusOutput();
+      expect(out).toContain('OFF (opted out)');
+      expect(out).toContain('OPENA2A_TELEMETRY');
+      expect(out).not.toContain('local opt-out marker');
+    } finally {
+      delete process.env.OPENA2A_TELEMETRY;
+    }
+  });
+
+  it('opt-in under OPENA2A_TELEMETRY=off names that spelling in its NOTE', async () => {
+    process.env.OPENA2A_TELEMETRY = 'off';
+    const lines: string[] = [];
+    vi.mocked(console.log).mockImplementation((...a: unknown[]) => {
+      lines.push(a.join(' '));
+    });
+    try {
+      const { telemetryOptIn } = await import('./telemetry');
+      telemetryOptIn(undefined);
+      const out = lines.join('\n');
+      expect(out).toContain('OPENA2A_TELEMETRY=off');
+    } finally {
+      delete process.env.OPENA2A_TELEMETRY;
+    }
+  });
+
+  it('opt-in on a clean home does not claim a marker was removed', async () => {
+    const lines: string[] = [];
+    vi.mocked(console.log).mockImplementation((...a: unknown[]) => {
+      lines.push(a.join(' '));
+    });
+    const { telemetryOptIn } = await import('./telemetry');
+    telemetryOptIn(undefined);
+    expect(lines.join('\n')).toContain('No opt-out marker was present');
+    expect(lines.join('\n')).not.toContain('marker removed');
+  });
+
+  it('opt-out --no-purge on a never-sent machine does not cite a later purge', async () => {
+    const lines: string[] = [];
+    vi.mocked(console.log).mockImplementation((...a: unknown[]) => {
+      lines.push(a.join(' '));
+    });
+    const { telemetryOptOut } = await import('./telemetry');
+    await telemetryOptOut(undefined, { noPurge: true });
+    const out = lines.join('\n');
+    expect(out).toContain('nothing to delete');
+    expect(out).not.toContain('Delete them later');
+  });
+});

--- a/sdk/typescript/src/arp/cli/telemetry.ts
+++ b/sdk/typescript/src/arp/cli/telemetry.ts
@@ -25,6 +25,8 @@ import {
   manualPurgeCurl,
   readEnrollmentRecord,
   sanitizeTerminalText,
+  ecosystemOptOut,
+  optOutMarkerExists,
 } from '../telemetry/signature';
 import type { SignatureTelemetryConfig } from '../types';
 
@@ -158,8 +160,12 @@ export async function telemetryOptOut(
   console.log(`  Marker: ${p}`);
 
   if (opts.noPurge) {
-    console.log('  Skipped deleting already-sent signatures (--no-purge).');
-    console.log(`  Delete them later with: ${SHIPPED_INVOCATION} purge`);
+    if (peekSensorId() === null) {
+      console.log('  Nothing was ever sent from this machine, so there is nothing to delete.');
+    } else {
+      console.log('  Skipped deleting already-sent signatures (--no-purge).');
+      console.log(`  Delete them later with: ${SHIPPED_INVOCATION} purge`);
+    }
   } else {
     await runRemotePurge(tcfg, 'opt-out');
   }
@@ -174,13 +180,14 @@ export async function telemetryPurge(tcfg?: SignatureTelemetryConfig): Promise<v
 }
 
 export function telemetryOptIn(tcfg?: SignatureTelemetryConfig): void {
+  const hadMarker = optOutMarkerExists();
   clearOptOutMarker();
   const stillOff = isOptedOut(tcfg);
-  console.log('\n  Opt-out marker removed.');
+  console.log(hadMarker ? '\n  Opt-out marker removed.' : '\n  No opt-out marker was present.');
   if (stillOff) {
     console.log('  NOTE: telemetry is still disabled by an env var or config');
-    console.log('  (OPENA2A_TELEMETRY_OPTOUT / ARP_TELEMETRY_DISABLED, or');
-    console.log('  signatureTelemetry.enabled: false). Clear those to re-enable.\n');
+    console.log('  (OPENA2A_TELEMETRY=off, OPENA2A_TELEMETRY_OPTOUT, ARP_TELEMETRY_DISABLED,');
+    console.log('  or signatureTelemetry.enabled: false). Clear those to re-enable.\n');
   } else if (signatureTelemetryEnabled(tcfg)) {
     console.log('  Structural signature telemetry is ON.\n');
   } else {
@@ -230,6 +237,9 @@ async function runRemotePurge(
 
 function optOutReason(tcfg?: SignatureTelemetryConfig): string {
   if (tcfg?.enabled === false) return 'config (signatureTelemetry.enabled: false)';
+  // The published ecosystem spelling gets its own attribution: the clear
+  // instruction differs (unset the variable; opt-in cannot clear it).
+  if (ecosystemOptOut()) return 'environment variable (OPENA2A_TELEMETRY; unset it to clear)';
   if (process.env.OPENA2A_TELEMETRY_OPTOUT || process.env.ARP_TELEMETRY_DISABLED) return 'environment variable';
   return `local opt-out marker (${SHIPPED_INVOCATION} opt-in to clear)`;
 }

--- a/sdk/typescript/src/arp/telemetry/signature/config.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.ts
@@ -63,7 +63,7 @@ function envTruthy(name: string): boolean {
  * That variable is an ecosystem CLI switch, while this SDK is a library inside
  * someone else's production process; opting in stays explicit and AIM-specific.
  */
-function ecosystemOptOut(): boolean {
+export function ecosystemOptOut(): boolean {
   const v = process.env.OPENA2A_TELEMETRY;
   if (v === undefined) return false;
   const s = v.trim().toLowerCase();

--- a/sdk/typescript/src/arp/telemetry/signature/index.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/index.ts
@@ -66,8 +66,9 @@ export type { AuditRecord, AuditPhase } from './audit-log';
 
 export {
   isOptedOut,
-  isOptedIn,
+  ecosystemOptOut,
   optOutMarkerExists,
+  isOptedIn,
   signatureTelemetryEnabled,
   resolveRegistryUrl,
   writeOptOutMarker,


### PR DESCRIPTION
Found by the 1.3.0 pre-tag release walkthrough (its one P2 plus three same-class P3s; the remaining P3s are filed separately).

`aim-arp telemetry status` under `OPENA2A_TELEMETRY=off` — the one spelling [opena2a.org/privacy](https://opena2a.org/privacy) publishes — attributed the opt-out to a "local opt-out marker" and cited `opt-in` as the fix, which cannot clear an env var. The 1.2.0 change that added the spelling to the opt-out decision never reached the CLI's attribution branch or the opt-in NOTE. Status now names the variable with "unset it to clear", and the NOTE lists it.

Also corrected to match reality: `opt-in` with no marker present no longer prints "Opt-out marker removed.", and `opt-out --no-purge` on a machine that never sent no longer suggests deleting later what does not exist.

Four new tests pin each behavior; suite at 1136.
