### PR TITLE
Glasshouse foundation: tokens, theme switch, shell and edge gate

### DIFF
--- a/apps/web/app/dashboard/admin/alerts/page.tsx
+++ b/apps/web/app/dashboard/admin/alerts/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState, Suspense, useMemo } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -113,11 +114,12 @@ function AlertsPageContent() {
         router.replace("/auth/login");
         return;
       }
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const userRole = (payload.role as any) || "viewer";
       setRole(userRole);
       const extractedUserId =
-        payload.userId || payload.sub || payload.id || null;
+        String(payload.userId ?? payload.sub ?? payload.id ?? "") || null;
       setUserId(extractedUserId);
       if (userRole !== "admin") {
         router.replace("/dashboard");

--- a/apps/web/app/dashboard/admin/capability-requests/page.tsx
+++ b/apps/web/app/dashboard/admin/capability-requests/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRouter } from "next/navigation";
 import {
@@ -92,7 +93,8 @@ export default function CapabilityRequestsPage() {
         router.replace("/auth/login");
         return;
       }
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const userRole = (payload.role as any) || "viewer";
       setRole(userRole);
       if (userRole !== "admin") {

--- a/apps/web/app/dashboard/admin/jit-requests/page.tsx
+++ b/apps/web/app/dashboard/admin/jit-requests/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter } from "next/navigation";
 import {
   Card,
@@ -147,7 +148,8 @@ export default function PendingVerificationsPage() {
         router.replace("/auth/login");
         return;
       }
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const userRole = (payload.role as any) || "viewer";
       setRole(userRole);
       if (userRole !== "admin") {

--- a/apps/web/app/dashboard/admin/security-policies/page.tsx
+++ b/apps/web/app/dashboard/admin/security-policies/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter } from "next/navigation";
 import {
   Card,
@@ -258,7 +259,8 @@ export default function SecurityPoliciesPage() {
         router.replace("/auth/login");
         return;
       }
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const userRole = (payload.role as any) || "viewer";
       setRole(userRole);
       if (userRole !== "admin") {

--- a/apps/web/app/dashboard/admin/users/page.tsx
+++ b/apps/web/app/dashboard/admin/users/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRouter } from "next/navigation";
 import {
@@ -122,7 +123,8 @@ export default function UsersPage() {
         router.replace("/auth/login");
         return;
       }
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const userRole = (payload.role as any) || "viewer";
       setRole(userRole);
       if (userRole !== "admin") {

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Sidebar } from "@/components/sidebar";
 import { DashboardHeader } from "@/components/dashboard-header";
+import { MobileTabBar } from "@/components/mobile-tab-bar";
 import { IdleTimeoutGuard } from "@/components/idle-timeout-guard";
 import { useDeactivationCheck } from "@/hooks/use-deactivation-check";
+import { api } from "@/lib/api";
+import type { UserRole } from "@/lib/permissions";
 
 export default function DashboardLayout({
   children,
@@ -12,22 +16,38 @@ export default function DashboardLayout({
 }) {
   // Check if user is deactivated and logout if necessary
   useDeactivationCheck();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [role, setRole] = useState<UserRole | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getCurrentUser()
+      .then((u) => {
+        if (cancelled) return;
+        setRole(u?.role === "pending" ? "viewer" : (u?.role as UserRole | undefined));
+      })
+      .catch(() => {
+        /* the sidebar and header handle the unauthenticated redirect */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
-    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="glass-page glass-page--layered relative min-h-screen">
+      <div className="glass-page-wash" aria-hidden="true" />
       {/* Idle / absolute session timeout (30m idle, 8h cap) */}
       <IdleTimeoutGuard />
-      <Sidebar />
-
-      {/* Main Content Area with Header */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <DashboardHeader />
-
-        {/* Page Content */}
-        <main className="flex-1 overflow-auto">
-          <div className="w-full px-4 sm:px-6 lg:px-8 py-8">{children}</div>
-        </main>
+      <div className="flex gap-5 p-4 pb-28 sm:p-6 lg:pb-6">
+        <Sidebar mobileOpen={mobileNavOpen} onMobileOpenChange={setMobileNavOpen} />
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <DashboardHeader />
+          <main className="min-w-0 flex-1">{children}</main>
+        </div>
       </div>
+      <MobileTabBar role={role} onOpenMenu={() => setMobileNavOpen(true)} />
     </div>
   );
 }

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Surface the failure in the console for support; nothing sensitive is logged here.
+    console.error("Unhandled error", error.digest ?? error.message);
+  }, [error]);
+
+  return (
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-6">
+      <div className="glass-chrome w-full max-w-md p-8 text-center">
+        <p className="text-overline">Error</p>
+        <h1 className="text-headline mt-2">This page could not load.</h1>
+        <p className="mt-2 text-sm text-ink-secondary">
+          Your last action may or may not have completed. Check the page you came from before retrying.
+          {error.digest ? (
+            <>
+              {" "}
+              Reference: <span className="font-mono text-xs text-ink">{error.digest}</span>
+            </>
+          ) : null}
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex h-10 items-center rounded-pill bg-brand px-5 text-sm font-bold text-white shadow-glow hover:bg-brand-hover"
+          >
+            Try again
+          </button>
+          <Link
+            href="/dashboard"
+            className="inline-flex h-10 items-center rounded-pill border border-stroke bg-glass px-5 text-sm font-bold text-ink"
+          >
+            Go to the dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2,52 +2,220 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+  Glasshouse design system.
+  Source of truth for the theme tokens: the colors, radii, blur and shadows the
+  Glasshouse surfaces use. Pages and components consume them through Tailwind
+  (`bg-glass`, `text-ink-secondary`, `rounded-card`, ...) or the `.glass*`
+  component classes below; new code must not add raw palette classes. Pages not
+  yet moved onto the tokens still carry raw palette classes and `dark:` twins,
+  which is why the theme defaults to light until they land. Values come from the
+  signed-off artboards; the handful that differ are contrast corrections (WCAG AA).
+*/
+
 @layer base {
   :root {
-    /* Light mode */
-    --background: 0 0% 98%; /* gray-50 */
-    --foreground: 222 47% 11%; /* gray-900 */
-    --card: 0 0% 100%; /* white */
-    --card-foreground: 222 47% 11%; /* gray-900 */
-    --popover: 0 0% 100%; /* white */
-    --popover-foreground: 222 47% 11%; /* gray-900 */
-    --primary: 221 83% 53%; /* blue-600 */
-    --primary-foreground: 0 0% 100%; /* white */
-    --secondary: 210 40% 96%; /* gray-100 */
-    --secondary-foreground: 222 47% 11%; /* gray-900 */
-    --muted: 210 40% 96%; /* gray-100 */
-    --muted-foreground: 215 16% 47%; /* gray-500 */
-    --accent: 210 40% 96%; /* gray-100 */
-    --accent-foreground: 222 47% 11%; /* gray-900 */
-    --destructive: 0 84% 60%; /* red-500 */
-    --destructive-foreground: 0 0% 100%; /* white */
-    --border: 214 32% 91%; /* gray-200 */
-    --input: 214 32% 91%; /* gray-200 */
-    --ring: 221 83% 53%; /* blue-600 */
-    --radius: 0.5rem;
+    color-scheme: light;
+
+    /* Fonts */
+    --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", var(--font-inter, "Inter"),
+      "Segoe UI", system-ui, sans-serif;
+    --font-mono: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+
+    /* Page */
+    --bg-page-solid: #e9eef7;
+    --bg-page: linear-gradient(135deg, #eef2f7 0%, #e9eef7 45%, #eaf3f3 100%);
+    --wash-1: rgba(103, 232, 249, 0.28);
+    --wash-2: rgba(167, 139, 250, 0.2);
+    --wash-3: rgba(52, 199, 89, 0.12);
+
+    /* Glass surfaces */
+    --glass-fill: rgba(255, 255, 255, 0.72);
+    --glass-border: rgba(255, 255, 255, 0.85);
+    --glass-fill-solid: #f9fafd;
+    --glass-chrome-fill: rgba(255, 255, 255, 0.65);
+    --glass-chrome-border: rgba(255, 255, 255, 0.8);
+    --glass-chrome-solid: #f7f9fc;
+    --surface-inset: rgba(255, 255, 255, 0.7);
+    --surface-inset-border: transparent;
+    --surface-inset-gray: rgba(120, 120, 128, 0.08);
+    --surface-contrast: rgba(29, 29, 31, 0.92);
+    --surface-contrast-border: transparent;
+    --code-fill: rgba(255, 255, 255, 0.08);
+    --segment-track: rgba(120, 120, 128, 0.14);
+    --segment-active: rgba(255, 255, 255, 0.95);
+    --segment-active-shadow: 0 1px 4px rgba(15, 23, 42, 0.1);
+    --segment-inactive-text: #66666b;
+    --nav-active-fill: rgba(0, 113, 227, 0.1);
+
+    /* Brand accent (fill vs text differ for contrast: white on #0071e3 = 4.7:1, #0066cc on glass = 5.3:1).
+       Named --brand because shadcn already owns --accent below. */
+    --brand: #0071e3;
+    --brand-hover: #0077ed;
+    --brand-text: #0066cc;
+    --brand-soft: rgba(0, 113, 227, 0.1);
+    --brand-shadow: 0 6px 18px rgba(0, 113, 227, 0.3);
+    --brand-sky: #38bdf8;
+    --brand-indigo: #6366f1;
+    --gradient-logo: linear-gradient(135deg, #38bdf8, #6366f1);
+    --gradient-bar: linear-gradient(90deg, #38bdf8, #0071e3);
+
+    /* Semantic */
+    --green: #34c759;
+    --green-text: #1f7a35;
+    --green-fill: rgba(52, 199, 89, 0.14);
+    --green-border: rgba(52, 199, 89, 0.28);
+    --amber: #f5a623;
+    --amber-text: #9a5b00;
+    --amber-fill: rgba(245, 166, 35, 0.14);
+    --amber-border: rgba(245, 166, 35, 0.3);
+    --red: #ff3b30;
+    --red-strong: #d70015; /* filled controls carrying white text (5.4:1); --red stays for tints and strokes */
+    --red-text: #c1000f;
+    --red-fill: rgba(255, 59, 48, 0.08);
+    --red-border: rgba(255, 59, 48, 0.25);
+
+    /* Text tiers */
+    --text-primary: #1d1d1f;
+    --text-body: #48484a;
+    --text-secondary: #6e6e73;
+    --text-tertiary: #737378;
+    --text-inverse: #f5f5f7;
+    --text-inverse-secondary: #a1a1a6;
+    --text-code: #0b5cad;
+
+    /* Lines */
+    --divider: rgba(60, 60, 67, 0.08);
+    --track: rgba(60, 60, 67, 0.1);
+    --stroke: rgba(60, 60, 67, 0.12);
+
+    /* Shadows */
+    --shadow-card: 0 12px 32px rgba(15, 23, 42, 0.06);
+    --shadow-chrome: 0 20px 50px rgba(15, 23, 42, 0.08);
+    --shadow-modal: 0 24px 60px rgba(15, 23, 42, 0.1);
+
+    /* shadcn-compatible variables (hsl triplets), re-pointed to Glasshouse */
+    --background: 220 33% 94%;
+    --foreground: 240 3% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 3% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 3% 12%;
+    --primary: 210 100% 45%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 5% 93%;
+    --secondary-foreground: 240 3% 12%;
+    --muted: 240 5% 93%;
+    --muted-foreground: 240 2% 44%;
+    --accent: 210 90% 95%;
+    --accent-foreground: 210 100% 40%;
+    --destructive: 355 100% 38%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 240 4% 85%;
+    --input: 240 4% 85%;
+    --ring: 210 100% 45%;
+    --radius: 0.875rem;
   }
 
   .dark {
-    /* Dark mode */
-    --background: 222 47% 11%; /* gray-900 */
-    --foreground: 210 20% 98%; /* gray-100 */
-    --card: 217 33% 17%; /* gray-800 */
-    --card-foreground: 210 20% 98%; /* gray-100 */
-    --popover: 217 33% 17%; /* gray-800 */
-    --popover-foreground: 210 20% 98%; /* gray-100 */
-    --primary: 221 83% 53%; /* blue-600 */
-    --primary-foreground: 0 0% 100%; /* white */
-    --secondary: 217 33% 17%; /* gray-800 */
-    --secondary-foreground: 210 20% 98%; /* gray-100 */
-    --muted: 223 47% 11%; /* gray-900/darker */
-    --muted-foreground: 215 20% 65%; /* gray-400 */
-    --accent: 217 33% 17%; /* gray-800 */
-    --accent-foreground: 210 20% 98%; /* gray-100 */
-    --destructive: 0 63% 31%; /* red-800 */
-    --destructive-foreground: 0 0% 100%; /* white */
-    --border: 217 33% 23%; /* gray-700 */
-    --input: 217 33% 23%; /* gray-700 */
-    --ring: 221 83% 53%; /* blue-600 */
+    color-scheme: dark;
+
+    --bg-page-solid: #131318;
+    --bg-page: linear-gradient(135deg, #0d0d0f 0%, #131318 45%, #101417 100%);
+    --wash-1: rgba(41, 151, 255, 0.14);
+    --wash-2: rgba(167, 139, 250, 0.1);
+    --wash-3: rgba(52, 199, 89, 0.08);
+
+    --glass-fill: rgba(29, 29, 31, 0.7);
+    --glass-border: rgba(255, 255, 255, 0.12);
+    --glass-fill-solid: #1a1a1d;
+    --glass-chrome-fill: rgba(29, 29, 31, 0.7);
+    --glass-chrome-border: rgba(255, 255, 255, 0.12);
+    --glass-chrome-solid: #1a1a1d;
+    --surface-inset: rgba(255, 255, 255, 0.06);
+    --surface-inset-border: rgba(255, 255, 255, 0.08);
+    --surface-inset-gray: rgba(255, 255, 255, 0.05);
+    --surface-contrast: rgba(255, 255, 255, 0.08);
+    --surface-contrast-border: rgba(255, 255, 255, 0.14);
+    --code-fill: rgba(0, 0, 0, 0.35);
+    --segment-track: rgba(255, 255, 255, 0.08);
+    --segment-active: rgba(255, 255, 255, 0.16);
+    --segment-active-shadow: none;
+    --segment-inactive-text: #86868b;
+    --nav-active-fill: rgba(41, 151, 255, 0.16);
+
+    --brand: #0071e3;
+    --brand-hover: #1a80f0;
+    --brand-text: #2997ff;
+    --brand-soft: rgba(41, 151, 255, 0.16);
+    --brand-shadow: 0 6px 18px rgba(41, 151, 255, 0.35);
+    --gradient-bar: linear-gradient(90deg, #38bdf8, #2997ff);
+
+    --green: #34c759;
+    --green-text: #34c759;
+    --green-fill: rgba(52, 199, 89, 0.14);
+    --green-border: rgba(52, 199, 89, 0.25);
+    --amber: #f5a623;
+    --amber-text: #f5a623;
+    --amber-fill: rgba(245, 166, 35, 0.14);
+    --amber-border: rgba(245, 166, 35, 0.3);
+    --red: #ff3b30;
+    --red-strong: #d70015; /* filled controls carrying white text (5.4:1); --red stays for tints and strokes */
+    --red-text: #ff6961;
+    --red-fill: rgba(255, 59, 48, 0.12);
+    --red-border: rgba(255, 59, 48, 0.35);
+
+    --text-primary: #f5f5f7;
+    --text-body: #a1a1a6;
+    --text-secondary: #a1a1a6;
+    --text-tertiary: #86868b;
+    --text-inverse: #f5f5f7;
+    --text-inverse-secondary: #a1a1a6;
+    --text-code: #7dd3fc;
+
+    --divider: rgba(255, 255, 255, 0.08);
+    --track: rgba(255, 255, 255, 0.1);
+    --stroke: rgba(255, 255, 255, 0.14);
+
+    --shadow-card: 0 12px 32px rgba(0, 0, 0, 0.3);
+    --shadow-chrome: 0 20px 50px rgba(0, 0, 0, 0.4);
+    --shadow-modal: 0 24px 60px rgba(0, 0, 0, 0.45);
+
+    --background: 240 12% 8%;
+    --foreground: 240 9% 96%;
+    --card: 240 3% 10%;
+    --card-foreground: 240 9% 96%;
+    --popover: 240 3% 12%;
+    --popover-foreground: 240 9% 96%;
+    --primary: 210 100% 45%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 3% 16%;
+    --secondary-foreground: 240 9% 96%;
+    --muted: 240 3% 16%;
+    --muted-foreground: 240 2% 65%;
+    --accent: 210 100% 20%;
+    --accent-foreground: 210 100% 58%;
+    --destructive: 3 100% 69%;
+    --destructive-foreground: 240 12% 8%;
+    --border: 240 3% 20%;
+    --input: 240 3% 20%;
+    --ring: 210 100% 58%;
+  }
+
+  /* Reduced transparency, or no backdrop-filter support: solid composites of the same glass */
+  @media (prefers-reduced-transparency: reduce) {
+    :root,
+    .dark {
+      --glass-fill: var(--glass-fill-solid);
+      --glass-chrome-fill: var(--glass-chrome-solid);
+    }
+  }
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    :root,
+    .dark {
+      --glass-fill: var(--glass-fill-solid);
+      --glass-chrome-fill: var(--glass-chrome-solid);
+    }
   }
 
   html {
@@ -55,8 +223,171 @@
   }
 
   body {
-    @apply bg-background text-foreground font-sans antialiased;
     margin: 0;
+    min-height: 100vh;
+    background-color: var(--bg-page-solid);
+    background-image: var(--bg-page);
+    background-attachment: fixed;
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  ::selection {
+    background: var(--brand-soft);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+}
+
+@layer components {
+  /*
+    Radial washes behind a page. Apply to a `relative overflow-hidden` wrapper.
+    A wrapper that must keep `overflow: visible` (the dashboard shell, whose sidebar is
+    `position: sticky`) uses `.glass-page--layered` instead and puts an empty
+    `.glass-page-wash` element inside it: the wash layer clips its own overflow.
+  */
+  .glass-page::before,
+  .glass-page::after,
+  .glass-page-wash::before,
+  .glass-page-wash::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .glass-page::before,
+  .glass-page-wash::before {
+    top: -180px;
+    right: -120px;
+    width: 560px;
+    height: 560px;
+    background: radial-gradient(circle, var(--wash-1), transparent 70%);
+  }
+  .glass-page::after,
+  .glass-page-wash::after {
+    bottom: -220px;
+    left: 240px;
+    width: 640px;
+    height: 640px;
+    background: radial-gradient(circle, var(--wash-2), transparent 70%);
+  }
+  .glass-page--layered::before,
+  .glass-page--layered::after {
+    content: none;
+  }
+  .glass-page > * {
+    position: relative;
+    z-index: 1;
+  }
+  .glass-page > .glass-page-wash {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .glass {
+    background: var(--glass-fill);
+    border: 1px solid var(--glass-border);
+    border-radius: 20px;
+    box-shadow: var(--shadow-card);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
+  .glass-chrome {
+    background: var(--glass-chrome-fill);
+    border: 1px solid var(--glass-chrome-border);
+    border-radius: 22px;
+    box-shadow: var(--shadow-chrome);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+  }
+  .glass-alert {
+    background: var(--red-fill);
+    border: 1px solid var(--red-border);
+    border-radius: 20px;
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
+  .glass-contrast {
+    background: var(--surface-contrast);
+    border: 1px solid var(--surface-contrast-border);
+    border-radius: 20px;
+    color: var(--text-inverse);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
+  .glass-inset {
+    background: var(--surface-inset-gray);
+    border-radius: 12px;
+  }
+  .glass-segment {
+    display: inline-flex;
+    padding: 3px;
+    gap: 2px;
+    background: var(--segment-track);
+    border-radius: 980px;
+  }
+  .glass-segment-item {
+    padding: 6px 12px;
+    border-radius: 980px;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--segment-inactive-text);
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+  .glass-segment-item[data-active="true"],
+  .glass-segment-item[aria-pressed="true"],
+  .glass-segment-item[aria-selected="true"] {
+    background: var(--segment-active);
+    box-shadow: var(--segment-active-shadow);
+    color: var(--text-primary);
+    font-weight: 700;
+  }
+
+  .code-block {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.9;
+    color: var(--text-code);
+    background: var(--code-fill);
+    border-radius: 12px;
+    padding: 13px 14px;
+    overflow-x: auto;
+    white-space: pre;
+  }
+
+  .text-headline {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--text-primary);
+  }
+  .text-overline {
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+  .text-kpi {
+    font-size: 32px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    color: var(--text-primary);
   }
 }
 
@@ -65,8 +396,10 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
-
   .scrollbar-none::-webkit-scrollbar {
     display: none;
+  }
+  .rounded-pill {
+    border-radius: 980px;
   }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Toaster } from "sonner";
 import { Toaster as ShadcnToaster } from "@/components/ui/toaster";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+// Inter is the fallback for platforms without SF Pro; see --font-sans in globals.css.
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
 
 export const metadata: Metadata = {
   title: "Agent Identity Management | OpenA2A",
@@ -23,17 +25,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={inter.className}>
-        {children}
-        <Toaster
-          position="top-right"
-          richColors
-          closeButton
-          expand={false}
-          duration={4000}
-        />
-        <ShadcnToaster />
+    // suppressHydrationWarning: next-themes sets the theme class on <html> before hydration.
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans`}>
+        <ThemeProvider>
+          {children}
+          <Toaster
+            position="top-right"
+            richColors
+            closeButton
+            expand={false}
+            duration={4000}
+          />
+          <ShadcnToaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6" aria-busy="true" aria-label="Loading">
+      <div className="glass w-full max-w-md space-y-3 p-6">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-7 w-2/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-6">
+      <div className="glass-chrome w-full max-w-md p-8 text-center">
+        <p className="text-overline">404</p>
+        <h1 className="text-headline mt-2">This page does not exist.</h1>
+        <p className="mt-2 text-sm text-ink-secondary">
+          The link may be out of date.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/dashboard"
+            className="inline-flex h-10 items-center rounded-pill bg-brand px-5 text-sm font-bold text-white shadow-glow hover:bg-brand-hover"
+          >
+            Go to the dashboard
+          </Link>
+          <Link
+            href="/auth/login"
+            className="inline-flex h-10 items-center rounded-pill border border-stroke bg-glass px-5 text-sm font-bold text-ink"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/dashboard-header.tsx
+++ b/apps/web/components/dashboard-header.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ChevronDown, LogOut, Lock, Loader2, Bell } from "lucide-react";
+import { Bell, ChevronDown, Loader2, Lock, LogOut } from "lucide-react";
 import { api } from "@/lib/api";
-import { type UserRole } from "@/lib/permissions";
+import { getRoleInfo, type UserRole } from "@/lib/permissions";
 import { eventEmitter } from "@/lib/event-emitter";
+import { AimLogo } from "@/components/sidebar";
+import { cn } from "@/lib/utils";
 
 export function DashboardHeader() {
   const router = useRouter();
@@ -62,7 +65,8 @@ export function DashboardHeader() {
         const token = api.getToken();
         if (token) {
           try {
-            const payload = JSON.parse(atob(token.split(".")[1]));
+            const payload = decodeJwtPayload(token);
+            if (!payload) throw new Error("token payload is not decodable");
 
             const now = Math.floor(Date.now() / 1000);
             if (payload?.exp && payload.exp < now) {
@@ -129,114 +133,94 @@ export function DashboardHeader() {
     }
   };
 
-  const getRoleBadge = (role?: UserRole) => {
-    if (!role) return null;
-
-    const roleColors = {
-      admin:
-        "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300",
-      manager:
-        "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300",
-      member:
-        "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300",
-      viewer: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300",
-    };
-
-    const roleLabels = {
-      admin: "System Administrator",
-      manager: "Manager",
-      member: "Member",
-      viewer: "Viewer",
-    };
-
-    return (
-      <span
-        className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${roleColors[role]}`}
-      >
-        {roleLabels[role]}
-      </span>
-    );
-  };
+  const roleLabel = user?.role ? getRoleInfo(user.role).label : null;
+  // Interim admin-only: the edge gate blocks managers from /dashboard/admin/alerts (prefix
+  // intersection); restore manager access when alerts move out of the admin prefix.
+  const canSeeAlerts = user?.role === "admin";
+  const initial = (user?.displayName || user?.email || "?").slice(0, 1).toUpperCase();
 
   return (
-    <header className="sticky top-0 z-30 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 shadow-sm">
-      <div className="flex items-center justify-end h-16 px-4 sm:px-6 lg:px-8">
-        {/* User Profile Dropdown */}
+    <header className="flex items-center justify-between gap-3 px-1 py-1">
+      {/* The sidebar carries the logo on large screens; show it here on small ones. */}
+      <Link href="/dashboard" className="flex items-center gap-2.5 lg:invisible" aria-label="Overview">
+        <AimLogo />
+        <span className="text-base font-bold tracking-[-0.02em] text-ink">AIM</span>
+      </Link>
+
+      <div className="flex items-center gap-2">
+        {canSeeAlerts && (
+          <Link
+            href="/dashboard/admin/alerts"
+            className="relative inline-flex h-9 w-9 items-center justify-center rounded-pill border border-glass-border bg-glass text-ink-secondary backdrop-blur-card hover:text-ink"
+            aria-label={priorityAlertCount > 0 ? `${priorityAlertCount} priority alerts` : "Alerts"}
+          >
+            <Bell className="h-4 w-4" aria-hidden="true" />
+            {priorityAlertCount > 0 && (
+              <span className="absolute -right-1 -top-1 inline-flex min-w-[18px] items-center justify-center rounded-pill bg-danger px-1 text-[10px] font-bold leading-[18px] text-white">
+                {priorityAlertCount > 99 ? "99+" : priorityAlertCount}
+              </span>
+            )}
+          </Link>
+        )}
+
         <div className="relative">
           <button
+            type="button"
             onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-            className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-haspopup="menu"
+            aria-expanded={isDropdownOpen}
+            className="flex items-center gap-2 rounded-pill border border-glass-border bg-glass py-1 pl-1 pr-2.5 backdrop-blur-card hover:bg-glass-inset"
           >
-            {/* Avatar */}
-            <div className="w-9 h-9 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center text-white font-semibold">
-              {user?.email?.[0]?.toUpperCase() || "U"}
-            </div>
-
-            {/* User Info */}
-            <div className="flex flex-col items-start min-w-0">
-              <div className="flex items-center gap-2">
-                {getRoleBadge(user?.role)}
-              </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-[200px]">
-                {user?.email || "Loading..."}
-              </p>
-            </div>
-
-            {/* Dropdown Icon */}
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-[#a78bfa] to-[#6366f1] text-xs font-bold text-white">
+              {initial}
+            </span>
+            <span className="hidden max-w-[160px] truncate text-xs font-bold text-ink sm:block">
+              {user?.displayName || "Account"}
+            </span>
             <ChevronDown
-              className={`h-4 w-4 text-gray-500 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
+              className={cn("h-3.5 w-3.5 text-ink-tertiary transition-transform", isDropdownOpen && "rotate-180")}
+              aria-hidden="true"
             />
           </button>
 
-          {/* Dropdown Menu */}
           {isDropdownOpen && (
             <>
-              {/* Backdrop */}
-              <div
-                className="fixed inset-0 z-40"
-                onClick={() => setIsDropdownOpen(false)}
-              />
-
-              {/* Menu */}
-              <div className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50">
-                {/* User Info Header */}
-                <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    {user?.displayName || "User Account"}
-                  </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                    {user?.email || "Loading..."}
-                  </p>
-                </div>
-
-                {/* Menu Items */}
-                <div className="py-2">
-                  {user?.provider === "local" && (
-                    <button
-                      onClick={() => {
-                        setIsDropdownOpen(false);
-                        router.push("/auth/change-password");
-                      }}
-                      className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      <Lock className="h-4 w-4" />
-                      <span>Change Password</span>
-                    </button>
+              <div className="fixed inset-0 z-40" onClick={() => setIsDropdownOpen(false)} aria-hidden="true" />
+              <div role="menu" className="glass absolute right-0 z-50 mt-2 w-64 p-1.5">
+                <div className="px-3 py-2.5">
+                  <p className="truncate text-sm font-bold text-ink">{user?.displayName || "Account"}</p>
+                  <p className="truncate text-2xs text-ink-tertiary">{user?.email || "Loading..."}</p>
+                  {roleLabel && (
+                    <span className="mt-1.5 inline-flex rounded-pill bg-brand-soft px-2 py-0.5 text-2xs font-bold text-brand-text">
+                      {roleLabel}
+                    </span>
                   )}
-
-                  <button
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                    className="w-full flex items-center gap-3 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {isLoggingOut ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <LogOut className="h-4 w-4" />
-                    )}
-                    <span>{isLoggingOut ? "Logging out..." : "Logout"}</span>
-                  </button>
                 </div>
+                <div className="my-1 border-t border-divider" />
+                {user?.provider === "local" && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setIsDropdownOpen(false);
+                      router.push("/auth/change-password");
+                    }}
+                    className="flex w-full items-center gap-2.5 rounded-nav px-3 py-2 text-sm font-medium text-ink-body hover:bg-glass-inset-gray hover:text-ink"
+                  >
+                    <Lock className="h-4 w-4 text-ink-tertiary" aria-hidden="true" />
+                    <span>Change password</span>
+                  </button>
+                )}
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleLogout}
+                  disabled={isLoggingOut}
+                  className="flex w-full items-center gap-2.5 rounded-nav px-3 py-2 text-sm font-medium text-danger-text hover:bg-danger-fill disabled:opacity-60"
+                >
+                  {isLoggingOut ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <LogOut className="h-4 w-4" aria-hidden="true" />}
+                  <span>{isLoggingOut ? "Signing out..." : "Sign out"}</span>
+                </button>
               </div>
             </>
           )}

--- a/apps/web/components/mobile-tab-bar.tsx
+++ b/apps/web/components/mobile-tab-bar.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BookOpen, Home, Menu, Shield, ShieldAlert, ShieldPlus } from "lucide-react";
+import { getAgentPermissions, getDashboardPermissions, type UserRole } from "@/lib/permissions";
+import { cn } from "@/lib/utils";
+
+interface MobileTabBarProps {
+  role?: UserRole;
+  onOpenMenu: () => void;
+}
+
+export interface MobileTab {
+  name: string;
+  href: string;
+  icon: typeof Home;
+  exact: boolean;
+}
+
+/**
+ * The tabs a role sees. Property (tested in lib/navigation-edge.test.ts): every rendered tab
+ * resolves to a route the role can open — no tab may silently retarget or redirect.
+ * The Secure action is shown only to roles that may register agents; the last slot is
+ * Security for the roles the sidebar and the backend admit there, the developer guide otherwise.
+ */
+export function tabsForRole(role?: UserRole): MobileTab[] {
+  const tabs: MobileTab[] = [
+    { name: "Overview", href: "/dashboard", icon: Home, exact: true },
+    { name: "Agents", href: "/dashboard/agents", icon: Shield, exact: false },
+  ];
+  if (getAgentPermissions(role).canCreateAgent) tabs.push({ name: "Secure", href: "/dashboard/agents?register=1", icon: ShieldPlus, exact: false });
+  tabs.push(
+    getDashboardPermissions(role).canViewSecurity
+      ? { name: "Security", href: "/dashboard/security", icon: ShieldAlert, exact: false }
+      : { name: "Guide", href: "/dashboard/developers", icon: BookOpen, exact: false }
+  );
+  return tabs;
+}
+
+/**
+ * Bottom tab bar for small screens (the sidebar is hidden below lg). The center "Secure"
+ * action starts agent registration; Menu opens the navigation drawer.
+ */
+export function MobileTabBar({ role, onOpenMenu }: MobileTabBarProps) {
+  const pathname = usePathname();
+  const tabs = tabsForRole(role);
+  const [overview, agents] = tabs;
+  const secure = tabs.find((t) => t.name === "Secure");
+  const fourth = tabs[tabs.length - 1];
+
+  const isActive = (href: string, exact: boolean) => {
+    const path = href.split("?")[0];
+    return exact ? pathname === path : pathname === path || pathname.startsWith(path + "/");
+  };
+
+  const item = "flex min-w-[44px] flex-col items-center gap-1 py-1 text-[10px] font-semibold";
+  const renderTab = ({ name, href, icon: Icon, exact }: MobileTab) => {
+    const active = isActive(href, exact);
+    return (
+      <Link key={name} href={href} aria-current={active ? "page" : undefined} className={cn(item, active ? "font-bold text-brand-text" : "text-ink-tertiary")}>
+        <Icon className="h-[22px] w-[22px]" strokeWidth={2} aria-hidden="true" />
+        {name}
+      </Link>
+    );
+  };
+
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-30 flex items-center justify-around border-t border-glass-chrome-border bg-glass-chrome px-2 pb-[max(env(safe-area-inset-bottom),22px)] pt-2.5 backdrop-blur-chrome lg:hidden"
+      style={{ boxShadow: "0 -8px 30px rgba(15, 23, 42, 0.06)" }}
+    >
+      {renderTab(overview)}
+      {renderTab(agents)}
+
+      {secure && (
+        <Link href={secure.href} className={cn(item, "p-0 text-ink-tertiary")}>
+          <span className="-mt-3.5 inline-flex h-[46px] w-[46px] items-center justify-center rounded-full bg-brand text-white shadow-[0_8px_20px_rgba(0,113,227,0.35)]">
+            <ShieldPlus className="h-[22px] w-[22px]" strokeWidth={2.2} aria-hidden="true" />
+          </span>
+          {secure.name}
+        </Link>
+      )}
+
+      {renderTab(fourth)}
+
+      <button type="button" onClick={onOpenMenu} className={cn(item, "text-ink-tertiary")} aria-label="Open menu">
+        <Menu className="h-[22px] w-[22px]" strokeWidth={2} aria-hidden="true" />
+        Menu
+      </button>
+    </nav>
+  );
+}

--- a/apps/web/components/persona-switch.tsx
+++ b/apps/web/components/persona-switch.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { PERSONAS, usePersona } from "@/lib/persona";
+import { cn } from "@/lib/utils";
+
+/**
+ * One-interaction lens switch (Dev / Sec / Exec). Presentation only; see lib/persona.ts.
+ */
+export function PersonaSwitch({
+  className,
+  long = false,
+  label = "Viewing as",
+}: {
+  className?: string;
+  long?: boolean;
+  label?: string | null;
+}) {
+  const persona = usePersona((s) => s.persona);
+  const setPersona = usePersona((s) => s.setPersona);
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {label ? <span className="text-overline pl-1">{label}</span> : null}
+      <div role="radiogroup" aria-label="Dashboard view" className="glass-segment w-full">
+        {PERSONAS.map((p) => {
+          const active = persona === p.value;
+          return (
+            <button
+              key={p.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              aria-label={p.label}
+              data-active={active}
+              title={p.description}
+              onClick={() => setPersona(p.value)}
+              className="glass-segment-item flex-1 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {long ? p.label : p.short}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -1,190 +1,51 @@
 "use client";
 
 import Link from "next/link";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { usePathname, useRouter } from "next/navigation";
-import {
-  Home,
-  Shield,
-  AlertTriangle,
-  CheckCircle,
-  Server,
-  Key,
-  Users,
-  Bell,
-  LogOut,
-  ChevronLeft,
-  Menu,
-  X,
-  Download,
-  Lock,
-  ShieldCheck,
-  CheckSquare,
-  ClipboardCheck,
-  Tag,
-  BarChart3,
-  Code,
-  Loader2,
-  Search,
-  GitBranch,
-  Link2,
-} from "lucide-react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+import { LogOut, Loader2, Shield, X } from "lucide-react";
 import { api } from "@/lib/api";
 import {
   filterNavigationByRole,
-  type UserRole,
   type NavSection,
+  type UserRole,
 } from "@/lib/permissions";
+import { navigationBase, orderNavigationForPersona } from "@/lib/navigation";
+import { usePersona } from "@/lib/persona";
 import { eventEmitter, Events } from "@/lib/events";
+import { PersonaSwitch } from "@/components/persona-switch";
+import { cn } from "@/lib/utils";
 
-// ✅ Navigation with role-based access control
-// Organized by natural user workflow: Main → Development → Monitoring → Administration → Settings
-const navigationBase: NavSection[] = [
-  {
-    title: "",
-    items: [
-      // Everyone starts here
-      {
-        name: "Dashboard",
-        href: "/dashboard",
-        icon: Home,
-        roles: ["admin", "manager", "member", "viewer"],
-      },
-      {
-        name: "Agents",
-        href: "/dashboard/agents",
-        icon: Shield,
-        roles: ["admin", "manager", "member", "viewer"],
-      },
-      {
-        name: "MCP Servers",
-        href: "/dashboard/mcp",
-        icon: Server,
-        roles: ["admin", "manager", "member"],
-      },
-      {
-        name: "MCP Discovery",
-        href: "/dashboard/mcp/discovery",
-        icon: Search,
-        roles: ["admin", "manager"],
-      },
-      {
-        name: "Supply Chain",
-        href: "/dashboard/mcp/supply-chain",
-        icon: GitBranch,
-        roles: ["admin", "manager"],
-      },
-      {
-        name: "A2A Protocol",
-        href: "/dashboard/a2a",
-        icon: Link2,
-        roles: ["admin", "manager", "member"],
-      },
-    ],
-  },
-  {
-    title: "Development",
-    items: [
-      // Developer resources and tools
-      {
-        name: "API Keys",
-        href: "/dashboard/api-keys",
-        icon: Key,
-        roles: ["admin", "manager", "member"],
-      },
-      {
-        name: "Download SDK",
-        href: "/dashboard/sdk",
-        icon: Download,
-        roles: ["admin", "manager", "member"],
-      },
-      {
-        name: "SDK Tokens",
-        href: "/dashboard/sdk-tokens",
-        icon: Lock,
-        roles: ["admin", "manager", "member"],
-      },
-    ],
-  },
-  {
-    title: "Monitoring",
-    items: [
-      {
-        name: "Security",
-        href: "/dashboard/security",
-        icon: AlertTriangle,
-        roles: ["admin", "manager"],
-      },
-    ],
-  },
-  {
-    title: "Administration",
-    items: [
-      // Admin-only access to alerts, approvals, and policies
-      {
-        name: "Alerts",
-        href: "/dashboard/admin/alerts",
-        icon: Bell,
-        roles: ["admin", "manager"], // Managers can view alerts
-      },
-      {
-        name: "JIT Requests",
-        href: "/dashboard/admin/jit-requests",
-        icon: CheckCircle,
-        roles: ["admin"], // Admin-only JIT access approvals
-      },
-      {
-        name: "Capability Requests",
-        href: "/dashboard/admin/capability-requests",
-        icon: CheckSquare,
-        roles: ["admin"], // Admin-only capability approval
-      },
-      {
-        name: "Security Policies",
-        href: "/dashboard/admin/security-policies",
-        icon: ShieldCheck,
-        roles: ["admin"], // Admin-only policy management (agents + MCP)
-      },
-      {
-        name: "Compliance",
-        href: "/dashboard/admin/compliance",
-        icon: ClipboardCheck,
-        roles: ["admin"], // Admin-only compliance monitoring
-      },
-    ],
-  },
-  {
-    title: "Settings",
-    items: [
-      // Less frequently used pages at the bottom
-      {
-        name: "Users",
-        href: "/dashboard/admin/users",
-        icon: Users,
-        roles: ["admin"],
-      },
-      {
-        name: "Tags",
-        href: "/dashboard/tags",
-        icon: Tag,
-        roles: ["admin", "manager", "member"],
-      },
-      {
-        name: "Developers",
-        href: "/dashboard/developers",
-        icon: Code,
-        roles: ["admin", "manager", "member", "viewer"],
-      },
-    ],
-  },
-];
+export interface SidebarProps {
+  /** Controlled mobile drawer state (the bottom tab bar's Menu opens it). */
+  mobileOpen?: boolean;
+  onMobileOpenChange?: (open: boolean) => void;
+}
 
-export function Sidebar() {
+export function AimLogo({ size = 30, className }: { size?: number; className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("inline-flex items-center justify-center rounded-full bg-logo text-white", className)}
+      style={{ width: size, height: size }}
+    >
+      <Shield style={{ width: Math.round(size / 2), height: Math.round(size / 2) }} strokeWidth={2.4} />
+    </span>
+  );
+}
+
+export function Sidebar({ mobileOpen: mobileOpenProp, onMobileOpenChange }: SidebarProps = {}) {
   const pathname = usePathname();
   const router = useRouter();
-  const [collapsed, setCollapsed] = useState(false);
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(true); // ✅ Add loading state
+  const [mobileOpenState, setMobileOpenState] = useState(false);
+  const mobileOpen = mobileOpenProp ?? mobileOpenState;
+  const setMobileOpen = (open: boolean) => {
+    setMobileOpenState(open);
+    onMobileOpenChange?.(open);
+  };
+  const persona = usePersona((s) => s.persona);
+  const [isLoading, setIsLoading] = useState(true); // Add loading state
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [user, setUser] = useState<{
     email: string;
@@ -203,7 +64,7 @@ export function Sidebar() {
     // Fetch current user
     const fetchUser = async () => {
       try {
-        setIsLoading(true); // ✅ Start loading
+        setIsLoading(true); // Start loading
         const userData = await api.getCurrentUser();
         const normalizedRole: UserRole | undefined =
           userData?.role === "pending"
@@ -224,7 +85,8 @@ export function Sidebar() {
         const token = api.getToken();
         if (token) {
           try {
-            const payload = JSON.parse(atob(token.split(".")[1]));
+            const payload = decodeJwtPayload(token);
+            if (!payload) throw new Error("token payload is not decodable");
 
             // Check if token is expired
             const now = Math.floor(Date.now() / 1000);
@@ -250,19 +112,36 @@ export function Sidebar() {
           setTimeout(() => router.push("/auth/login"), 0);
         }
       } finally {
-        setIsLoading(false); // ✅ Stop loading
+        setIsLoading(false); // Stop loading
       }
     };
     fetchUser();
   }, [router]);
 
-  // ✅ Filter navigation based on user role using permissions system
+  // The navigation is derived from the role filter, the lens order and the live counts.
+  // Badges are matched by href so a label change cannot detach them, and a lens switch
+  // rebuilds the list with the counts it already has.
   useEffect(() => {
     if (!user?.role) return;
 
-    const filteredNav = filterNavigationByRole(navigationBase, user.role);
-    setNavigation(filteredNav);
-  }, [user?.role]);
+    const badges: Record<string, number> = {
+      "/dashboard/security": securityAlertCount,
+      "/dashboard/admin/alerts": alertCount,
+      "/dashboard/admin/capability-requests": capabilityRequestCount,
+      "/dashboard/admin/jit-requests": verificationCount,
+    };
+    const filteredNav = filterNavigationByRole(navigationBase, user.role).map((section) => ({
+      ...section,
+      items: section.items.map((item) => {
+        const count = badges[item.href];
+        if (count && count > 0) return { ...item, badge: count };
+        const { badge: _badge, ...withoutBadge } = item;
+        return withoutBadge;
+      }),
+    }));
+    // The lens only reorders what the role filter already allowed (lib/persona.test.ts).
+    setNavigation(orderNavigationForPersona(filteredNav, persona));
+  }, [user?.role, persona, alertCount, securityAlertCount, capabilityRequestCount, verificationCount]);
 
   useEffect(() => {
     // Fetch alert count, capability request count, and verification approvals
@@ -294,49 +173,7 @@ export function Sidebar() {
           setVerificationCount(pendingVerificationCount);
         }
 
-        // Update navigation with badges
-        setNavigation((prev) =>
-          prev.map((section) => ({
-            ...section,
-            items: section.items.map((item) => {
-              // Update Security badge (critical + high alerts)
-              if (item.name === "Security" && securityAlertCount > 0) {
-                return { ...item, badge: securityAlertCount };
-              }
-              // Update Alerts badge
-              if (item.name === "Alerts" && alertCount > 0) {
-                return { ...item, badge: alertCount };
-              }
-              // Update Capability Requests badge
-              if (
-                item.name === "Capability Requests" &&
-                capabilityRequestCount > 0
-              ) {
-                return { ...item, badge: capabilityRequestCount };
-              }
-              // Update JIT Requests badge
-              if (
-                item.name === "JIT Requests" &&
-                verificationCount > 0
-              ) {
-                return { ...item, badge: verificationCount };
-              }
-              // Remove badges when count is 0
-              if (
-                (item.name === "Security" && securityAlertCount === 0) ||
-                (item.name === "Alerts" && alertCount === 0) ||
-                (item.name === "Capability Requests" &&
-                  capabilityRequestCount === 0) ||
-                (item.name === "JIT Requests" &&
-                  verificationCount === 0)
-              ) {
-                const { badge, ...itemWithoutBadge } = item;
-                return itemWithoutBadge;
-              }
-              return item;
-            }),
-          }))
-        );
+        // Badges are applied by the navigation effect from these counts.
       } catch (error) {
         console.log("Failed to fetch counts:", error);
       }
@@ -436,196 +273,133 @@ export function Sidebar() {
     return pathname === href || pathname.startsWith(href + "/");
   };
 
-  // ✅ Sidebar Loading Skeleton
-  const SidebarSkeleton = () => (
-    <>
-      {/* Logo Skeleton */}
-      <div className="px-4 py-4 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
-          {!collapsed && (
-            <div className="flex flex-col gap-1 flex-1">
-              <div className="h-5 w-16 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              <div className="h-3 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-            </div>
+  // Sidebar Loading Skeleton
+  const NavList = () => (
+    <nav className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-0.5" aria-label="Main">
+      {navigation.map((section, idx) => (
+        <div key={section.title || idx} className="flex flex-col gap-[2px]">
+          {section.title && (
+            <h3 className="text-overline mb-0.5 pl-3">{section.title}</h3>
           )}
-        </div>
-      </div>
-
-      {/* Navigation Skeleton */}
-      <nav className="flex-1 px-3 py-4 space-y-6 overflow-y-auto">
-        {/* Main Section */}
-        <div className="space-y-1">
-          {[...Array(6)].map((_, idx) => (
-            <div
-              key={idx}
-              className={`flex items-center gap-3 px-3 py-2 rounded-lg ${collapsed ? "justify-center" : ""}`}
-            >
-              <div className="w-5 h-5 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              {!collapsed && (
-                <div className="h-4 flex-1 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Administration Section */}
-        {!collapsed && (
-          <div className="space-y-1">
-            <div className="h-3 w-24 mx-3 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-2" />
-            {[...Array(4)].map((_, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-3 px-3 py-2 rounded-lg"
+          {section.items.map((item) => {
+            const active = isActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setMobileOpen(false)}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-nav px-[11px] py-[7px] text-[13px] transition-colors",
+                  active
+                    ? "bg-nav-active font-bold text-brand-text"
+                    : "font-medium text-ink-body hover:bg-glass-inset-gray hover:text-ink"
+                )}
               >
-                <div className="w-5 h-5 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                <div className="h-4 flex-1 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-              </div>
-            ))}
-          </div>
-        )}
-      </nav>
-    </>
+                <item.icon
+                  className={cn("h-4 w-4 flex-shrink-0", active ? "text-brand-text" : "text-ink-tertiary")}
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+                <span className="flex-1 truncate">{item.name}</span>
+                {item.badge ? (
+                  <span
+                    className="inline-flex min-w-[20px] items-center justify-center rounded-pill bg-danger px-1.5 py-0.5 text-2xs font-bold text-white"
+                    aria-label={`${item.badge} pending`}
+                  >
+                    {item.badge}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </div>
+      ))}
+    </nav>
   );
 
-  const SidebarContent = () => (
-    <div className="flex flex-col h-full">
-      {isLoading ? (
-        <SidebarSkeleton />
-      ) : (
-        <>
-          {/* Logo */}
-          <div className="relative flex items-center justify-between px-4 py-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
-            <Link href="/dashboard" className="flex items-center gap-3">
-              <div className="w-8 h-8 flex items-center justify-center">
-                <img
-                  src="/opena2a-logo.svg"
-                  alt="OpenA2A Logo"
-                  className="w-full h-full object-contain"
-                />
-              </div>
-              {!collapsed && (
-                <div className="flex flex-col">
-                  <span className="text-lg font-bold text-gray-900 dark:text-white">
-                    AIM
-                  </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    Agent Identity Management
-                  </span>
-                </div>
-              )}
-            </Link>
-            {collapsed && (
-              <button
-                onClick={() => setCollapsed(false)}
-                className="absolute top-1/2 -translate-y-1/2 right-0 z-10 translate-x-1/2 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow p-1 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
-                aria-label="Expand sidebar"
-              >
-                <ChevronLeft className="h-4 w-4 rotate-180" />
-              </button>
-            )}
-            {!collapsed && (
-              <button
-                onClick={() => setCollapsed(true)}
-                className="lg:flex hidden p-1 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
-              >
-                <ChevronLeft className="h-5 w-5" />
-              </button>
-            )}
-          </div>
+  const SidebarSkeleton = () => (
+    <div className="flex flex-col gap-2 pt-2" aria-busy="true" aria-label="Loading navigation">
+      {[...Array(7)].map((_, idx) => (
+        <div key={idx} className="flex items-center gap-2.5 px-[11px] py-[9px]">
+          <div className="h-4 w-4 animate-pulse rounded bg-track" />
+          <div className="h-3.5 flex-1 animate-pulse rounded bg-track" />
+        </div>
+      ))}
+    </div>
+  );
 
-          {/* Navigation */}
-          <nav className="flex-1 px-3 py-4 space-y-6 overflow-y-auto min-h-0">
-            {navigation.map((section, idx) => (
-              <div key={idx} className="space-y-1">
-                {section.title && !collapsed && (
-                  <h3 className="px-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {section.title}
-                  </h3>
-                )}
-                <div className="space-y-1">
-                  {section.items.map((item) => {
-                    const active = isActive(item.href);
-                    return (
-                      <Link
-                        key={item.name}
-                        href={item.href}
-                        onClick={() => setMobileOpen(false)}
-                        className={`
-                          flex items-center gap-3 px-3 py-2 rounded-lg transition-all
-                          ${active
-                            ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
-                            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
-                          }
-                          ${collapsed ? "justify-center" : ""}
-                        `}
-                        title={collapsed ? item.name : undefined}
-                      >
-                        <item.icon
-                          className={`h-5 w-5 flex-shrink-0 ${active ? "text-blue-600 dark:text-blue-400" : ""}`}
-                        />
-                        {!collapsed && (
-                          <>
-                            <span className="flex-1 font-medium">
-                              {item.name}
-                            </span>
-                            {item.badge && (
-                              <span className="inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold text-white bg-red-500 rounded-full">
-                                {item.badge}
-                              </span>
-                            )}
-                          </>
-                        )}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-          </nav>
-        </>
-      )}
+  const SidebarContent = ({ inDrawer = false }: { inDrawer?: boolean }) => (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-shrink-0 items-center justify-between px-2.5 pb-4">
+        <Link href="/dashboard" className="flex items-center gap-2.5" onClick={() => setMobileOpen(false)}>
+          <AimLogo />
+          <span className="text-base font-bold tracking-[-0.02em] text-ink">AIM</span>
+        </Link>
+        {inDrawer && (
+          <button
+            type="button"
+            onClick={() => setMobileOpen(false)}
+            className="rounded-pill p-1.5 text-ink-secondary hover:bg-glass-inset-gray"
+            aria-label="Close menu"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        )}
+      </div>
+
+      <PersonaSwitch className="mx-1.5 mb-4 flex-shrink-0" />
+
+      {isLoading ? <SidebarSkeleton /> : <NavList />}
+
+      <div className="mt-4 flex flex-shrink-0 flex-col gap-1 border-t border-divider pt-3">
+        {user && (
+          <div className="flex items-center gap-2.5 px-2">
+            <span className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#a78bfa] to-[#6366f1] text-xs font-bold text-white">
+              {(user.display_name || user.email || "?").slice(0, 1).toUpperCase()}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-xs font-bold text-ink">{user.display_name}</span>
+              <span className="block truncate text-2xs text-ink-tertiary">{user.email}</span>
+            </span>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={handleLogout}
+          disabled={isLoggingOut}
+          className="flex items-center gap-2.5 rounded-nav px-[11px] py-[7px] text-[13px] font-medium text-ink-body hover:bg-glass-inset-gray hover:text-ink disabled:opacity-60"
+        >
+          {isLoggingOut ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogOut className="h-4 w-4 text-ink-tertiary" />}
+          <span>{isLoggingOut ? "Signing out..." : "Sign out"}</span>
+        </button>
+      </div>
     </div>
   );
 
   return (
     <>
-      {/* Mobile Menu Button */}
-      <button
-        onClick={() => setMobileOpen(!mobileOpen)}
-        className="lg:hidden fixed top-4 right-4 z-50 p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg"
-      >
-        {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-      </button>
-
-      {/* Mobile Overlay */}
-      {mobileOpen && (
-        <div
-          className="lg:hidden fixed inset-0 bg-black/50 z-40"
-          onClick={() => setMobileOpen(false)}
-        />
-      )}
-
-      {/* Desktop Sidebar */}
-      <aside
-        className={`
-          hidden lg:flex flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700
-          transition-all duration-300 ease-in-out sticky top-0 h-screen
-          ${collapsed ? "w-20" : "w-64"}
-        `}
-      >
+      {/* Desktop: floating glass chrome */}
+      <aside className="glass-chrome sticky top-6 hidden h-[calc(100vh-3rem)] w-56 flex-shrink-0 flex-col px-3.5 py-5 lg:flex">
         <SidebarContent />
       </aside>
 
-      {/* Mobile Sidebar */}
+      {/* Mobile: drawer opened from the bottom tab bar */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm lg:hidden"
+          onClick={() => setMobileOpen(false)}
+          aria-hidden="true"
+        />
+      )}
       <aside
-        className={`
-          lg:hidden fixed top-0 left-0 bottom-0 z-40 w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700
-          transform transition-transform duration-300 ease-in-out flex flex-col
-          ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
-        `}
+        className={cn(
+          "glass-chrome fixed bottom-3 left-3 top-3 z-50 flex w-[280px] max-w-[85vw] flex-col px-3.5 py-5 transition-transform duration-300 ease-out lg:hidden",
+          mobileOpen ? "translate-x-0" : "-translate-x-[120%]"
+        )}
+        aria-hidden={!mobileOpen}
       >
-        <SidebarContent />
+        <SidebarContent inDrawer />
       </aside>
     </>
   );

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+/**
+ * Light/dark theme provider. Adds the `dark` class to <html> (Tailwind darkMode: 'class')
+ * and persists the user's pick in localStorage under the key `theme`. Mount once in
+ * app/layout.tsx.
+ *
+ * The default stays "light" and the OS preference is not followed until every core surface
+ * has been moved onto the design tokens: pages still carrying raw palette classes render as
+ * light islands inside a dark shell. Flip `defaultTheme` to "system" and set `enableSystem`
+ * in the change that completes that sweep.
+ */
+export function ThemeProvider({ children, ...props }: ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem={false}
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const OPTIONS = [
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+  { value: "system", label: "System", Icon: Monitor },
+] as const;
+
+type ThemeValue = (typeof OPTIONS)[number]["value"];
+
+/**
+ * Segmented light / dark / system control. Renders a fixed-size placeholder until mounted so
+ * the server and client markup agree (the theme is only known in the browser).
+ */
+export function ThemeToggle({ className, compact = false }: { className?: string; compact?: boolean }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const current: ThemeValue = mounted && (theme === "light" || theme === "dark") ? theme : "system";
+
+  return (
+    <div
+      role="group"
+      aria-label="Color theme"
+      className={cn("glass-segment", className)}
+      data-testid="theme-toggle"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => {
+        const active = mounted && current === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            aria-pressed={active}
+            aria-label={label}
+            title={label}
+            onClick={() => setTheme(value)}
+            className={cn(
+              "glass-segment-item inline-flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              compact && "px-2.5"
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {!compact && <span>{label}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -3,24 +3,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+// Glasshouse status chips: tinted fill + tinted border + readable text, never white-on-color.
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center gap-1.5 rounded-pill border px-2.5 py-0.5 text-2xs font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
-        success:
-          "border-transparent bg-green-500 text-white hover:bg-green-600",
-        warning:
-          "border-transparent bg-yellow-500 text-white hover:bg-yellow-600",
-        info:
-          "border-transparent bg-blue-500 text-white hover:bg-blue-600",
+        default: "border-transparent bg-brand-soft text-brand-text",
+        secondary: "border-glass-inset-border bg-glass-inset-gray text-ink-body",
+        destructive: "border-danger-border bg-danger-fill text-danger-text",
+        outline: "border-stroke text-ink-body",
+        success: "border-success-border bg-success-fill text-success-text",
+        warning: "border-warning-border bg-warning-fill text-warning-text",
+        info: "border-transparent bg-brand-soft text-brand-text",
       },
     },
     defaultVariants: {

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -2,22 +2,24 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
+// Glasshouse pill buttons. Colors come from tokens in app/globals.css; never add raw palette classes here.
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-pill text-sm font-bold tracking-[-0.01em] transition-[background-color,color,box-shadow,transform] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]",
   {
     variants: {
       variant: {
-        default: "bg-blue-600 text-white hover:bg-blue-700",
-        destructive: "bg-red-600 text-white hover:bg-red-700",
-        outline: "border border-gray-300 bg-white hover:bg-gray-50",
-        secondary: "bg-purple-600 text-white hover:bg-purple-700",
-        ghost: "hover:bg-gray-100",
-        link: "text-blue-600 underline-offset-4 hover:underline",
+        default: "bg-brand text-white shadow-glow hover:bg-brand-hover",
+        destructive: "bg-danger-strong text-white hover:bg-danger-strong hover:brightness-95",
+        outline:
+          "border border-stroke bg-glass text-ink backdrop-blur-card hover:bg-glass-inset",
+        secondary: "bg-brand-soft text-brand-text hover:brightness-95",
+        ghost: "text-ink-body hover:bg-glass-inset-gray hover:text-ink",
+        link: "text-brand-text underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "h-10 px-5",
+        sm: "h-8 px-4 text-xs",
+        lg: "h-11 px-6 text-[15px]",
         icon: "h-10 w-10",
       },
     },

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,16 +1,14 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 
+// Glasshouse card: frosted glass surface (see .glass in app/globals.css).
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "rounded-lg border border-gray-200 bg-white text-gray-900 shadow-sm",
-      className
-    )}
+    className={cn("glass text-ink", className)}
     {...props}
   />
 ))
@@ -22,7 +20,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-5", className)}
     {...props}
   />
 ))
@@ -35,7 +33,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-[15px] font-bold leading-none tracking-[-0.02em] text-ink",
       className
     )}
     {...props}
@@ -49,7 +47,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-gray-500", className)}
+    className={cn("text-xs text-ink-tertiary", className)}
     {...props}
   />
 ))
@@ -59,7 +57,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -69,7 +67,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-5 pt-0", className)}
     {...props}
   />
 ))

--- a/apps/web/components/ui/content-loaders.tsx
+++ b/apps/web/components/ui/content-loaders.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "./skeleton";
 // Stat Card Skeleton
 export function StatCardSkeleton() {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className="flex-shrink-0">
           <Skeleton className="h-6 w-6" />
@@ -28,7 +28,7 @@ export function ChartSkeleton({ title }: { title?: string }) {
   const heights = [120, 80, 160, 100, 140, 90];
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+    <div className="glass p-6">
       <div className="flex items-center justify-between mb-4">
         <Skeleton className="h-6 w-48" />
         <Skeleton className="h-5 w-5" />
@@ -60,10 +60,10 @@ export function TableSkeleton({
   columns?: number;
 }) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass">
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="bg-gray-50 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-divider">
+          <thead className="bg-glass-inset-gray">
             <tr>
               {[...Array(columns)].map((_, i) => (
                 <th key={i} className="px-6 py-3">
@@ -72,7 +72,7 @@ export function TableSkeleton({
               ))}
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+          <tbody className="bg-glass divide-y divide-divider">
             {[...Array(rows)].map((_, rowIndex) => (
               <tr key={rowIndex}>
                 {[...Array(columns)].map((_, colIndex) => (
@@ -103,10 +103,10 @@ export function TableSkeleton({
 // Agent Table Specific Skeleton
 export function AgentTableSkeleton({ rows = 8 }: { rows?: number }) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass">
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="bg-gray-50 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-divider">
+          <thead className="bg-glass-inset-gray">
             <tr>
               <th className="px-6 py-3">
                 <Skeleton className="h-4 w-24" />
@@ -131,7 +131,7 @@ export function AgentTableSkeleton({ rows = 8 }: { rows?: number }) {
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+          <tbody className="bg-glass divide-y divide-divider">
             {[...Array(rows)].map((_, rowIndex) => (
               <tr key={rowIndex}>
                 <td className="px-6 py-4">
@@ -180,7 +180,7 @@ export function AgentTableSkeleton({ rows = 8 }: { rows?: number }) {
 // Metrics Card Skeleton
 export function MetricsCardSkeleton({ title }: { title?: string }) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+    <div className="glass p-6">
       <div className="flex items-center gap-2 mb-4">
         <Skeleton className="h-5 w-5" />
         <Skeleton className="h-5 w-32" />
@@ -192,7 +192,7 @@ export function MetricsCardSkeleton({ title }: { title?: string }) {
             <Skeleton className="h-4 w-12" />
           </div>
         ))}
-        <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+        <div className="pt-2 border-t border-divider">
           <div className="flex justify-between items-center">
             <Skeleton className="h-4 w-28" />
             <div className="flex items-center gap-1">
@@ -240,8 +240,8 @@ export function DashboardSkeleton() {
       </div>
 
       {/* Recent Activity Table Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-        <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+      <div className="glass">
+        <div className="p-6 border-b border-divider">
           <div className="flex items-center justify-between">
             <Skeleton className="h-6 w-32" />
             <Skeleton className="h-5 w-5" />
@@ -274,7 +274,7 @@ export function AgentsPageSkeleton() {
       </div>
 
       {/* Filters Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <Skeleton className="flex-1 h-10 rounded-lg" />
           <Skeleton className="h-10 w-40 rounded-lg" />
@@ -308,7 +308,7 @@ export function SDKTokensPageSkeleton() {
         {[...Array(3)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+            className="glass"
           >
             <div className="p-6 space-y-4">
               <div className="flex items-center justify-between">
@@ -327,7 +327,7 @@ export function SDKTokensPageSkeleton() {
         {[...Array(3)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+            className="glass"
           >
             <div className="p-6 space-y-4">
               <div className="flex items-start justify-between">
@@ -351,7 +351,7 @@ export function SDKTokensPageSkeleton() {
                   </div>
                 ))}
               </div>
-              <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="pt-4 border-t border-divider">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-6">
                     <Skeleton className="h-4 w-32" />
@@ -397,14 +397,14 @@ export function MCPServerDetailSkeleton() {
       </div>
 
       {/* Separator */}
-      <div className="border-t border-gray-200 dark:border-gray-700" />
+      <div className="border-t border-divider" />
 
       {/* Info Cards Skeleton */}
       <div className="grid gap-4 md:grid-cols-3">
         {[...Array(3)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+            className="glass"
           >
             <div className="p-6 pb-3">
               <Skeleton className="h-4 w-32" />
@@ -420,15 +420,15 @@ export function MCPServerDetailSkeleton() {
       {/* Tabs Skeleton */}
       <div className="space-y-4">
         {/* Tab Headers */}
-        <div className="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center gap-2 border-b border-divider">
           <Skeleton className="h-10 w-32 rounded-t-lg" />
           <Skeleton className="h-10 w-36 rounded-t-lg" />
           <Skeleton className="h-10 w-24 rounded-t-lg" />
         </div>
 
         {/* Tab Content - Card */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-6 border-b border-gray-200 dark:border-gray-700 space-y-2">
+        <div className="glass">
+          <div className="p-6 border-b border-divider space-y-2">
             <Skeleton className="h-6 w-48" />
             <Skeleton className="h-4 w-96" />
           </div>
@@ -436,7 +436,7 @@ export function MCPServerDetailSkeleton() {
             {[...Array(4)].map((_, i) => (
               <div
                 key={i}
-                className="flex items-start gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg"
+                className="flex items-start gap-3 p-3 border border-divider rounded-lg"
               >
                 <Skeleton className="h-6 w-16 rounded-full mt-1" />
                 <div className="flex-1 space-y-2">
@@ -465,7 +465,7 @@ export function DevelopersPageSkeleton() {
       </div>
 
       {/* Search and Filters Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <Skeleton className="flex-1 h-10 rounded-lg" />
           <Skeleton className="h-10 w-32 rounded-lg" />
@@ -476,7 +476,7 @@ export function DevelopersPageSkeleton() {
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
         {/* Sidebar Skeleton */}
         <div className="lg:col-span-3">
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4 space-y-4">
+          <div className="glass p-4 space-y-4">
             {/* Categories */}
             {[...Array(6)].map((_, i) => (
               <div key={i} className="space-y-2">
@@ -501,9 +501,9 @@ export function DevelopersPageSkeleton() {
 
         {/* Content Area Skeleton */}
         <div className="lg:col-span-9">
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+          <div className="glass">
             {/* Header */}
-            <div className="p-6 border-b border-gray-200 dark:border-gray-700 space-y-3">
+            <div className="p-6 border-b border-divider space-y-3">
               <div className="flex items-center gap-2">
                 <Skeleton className="h-6 w-16 rounded" />
                 <Skeleton className="h-6 w-64" />
@@ -512,7 +512,7 @@ export function DevelopersPageSkeleton() {
             </div>
 
             {/* Tabs */}
-            <div className="border-b border-gray-200 dark:border-gray-700">
+            <div className="border-b border-divider">
               <div className="flex items-center gap-4 px-6">
                 <Skeleton className="h-10 w-24" />
                 <Skeleton className="h-10 w-32" />
@@ -534,7 +534,7 @@ export function DevelopersPageSkeleton() {
                 {[...Array(3)].map((_, i) => (
                   <div
                     key={i}
-                    className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-2"
+                    className="p-3 glass-inset space-y-2"
                   >
                     <div className="flex items-center justify-between">
                       <Skeleton className="h-4 w-24" />
@@ -554,7 +554,7 @@ export function DevelopersPageSkeleton() {
                 {[...Array(3)].map((_, i) => (
                   <div
                     key={i}
-                    className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-2"
+                    className="p-3 glass-inset space-y-2"
                   >
                     <div className="flex items-center justify-between">
                       <Skeleton className="h-4 w-24" />

--- a/apps/web/components/ui/loading-overlay.tsx
+++ b/apps/web/components/ui/loading-overlay.tsx
@@ -17,27 +17,22 @@ export function LoadingOverlay({
 
   return (
     <div
+      role="status"
+      aria-live="polite"
       className={cn(
-        "absolute inset-0 z-50 flex items-center justify-center bg-white/40 dark:bg-gray-900/40 backdrop-blur-sm",
+        "absolute inset-0 z-50 flex items-center justify-center bg-glass-chrome backdrop-blur-sm",
         className
       )}
     >
-      <div className="flex flex-col items-center gap-3 text-center px-6 py-4 bg-white/80 dark:bg-gray-900/80 rounded-lg shadow-lg">
-        <span className="relative flex h-12 w-12 items-center justify-center">
-          <span className="absolute inset-0 rounded-full border-2 border-transparent">
-            <span className="absolute inset-0 rounded-full border-[3px] border-blue-100 animate-pulse delay-150" />
-            <span className="absolute inset-2 rounded-full border-[3px] border-blue-300 animate-pulse delay-300" />
-            <span className="absolute inset-4 rounded-full border-[3px] border-blue-500 animate-pulse delay-500" />
-          </span>
-          <span className="absolute inset-0 rounded-full border-[3px] border-t-blue-500 border-r-transparent border-b-transparent animate-spin" />
+      <div className="glass flex flex-col items-center gap-3 px-6 py-4 text-center">
+        <span className="relative flex h-10 w-10 items-center justify-center">
+          <span className="absolute inset-0 rounded-full border-[3px] border-track" />
+          <span className="absolute inset-0 animate-spin rounded-full border-[3px] border-transparent border-t-brand" />
         </span>
         {label && (
-          <p className="text-sm font-medium text-gray-800 dark:text-gray-100">
-            {label}
-          </p>
+          <p className="text-sm font-semibold text-ink">{label}</p>
         )}
       </div>
     </div>
   );
 }
-

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -6,10 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn(
-        "animate-pulse rounded-md bg-gray-200 dark:bg-gray-700",
-        className
-      )}
+      className={cn("animate-pulse rounded-inset-sm bg-track", className)}
       {...props}
     />
   );

--- a/apps/web/lib/jwt-payload.test.ts
+++ b/apps/web/lib/jwt-payload.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
+
+const token = (payload: Record<string, unknown>, encoding: "base64" | "base64url" = "base64url") =>
+  `header.${Buffer.from(JSON.stringify(payload)).toString(encoding).replace(/=+$/, "")}.signature`;
+
+describe("decodeJwtPayload", () => {
+  it("decodes the base64url alphabet real JWTs use, with and without padding", () => {
+    let t = "";
+    for (let n = 1; n <= 3 && !/[-_]/.test(t); n++) t = token({ role: "admin", name: "?".repeat(n) });
+    expect(t).toMatch(/[-_]/);
+    expect(decodeJwtPayload(t)?.role).toBe("admin");
+    expect(decodeJwtPayload(token({ role: "member", exp: 1 }, "base64"))).toEqual({ role: "member", exp: 1 });
+  });
+
+  it("returns null for anything that is not a decodable JWT payload", () => {
+    for (const bad of ["not.a-jwt.at-all", "onlyonesegment", "", "a..b", "h.!!!.s"]) {
+      expect(decodeJwtPayload(bad), bad).toBeNull();
+    }
+    expect(decodeJwtPayload(null)).toBeNull();
+    expect(decodeJwtPayload(undefined)).toBeNull();
+    // A payload that decodes to a non-object (a JSON string) is not a claims set.
+    expect(decodeJwtPayload(`h.${Buffer.from('"just a string"').toString("base64url")}.s`)).toBeNull();
+  });
+});

--- a/apps/web/lib/jwt-payload.ts
+++ b/apps/web/lib/jwt-payload.ts
@@ -1,0 +1,29 @@
+/**
+ * Decodes the payload segment of a JWT for display and routing decisions only; nothing here
+ * verifies the signature, and no authorization may rest on the result (the backend verifies).
+ * JWT segments use the base64url alphabet, which atob() rejects; a token that cannot be
+ * decoded yields null so callers treat it as invalid instead of crashing.
+ */
+/** The claims this dashboard reads from its own session token (apps/backend/internal/infrastructure/auth/jwt.go). */
+export interface JwtClaims {
+  user_id?: string;
+  organization_id?: string;
+  email?: string;
+  role?: string;
+  exp?: number;
+  iat?: number;
+  sub?: string;
+  [claim: string]: unknown;
+}
+
+export function decodeJwtPayload(token: string | null | undefined): JwtClaims | null {
+  const segment = token?.split(".")[1];
+  if (!segment) return null;
+  const standard = segment.replace(/-/g, "+").replace(/_/g, "/");
+  try {
+    const parsed: unknown = JSON.parse(atob(standard));
+    return parsed && typeof parsed === "object" ? (parsed as JwtClaims) : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/navigation-edge.test.ts
+++ b/apps/web/lib/navigation-edge.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { filterNavigationByRole } from "@/lib/permissions";
+import { navigationBase } from "@/lib/navigation";
+import { ALL_ROLES, ROUTE_PERMISSIONS, effectiveEdgeRoles } from "@/lib/route-permissions";
+import { tabsForRole } from "@/components/mobile-tab-bar";
+
+/**
+ * The navigation and the edge gate must agree: nothing the navigation renders for a role may
+ * be a route the edge redirects that role away from. The reverse (edge wider than nav) is
+ * deliberate and not asserted. Both structures are imported, never restated, so a new nav
+ * item or gate entry is checked automatically.
+ */
+describe("navigation never shows a route the edge gate blocks", () => {
+  for (const role of ALL_ROLES) {
+    it(`role=${role}: every rendered nav href passes the edge intersection`, () => {
+      const sections = filterNavigationByRole(navigationBase, role);
+      for (const section of sections) {
+        for (const item of section.items) {
+          expect(
+            effectiveEdgeRoles(item.href),
+            `${item.name} (${item.href}) is shown to ${role} but the edge blocks it`
+          ).toContain(role);
+        }
+      }
+    });
+
+    it(`role=${role}: every mobile tab resolves for the role`, () => {
+      for (const tab of tabsForRole(role)) {
+        const path = tab.href.split("?")[0];
+        expect(
+          effectiveEdgeRoles(path),
+          `tab ${tab.name} (${tab.href}) is shown to ${role} but the edge blocks it`
+        ).toContain(role);
+      }
+    });
+  }
+
+  it("documents the intersection hazard: a specific entry cannot widen a broader prefix", () => {
+    // /dashboard/admin/alerts lists managers, but /dashboard/admin narrows it to admin.
+    expect(ROUTE_PERMISSIONS["/dashboard/admin/alerts"]).toContain("manager");
+    expect(effectiveEdgeRoles("/dashboard/admin/alerts")).toEqual(["admin"]);
+  });
+});

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -1,0 +1,100 @@
+import {
+  AlertTriangle,
+  Bell,
+  BookOpen,
+  CheckCircle,
+  CheckSquare,
+  ClipboardCheck,
+  Code,
+  GitBranch,
+  Home,
+  Key,
+  Link2,
+  Lock,
+  Search,
+  Server,
+  Shield,
+  ShieldCheck,
+  Tag,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import type { NavSection } from "@/lib/permissions";
+import type { Persona } from "@/lib/persona";
+
+export const SECTION_MAIN = "";
+export const SECTION_BUILD = "Developers";
+export const SECTION_MONITORING = "Security";
+export const SECTION_ACCOUNT = "Organization";
+
+/**
+ * Navigation with role-based access control. `roles` is the authorization
+ * filter (see filterNavigationByRole); the persona lens only reorders sections.
+ */
+export const navigationBase: NavSection[] = [
+  {
+    title: SECTION_MAIN,
+    items: [
+      { name: "Overview", href: "/dashboard", icon: Home, roles: ["admin", "manager", "member", "viewer"] },
+      { name: "Agents", href: "/dashboard/agents", icon: Shield, roles: ["admin", "manager", "member", "viewer"] },
+      { name: "MCP servers", href: "/dashboard/mcp", icon: Server, roles: ["admin", "manager", "member"] },
+      { name: "MCP discovery", href: "/dashboard/mcp/discovery", icon: Search, roles: ["admin", "manager"] },
+      { name: "Supply chain", href: "/dashboard/mcp/supply-chain", icon: GitBranch, roles: ["admin", "manager"] },
+      { name: "A2A protocol", href: "/dashboard/a2a", icon: Link2, roles: ["admin", "manager", "member"] },
+    ],
+  },
+  {
+    title: SECTION_BUILD,
+    items: [
+      { name: "API keys", href: "/dashboard/api-keys", icon: Key, roles: ["admin", "manager", "member"] },
+      { name: "SDK tokens", href: "/dashboard/sdk-tokens", icon: Lock, roles: ["admin", "manager", "member"] },
+      { name: "SDK & docs", href: "/dashboard/sdk", icon: Code, roles: ["admin", "manager", "member"] },
+      { name: "Developer guide", href: "/dashboard/developers", icon: BookOpen, roles: ["admin", "manager", "member", "viewer"] },
+    ],
+  },
+  {
+    title: SECTION_MONITORING,
+    items: [
+      { name: "Security", href: "/dashboard/security", icon: AlertTriangle, roles: ["admin", "manager"] },
+      // Interim: the edge gate's /dashboard/admin prefix rule blocks managers from this page
+      // (middleware.ts / proxy.ts intersect all matching prefixes), so the nav must not show it
+      // to managers until the IA move relocates alerts out of the admin prefix.
+      { name: "Alerts", href: "/dashboard/admin/alerts", icon: Bell, roles: ["admin"] },
+    ],
+  },
+  {
+    // Administering your own organization (every signup administers its own account).
+    title: SECTION_ACCOUNT,
+    items: [
+      // The approval queue for new accounts (the registration-pending page points here).
+      { name: "Registrations", href: "/admin/registrations", icon: UserPlus, roles: ["admin"] },
+      { name: "JIT requests", href: "/dashboard/admin/jit-requests", icon: CheckCircle, roles: ["admin"] },
+      { name: "Capability requests", href: "/dashboard/admin/capability-requests", icon: CheckSquare, roles: ["admin"] },
+      { name: "Security policies", href: "/dashboard/admin/security-policies", icon: ShieldCheck, roles: ["admin"] },
+      { name: "Compliance", href: "/dashboard/admin/compliance", icon: ClipboardCheck, roles: ["admin"] },
+      { name: "Users", href: "/dashboard/admin/users", icon: Users, roles: ["admin"] },
+      { name: "Tags", href: "/dashboard/tags", icon: Tag, roles: ["admin", "manager", "member"] },
+    ],
+  },
+];
+
+const SECTION_ORDER: Record<Persona, string[]> = {
+  developer: [SECTION_MAIN, SECTION_BUILD, SECTION_MONITORING, SECTION_ACCOUNT],
+  security: [SECTION_MONITORING, SECTION_MAIN, SECTION_ACCOUNT, SECTION_BUILD],
+  executive: [SECTION_MAIN, SECTION_ACCOUNT, SECTION_MONITORING, SECTION_BUILD],
+};
+
+/**
+ * Reorders already-authorized sections for a lens. Pure and lossless: it never
+ * adds, removes or renames an item, so authorization stays exactly what the
+ * role filter produced (proved by lib/persona.test.ts).
+ */
+export function orderNavigationForPersona(sections: NavSection[], persona: Persona): NavSection[] {
+  const order = SECTION_ORDER[persona] ?? SECTION_ORDER.developer;
+  const rank = (title?: string) => {
+    const i = order.indexOf(title ?? SECTION_MAIN);
+    return i === -1 ? order.length : i;
+  };
+  return [...sections].sort((a, b) => rank(a.title) - rank(b.title));
+}
+

--- a/apps/web/lib/persona.test.ts
+++ b/apps/web/lib/persona.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { filterNavigationByRole, type UserRole } from "@/lib/permissions";
+import { navigationBase, orderNavigationForPersona } from "@/lib/navigation";
+import { PERSONAS, personaFromSignupRole, type Persona } from "@/lib/persona";
+
+const ROLES: (UserRole | undefined)[] = ["admin", "manager", "member", "viewer", undefined];
+const hrefs = (sections: ReturnType<typeof filterNavigationByRole>) =>
+  sections.flatMap((s) => s.items.map((i) => i.href)).sort();
+
+describe("persona lens never changes authorization", () => {
+  for (const role of ROLES) {
+    for (const { value: persona } of PERSONAS) {
+      it(`role=${role ?? "none"} persona=${persona}: same hrefs as the role filter`, () => {
+        const authorized = filterNavigationByRole(navigationBase, role);
+        const lensed = orderNavigationForPersona(authorized, persona);
+        expect(hrefs(lensed)).toEqual(hrefs(authorized));
+        // Every item keeps its roles array untouched (no lens-side widening).
+        for (const section of lensed) {
+          for (const item of section.items) {
+            expect(role === undefined || item.roles.includes(role)).toBe(true);
+          }
+        }
+      });
+    }
+  }
+
+  it("a lens for an unknown persona value falls back to the developer order", () => {
+    const authorized = filterNavigationByRole(navigationBase, "admin");
+    expect(orderNavigationForPersona(authorized, "nope" as Persona)).toEqual(
+      orderNavigationForPersona(authorized, "developer")
+    );
+  });
+
+});
+
+describe("personaFromSignupRole", () => {
+  it("maps the signup roles onto the three lenses", () => {
+    expect(personaFromSignupRole("developer")).toBe("developer");
+    expect(personaFromSignupRole("student-or-researcher")).toBe("developer");
+    expect(personaFromSignupRole("security-engineer")).toBe("security");
+    expect(personaFromSignupRole("founder-or-exec")).toBe("executive");
+    expect(personaFromSignupRole("other")).toBe("developer");
+    expect(personaFromSignupRole(undefined)).toBe("developer");
+  });
+});

--- a/apps/web/lib/persona.ts
+++ b/apps/web/lib/persona.ts
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * Persona lens: a PRESENTATION preference, never an authorization boundary.
+ *
+ * The lens reorders and emphasizes what an already-authorized user sees first
+ * (developer / security practitioner / executive). It must never be consulted
+ * to decide whether a route, object or action is permitted: that stays with
+ * `getDashboardPermissions()` in lib/permissions.ts and the route gates. A
+ * surface that shows something in one lens that the role cannot reach in
+ * another is a defect (see lib/persona.test.ts).
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type Persona = "developer" | "security" | "executive";
+
+export const PERSONAS: ReadonlyArray<{ value: Persona; label: string; short: string; description: string }> = [
+  { value: "developer", label: "Developer", short: "Dev", description: "Your agents, the quickstart and your keys first." },
+  { value: "security", label: "Security", short: "Sec", description: "What needs attention, the verification stream and policy first." },
+  { value: "executive", label: "Executive", short: "Exec", description: "Posture, coverage and one recommended action first." },
+];
+
+export function isPersona(value: unknown): value is Persona {
+  return value === "developer" || value === "security" || value === "executive";
+}
+
+/** Maps a signup role (the hosted deployment's profile question) to the initial lens. */
+export function personaFromSignupRole(role?: string | null): Persona {
+  switch (role) {
+    case "security-engineer":
+      return "security";
+    case "founder-or-exec":
+      return "executive";
+    case "developer":
+    case "student-or-researcher":
+    default:
+      return "developer";
+  }
+}
+
+
+type PersonaSource = "default" | "signup" | "user";
+
+interface PersonaState {
+  persona: Persona;
+  source: PersonaSource;
+  /** Explicit user choice (the switcher). Always wins and is remembered. */
+  setPersona: (persona: Persona) => void;
+  /**
+   * Seeds the lens from the role collected at signup unless the user already picked one. Fed
+   * only where /auth/me returns a signup profile (the hosted deployment); elsewhere it is never
+   * called.
+   */
+  seedFromSignupRole: (role?: string | null) => void;
+}
+
+export const usePersona = create<PersonaState>()(
+  persist(
+    (set, get) => ({
+      persona: "developer",
+      source: "default",
+      setPersona: (persona) => set({ persona, source: "user" }),
+      seedFromSignupRole: (role) => {
+        if (get().source === "user") return;
+        set({ persona: personaFromSignupRole(role), source: "signup" });
+      },
+    }),
+    {
+      name: "aim.persona",
+      version: 1,
+      partialize: (state) => ({ persona: state.persona, source: state.source }),
+    }
+  )
+);

--- a/apps/web/lib/route-permissions.ts
+++ b/apps/web/lib/route-permissions.ts
@@ -1,0 +1,37 @@
+/**
+ * Role requirements for dashboard routes, enforced at the edge (middleware.ts in the OSS
+ * build, proxy.ts on the hosted product). Kept in one module so the navigation tests can
+ * assert that nothing the navigation renders is blocked by the edge.
+ *
+ * Matching semantics (mirrors the edge loop exactly): every entry whose path is a prefix of
+ * the requested pathname applies, and access requires the role to be in EVERY matching
+ * entry — an intersection, because the loop denies on any failing match and does not break.
+ * Consequence worth knowing: a specific entry cannot WIDEN what a broader prefix allows
+ * (e.g. '/dashboard/admin/alerts' listing managers is still narrowed to admin by
+ * '/dashboard/admin').
+ */
+import type { UserRole } from "@/lib/permissions";
+
+export const ROUTE_PERMISSIONS: Record<string, UserRole[]> = {
+  // Top-level /admin (registration review lives here in the OSS tree): admins only.
+  // Measured 2026-08-24: without this entry the proxy passed any authenticated role.
+  "/admin": ["admin"],
+  "/dashboard/admin": ["admin"],
+  "/dashboard/admin/users": ["admin"],
+  "/dashboard/admin/alerts": ["admin", "manager"],
+  "/dashboard/admin/audit": ["admin", "manager"],
+  "/dashboard/admin/security-policies": ["admin"],
+  "/dashboard/admin/capability-requests": ["admin"],
+  "/dashboard/security": ["admin", "manager", "member"],
+};
+
+export const ALL_ROLES: UserRole[] = ["admin", "manager", "member", "viewer"];
+
+/** Roles the edge allows for a pathname: the intersection of all matching prefix entries. */
+export function effectiveEdgeRoles(pathname: string): UserRole[] {
+  return ALL_ROLES.filter((role) =>
+    Object.entries(ROUTE_PERMISSIONS).every(
+      ([prefix, roles]) => !pathname.startsWith(prefix) || roles.includes(role)
+    )
+  );
+}

--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "@/middleware";
+import { ALL_ROLES, ROUTE_PERMISSIONS, effectiveEdgeRoles } from "@/lib/route-permissions";
+
+/**
+ * The edge gate exercised end to end: a request carrying a role cookie either passes
+ * (NextResponse.next) or is redirected. The nav/edge parity suite proves the navigation
+ * agrees with the permission map; only these tests prove the middleware enforces it.
+ * Mutation check: delete the "/admin" entry in lib/route-permissions.ts and the viewer case
+ * goes red; restore the strict atob() decode and the base64url case goes red.
+ */
+const ORIGIN = "http://localhost:3000";
+
+const token = (payload: Record<string, unknown>, encoding: "base64" | "base64url" = "base64") =>
+  `header.${Buffer.from(JSON.stringify(payload)).toString(encoding).replace(/=+$/, "")}.signature`;
+
+function request(pathname: string, cookie?: string) {
+  return new NextRequest(
+    new URL(pathname, ORIGIN),
+    cookie ? { headers: { cookie: `access_token=${cookie}` } } : undefined
+  );
+}
+
+function verdict(res: Response) {
+  const location = res.headers.get("location");
+  if (location) return { kind: "redirect" as const, to: new URL(location).pathname };
+  return { kind: "pass" as const, to: null };
+}
+
+describe("edge gate", () => {
+  it("redirects an unauthenticated request to login and keeps the return path", () => {
+    const res = middleware(request("/admin/registrations"));
+    expect(res.status).toBe(307);
+    const to = new URL(res.headers.get("location") ?? "");
+    expect(to.pathname).toBe("/auth/login");
+    expect(to.searchParams.get("returnUrl")).toBe("/admin/registrations");
+  });
+
+  it("sends a viewer who opens the registration review queue to /dashboard/forbidden", () => {
+    expect(verdict(middleware(request("/admin/registrations", token({ role: "viewer" }))))).toEqual({
+      kind: "redirect",
+      to: "/dashboard/forbidden",
+    });
+  });
+
+  it("lets an admin through to the registration review queue", () => {
+    expect(verdict(middleware(request("/admin/registrations", token({ role: "admin" })))).kind).toBe("pass");
+  });
+
+  it("lets a pending account reach ungated pages and keeps it out of gated ones", () => {
+    expect(verdict(middleware(request("/dashboard", token({ role: "pending" })))).kind).toBe("pass");
+    expect(verdict(middleware(request("/dashboard/security", token({ role: "pending" }))))).toEqual({
+      kind: "redirect",
+      to: "/dashboard/forbidden",
+    });
+  });
+
+  it("redirects a token whose payload is not JSON to login", () => {
+    expect(verdict(middleware(request("/dashboard", "not.a-jwt.at-all")))).toEqual({
+      kind: "redirect",
+      to: "/auth/login",
+    });
+  });
+
+  it("accepts the base64url alphabet real JWTs are encoded with", () => {
+    // A '?' in a claim encodes to the url-safe '_' when it lands on the last byte of a
+    // triple; a strict atob() rejects that alphabet and would bounce the user to login.
+    let t = "";
+    for (let n = 1; n <= 3 && !/[-_]/.test(t); n++) {
+      t = token({ role: "admin", name: "?".repeat(n) }, "base64url");
+    }
+    expect(t).toMatch(/[-_]/);
+    expect(verdict(middleware(request("/dashboard/agents", t))).kind).toBe("pass");
+  });
+
+  it("leaves public and backend-proxied routes alone without a cookie", () => {
+    for (const p of ["/auth/login", "/auth/register", "/auth/reset-password", "/api/v1/agents", "/health"]) {
+      expect(verdict(middleware(request(p))).kind, p).toBe("pass");
+    }
+  });
+
+  describe("agrees with effectiveEdgeRoles for every gated prefix and role", () => {
+    for (const prefix of Object.keys(ROUTE_PERMISSIONS)) {
+      for (const role of ALL_ROLES) {
+        it(`${role} -> ${prefix}`, () => {
+          const allowed = effectiveEdgeRoles(prefix).includes(role);
+          const v = verdict(middleware(request(prefix, token({ role }))));
+          expect(v.kind).toBe(allowed ? "pass" : "redirect");
+          if (!allowed) expect(v.to).toBe("/dashboard/forbidden");
+        });
+      }
+    }
+  });
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,15 +2,9 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 // Define role-based route protection
-const ROUTE_PERMISSIONS: Record<string, string[]> = {
-  '/dashboard/admin': ['admin'],
-  '/dashboard/admin/users': ['admin'],
-  '/dashboard/admin/alerts': ['admin', 'manager'],
-  '/dashboard/admin/audit': ['admin', 'manager'],
-  '/dashboard/admin/security-policies': ['admin'],
-  '/dashboard/admin/capability-requests': ['admin'],
-  '/dashboard/security': ['admin', 'manager', 'member'],
-};
+import { ROUTE_PERMISSIONS } from './lib/route-permissions';
+import { decodeJwtPayload } from './lib/jwt-payload';
+import type { UserRole } from './lib/permissions';
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -41,17 +35,18 @@ export function middleware(request: NextRequest) {
   }
 
   try {
-    // Decode JWT to get role (basic check, real validation happens server-side)
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    const userRole = payload?.role;
+    // Decode JWT to get role (basic check, real validation happens server-side).
+    const payload = decodeJwtPayload(token);
+    if (!payload) throw new Error('token payload is not decodable');
+    const userRole = payload.role;
 
     // Normalize "pending" role to "viewer"
-    const normalizedRole = userRole === 'pending' ? 'viewer' : userRole;
+    const normalizedRole = (userRole === 'pending' ? 'viewer' : userRole) as UserRole | undefined;
 
     // Check if current route requires specific role
     for (const [route, allowedRoles] of Object.entries(ROUTE_PERMISSIONS)) {
       if (pathname.startsWith(route)) {
-        if (!allowedRoles.includes(normalizedRole)) {
+        if (!normalizedRole || !allowedRoles.includes(normalizedRole)) {
           // User doesn't have required role, redirect to forbidden page
           return NextResponse.redirect(new URL('/dashboard/forbidden', request.url));
         }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "date-fns": "^3.6.0",
     "lucide-react": "^0.363.0",
     "next": "^16.2.3",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.51.2",

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -16,38 +16,29 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['var(--font-sans)'],
+        mono: ['var(--font-mono)'],
+      },
       colors: {
-        primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          900: '#1e3a8a',
-          DEFAULT: '#2563eb',
-          foreground: '#ffffff',
-        },
-        secondary: {
-          DEFAULT: '#7c3aed',
-          foreground: '#ffffff',
-        },
-        success: {
-          DEFAULT: '#10b981',
-          foreground: '#ffffff',
-        },
-        destructive: {
-          DEFAULT: '#ef4444',
-          foreground: '#ffffff',
-        },
-        warning: {
-          DEFAULT: '#f59e0b',
-          foreground: '#ffffff',
-        },
+        // shadcn-compatible semantic colors; every value lives in app/globals.css
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
         muted: {
           DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',
@@ -64,11 +55,105 @@ module.exports = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        // Glasshouse tokens
+        brand: {
+          DEFAULT: 'var(--brand)',
+          hover: 'var(--brand-hover)',
+          text: 'var(--brand-text)',
+          soft: 'var(--brand-soft)',
+          sky: 'var(--brand-sky)',
+          indigo: 'var(--brand-indigo)',
+        },
+        success: {
+          DEFAULT: 'var(--green)',
+          text: 'var(--green-text)',
+          fill: 'var(--green-fill)',
+          border: 'var(--green-border)',
+          foreground: '#ffffff',
+        },
+        warning: {
+          DEFAULT: 'var(--amber)',
+          text: 'var(--amber-text)',
+          fill: 'var(--amber-fill)',
+          border: 'var(--amber-border)',
+          foreground: '#1d1d1f',
+        },
+        danger: {
+          DEFAULT: 'var(--red)',
+          strong: 'var(--red-strong)',
+          text: 'var(--red-text)',
+          fill: 'var(--red-fill)',
+          border: 'var(--red-border)',
+          foreground: '#ffffff',
+        },
+        ink: {
+          DEFAULT: 'var(--text-primary)',
+          body: 'var(--text-body)',
+          secondary: 'var(--text-secondary)',
+          tertiary: 'var(--text-tertiary)',
+          inverse: 'var(--text-inverse)',
+          'inverse-secondary': 'var(--text-inverse-secondary)',
+          code: 'var(--text-code)',
+        },
+        glass: {
+          DEFAULT: 'var(--glass-fill)',
+          border: 'var(--glass-border)',
+          chrome: 'var(--glass-chrome-fill)',
+          'chrome-border': 'var(--glass-chrome-border)',
+          inset: 'var(--surface-inset)',
+          'inset-border': 'var(--surface-inset-border)',
+          'inset-gray': 'var(--surface-inset-gray)',
+          contrast: 'var(--surface-contrast)',
+          'contrast-border': 'var(--surface-contrast-border)',
+          code: 'var(--code-fill)',
+        },
+        segment: {
+          track: 'var(--segment-track)',
+          active: 'var(--segment-active)',
+          text: 'var(--segment-inactive-text)',
+        },
+        nav: {
+          active: 'var(--nav-active-fill)',
+        },
+        divider: 'var(--divider)',
+        track: 'var(--track)',
+        stroke: 'var(--stroke)',
+        page: 'var(--bg-page-solid)',
       },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+        pill: '980px',
+        chrome: '22px',
+        card: '20px',
+        'card-sm': '18px',
+        panel: '16px',
+        inset: '14px',
+        'inset-sm': '12px',
+        nav: '11px',
+        avatar: '10px',
+      },
+      // Keys here must not collide with color names (colors.card / colors.accent would make
+      // Tailwind emit a second .shadow-* rule for the ring color); hence panel/glow.
+      boxShadow: {
+        panel: 'var(--shadow-card)',
+        chrome: 'var(--shadow-chrome)',
+        modal: 'var(--shadow-modal)',
+        glow: 'var(--brand-shadow)',
+        segment: 'var(--segment-active-shadow)',
+      },
+      backdropBlur: {
+        card: '20px',
+        chrome: '24px',
+      },
+      backgroundImage: {
+        logo: 'var(--gradient-logo)',
+        bar: 'var(--gradient-bar)',
+        'page-gradient': 'var(--bg-page)',
+      },
+      fontSize: {
+        '2xs': ['10.5px', { lineHeight: '1.3' }],
       },
       keyframes: {
         'accordion-down': {
@@ -79,10 +164,16 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: 0 },
         },
+        'pulse-ring': {
+          '0%': { boxShadow: '0 0 0 0 var(--brand-soft)' },
+          '70%': { boxShadow: '0 0 0 8px transparent' },
+          '100%': { boxShadow: '0 0 0 0 transparent' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'pulse-ring': 'pulse-ring 1.8s ease-out infinite',
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-identity-management",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-identity-management",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/*",
@@ -24,7 +24,7 @@
     },
     "apps/web": {
       "name": "@aim/web",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@hookform/resolvers": "^3.3.4",
@@ -51,6 +51,7 @@
         "date-fns": "^3.6.0",
         "lucide-react": "^0.363.0",
         "next": "^16.2.3",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.51.2",
@@ -1425,6 +1426,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1446,6 +1448,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1455,12 +1458,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1640,6 +1645,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1653,6 +1659,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1662,6 +1669,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1704,7 +1712,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -3676,7 +3684,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3686,7 +3694,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4500,12 +4508,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4519,6 +4529,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4843,6 +4854,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4866,6 +4878,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4972,6 +4985,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5028,6 +5042,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5052,6 +5067,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5117,6 +5133,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5169,6 +5186,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5618,12 +5636,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5781,6 +5801,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6477,6 +6498,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6486,6 +6508,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6516,6 +6539,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6596,6 +6620,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6610,6 +6635,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6749,6 +6775,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6885,6 +6912,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7087,6 +7115,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7139,6 +7168,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7189,6 +7219,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7234,6 +7265,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7272,6 +7304,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7482,6 +7515,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7930,6 +7964,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7942,6 +7977,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8045,6 +8081,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -8054,6 +8091,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -8097,6 +8135,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -8198,6 +8237,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8266,6 +8315,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8284,6 +8334,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8548,6 +8599,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -8567,6 +8619,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8579,6 +8632,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8588,6 +8642,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8597,7 +8652,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -8616,7 +8671,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8639,6 +8694,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8667,6 +8723,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8684,6 +8741,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8705,6 +8763,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8730,6 +8789,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8772,6 +8832,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8797,6 +8858,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8810,6 +8872,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8897,6 +8960,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9071,6 +9135,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -9080,6 +9145,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -9228,6 +9294,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -9279,6 +9346,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9802,6 +9870,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -9837,6 +9906,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9866,6 +9936,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -9912,6 +9983,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9928,6 +10000,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9940,6 +10013,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9961,6 +10035,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -9970,6 +10045,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -10005,6 +10081,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10021,6 +10098,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10063,6 +10141,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10114,6 +10193,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -10453,6 +10533,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {


### PR DESCRIPTION
First of six stacked pull requests that move the dashboard onto the Glasshouse design system; the whole change is #418, split so each part fits the automated review. Merge order: this one first.

## What this part contains

**Theme.** Design tokens (frosted-glass surfaces, one accent, text tiers, radii, blur, shadows) as CSS custom properties in a light and a dark scheme, wired through Tailwind; a class-based theme provider (`next-themes`) that follows the system preference until the user picks one. The default stays light until every page has been moved onto the tokens. The Tailwind primary/secondary/destructive colours were literal hex values that bypassed the CSS variables. Button, card, badge, skeleton and loading overlay rebuilt on tokens; `not-found`, `error` and `loading` routes replace the stock Next.js pages. The light scheme's code colour (6.1:1) and the filled destructive button (5.4:1) meet WCAG AA.

**Shell.** Floating glass sidebar (sticky; badges matched by route and rebuilt from the live counts on every lens switch) with a Developer / Security / Executive lens that reorders navigation for the reader in front of it. The lens is a presentation preference only: it never adds or removes a destination beyond the role filter, and `lib/persona.test.ts` proves that for every role and lens. Bottom tab bar on small screens fitted to what each role may open; sentence-case labels; a Registrations entry for the account approval queue.

**Edge gate.** The route-permission map moves to `lib/route-permissions.ts` and gains the `/admin` prefix, which had no entry: any authenticated role could open the registration review queue. `lib/navigation-edge.test.ts` asserts nothing the navigation or tab bar renders is edge-blocked; `middleware.test.ts` exercises the gate for every prefix and role. The gate decodes token payloads with the base64url alphabet JWTs use; a strict `atob()` sent users whose claims contained `?`, `~`, `>` or a non-ASCII character back to login.

## Verification

- `apps/web`: `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch alone.
- Edge gate probed live: no cookie -> login; viewer -> `/admin/registrations` -> `/dashboard/forbidden`; admin passes; base64url payload passes. Mutation check on the new suite: removing the `/admin` entry, restoring the strict decode, disabling the role check and redirecting elsewhere each turn the named tests red.
- Sidebar stays at its sticky offset after scrolling (probed at 1440 px); no horizontal overflow at 375 px.
