### PR TITLE
A help request answers with help, never by running the command

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -30,6 +30,21 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Asking a subcommand for help no longer runs it.** `aim-arp telemetry
+  opt-out --help` performed a real opt-out — the marker was written by the
+  question — `opt-in --help` removed one, and on a machine that had sent,
+  `purge --help` would have fired the right-to-delete from a help query.
+  The dispatcher read only the subcommand name and ignored every argument
+  after it, so unknown options were silently swallowed too. `--help` / `-h`
+  anywhere in the arguments now print usage and change nothing, and an
+  unrecognised option is an error naming the option instead of a no-op.
+
+- **`telemetry status` names every environment variable it attributes an
+  opt-out to.** `OPENA2A_TELEMETRY_OPTOUT` and `ARP_TELEMETRY_DISABLED` were
+  reported as a bare "environment variable" with no clearing instruction,
+  while `OPENA2A_TELEMETRY` already got "unset it to clear". All three now
+  name the variable in effect.
+
 - **`telemetry status` no longer creates identity state.** Reading status on a
   clean machine minted three files — the sensor id, the org id, and the org
   root secret — as a side effect of looking. A read command now reads: identity

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -38,12 +38,20 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
   after it, so unknown options were silently swallowed too. `--help` / `-h`
   anywhere in the arguments now print usage and change nothing, and an
   unrecognised option is an error naming the option instead of a no-op.
+  A mistyped subcommand is still reported as the error even when `--help`
+  rides along, so scripts keep the typo signal. The internal CLI's
+  `register` subcommand had the same defect — its help query built and sent
+  a real enrollment — and is guarded the same way.
 
 - **`telemetry status` names every environment variable it attributes an
