### PR TITLE
Declare the license in PyPI metadata

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -22,6 +22,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/opena2a-org/agent-identity-management",
+    license="Apache-2.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
One line: `license="Apache-2.0"` (SPDX form) in `sdk/python/setup.py`. The package carried only the trove classifier, so PyPI's license field is empty today (measured 2026-08-23 in the conference-sprint discovery); the field fills at the next aim-sdk publish. Part of the license-integrity work directed by the security review.