### PR TITLE
Date 1.3.0 by its tag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent

--- a/sdk/python/LICENSE
+++ b/sdk/python/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@opena2a/aim-sdk` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.3.0] - 2026-08-22
+## [1.3.0] - 2026-08-24
 
 ### Added
 

--- a/sdk/typescript/LICENSE
+++ b/sdk/typescript/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent


### PR DESCRIPTION
CHANGELOG [1.3.0] header date moves 2026-08-22 -> 2026-08-24: the 08-22 tag was blocked by the pre-tag release test (fixed in #413), and Keep a Changelog dates the release. Pre-approved as CCO condition R5 (approved 2026-08-24), due at tag time.

Also restores the canonical Apache-2.0 text in all three LICENSE copies (root, sdk/python, sdk/typescript): each carried a one-word rewrite of clause 5 ("submitted to the Licensor") and a dropped leading blank line. sdk/typescript/LICENSE ships in every npm tarball, so this lands before the sdk-ts-v1.3.0 tag to keep the altered clause out of the published artifact. Only the appendix copyright line now differs from the canonical text, which is the substitution the appendix itself instructs.