-  opt-out to.** `OPENA2A_TELEMETRY_OPTOUT` and `ARP_TELEMETRY_DISABLED` were
-  reported as a bare "environment variable" with no clearing instruction,
-  while `OPENA2A_TELEMETRY` already got "unset it to clear". All three now
-  name the variable in effect.
+  opt-out to, and only when that variable is what opted you out.**
+  `OPENA2A_TELEMETRY_OPTOUT` and `ARP_TELEMETRY_DISABLED` were reported as a
+  bare "environment variable" with no clearing instruction, while
+  `OPENA2A_TELEMETRY` already got "unset it to clear". All three now name
+  the variable in effect, and attribution reads the same strict truthiness
+  as the opt-out decision — `OPENA2A_TELEMETRY_OPTOUT=0` alongside a local
+  marker names the marker, not a variable whose unsetting would clear
+  nothing.
 
 - **`telemetry status` no longer creates identity state.** Reading status on a
   clean machine minted three files — the sensor id, the org id, and the org

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -34,10 +34,11 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
   opt-out --help` performed a real opt-out — the marker was written by the
   question — `opt-in --help` removed one, and on a machine that had sent,
   `purge --help` would have fired the right-to-delete from a help query.
-  The dispatcher read only the subcommand name and ignored every argument
-  after it, so unknown options were silently swallowed too. `--help` / `-h`
-  anywhere in the arguments now print usage and change nothing, and an
-  unrecognised option is an error naming the option instead of a no-op.
+  The dispatcher chose what to run from the subcommand name alone and never
+  validated the arguments, so `--help` never stopped execution and unknown
+  options were silently swallowed. `--help` / `-h` anywhere in the arguments
+  now print usage and change nothing, and an unrecognized option is an error
+  naming the option instead of a no-op.
   A mistyped subcommand is still reported as the error even when `--help`
   rides along, so scripts keep the typo signal. The internal CLI's
   `register` subcommand had the same defect — its help query built and sent

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -41,8 +41,8 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
   naming the option instead of a no-op.
   A mistyped subcommand is still reported as the error even when `--help`
   rides along, so scripts keep the typo signal. The internal CLI's
-  `register` subcommand had the same defect — its help query built and sent
-  a real enrollment — and is guarded the same way.
+  `register` subcommand had the same defect — its help query would have
+  built and sent a real enrollment — and is guarded the same way.
 
 - **`telemetry status` names every environment variable it attributes an
   opt-out to, and only when that variable is what opted you out.**

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -258,17 +258,35 @@ async function telemetryCommand(): Promise<void> {
   // the shared shipped surface, dispatched through the same code path the
   // `aim-arp` bin uses so the two cannot drift.
   if (sub === 'register') {
+    // Same contract as runTelemetrySubcommand: a help request is answered
+    // with help, never by running the command — register builds a signed
+    // enrollment proof and POSTs it, the worst possible answer to a question.
+    const rest = args.slice(2);
+    if (rest.some((a) => a === '--help' || a === '-h')) {
+      printTelemetryHelpWithInternal();
+      return;
+    }
+    const unknown = rest.find((a) => a.startsWith('-'));
+    if (unknown !== undefined) {
+      console.error(`  Unknown option for register: ${unknown}`);
+      console.error('  Run: arp-guard telemetry --help');
+      process.exit(1);
+    }
     await telemetryRegister(tcfg);
     return;
   }
   if (sub === undefined || sub === '--help' || sub === '-h') {
-    console.log(telemetryHelpText());
-    console.log('  Internal-only (this CLI, not the shipped bin):');
-    console.log('    register      Enroll this sensor with the registry (pending admin approval)\n');
+    printTelemetryHelpWithInternal();
     return;
   }
   const code = await runTelemetrySubcommand(sub, args.slice(2), tcfg);
   if (code !== 0) process.exit(code);
+}
+
+function printTelemetryHelpWithInternal(): void {
+  console.log(telemetryHelpText());
+  console.log('  Internal-only (this CLI, not the shipped bin):');
+  console.log('    register      Enroll this sensor with the registry (pending admin approval)\n');
 }
 
 // telemetryRegister enrolls this sensor with the registry (the producer half of the

--- a/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
+++ b/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
@@ -49,6 +49,9 @@ describe('--help on a subcommand prints help and executes nothing', () => {
     expect(existsSync(marker())).toBe(false);
     expect(existsSync(home)).toBe(false);
     expect(logLines.join('\n')).not.toContain('DISABLED');
+    // Help must actually be PRINTED, not just nothing executed: a guard that
+    // silently returned 0 would pass every negative assertion in this file.
+    expect(logLines.join('\n')).toContain('aim-arp telemetry <subcommand>');
   });
 
   it('opt-out -h writes no marker and exits 0', async () => {
@@ -105,6 +108,41 @@ describe('unrecognised options are an error, not a silent no-op', () => {
   });
 });
 
+describe('dispatch ordering: help slot, typo signal, then options', () => {
+  it('--help in the subcommand slot wins over junk args', async () => {
+    const code = await runTelemetrySubcommand('--help', ['-x']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('aim-arp telemetry <subcommand>');
+    expect(errLines.join('\n')).toBe('');
+  });
+
+  it('-h in the subcommand slot wins over junk args', async () => {
+    const code = await runTelemetrySubcommand('-h', ['--bogus']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('aim-arp telemetry <subcommand>');
+  });
+
+  it('a typo\'d subcommand is the reported error even with --help alongside', async () => {
+    const code = await runTelemetrySubcommand('frobnicate', ['--help']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('frobnicate');
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('a typo\'d subcommand outranks its unknown options in the error', async () => {
+    const code = await runTelemetrySubcommand('frobnicate', ['--bogus']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('Unknown telemetry subcommand: frobnicate');
+    expect(errLines.join('\n')).not.toContain('Unknown option');
+  });
+
+  it('no subcommand at all still helps, junk args and all (API path)', async () => {
+    const code = await runTelemetrySubcommand(undefined, ['-x']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('aim-arp telemetry <subcommand>');
+  });
+});
+
 describe('env-var opt-outs are attributed to the variable actually set', () => {
   const VARS = ['OPENA2A_TELEMETRY', 'OPENA2A_TELEMETRY_OPTOUT', 'ARP_TELEMETRY_DISABLED'] as const;
   const saved: Record<string, string | undefined> = {};
@@ -133,5 +171,18 @@ describe('env-var opt-outs are attributed to the variable actually set', () => {
     process.env.ARP_TELEMETRY_DISABLED = '1';
     await telemetryStatus(undefined);
     expect(logLines.join('\n')).toContain('ARP_TELEMETRY_DISABLED; unset it to clear');
+  });
+
+  it('a non-truthy value is not blamed: OPTOUT=0 with a marker names the marker', async () => {
+    // isOptedOut treats only 1/true/yes/on as an env opt-out. Attribution must
+    // read the SAME predicate: with OPTOUT=0 the marker is the deciding source,
+    // and telling the user to unset the variable would not clear anything.
+    process.env.OPENA2A_TELEMETRY_OPTOUT = '0';
+    await runTelemetrySubcommand('opt-out', ['--no-purge']);
+    logLines.length = 0;
+    await telemetryStatus(undefined);
+    const out = logLines.join('\n');
+    expect(out).toContain('local opt-out marker');
+    expect(out).not.toContain('OPENA2A_TELEMETRY_OPTOUT');
   });
 });

--- a/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
+++ b/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
@@ -4,8 +4,9 @@
  * opt-out — the marker was written by the question — `opt-in --help` removed
  * one, and on a machine that had sent, `purge --help` would have fired the
  * right-to-delete from a help query (found in the 1.3.0 release test,
- * 2026-08-24). The dispatcher read only the subcommand and never looked at
- * the args, so unknown options were silently ignored too.
+ * 2026-08-24). The dispatcher chose what to run from the subcommand name
+ * alone and never validated the args, so unknown options were silently
+ * ignored too.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
+++ b/sdk/typescript/src/arp/cli/telemetry-help-noexec.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `aim-arp telemetry <sub> --help` must answer the question, never run the
+ * command. Before this guarantee existed, `opt-out --help` performed a real
+ * opt-out — the marker was written by the question — `opt-in --help` removed
+ * one, and on a machine that had sent, `purge --help` would have fired the
+ * right-to-delete from a help query (found in the 1.3.0 release test,
+ * 2026-08-24). The dispatcher read only the subcommand and never looked at
+ * the args, so unknown options were silently ignored too.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runTelemetrySubcommand, telemetryStatus } from './telemetry';
+
+let home: string;
+let savedHome: string | undefined;
+let logLines: string[];
+let errLines: string[];
+
+const marker = () => join(home, 'telemetry-optout');
+
+beforeEach(() => {
+  home = join(mkdtempSync(join(tmpdir(), 'aim-arp-help-')), 'opena2a-home');
+  savedHome = process.env.OPENA2A_HOME;
+  process.env.OPENA2A_HOME = home;
+  logLines = [];
+  errLines = [];
+  vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    logLines.push(a.join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    errLines.push(a.join(' '));
+  });
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.OPENA2A_HOME;
+  else process.env.OPENA2A_HOME = savedHome;
+  vi.restoreAllMocks();
+  rmSync(join(home, '..'), { recursive: true, force: true });
+});
+
+describe('--help on a subcommand prints help and executes nothing', () => {
+  it('opt-out --help writes no marker and exits 0', async () => {
+    const code = await runTelemetrySubcommand('opt-out', ['--help']);
+    expect(code).toBe(0);
+    expect(existsSync(marker())).toBe(false);
+    expect(existsSync(home)).toBe(false);
+    expect(logLines.join('\n')).not.toContain('DISABLED');
+  });
+
+  it('opt-out -h writes no marker and exits 0', async () => {
+    const code = await runTelemetrySubcommand('opt-out', ['-h']);
+    expect(code).toBe(0);
+    expect(existsSync(marker())).toBe(false);
+  });
+
+  it('opt-in --help leaves an existing marker in place', async () => {
+    await runTelemetrySubcommand('opt-out', ['--no-purge']);
+    expect(existsSync(marker())).toBe(true);
+    const code = await runTelemetrySubcommand('opt-in', ['--help']);
+    expect(code).toBe(0);
+    expect(existsSync(marker())).toBe(true);
+  });
+
+  it('status --help shows help, not status', async () => {
+    const code = await runTelemetrySubcommand('status', ['--help']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).not.toContain('State:');
+  });
+
+  it('purge --help does not run purge', async () => {
+    const code = await runTelemetrySubcommand('purge', ['--help']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).not.toContain('nothing to purge');
+  });
+
+  it('--help wins even alongside a recognised option', async () => {
+    const code = await runTelemetrySubcommand('opt-out', ['--no-purge', '--help']);
+    expect(code).toBe(0);
+    expect(existsSync(marker())).toBe(false);
+  });
+});
+
+describe('unrecognised options are an error, not a silent no-op', () => {
+  it('status --bogus exits 1 and names the option', async () => {
+    const code = await runTelemetrySubcommand('status', ['--bogus']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('--bogus');
+    expect(logLines.join('\n')).not.toContain('State:');
+  });
+
+  it('log -5 exits 1 and names the option', async () => {
+    const code = await runTelemetrySubcommand('log', ['-5']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('-5');
+  });
+
+  it('opt-out --no-purge still executes (the recognised option keeps working)', async () => {
+    const code = await runTelemetrySubcommand('opt-out', ['--no-purge']);
+    expect(code).toBe(0);
+    expect(existsSync(marker())).toBe(true);
+  });
+});
+
+describe('env-var opt-outs are attributed to the variable actually set', () => {
+  const VARS = ['OPENA2A_TELEMETRY', 'OPENA2A_TELEMETRY_OPTOUT', 'ARP_TELEMETRY_DISABLED'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const v of VARS) {
+      saved[v] = process.env[v];
+      delete process.env[v];
+    }
+  });
+
+  afterEach(() => {
+    for (const v of VARS) {
+      if (saved[v] === undefined) delete process.env[v];
+      else process.env[v] = saved[v];
+    }
+  });
+
+  it('OPENA2A_TELEMETRY_OPTOUT is named with a clearing instruction', async () => {
+    process.env.OPENA2A_TELEMETRY_OPTOUT = '1';
+    await telemetryStatus(undefined);
+    expect(logLines.join('\n')).toContain('OPENA2A_TELEMETRY_OPTOUT; unset it to clear');
+  });
+
+  it('ARP_TELEMETRY_DISABLED is named with a clearing instruction', async () => {
+    process.env.ARP_TELEMETRY_DISABLED = '1';
+    await telemetryStatus(undefined);
+    expect(logLines.join('\n')).toContain('ARP_TELEMETRY_DISABLED; unset it to clear');
+  });
+});

--- a/sdk/typescript/src/arp/cli/telemetry.ts
+++ b/sdk/typescript/src/arp/cli/telemetry.ts
@@ -26,6 +26,7 @@ import {
   readEnrollmentRecord,
   sanitizeTerminalText,
   ecosystemOptOut,
+  envTruthy,
   optOutMarkerExists,
 } from '../telemetry/signature';
 import type { SignatureTelemetryConfig } from '../types';
@@ -240,8 +241,8 @@ function optOutReason(tcfg?: SignatureTelemetryConfig): string {
   // The published ecosystem spelling gets its own attribution: the clear
   // instruction differs (unset the variable; opt-in cannot clear it).
   if (ecosystemOptOut()) return 'environment variable (OPENA2A_TELEMETRY; unset it to clear)';
-  if (process.env.OPENA2A_TELEMETRY_OPTOUT) return 'environment variable (OPENA2A_TELEMETRY_OPTOUT; unset it to clear)';
-  if (process.env.ARP_TELEMETRY_DISABLED) return 'environment variable (ARP_TELEMETRY_DISABLED; unset it to clear)';
+  if (envTruthy('OPENA2A_TELEMETRY_OPTOUT')) return 'environment variable (OPENA2A_TELEMETRY_OPTOUT; unset it to clear)';
+  if (envTruthy('ARP_TELEMETRY_DISABLED')) return 'environment variable (ARP_TELEMETRY_DISABLED; unset it to clear)';
   return `local opt-out marker (${SHIPPED_INVOCATION} opt-in to clear)`;
 }
 
@@ -254,19 +255,35 @@ const KNOWN_SUBCOMMAND_OPTIONS: Record<string, readonly string[]> = {
   'opt-out': ['--no-purge'],
 };
 
+const isHelpFlag = (a: string): boolean => a === '--help' || a === '-h';
+
 export async function runTelemetrySubcommand(
   sub: string | undefined,
   rest: string[],
   tcfg?: SignatureTelemetryConfig,
 ): Promise<number> {
-  // A help request anywhere in the args is answered with help, never by
-  // running the command: `opt-out --help` asks what opt-out does, and
-  // executing it would change the consent state the question was about.
-  if (rest.includes('--help') || rest.includes('-h')) {
+  // A help request in the subcommand slot (or no subcommand at all) is
+  // answered with help regardless of what else is on the line.
+  if (sub === undefined || isHelpFlag(sub)) {
     console.log(telemetryHelpText());
     return 0;
   }
-  const known = KNOWN_SUBCOMMAND_OPTIONS[sub ?? ''] ?? [];
+  // A typo'd subcommand is reported as the error even when --help rides
+  // along: the typo signal outranks the help shortcut, and nothing executes
+  // either way.
+  if (!(TELEMETRY_SUBCOMMANDS as readonly string[]).includes(sub)) {
+    console.error(`  Unknown telemetry subcommand: ${sub}`);
+    console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
+    return 1;
+  }
+  // A help request anywhere in the args is answered with help, never by
+  // running the command: `opt-out --help` asks what opt-out does, and
+  // executing it would change the consent state the question was about.
+  if (rest.some(isHelpFlag)) {
+    console.log(telemetryHelpText());
+    return 0;
+  }
+  const known = KNOWN_SUBCOMMAND_OPTIONS[sub] ?? [];
   const unknown = rest.find((a) => a.startsWith('-') && !known.includes(a));
   if (unknown !== undefined) {
     console.error(`  Unknown option for ${sub}: ${unknown}`);
@@ -292,12 +309,10 @@ export async function runTelemetrySubcommand(
     case 'opt-in':
       telemetryOptIn(tcfg);
       return 0;
-    case undefined:
-    case '--help':
-    case '-h':
-      console.log(telemetryHelpText());
-      return 0;
     default:
+      // Unreachable while the list and the arms agree: `sub` was validated
+      // against TELEMETRY_SUBCOMMANDS above. A list entry with no arm lands
+      // here instead of silently succeeding.
       console.error(`  Unknown telemetry subcommand: ${sub}`);
       console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
       return 1;

--- a/sdk/typescript/src/arp/cli/telemetry.ts
+++ b/sdk/typescript/src/arp/cli/telemetry.ts
@@ -240,7 +240,8 @@ function optOutReason(tcfg?: SignatureTelemetryConfig): string {
   // The published ecosystem spelling gets its own attribution: the clear
   // instruction differs (unset the variable; opt-in cannot clear it).
   if (ecosystemOptOut()) return 'environment variable (OPENA2A_TELEMETRY; unset it to clear)';
-  if (process.env.OPENA2A_TELEMETRY_OPTOUT || process.env.ARP_TELEMETRY_DISABLED) return 'environment variable';
+  if (process.env.OPENA2A_TELEMETRY_OPTOUT) return 'environment variable (OPENA2A_TELEMETRY_OPTOUT; unset it to clear)';
+  if (process.env.ARP_TELEMETRY_DISABLED) return 'environment variable (ARP_TELEMETRY_DISABLED; unset it to clear)';
   return `local opt-out marker (${SHIPPED_INVOCATION} opt-in to clear)`;
 }
 
@@ -248,11 +249,30 @@ function optOutReason(tcfg?: SignatureTelemetryConfig): string {
  * Dispatch a telemetry subcommand. Returns the process exit code. Shared by the
  * shipped bin and the internal CLI so the two surfaces cannot diverge.
  */
+/** Options each subcommand recognises; any other option-shaped arg is an error. */
+const KNOWN_SUBCOMMAND_OPTIONS: Record<string, readonly string[]> = {
+  'opt-out': ['--no-purge'],
+};
+
 export async function runTelemetrySubcommand(
   sub: string | undefined,
   rest: string[],
   tcfg?: SignatureTelemetryConfig,
 ): Promise<number> {
+  // A help request anywhere in the args is answered with help, never by
+  // running the command: `opt-out --help` asks what opt-out does, and
+  // executing it would change the consent state the question was about.
+  if (rest.includes('--help') || rest.includes('-h')) {
+    console.log(telemetryHelpText());
+    return 0;
+  }
+  const known = KNOWN_SUBCOMMAND_OPTIONS[sub ?? ''] ?? [];
+  const unknown = rest.find((a) => a.startsWith('-') && !known.includes(a));
+  if (unknown !== undefined) {
+    console.error(`  Unknown option for ${sub}: ${unknown}`);
+    console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
+    return 1;
+  }
   switch (sub) {
     case 'log':
       await telemetryLog(rest[0]);

--- a/sdk/typescript/src/arp/telemetry/signature/config.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/config.ts
@@ -38,7 +38,12 @@ export type { SignatureTelemetryConfig };
 
 const DEFAULT_REGISTRY_URL = 'https://api.oa2a.org';
 
-function envTruthy(name: string): boolean {
+/**
+ * Strict truthiness for opt-out env vars: only 1/true/yes/on count. Exported so
+ * user-facing attribution (`optOutReason`) reads the SAME predicate as the
+ * decision (`isOptedOut`) — a value like `0` must neither opt out nor be blamed.
+ */
+export function envTruthy(name: string): boolean {
   const v = process.env[name];
   if (!v) return false;
   const s = v.trim().toLowerCase();

--- a/sdk/typescript/src/arp/telemetry/signature/index.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/index.ts
@@ -67,6 +67,7 @@ export type { AuditRecord, AuditPhase } from './audit-log';
 export {
   isOptedOut,
   ecosystemOptOut,
+  envTruthy,
   optOutMarkerExists,
   isOptedIn,
   signatureTelemetryEnabled,


### PR DESCRIPTION
The 1.3.0 pre-tag release test found that every `aim-arp telemetry` subcommand executed when asked for help: the dispatcher chose what to run from the subcommand name alone and never validated the arguments, so `--help` rode along invisibly.

- `telemetry opt-out --help` performed a real opt-out — the marker was written by the question. `opt-in --help` removed one.
- On a machine that had sent, `purge --help` would have fired the right-to-delete from a help query.
- Unknown options were silently swallowed the same way (`status --bogus` ran status).

**Fix (first commit)**
- `--help` / `-h` anywhere in the arguments print usage and change nothing; help wins even alongside a recognized option.
- An unrecognized option is an error naming the option (exit 1) instead of a silent no-op. `opt-out --no-purge` keeps working.
- From the same release test (P2): `telemetry status` attributed `OPENA2A_TELEMETRY_OPTOUT` and `ARP_TELEMETRY_DISABLED` to a bare "environment variable" with no clearing instruction, while `OPENA2A_TELEMETRY` already got "unset it to clear". All three now name their variable.

**Second commit — adversarial review of the first found the guard incomplete**
- `telemetry --help -x` (help in the subcommand slot plus junk) fell through to the unknown-option check and errored a help query that succeeded before; help in the subcommand slot now answers first.
- A mistyped subcommand with `--help` alongside exited 0, losing the typo signal; the subcommand is validated against `TELEMETRY_SUBCOMMANDS` before either shortcut, so `frobnicate --help` reports the typo.
- The internal CLI dispatched `register` before the shared guard, so `register --help` would have built and sent a real enrollment — the same class on the highest-side-effect subcommand. Guarded the same way. (Not a shipped-bin path; the npm package registers only `aim-arp`.)
- Attribution read raw env truthiness while `isOptedOut` reads strict truthiness, so `OPENA2A_TELEMETRY_OPTOUT=0` alongside a marker blamed the variable with a clearing instruction that would clear nothing. `optOutReason` now reads the same `envTruthy` predicate as the decision.
- The help tests asserted only that nothing executed; help output is now asserted positively.

**Tests**: 17 regression tests in `telemetry-help-noexec.test.ts`; 11 fail against the pre-fix dispatcher and 6 against the first commit (the OPTOUT=0 attribution test fails against both; the one remaining is the existing-behavior control for `--no-purge`). Full suite 1153 green.

Blocks the `sdk-ts-v1.3.0` tag until merged. Remaining release-test P3s are filed on #412.
