### PR TITLE
Glasshouse overview with Developer, Security and Executive lenses

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,52 +1,27 @@
 "use client";
 
-import { useState, useEffect, Suspense, useCallback } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { toast } from "sonner";
-import {
-  Shield,
-  Users,
-  Activity,
-  TrendingUp,
-  AlertTriangle,
-  CheckCircle,
-  Clock,
-  Loader2,
-  AlertCircle,
-  ExternalLink,
-  XCircle,
-  Server,
-  Bot,
-  Key,
-  FileCheck,
-  ShieldCheck,
-  ArrowRight,
-  Eye,
-} from "lucide-react";
-import {
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  Legend,
-  Cell,
-  PieChart,
-  Pie,
-} from "recharts";
-import { api } from "@/lib/api";
+import { formatDistanceToNowStrict } from "date-fns";
+import { ArrowRight, Bell, Server, ShieldCheck, ShieldPlus } from "lucide-react";
+import { api, type Agent } from "@/lib/api";
 import { getDashboardPermissions, type UserRole } from "@/lib/permissions";
-import { TimezoneIndicator } from "@/components/timezone-indicator";
+import { effectiveEdgeRoles } from "@/lib/route-permissions";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { getErrorMessage } from "@/lib/error-messages";
-import {
-  DashboardSkeleton,
-  ChartSkeleton,
-} from "@/components/ui/content-loaders";
+import { usePersona } from "@/lib/persona";
 import { AuthGuard } from "@/components/auth-guard";
 import { ActivityTimeline } from "@/components/analytics/activity-timeline";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SecurityLens } from "@/components/overview/security-lens";
+import { ExecutiveLens } from "@/components/overview/executive-lens";
+import type { LensData } from "@/components/overview/types";
+import { cn } from "@/lib/utils";
+
+/* ----------------------------------------------------------------------------
+ * Data
+ * ------------------------------------------------------------------------- */
 
 interface DashboardStats {
   totalAgents: number;
@@ -64,729 +39,543 @@ interface DashboardStats {
   organizationId: string;
 }
 
-interface VerificationActivityData {
-  period: string;
-  activity: Array<{
-    month: string;
-    verified: number;
-    pending: number;
-    agentsVerified: number;
-    agentsPending: number;
-    mcpVerified: number;
-    mcpPending: number;
-    monthYear: string;
-  }>;
-  currentStats: {
-    totalVerified: number;
-    totalPending: number;
-    totalAgents: number;
-    totalMCP: number;
-    agentsVerified: number;
-    agentsPending: number;
-    mcpVerified: number;
-    mcpPending: number;
-  };
+interface VerificationStatistics {
+  totalVerifications: number;
+  successCount: number;
+  failedCount: number;
+  pendingCount: number;
+  uniqueAgentsVerified: number;
 }
 
-interface MCPServerEntry {
-  id: string;
-  name: string;
-  url: string;
-  status: "active" | "inactive" | "pending" | "verified" | "suspended" | "revoked";
-  isVerified?: boolean;
-  confidenceScore?: number;
-  attestationCount?: number;
-  lastVerifiedAt?: string;
-  createdAt: string;
+interface VerificationActivityMonth {
+  month: string;
+  verified: number;
+  pending: number;
+  monthYear: string;
 }
 
-// Compact stat card for key metrics
-function KeyMetricCard({ label, value, icon: Icon, color, trend }: {
+interface HomeData {
+  stats: DashboardStats | null;
+  verification: VerificationStatistics | null;
+  activity: VerificationActivityMonth[];
+  agents: Agent[];
+  user: { name: string; role: UserRole } | null;
+}
+
+// The canonical quickstart. Every surface that teaches the install path must match this.
+// Python only: the npm SDK does not export secure() and ships no aim-sdk binary (measured
+// 2026-08-24, @opena2a/aim-sdk 1.3.0), so a TypeScript command block would not run.
+export const QUICKSTART_LANGS = ["python"] as const;
+type QuickstartLang = (typeof QUICKSTART_LANGS)[number];
+
+/**
+ * `aim-sdk login` defaults to the hosted service (sdk/python/aim_sdk/cli.py DEFAULT_AIM_URL);
+ * a self-hosted dashboard passes its own origin, which proxies /api to the backend.
+ */
+export function quickstartLines(lang: QuickstartLang, origin: string): readonly string[] {
+  const login = origin ? `aim-sdk login --url ${origin}` : "aim-sdk login";
+  switch (lang) {
+    case "python":
+    default:
+      return ["pip install aim-sdk", login, 'python -c "from aim_sdk import secure; secure(\\"my-first-agent\\")"'];
+  }
+}
+
+/** The page origin, known only in the browser (empty during prerender). */
+function useOrigin() {
+  const [origin, setOrigin] = useState("");
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+  return origin;
+}
+
+/** The role claim of the session token, for when /users/me is unavailable; pending reads as viewer. */
+function roleFromToken(): UserRole {
+  const role = decodeJwtPayload(api.getToken())?.role;
+  return role === "admin" || role === "manager" || role === "member" ? role : "viewer";
+}
+
+function greeting(name?: string) {
+  const h = new Date().getHours();
+  const part = h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening";
+  return name ? `${part}, ${name}` : part;
+}
+
+function firstName(user: { name?: string; email?: string } | null | undefined) {
+  const n = user?.name?.trim();
+  if (n) return n.split(/\s+/)[0];
+  return user?.email?.split("@")[0] ?? "";
+}
+
+function relative(iso?: string) {
+  if (!iso) return "";
+  try {
+    return formatDistanceToNowStrict(new Date(iso), { addSuffix: true });
+  } catch {
+    return "";
+  }
+}
+
+const AVATAR_TINTS = [
+  "from-[#e0f2fe] to-[#bae6fd] text-[#0369a1] dark:from-[#0c4a6e] dark:to-[#075985] dark:text-[#7dd3fc]",
+  "from-[#ede9fe] to-[#ddd6fe] text-[#6d28d9] dark:from-[#4c1d95] dark:to-[#5b21b6] dark:text-[#c4b5fd]",
+  "from-[#dcfce7] to-[#bbf7d0] text-[#15803d] dark:from-[#14532d] dark:to-[#166534] dark:text-[#86efac]",
+  "from-[#ffe4e6] to-[#fecdd3] text-[#be123c] dark:from-[#881337] dark:to-[#9f1239] dark:text-[#fda4af]",
+];
+
+/* ----------------------------------------------------------------------------
+ * Pieces
+ * ------------------------------------------------------------------------- */
+
+function KpiTile({
+  label,
+  value,
+  delta,
+  tone = "default",
+  href,
+}: {
   label: string;
-  value: string | number;
-  icon: any;
-  color: string;
-  trend?: { value: string; positive: boolean };
+  value: string;
+  delta?: string;
+  tone?: "default" | "accent" | "alert";
+  href?: string;
 }) {
+  const body = (
+    <>
+      <p className={cn("text-xs font-semibold", tone === "alert" ? "text-danger-text" : "text-ink-secondary")}>{label}</p>
+      <p className={cn("text-kpi mt-2", tone === "accent" && "text-brand-text", tone === "alert" && "text-danger-text")}>{value}</p>
+      {delta ? <p className="mt-1 text-xs font-semibold text-ink-secondary">{delta}</p> : null}
+    </>
+  );
+  const cls = cn(tone === "alert" ? "glass-alert" : "glass", "block p-5 transition-transform", href && "hover:-translate-y-0.5");
+  return href ? (
+    <Link href={href} className={cls}>
+      {body}
+    </Link>
+  ) : (
+    <div className={cls}>{body}</div>
+  );
+}
+
+function CodeBlock({ lines, className }: { lines: readonly string[]; className?: string }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className={`p-2 rounded-lg ${color}`}>
-            <Icon className="h-5 w-5 text-white" />
-          </div>
-          <div>
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
-          </div>
+    <pre className={cn("code-block", className)} aria-label="Commands">
+      {lines.map((l, i) => (
+        <span key={i} className="block">
+          <span className="select-none text-ink-inverse-secondary">$ </span>
+          {l}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
+function OriginQuickstart({ className }: { className?: string }) {
+  const origin = useOrigin();
+  return <CodeBlock lines={quickstartLines("python", origin)} className={className} />;
+}
+
+function Quickstart({ compact = false }: { compact?: boolean }) {
+  const [lang, setLang] = useState<QuickstartLang>("python");
+  const origin = useOrigin();
+  return (
+    <div className={cn("glass-contrast flex min-w-0 flex-col gap-3 overflow-hidden p-5", compact && "p-4")}>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-[13.5px] font-bold">Quickstart</h3>
+        <div className="flex gap-1.5" role="tablist" aria-label="Language">
+          {QUICKSTART_LANGS.map((k) => (
+            <button
+              key={k}
+              type="button"
+              role="tab"
+              aria-selected={lang === k}
+              onClick={() => setLang(k)}
+              className={cn(
+                "rounded-pill px-3 py-1 text-2xs font-bold transition-colors",
+                lang === k ? "bg-brand text-white shadow-glow" : "bg-white/10 text-ink-inverse-secondary hover:text-ink-inverse"
+              )}
+            >
+              {k === "python" ? "Python" : "TypeScript"}
+            </button>
+          ))}
         </div>
-        {trend && (
-          <div className={`text-xs font-medium ${trend.positive ? "text-green-600" : "text-red-600"}`}>
-            {trend.value}
-          </div>
+      </div>
+      <CodeBlock lines={quickstartLines(lang, origin)} />
+      <p className="text-xs leading-relaxed text-ink-inverse-secondary">
+        The SDK creates an Ed25519 keypair on your machine, registers the agent under your account and stores the credentials in{" "}
+        <span className="font-mono text-ink-inverse">~/.aim/</span>. The private key never leaves your machine.
+      </p>
+      <Link href="/dashboard/developers" className="inline-flex items-center gap-1.5 self-start rounded-pill bg-white/10 px-4 py-2 text-xs font-bold text-ink-inverse hover:bg-white/15">
+        Open the developer guide <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+      </Link>
+    </div>
+  );
+}
+
+function VerificationActivityCard({ activity }: { activity: VerificationActivityMonth[] }) {
+  const max = Math.max(1, ...activity.map((m) => m.verified + m.pending));
+  return (
+    <div className="glass flex flex-col p-5">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[13.5px] font-bold text-ink">Verification activity</h3>
+        {activity.length > 0 && (
+          <span className="text-2xs text-ink-tertiary">last {activity.length} months</span>
         )}
       </div>
+      {activity.length === 0 ? (
+        <p className="mt-3 text-xs text-ink-secondary">No verifications yet. They show up here as your agents check in.</p>
+      ) : (
+        <>
+          <div className="mt-3 flex h-16 items-end gap-1.5" role="img" aria-label={`Verified per month: ${activity.map((m) => `${m.month} ${m.verified}`).join(", ")}`}>
+            {activity.map((m, i) => {
+              const total = m.verified + m.pending;
+              const h = Math.max(4, Math.round((total / max) * 100));
+              const last = i === activity.length - 1;
+              return (
+                <div key={m.monthYear} className="flex flex-1 flex-col justify-end" style={{ height: "100%" }} title={`${m.month}: ${m.verified} verified, ${m.pending} pending`}>
+                  <div className="w-full rounded-[4px] bg-brand" style={{ height: `${h}%`, opacity: last ? 1 : 0.2 + 0.5 * (total / max) }} />
+                </div>
+              );
+            })}
+          </div>
+          <div className="mt-2 flex justify-between text-2xs text-ink-tertiary">
+            <span>{activity[0]?.month}</span>
+            <span>{activity[activity.length - 1]?.month}</span>
+          </div>
+        </>
+      )}
     </div>
   );
 }
 
-function ErrorDisplay({ message, onRetry }: { message: string; onRetry: () => void }) {
+function AgentsCard({ agents, total }: { agents: Agent[]; total: number }) {
   return (
-    <div className="flex items-center justify-center min-h-[400px]">
-      <div className="flex flex-col items-center gap-4 max-w-md text-center">
-        <AlertCircle className="h-12 w-12 text-red-500" />
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          Something went wrong!
-        </h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
-        <button
-          onClick={onRetry}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-        >
-          Retry
-        </button>
+    <div className="glass flex flex-col p-5">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[15px] font-bold tracking-[-0.02em] text-ink">Agents</h3>
+        <Link href="/dashboard/agents" className="text-xs font-semibold text-brand-text hover:underline">
+          See all {total > agents.length ? `(${total})` : ""}
+        </Link>
+      </div>
+      <ul className="mt-2 divide-y divide-divider">
+        {agents.map((a, i) => {
+          const score = typeof a.trustScore === "number" ? a.trustScore : null;
+          const pct = score === null ? 0 : Math.round((score <= 1 ? score : score / 100) * 100);
+          const attention = a.status === "suspended" || a.status === "revoked";
+          return (
+            <li key={a.id}>
+              <Link href={`/dashboard/agents/${a.id}`} className="flex items-center gap-3.5 py-3 hover:opacity-90">
+                <span className={cn("inline-flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-avatar bg-gradient-to-br text-[13px] font-bold", AVATAR_TINTS[i % AVATAR_TINTS.length])}>
+                  {(a.displayName || a.name || "?").slice(0, 1).toLowerCase()}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[13.5px] font-bold text-ink">{a.displayName || a.name}</span>
+                  <span className={cn("block truncate text-xs", attention ? "font-semibold text-danger-text" : "text-ink-tertiary")}>
+                    {a.status}
+                    {a.updatedAt ? ` · updated ${relative(a.updatedAt)}` : ""}
+                  </span>
+                </span>
+                {score !== null && (
+                  <>
+                    <span className={cn("text-[13px] font-bold", attention ? "text-danger-text" : "text-brand-text")}>{(pct / 100).toFixed(2)}</span>
+                    <span className="hidden h-[5px] w-[90px] overflow-hidden rounded-[3px] bg-track sm:block" aria-hidden="true">
+                      <span className={cn("block h-full rounded-[3px]", attention ? "bg-danger" : "bg-bar")} style={{ width: `${pct}%` }} />
+                    </span>
+                  </>
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function FirstAgentCard() {
+  return (
+    <div className="glass flex flex-col gap-4 p-6">
+      <div className="flex items-start gap-3">
+        <span className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-brand-soft text-brand-text">
+          <ShieldPlus className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <h3 className="text-[15px] font-bold tracking-[-0.02em] text-ink">Secure your first agent</h3>
+          <p className="mt-1 text-xs leading-relaxed text-ink-secondary">
+            Three commands give an agent a verifiable identity. Refresh this page once it has checked in and it appears here with its trust score.
+          </p>
+        </div>
+      </div>
+      <OriginQuickstart className="!bg-glass-inset-gray !text-ink" />
+      <div className="flex flex-wrap items-center gap-2">
+        <Link href="/dashboard/agents?register=1" className="inline-flex h-9 items-center gap-2 rounded-pill bg-brand px-4 text-xs font-bold text-white shadow-glow hover:bg-brand-hover">
+          Secure it in the browser instead
+        </Link>
+        <Link href="/dashboard/developers" className="inline-flex h-9 items-center rounded-pill border border-stroke bg-glass px-4 text-xs font-bold text-ink">
+          Developer guide
+        </Link>
       </div>
     </div>
   );
 }
+
+function HomeSkeleton() {
+  return (
+    <div className="flex flex-col gap-4" aria-busy="true" aria-label="Loading overview">
+      <div className="px-1">
+        <Skeleton className="h-3 w-40" />
+        <Skeleton className="mt-2 h-7 w-96 max-w-full" />
+      </div>
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="glass p-5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="mt-3 h-8 w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[1.7fr_1fr]">
+        <div className="glass h-64 p-5" />
+        <div className="glass h-64 p-5" />
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------------------
+ * Page
+ * ------------------------------------------------------------------------- */
 
 function DashboardContent() {
   const searchParams = useSearchParams();
-  const router = useRouter();
+  const persona = usePersona((s) => s.persona);
+  const [data, setData] = useState<HomeData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [dashboardData, setDashboardData] = useState<DashboardStats | null>(null);
-  const [verificationActivity, setVerificationActivity] = useState<VerificationActivityData | null>(null);
-  const [activityLoading, setActivityLoading] = useState(true);
-  const [userRole, setUserRole] = useState<UserRole>("viewer");
-  const [mcpServers, setMcpServers] = useState<MCPServerEntry[]>([]);
-  const [mcpLoading, setMcpLoading] = useState(true);
+  const [lensData, setLensData] = useState<LensData | null>(null);
+  const [lensLoading, setLensLoading] = useState(false);
 
-  useEffect(() => {
-    const token = api.getToken();
-    if (token) {
-      try {
-        const payload = JSON.parse(atob(token.split(".")[1]));
-        setUserRole((payload.role as UserRole) || "viewer");
-      } catch (e) {
-        console.error("Failed to decode JWT token:", e);
-        setUserRole("viewer");
-      }
-    }
-  }, []);
-
-  // Fetch all dashboard data in parallel for better performance
-  const fetchAllDashboardData = useCallback(async () => {
+  const load = useCallback(async () => {
+    // A token handed over on the URL (device flow, OAuth) becomes the session.
     const token = searchParams.get("token");
     if (token) {
-      // A token arriving in the URL is a sign-in handoff, so it starts a new
-      // session window rather than extending whatever was left in localStorage.
       api.setToken(token, undefined, "new-session");
       window.history.replaceState({}, "", "/dashboard");
     }
-
     setLoading(true);
-    setActivityLoading(true);
-    setMcpLoading(true);
     setError(null);
-
-    // Run all API calls in parallel
-    const [dashboardResult, activityResult, mcpResult] = await Promise.allSettled([
+    const [stats, verification, activity, agents, user] = await Promise.allSettled([
       api.getDashboardStats(),
+      api.getVerificationStatistics("24h"),
       api.getVerificationActivity(6),
-      api.listMCPServers(100, 0),
+      api.listAgents(),
+      api.getCurrentUser(),
     ]);
-
-    // Process dashboard stats
-    if (dashboardResult.status === "fulfilled") {
-      setDashboardData(dashboardResult.value);
-    } else {
-      console.error("Failed to fetch dashboard data:", dashboardResult.reason);
-      const errorMessage = getErrorMessage(dashboardResult.reason, { resource: "dashboard data", action: "load" });
-      setError(errorMessage);
+    if (stats.status !== "fulfilled") {
+      setError(getErrorMessage(stats.reason, { resource: "dashboard data", action: "load" }));
+      setLoading(false);
+      return;
     }
+    const role: UserRole = user.status === "fulfilled" && user.value?.role && user.value.role !== "pending" ? (user.value.role as UserRole) : roleFromToken();
+    setData({
+      stats: stats.value as DashboardStats,
+      verification: verification.status === "fulfilled" ? (verification.value as VerificationStatistics) : null,
+      activity: activity.status === "fulfilled" ? (activity.value?.activity ?? []) : [],
+      agents: agents.status === "fulfilled" ? agents.value?.agents ?? [] : [],
+      user: { name: user.status === "fulfilled" ? firstName(user.value) : "", role },
+    });
     setLoading(false);
-
-    // Process verification activity
-    if (activityResult.status === "fulfilled") {
-      const data = activityResult.value;
-      if (data && data.activity && data.activity.length > 0) {
-        setVerificationActivity(data);
-      } else {
-        setVerificationActivity(null);
-      }
-    } else {
-      console.error("Failed to fetch verification activity:", activityResult.reason);
-      setVerificationActivity(null);
-    }
-    setActivityLoading(false);
-
-    // Process MCP servers
-    if (mcpResult.status === "fulfilled") {
-      setMcpServers(mcpResult.value.mcpServers || []);
-    } else {
-      console.error("Failed to fetch MCP servers:", mcpResult.reason);
-    }
-    setMcpLoading(false);
   }, [searchParams]);
 
   useEffect(() => {
-    fetchAllDashboardData();
-  }, [fetchAllDashboardData]);
+    load();
+  }, [load]);
 
-  if (loading) {
-    return <DashboardSkeleton />;
+  const permissions = useMemo(() => getDashboardPermissions(data?.user?.role), [data?.user?.role]);
+
+  // The Security and Executive lenses read endpoints the developer lens does not need. They are
+  // fetched only for roles the permission map already allows; a lens never widens authorization.
+  useEffect(() => {
+    if (persona === "developer") return;
+    if (!data?.user || !permissions.canViewSecurityMetrics) {
+      setLensData({ security: null, violations: null, events: null, compliance: null });
+      return;
+    }
+    let cancelled = false;
+    setLensLoading(true);
+    Promise.allSettled([
+      api.getSecurityMetrics(),
+      api.getSecurityViolations(20, 0),
+      api.getRecentVerificationEvents(60),
+      permissions.canViewAdmin ? api.getComplianceStatus() : Promise.reject(new Error("admin only")),
+    ]).then(([security, violations, events, compliance]) => {
+      if (cancelled) return;
+      setLensData({
+        security: security.status === "fulfilled" ? (security.value as LensData["security"]) : null,
+        violations: violations.status === "fulfilled" ? (violations.value as LensData["violations"]) : null,
+        events: events.status === "fulfilled" ? ((events.value as { events: LensData["events"] }).events ?? []) : null,
+        compliance: compliance.status === "fulfilled" ? (compliance.value as LensData["compliance"]) : null,
+      });
+      setLensLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [data?.user, persona, permissions.canViewSecurityMetrics, permissions.canViewAdmin]);
+
+  if (loading) return <HomeSkeleton />;
+  if (error || !data?.stats) {
+    return (
+      <div className="glass mx-auto mt-10 max-w-md p-8 text-center">
+        <p className="text-overline">Overview</p>
+        <h2 className="text-headline mt-2">The overview could not load.</h2>
+        <p className="mt-2 text-sm text-ink-secondary">{error ?? "No data was returned."}</p>
+        <button type="button" onClick={load} className="mt-5 inline-flex h-10 items-center rounded-pill bg-brand px-5 text-sm font-bold text-white shadow-glow hover:bg-brand-hover">
+          Try again
+        </button>
+      </div>
+    );
   }
 
-  if (error && !dashboardData) {
-    return <ErrorDisplay message={error} onRetry={fetchAllDashboardData} />;
-  }
+  const { stats, verification, activity, agents } = data;
+  const zero = stats.totalAgents === 0 && agents.length === 0;
+  const approvedPct =
+    verification && verification.totalVerifications > 0
+      ? Math.round((verification.successCount / verification.totalVerifications) * 1000) / 10
+      : null;
 
-  const data = dashboardData!;
-  const permissions = getDashboardPermissions(userRole);
+  // Violations carry no open/resolved state, so the count is all-time. Null means the role may
+  // not read them or the request failed; the headline then falls through to the developer one.
+  const violationCount = lensData?.violations?.total ?? null;
+  const lensReady = persona === "developer" || (lensData !== null && !lensLoading);
+  const developerHeadline =
+    stats.criticalAlerts > 0
+      ? `${stats.criticalAlerts} critical ${stats.criticalAlerts === 1 ? "alert needs" : "alerts need"} attention.`
+      : stats.pendingAgents > 0
+        ? `${stats.pendingAgents} ${stats.pendingAgents === 1 ? "agent is" : "agents are"} waiting for verification.`
+        : "No critical alerts. No agents waiting for verification.";
+  const headline = zero
+    ? "No agents secured yet."
+    : persona === "security" && lensReady && violationCount !== null
+      ? violationCount > 0
+        ? `${violationCount} capability ${violationCount === 1 ? "violation" : "violations"} recorded.`
+        : "No capability violations recorded."
+      : persona === "executive" && lensReady
+        ? `${stats.verifiedAgents.toLocaleString()} of ${stats.totalAgents.toLocaleString()} agents verified.`
+        : developerHeadline;
+  // Only asserted when every input it depends on is known and zero.
+  const allClear =
+    stats.criticalAlerts === 0 && stats.activeAlerts === 0 && violationCount === 0 && verification !== null && verification.failedCount === 0;
+  const role = data.user?.role ?? "viewer";
+  const canOpenAlerts = permissions.canViewAlerts && effectiveEdgeRoles("/dashboard/admin/alerts").includes(role);
 
-  // Calculate derived metrics
-  const verifiedMcps = mcpServers.filter((m) => m.isVerified || m.status === "verified").length;
-  const pendingMcps = mcpServers.filter((m) => m.status === "pending").length;
-  const totalAttestations = mcpServers.reduce((sum, m) => sum + (m.attestationCount || 0), 0);
-
-  // Verification status data for pie charts
-  const agentStatusData = [
-    { name: "Verified", value: data?.verifiedAgents || 0, color: "#22c55e" },
-    { name: "Pending", value: data?.pendingAgents || 0, color: "#f59e0b" },
-    { name: "Other", value: Math.max(0, (data?.totalAgents || 0) - (data?.verifiedAgents || 0) - (data?.pendingAgents || 0)), color: "#6b7280" },
-  ].filter((d) => d.value > 0);
-
-  const mcpStatusData = [
-    { name: "Verified", value: verifiedMcps, color: "#22c55e" },
-    { name: "Active", value: mcpServers.filter((m) => m.status === "active" && !m.isVerified).length, color: "#3b82f6" },
-    { name: "Pending", value: pendingMcps, color: "#f59e0b" },
-    { name: "Inactive", value: mcpServers.filter((m) => m.status === "inactive" || m.status === "suspended").length, color: "#ef4444" },
-  ].filter((d) => d.value > 0);
+  const sortedAgents = [...agents]
+    .sort((a, b) => (a.status === "suspended" || a.status === "revoked" ? -1 : 0) - (b.status === "suspended" || b.status === "revoked" ? -1 : 0) || (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""))
+    .slice(0, 6);
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-4" data-persona={persona}>
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-end justify-between gap-3 px-1">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Security Overview
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Security posture overview for agents and MCP servers
-          </p>
+          <p className="text-xs font-semibold text-ink-secondary">{persona === "executive" && !zero ? "Overview" : greeting(data.user?.name)}</p>
+          <h1 className="text-headline mt-0.5">{headline}</h1>
+          {persona === "executive" && !zero && lensReady && (stats.criticalAlerts > 0 || allClear) && (
+            <p className="mt-1 text-xs text-ink-secondary">
+              {stats.criticalAlerts > 0
+                ? `${stats.criticalAlerts} critical ${stats.criticalAlerts === 1 ? "alert needs" : "alerts need"} attention.`
+                : "No open alerts, no failed verifications in the last 24 hours, no violations recorded."}
+            </p>
+          )}
         </div>
-        <TimezoneIndicator />
-      </div>
-
-      {/* Security Alert Banner (if critical) */}
-      {data?.criticalAlerts > 0 && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <AlertTriangle className="h-6 w-6 text-red-600" />
-              <div>
-                <p className="font-medium text-red-800 dark:text-red-200">
-                  {data.criticalAlerts} Critical Security Alert{data.criticalAlerts > 1 ? "s" : ""}
-                </p>
-                <p className="text-sm text-red-600 dark:text-red-300">
-                  Immediate attention required
-                </p>
-              </div>
-            </div>
-            <Link
-              href="/dashboard/security"
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 text-sm font-medium"
-            >
-              View Alerts
-            </Link>
-          </div>
-        </div>
-      )}
-
-      {/* Key Metrics Row - 6 cards balanced between agents, MCPs, and security */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-        <KeyMetricCard
-          label="Total Agents"
-          value={data?.totalAgents || 0}
-          icon={Bot}
-          color="bg-blue-500"
-        />
-        <KeyMetricCard
-          label="Verified Agents"
-          value={data?.verifiedAgents || 0}
-          icon={CheckCircle}
-          color="bg-green-500"
-        />
-        <KeyMetricCard
-          label="Avg Trust Score"
-          value={data?.avgTrustScore ? `${(data.avgTrustScore * 100).toFixed(0)}%` : "0%"}
-          icon={TrendingUp}
-          color="bg-purple-500"
-        />
-        <KeyMetricCard
-          label="MCP Servers"
-          value={data?.totalMcpServers || 0}
-          icon={Server}
-          color="bg-indigo-500"
-        />
-        <KeyMetricCard
-          label="Verified MCPs"
-          value={verifiedMcps}
-          icon={ShieldCheck}
-          color="bg-emerald-500"
-        />
-        <KeyMetricCard
-          label="Active Alerts"
-          value={data?.activeAlerts || 0}
-          icon={AlertTriangle}
-          color={data?.activeAlerts > 0 ? "bg-yellow-500" : "bg-gray-400"}
-        />
-      </div>
-
-      {/* Main Content Grid - Side by Side Agent vs MCP */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Agent Section */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Bot className="h-5 w-5 text-blue-500" />
-                Agent Verification Status
-              </h3>
-              <Link href="/dashboard/agents" className="text-sm text-blue-600 hover:text-blue-700 flex items-center gap-1">
-                View All <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </div>
-          <div className="p-4">
-            <div className="flex items-center gap-6">
-              {/* Pie Chart */}
-              <div className="w-32 h-32 flex-shrink-0">
-                {agentStatusData.length > 0 ? (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={agentStatusData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={30}
-                        outerRadius={50}
-                        paddingAngle={2}
-                        dataKey="value"
-                      >
-                        {agentStatusData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </PieChart>
-                  </ResponsiveContainer>
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <Bot className="h-12 w-12 text-gray-300" />
-                  </div>
-                )}
-              </div>
-              {/* Stats */}
-              <div className="flex-1 space-y-3">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-green-500"></div>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">Verified</span>
-                  </div>
-                  <span className="font-semibold text-gray-900 dark:text-white">{data?.verifiedAgents || 0}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">Pending</span>
-                  </div>
-                  <span className="font-semibold text-gray-900 dark:text-white">{data?.pendingAgents || 0}</span>
-                </div>
-                <div className="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
-                  <span className="text-sm text-gray-600 dark:text-gray-400">Verification Rate</span>
-                  <span className="font-semibold text-gray-900 dark:text-white">{data?.verificationRate?.toFixed(1) || 0}%</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* MCP Section */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Server className="h-5 w-5 text-indigo-500" />
-                MCP Server Status
-              </h3>
-              <Link href="/dashboard/mcp" className="text-sm text-blue-600 hover:text-blue-700 flex items-center gap-1">
-                View All <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </div>
-          <div className="p-4">
-            <div className="flex items-center gap-6">
-              {/* Pie Chart */}
-              <div className="w-32 h-32 flex-shrink-0">
-                {mcpLoading ? (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
-                  </div>
-                ) : mcpStatusData.length > 0 ? (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={mcpStatusData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={30}
-                        outerRadius={50}
-                        paddingAngle={2}
-                        dataKey="value"
-                      >
-                        {mcpStatusData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </PieChart>
-                  </ResponsiveContainer>
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <Server className="h-12 w-12 text-gray-300" />
-                  </div>
-                )}
-              </div>
-              {/* Stats */}
-              <div className="flex-1 space-y-3">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-green-500"></div>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">Verified</span>
-                  </div>
-                  <span className="font-semibold text-gray-900 dark:text-white">{verifiedMcps}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-blue-500"></div>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">Active</span>
-                  </div>
-                  <span className="font-semibold text-gray-900 dark:text-white">{data?.activeMcpServers || 0}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">Pending</span>
-                  </div>
-                  <span className="font-semibold text-gray-900 dark:text-white">{pendingMcps}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Verification Activity - Historical trend (Agents + MCP Servers) */}
-      {permissions.canViewActivityChart && (
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-6">
-          <div className="flex items-center justify-between mb-4">
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <FileCheck className="h-5 w-5 text-blue-500" />
-                Verification Activity Trend
-              </h3>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                Agents & MCP Servers Combined
-              </p>
-            </div>
-            <div className="flex items-center gap-3">
-              {verificationActivity?.currentStats && (
-                <div className="flex items-center gap-4 text-xs">
-                  <div className="flex items-center gap-1">
-                    <Bot className="h-3 w-3 text-emerald-500" />
-                    <span className="text-gray-600 dark:text-gray-400">
-                      {verificationActivity.currentStats.agentsVerified || 0} agents
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Server className="h-3 w-3 text-blue-500" />
-                    <span className="text-gray-600 dark:text-gray-400">
-                      {verificationActivity.currentStats.mcpVerified || 0} MCP
-                    </span>
-                  </div>
-                </div>
-              )}
-              <span className="text-xs px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
-                Last 6 Months
-              </span>
-            </div>
-          </div>
-          <div className="h-64">
-            {activityLoading ? (
-              <ChartSkeleton />
-            ) : verificationActivity && verificationActivity.activity.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={verificationActivity.activity.slice(-6)} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                  <defs>
-                    <linearGradient id="agentsVerifiedGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#10b981" stopOpacity={1} />
-                      <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
-                    </linearGradient>
-                    <linearGradient id="mcpVerifiedGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#3b82f6" stopOpacity={1} />
-                      <stop offset="100%" stopColor="#2563eb" stopOpacity={0.8} />
-                    </linearGradient>
-                    <linearGradient id="agentsPendingGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#f59e0b" stopOpacity={1} />
-                      <stop offset="100%" stopColor="#d97706" stopOpacity={0.8} />
-                    </linearGradient>
-                    <linearGradient id="mcpPendingGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#8b5cf6" stopOpacity={1} />
-                      <stop offset="100%" stopColor="#7c3aed" stopOpacity={0.8} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
-                  <XAxis dataKey="month" tick={{ fontSize: 12, fill: "#6b7280" }} axisLine={{ stroke: "#e5e7eb" }} tickLine={false} />
-                  <YAxis tick={{ fontSize: 12, fill: "#6b7280" }} axisLine={false} tickLine={false} width={40} />
-                  <Tooltip
-                    cursor={{ fill: "rgba(0, 0, 0, 0.04)" }}
-                    contentStyle={{
-                      backgroundColor: "#fff",
-                      border: "none",
-                      borderRadius: "0.5rem",
-                      boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
-                    }}
-                    formatter={(value: number, name: string) => {
-                      const labels: Record<string, string> = {
-                        agentsVerified: "Agents Verified",
-                        mcpVerified: "MCP Verified",
-                        agentsPending: "Agents Pending",
-                        mcpPending: "MCP Pending",
-                      };
-                      return [value, labels[name] || name];
-                    }}
-                  />
-                  <Legend
-                    verticalAlign="top"
-                    align="right"
-                    wrapperStyle={{ paddingBottom: "10px" }}
-                    formatter={(value: string) => {
-                      const labels: Record<string, string> = {
-                        agentsVerified: "Agents ✓",
-                        mcpVerified: "MCP ✓",
-                        agentsPending: "Agents ⏳",
-                        mcpPending: "MCP ⏳",
-                      };
-                      return labels[value] || value;
-                    }}
-                  />
-                  <Bar dataKey="agentsVerified" stackId="verified" fill="url(#agentsVerifiedGradient)" name="agentsVerified" radius={[0, 0, 0, 0]} maxBarSize={35} />
-                  <Bar dataKey="mcpVerified" stackId="verified" fill="url(#mcpVerifiedGradient)" name="mcpVerified" radius={[4, 4, 0, 0]} maxBarSize={35} />
-                  <Bar dataKey="agentsPending" stackId="pending" fill="url(#agentsPendingGradient)" name="agentsPending" radius={[0, 0, 0, 0]} maxBarSize={35} />
-                  <Bar dataKey="mcpPending" stackId="pending" fill="url(#mcpPendingGradient)" name="mcpPending" radius={[4, 4, 0, 0]} maxBarSize={35} />
-                </BarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex flex-col items-center justify-center h-full text-gray-500">
-                <AlertCircle className="h-10 w-10 mb-2 text-gray-300" />
-                <p className="text-sm">No verification activity data available</p>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Security Overview and Quick Links */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-6">
-        {/* Security Status */}
-        {permissions.canViewSecurityMetrics && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Shield className="h-5 w-5 text-yellow-500" />
-                Security Status
-              </h3>
-            </div>
-            <div className="p-4 space-y-4">
-              <div className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-                <span className="text-sm text-gray-600 dark:text-gray-400">System Status</span>
-                {data?.criticalAlerts > 0 ? (
-                  <span className="flex items-center gap-1 text-red-600 font-medium">
-                    <XCircle className="h-4 w-4" /> Critical
-                  </span>
-                ) : data?.activeAlerts > 0 ? (
-                  <span className="flex items-center gap-1 text-yellow-600 font-medium">
-                    <AlertTriangle className="h-4 w-4" /> Warning
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-1 text-green-600 font-medium">
-                    <CheckCircle className="h-4 w-4" /> Healthy
-                  </span>
-                )}
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="text-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">{data?.activeAlerts || 0}</p>
-                  <p className="text-xs text-gray-500">Active Alerts</p>
-                </div>
-                <div className="text-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-                  <p className="text-2xl font-bold text-red-600">{data?.criticalAlerts || 0}</p>
-                  <p className="text-xs text-gray-500">Critical</p>
-                </div>
-              </div>
-              <Link
-                href="/dashboard/security"
-                className="block w-full py-2 text-center text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-              >
-                View Security Dashboard
-              </Link>
-            </div>
-          </div>
+        {!zero && (
+          <Link href="/dashboard/agents?register=1" className="hidden h-10 items-center gap-2 rounded-pill bg-brand px-5 text-[13.5px] font-bold text-white shadow-glow hover:bg-brand-hover sm:inline-flex">
+            <ShieldPlus className="h-4 w-4" aria-hidden="true" />
+            Secure an agent
+          </Link>
         )}
+      </div>
 
-        {/* MCP Attestations */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-              <FileCheck className="h-5 w-5 text-cyan-500" />
-              MCP Attestations
-            </h3>
-          </div>
-          <div className="p-4 space-y-4">
-            <div className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Attestation Status</span>
-              {mcpServers.length > 0 ? (
-                mcpServers.filter(m => (m.attestationCount || 0) > 0).length === mcpServers.length ? (
-                  <span className="flex items-center gap-1 text-green-600 font-medium">
-                    <CheckCircle className="h-4 w-4" /> All Attested
-                  </span>
-                ) : mcpServers.filter(m => (m.attestationCount || 0) > 0).length > 0 ? (
-                  <span className="flex items-center gap-1 text-yellow-600 font-medium">
-                    <Clock className="h-4 w-4" /> Partial
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-1 text-gray-500 font-medium">
-                    <AlertCircle className="h-4 w-4" /> None
-                  </span>
-                )
-              ) : (
-                <span className="flex items-center gap-1 text-gray-500 font-medium">
-                  <AlertCircle className="h-4 w-4" /> No MCPs
-                </span>
-              )}
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="text-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-                <p className="text-2xl font-bold text-cyan-600">{totalAttestations}</p>
-                <p className="text-xs text-gray-500">Total Attestations</p>
-              </div>
-              <div className="text-center p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {mcpServers.filter(m => (m.attestationCount || 0) > 0).length}/{mcpServers.length}
-                </p>
-                <p className="text-xs text-gray-500">MCPs Attested</p>
-              </div>
-            </div>
-            <Link
-              href="/dashboard/mcp"
-              className="block w-full py-2 text-center text-sm font-medium bg-cyan-600 text-white rounded-lg hover:bg-cyan-700"
-            >
-              View MCP Servers
-            </Link>
-          </div>
-        </div>
+      {!zero && persona !== "developer" && !lensReady && <HomeSkeleton />}
+      {!zero && persona === "security" && lensReady && lensData && (
+        <SecurityLens stats={{ ...stats, agentsById: Object.fromEntries(agents.map((a) => [a.id, a])) }} verification={verification} lens={lensData} role={role} />
+      )}
+      {!zero && persona === "executive" && lensReady && lensData && (
+        <ExecutiveLens stats={stats} verification={verification} activity={activity} agents={agents} lens={lensData} role={role} />
+      )}
+      {(zero || persona === "developer") && (
+        <>
+      {/* KPIs */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+        <KpiTile label="Agents secured" value={stats.totalAgents.toLocaleString()} delta={`${stats.verifiedAgents.toLocaleString()} verified`} href="/dashboard/agents" />
+        <KpiTile
+          label="Verifications, last 24h"
+          value={verification ? verification.totalVerifications.toLocaleString() : "–"}
+          delta={approvedPct !== null ? `${approvedPct}% approved` : verification ? "none yet" : "unavailable"}
+        />
+        <KpiTile
+          label="Avg trust score"
+          value={stats.totalAgents > 0 ? (stats.avgTrustScore <= 1 ? stats.avgTrustScore : stats.avgTrustScore / 100).toFixed(2) : "–"}
+          delta={stats.totalAgents > 0 ? `across ${stats.totalAgents.toLocaleString()} ${stats.totalAgents === 1 ? "agent" : "agents"}` : "no agents yet"}
+          tone="accent"
+        />
+        <KpiTile
+          label="Open alerts"
+          value={stats.activeAlerts.toLocaleString()}
+          delta={stats.criticalAlerts > 0 ? `${stats.criticalAlerts} critical` : "none critical"}
+          tone={stats.criticalAlerts > 0 ? "alert" : "default"}
+          href={canOpenAlerts ? "/dashboard/admin/alerts" : undefined}
+        />
+      </div>
 
-        {/* Quick Actions */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-              <Activity className="h-5 w-5 text-blue-500" />
-              Quick Actions
-            </h3>
-          </div>
-          <div className="p-4 space-y-2">
-            <Link
-              href="/dashboard/agents"
-              className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <Bot className="h-5 w-5 text-blue-500" />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Manage Agents</span>
-              </div>
-              <ArrowRight className="h-4 w-4 text-gray-400" />
-            </Link>
-            <Link
-              href="/dashboard/mcp"
-              className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <Server className="h-5 w-5 text-indigo-500" />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Manage MCP Servers</span>
-              </div>
-              <ArrowRight className="h-4 w-4 text-gray-400" />
-            </Link>
-            <Link
-              href="/dashboard/admin/jit-requests"
-              className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <Eye className="h-5 w-5 text-green-500" />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Review Requests</span>
-              </div>
-              <ArrowRight className="h-4 w-4 text-gray-400" />
-            </Link>
-            <Link
-              href="/dashboard/compliance"
-              className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <ShieldCheck className="h-5 w-5 text-purple-500" />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Compliance Reports</span>
-              </div>
-              <ArrowRight className="h-4 w-4 text-gray-400" />
-            </Link>
-          </div>
-        </div>
-
-        {/* Platform Summary */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-              <Users className="h-5 w-5 text-green-500" />
-              Platform Summary
-            </h3>
-          </div>
-          <div className="p-4 space-y-3">
-            <div className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Total Users</span>
-              <span className="font-semibold text-gray-900 dark:text-white">{data?.totalUsers || 0}</span>
-            </div>
-            <div className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Active Users</span>
-              <span className="font-semibold text-green-600">{data?.activeUsers || 0}</span>
-            </div>
-            <div className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Total Agents</span>
-              <span className="font-semibold text-gray-900 dark:text-white">{data?.totalAgents || 0}</span>
-            </div>
-            <div className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Total MCP Servers</span>
-              <span className="font-semibold text-gray-900 dark:text-white">{data?.totalMcpServers || 0}</span>
-            </div>
-            <div className="flex items-center justify-between py-2">
-              <span className="text-sm text-gray-600 dark:text-gray-400">Security Incidents</span>
-              <span className={`font-semibold ${data?.securityIncidents > 0 ? "text-red-600" : "text-green-600"}`}>
-                {data?.securityIncidents || 0}
-              </span>
-            </div>
-          </div>
+      {/* Main */}
+      <div className="grid gap-4 lg:grid-cols-[1.7fr_1fr] [&>*]:min-w-0">
+        {zero ? <FirstAgentCard /> : <AgentsCard agents={sortedAgents} total={stats.totalAgents} />}
+        <div className="flex min-w-0 flex-col gap-4">
+          <Quickstart compact />
+          <VerificationActivityCard activity={activity} />
         </div>
       </div>
 
-      {/* Activity Timeline */}
-      <ActivityTimeline defaultLimit={10} />
+      {/* Secondary, role-gated */}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 [&>*]:min-w-0">
+        {permissions.canViewMCPStats && (
+          <Link href="/dashboard/mcp" className="glass flex items-start gap-3 p-5 hover:-translate-y-0.5 transition-transform">
+            <Server className="mt-0.5 h-4 w-4 text-ink-tertiary" aria-hidden="true" />
+            <span>
+              <span className="block text-[13.5px] font-bold text-ink">MCP servers</span>
+              <span className="block text-xs text-ink-secondary">
+                {stats.totalMcpServers.toLocaleString()} registered · {stats.activeMcpServers.toLocaleString()} active
+              </span>
+            </span>
+          </Link>
+        )}
+        {permissions.canViewSecurityMetrics && (
+          <Link href="/dashboard/security" className="glass flex items-start gap-3 p-5 hover:-translate-y-0.5 transition-transform">
+            <ShieldCheck className="mt-0.5 h-4 w-4 text-ink-tertiary" aria-hidden="true" />
+            <span>
+              <span className="block text-[13.5px] font-bold text-ink">Security</span>
+              <span className="block text-xs text-ink-secondary">
+                {stats.securityIncidents.toLocaleString()} {stats.securityIncidents === 1 ? "incident" : "incidents"} · {stats.activeAlerts.toLocaleString()} open {stats.activeAlerts === 1 ? "alert" : "alerts"}
+              </span>
+            </span>
+          </Link>
+        )}
+        {canOpenAlerts && (
+          <Link href="/dashboard/admin/alerts" className="glass flex items-start gap-3 p-5 hover:-translate-y-0.5 transition-transform">
+            <Bell className="mt-0.5 h-4 w-4 text-ink-tertiary" aria-hidden="true" />
+            <span>
+              <span className="block text-[13.5px] font-bold text-ink">Alerts</span>
+              <span className="block text-xs text-ink-secondary">{stats.criticalAlerts.toLocaleString()} critical waiting for review</span>
+            </span>
+          </Link>
+        )}
+      </div>
+
+        </>
+      )}
+      {permissions.canViewRecentActivity && !zero && <ActivityTimeline defaultLimit={8} />}
     </div>
   );
 }
@@ -794,7 +583,7 @@ function DashboardContent() {
 export default function DashboardPage() {
   return (
     <AuthGuard>
-      <Suspense fallback={<DashboardSkeleton />}>
+      <Suspense fallback={<HomeSkeleton />}>
         <DashboardContent />
       </Suspense>
     </AuthGuard>

--- a/apps/web/components/overview/executive-lens.tsx
+++ b/apps/web/components/overview/executive-lens.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import type { Agent } from "@/lib/api";
+import { CardTitle, EmptyNote, KpiTile, relativeTime, trustDisplay } from "@/components/overview/shared";
+import type { LensData, StatsData, VerificationActivityMonth, VerificationStatistics } from "@/components/overview/types";
+import type { UserRole } from "@/lib/permissions";
+import { effectiveEdgeRoles } from "@/lib/route-permissions";
+import { cn } from "@/lib/utils";
+
+/**
+ * Executive lens of the overview: posture, coverage, incidents and one recommended action,
+ * recovery-framed (no letter grades). Tiles without a backend source are not rendered, and
+ * links are rendered only for roles the edge gate lets through.
+ */
+export function ExecutiveLens({
+  stats,
+  verification,
+  activity,
+  agents,
+  lens,
+  role,
+}: {
+  stats: StatsData;
+  verification: VerificationStatistics | null;
+  activity: VerificationActivityMonth[];
+  agents: Agent[];
+  lens: LensData;
+  role: UserRole;
+}) {
+  const m = lens.security;
+  const c = lens.compliance;
+  const openViolations = lens.violations?.total ?? null;
+  const canOpenSecurity = effectiveEdgeRoles("/dashboard/security").includes(role);
+  const alertsHref = effectiveEdgeRoles("/dashboard/admin/alerts").includes(role) ? "/dashboard/admin/alerts" : canOpenSecurity ? "/dashboard/security" : undefined;
+  const approved = verification && verification.totalVerifications > 0 ? Math.round((verification.successCount / verification.totalVerifications) * 1000) / 10 : null;
+  const weekAgo = Date.now() - 7 * 86400000;
+  const newThisWeek = agents.filter((a) => a.createdAt && new Date(a.createdAt).getTime() >= weekAgo).length;
+
+  // Trust distribution from the agents list (0-1 scale), bucketed by score.
+  const buckets = [
+    { label: "High (0.80+)", color: "var(--brand)", n: 0 },
+    { label: "Medium (0.50–0.79)", color: "var(--brand-sky)", n: 0 },
+    { label: "Low (below 0.50)", color: "var(--amber)", n: 0 },
+    { label: "Not scored", color: "var(--track)", n: 0 },
+  ];
+  for (const a of agents) {
+    const s = typeof a.trustScore === "number" ? (a.trustScore <= 1 ? a.trustScore : a.trustScore / 100) : null;
+    if (s === null) buckets[3].n++;
+    else if (s >= 0.8) buckets[0].n++;
+    else if (s >= 0.5) buckets[1].n++;
+    else buckets[2].n++;
+  }
+  const total = agents.length;
+  const r = 52;
+  const circ = 2 * Math.PI * r;
+  let offset = 0;
+  const arcs = buckets.map((b) => {
+    const frac = total ? b.n / total : 0;
+    const arc = { ...b, dash: `${frac * circ} ${circ}`, offset: -offset * circ };
+    offset += frac;
+    return arc;
+  });
+
+  const recommended =
+    stats.criticalAlerts > 0
+      ? { text: `Review ${stats.criticalAlerts.toLocaleString()} critical ${stats.criticalAlerts === 1 ? "alert" : "alerts"}.`, href: alertsHref }
+      : m && m.openIncidents > 0
+      ? { text: `Review ${m.openIncidents.toLocaleString()} open ${m.openIncidents === 1 ? "incident" : "incidents"}.`, href: canOpenSecurity ? "/dashboard/security" : undefined }
+      : stats.activeAlerts > 0
+        ? { text: `Review ${stats.activeAlerts.toLocaleString()} open ${stats.activeAlerts === 1 ? "alert" : "alerts"}.`, href: alertsHref }
+      : stats.pendingAgents > 0
+        ? { text: `Verify ${stats.pendingAgents.toLocaleString()} pending ${stats.pendingAgents === 1 ? "agent" : "agents"}.`, href: "/dashboard/agents?filter=pending" }
+        : m && m.mcpServersTotal > m.mcpServersVerified
+          ? { text: `Attest ${(m.mcpServersTotal - m.mcpServersVerified).toLocaleString()} MCP ${m.mcpServersTotal - m.mcpServersVerified === 1 ? "server" : "servers"}.`, href: "/dashboard/mcp" }
+          : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5 xl:gap-3.5">
+        <KpiTile size="sm" label="Agents registered" value={stats.totalAgents.toLocaleString()} delta={newThisWeek > 0 ? `+${newThisWeek} in the last 7 days` : "none new in the last 7 days"} href="/dashboard/agents" />
+        <KpiTile size="sm" label="MCP servers" value={stats.totalMcpServers.toLocaleString()} delta={m ? `${m.mcpServersVerified.toLocaleString()} of ${m.mcpServersTotal.toLocaleString()} attested` : `${stats.activeMcpServers.toLocaleString()} active`} href="/dashboard/mcp" />
+        <KpiTile size="sm" label="Verifications, last 24h" value={verification ? verification.totalVerifications.toLocaleString() : "–"} delta={approved !== null ? `${approved}% approved` : verification ? "none yet" : "unavailable"} />
+        {openViolations !== null && (
+          <KpiTile size="sm" label="Violations, all time" value={openViolations.toLocaleString()} delta={m ? `${m.highSeverityCount.toLocaleString()} high severity` : undefined} tone={openViolations > 0 ? "alert" : "default"} href={canOpenSecurity ? "/dashboard/security/violations" : undefined} />
+        )}
+        {m && (
+          <KpiTile size="sm" label="Security posture" value={m.securityScore.toLocaleString()} delta="of 100" tone="accent" href={canOpenSecurity ? "/dashboard/security" : undefined} />
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.7fr_1fr] [&>*]:min-w-0">
+        <div className="glass p-5">
+          <CardTitle sub={verification ? `${verification.totalVerifications.toLocaleString()} today${approved !== null ? ` · ${approved}% approved` : ""}` : undefined}>Verification activity</CardTitle>
+          {activity.length === 0 ? (
+            <EmptyNote>No verifications recorded yet.</EmptyNote>
+          ) : (
+            <>
+              <div className="mt-4 flex h-[150px] items-end gap-2" role="img" aria-label={`Verified per month: ${activity.map((a) => `${a.month} ${a.verified}`).join(", ")}`}>
+                {activity.map((a, i) => {
+                  const max = Math.max(1, ...activity.map((x) => x.verified + x.pending));
+                  const h = Math.max(3, Math.round(((a.verified + a.pending) / max) * 100));
+                  return (
+                    <div key={a.monthYear} className="flex h-full flex-1 flex-col justify-end" title={`${a.month}: ${a.verified} verified, ${a.pending} pending`}>
+                      <div className="w-full rounded-[4px] bg-brand" style={{ height: `${h}%`, opacity: i === activity.length - 1 ? 1 : 0.25 + 0.5 * ((a.verified + a.pending) / max) }} />
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-2 flex justify-between text-2xs text-ink-tertiary">
+                <span>{activity[0]?.month}</span>
+                <span>{activity[activity.length - 1]?.month}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="glass p-5">
+          <CardTitle sub="By trust score, from the agents list.">Trust distribution</CardTitle>
+          {total === 0 ? (
+            <EmptyNote>No agents yet.</EmptyNote>
+          ) : (
+            <div className="mt-3 flex items-center gap-5">
+              <svg viewBox="0 0 140 140" width="118" height="118" role="img" aria-label={arcs.map((a) => `${a.label}: ${a.n}`).join(", ")}>
+                <circle cx="70" cy="70" r={r} fill="none" stroke="var(--track)" strokeWidth="16" />
+                {arcs.map((a) => (
+                  <circle key={a.label} cx="70" cy="70" r={r} fill="none" stroke={a.color} strokeWidth="16" strokeDasharray={a.dash} strokeDashoffset={a.offset} transform="rotate(-90 70 70)" />
+                ))}
+                <text x="70" y="66" textAnchor="middle" fontSize="22" fontWeight="700" fill="var(--text-primary)">{trustDisplay(stats.avgTrustScore) ?? "–"}</text>
+                <text x="70" y="82" textAnchor="middle" fontSize="9" letterSpacing="0.5" fill="var(--text-tertiary)">Avg trust</text>
+              </svg>
+              <ul className="flex flex-1 flex-col gap-2">
+                {arcs.map((a) => (
+                  <li key={a.label} className="flex items-center gap-2 text-xs text-ink-body">
+                    <span className="h-[9px] w-[9px] rounded-[2px]" style={{ background: a.color }} aria-hidden="true" />
+                    <span className="flex-1">{a.label}</span>
+                    <span className="font-bold text-ink">{a.n}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4 [&>*]:min-w-0">
+        <div className="glass flex flex-col p-4">
+          <CardTitle>Security</CardTitle>
+          {m ? (
+            <>
+              <p className="mt-2 flex items-baseline gap-1.5">
+                <span className="text-[30px] font-bold tracking-[-0.03em] text-ink">{m.securityScore}</span>
+                <span className="text-xs font-semibold text-ink-tertiary">/ 100 posture</span>
+              </p>
+              <dl className="mt-auto pt-3 text-xs">
+                {[
+                  ["Open violations", openViolations !== null ? openViolations.toLocaleString() : "–"],
+                  ["Open incidents", m.openIncidents.toLocaleString()],
+                  ["Trusted agents", `${m.agentsTrusted.toLocaleString()} / ${m.agentsMonitored.toLocaleString()}`],
+                ].map(([k, v]) => (
+                  <div key={k} className="flex justify-between py-1">
+                    <dt className="text-ink-secondary">{k}</dt>
+                    <dd className="font-bold text-ink">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            </>
+          ) : (
+            <EmptyNote>Security metrics need the manager role. Ask an organization admin to change your role.</EmptyNote>
+          )}
+        </div>
+
+        <div className="glass flex flex-col p-4">
+          <CardTitle>MCP servers</CardTitle>
+          <p className="mt-2 flex items-baseline gap-1.5">
+            <span className="text-[30px] font-bold tracking-[-0.03em] text-ink">{stats.totalMcpServers.toLocaleString()}</span>
+            <span className="text-xs font-semibold text-ink-tertiary">registered</span>
+          </p>
+          {m && m.mcpServersTotal > m.mcpServersVerified ? (
+            <p className="text-xs font-semibold text-warning-text">{(m.mcpServersTotal - m.mcpServersVerified).toLocaleString()} awaiting attestation</p>
+          ) : (
+            <p className="text-xs font-semibold text-success-text">{stats.activeMcpServers.toLocaleString()} active</p>
+          )}
+          <dl className="mt-auto pt-3 text-xs">
+            {[
+              ["Attested", m ? `${m.mcpServersVerified.toLocaleString()} / ${m.mcpServersTotal.toLocaleString()}` : "–"],
+              ["Active", stats.activeMcpServers.toLocaleString()],
+            ].map(([k, v]) => (
+              <div key={k} className="flex justify-between py-1">
+                <dt className="text-ink-secondary">{k}</dt>
+                <dd className="font-bold text-ink">{v}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="glass flex flex-col p-4">
+          <CardTitle>Compliance</CardTitle>
+          {c ? (
+            <>
+              <p className="mt-2 text-[22px] font-bold capitalize tracking-[-0.02em] text-ink">{c.complianceLevel.replace(/[_-]/g, " ")}</p>
+              <p className="text-xs font-semibold text-ink-secondary">{Math.round(c.verificationRate)}% of agents verified</p>
+              <dl className="mt-auto pt-3 text-xs">
+                {[
+                  ["Verified agents", `${c.verifiedAgents.toLocaleString()} / ${c.totalAgents.toLocaleString()}`],
+                  ["Recent audit events", c.recentAuditCount.toLocaleString()],
+                ].map(([k, v]) => (
+                  <div key={k} className="flex justify-between py-1">
+                    <dt className="text-ink-secondary">{k}</dt>
+                    <dd className="font-bold text-ink">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+              <Link href="/dashboard/admin/compliance" className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-brand-text hover:underline">
+                Open compliance <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </>
+          ) : (
+            <EmptyNote>Compliance status needs the admin role. Ask an organization admin to change your role.</EmptyNote>
+          )}
+        </div>
+
+        <div className="glass flex flex-col p-4">
+          <CardTitle>Recommended action</CardTitle>
+          {recommended ? (
+            <>
+              <p className="mt-2 text-[15px] font-bold tracking-[-0.02em] text-ink">{recommended.text}</p>
+              {recommended.href && (
+                <Link href={recommended.href} className="mt-auto inline-flex h-9 items-center justify-center gap-1.5 self-start rounded-pill bg-brand px-4 text-xs font-bold text-white shadow-glow hover:bg-brand-hover">
+                  Open <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              )}
+            </>
+          ) : m && openViolations !== null ? (
+            <EmptyNote>Nothing is waiting on you: no open alerts, incidents or pending agents, and every MCP server is attested.</EmptyNote>
+          ) : (
+            <EmptyNote>Recommended actions need the security metrics, which could not be loaded. Refresh to retry.</EmptyNote>
+          )}
+          {m?.recentBlockedActions?.length ? (
+            <ul className="mt-4 divide-y divide-divider border-t border-divider pt-1">
+              {m.recentBlockedActions.slice(0, 3).map((b) => (
+                <li key={b.id} className="flex gap-2.5 py-2 text-xs">
+                  <span className="mt-1.5 h-[7px] w-[7px] flex-shrink-0 rounded-full bg-danger" aria-hidden="true" />
+                  <span className="min-w-0">
+                    <span className="block truncate text-ink"><b>{b.agentName || b.agentId}</b> blocked from {b.attemptedCapability}</span>
+                    <span className={cn("block text-2xs text-ink-tertiary")}>{relativeTime(b.createdAt)}{b.details ? ` · ${b.details}` : ""}</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/overview/security-lens.tsx
+++ b/apps/web/components/overview/security-lens.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import { CardTitle, EmptyNote, KpiTile, StatusChip, relativeTime, shortTime, trustDisplay } from "@/components/overview/shared";
+import type { LensData, StatsData, VerificationStatistics } from "@/components/overview/types";
+import type { UserRole } from "@/lib/permissions";
+import { effectiveEdgeRoles } from "@/lib/route-permissions";
+import { cn } from "@/lib/utils";
+
+/**
+ * Security practitioner lens of the overview: what needs attention first, the verification
+ * stream, policy coverage. Same objects as the developer lens, reordered and emphasized.
+ * Every value comes from /security/metrics, /security/violations, /verification-events/*.
+ * A null section of the lens data means the endpoint failed or the role may not read it; it
+ * renders as unavailable, never as empty. Violations carry no open/resolved state, so counts
+ * are all-time. Links are rendered only for roles the edge gate lets through.
+ */
+export function SecurityLens({ stats, verification, lens, role }: { stats: StatsData; verification: VerificationStatistics | null; lens: LensData; role: UserRole }) {
+  const m = lens.security;
+  const violations = lens.violations?.violations ?? [];
+  const violationCount = lens.violations ? lens.violations.total ?? violations.length : null;
+  const events = lens.events ?? [];
+  const canOpenSecurity = effectiveEdgeRoles("/dashboard/security").includes(role);
+  const approved = verification && verification.totalVerifications > 0 ? Math.round((verification.successCount / verification.totalVerifications) * 1000) / 10 : null;
+  const hero = violations[0] ?? null;
+  const heroAgent = hero ? stats.agentsById?.[hero.agentId] : undefined;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+        <KpiTile
+          label="Violations, all time"
+          value={violationCount !== null ? violationCount.toLocaleString() : "–"}
+          delta={m ? `${m.highSeverityCount.toLocaleString()} high severity` : violationCount === null ? "unavailable" : undefined}
+          tone={violationCount ? "alert" : "default"}
+          href={canOpenSecurity ? "/dashboard/security/violations" : undefined}
+        />
+        <KpiTile label="Verifications, last 24h" value={verification ? verification.totalVerifications.toLocaleString() : "–"} delta={approved !== null ? `${approved}% approved` : verification ? "none yet" : "unavailable"} />
+        <KpiTile label="Blocked today" value={m ? m.actionsBlockedToday.toLocaleString() : "–"} delta={m ? `${m.blockedThreats.toLocaleString()} of ${m.totalThreats.toLocaleString()} capability violations blocked, all time` : "unavailable"} />
+        <KpiTile label="Avg trust" value={trustDisplay(m?.averageTrustScore ?? stats.avgTrustScore) ?? "–"} delta={`across ${stats.totalAgents.toLocaleString()} ${stats.totalAgents === 1 ? "agent" : "agents"}`} tone="accent" />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.7fr_1fr] [&>*]:min-w-0">
+        <div className="flex min-w-0 flex-col gap-4">
+          {hero ? (
+            <div className="glass-alert flex flex-col gap-4 p-5 sm:p-6">
+              <p className="inline-flex items-center gap-2 text-2xs font-bold uppercase tracking-[0.06em] text-danger-text">
+                <AlertTriangle className="h-4 w-4" aria-hidden="true" /> Most recent violation
+              </p>
+              <div className="flex flex-wrap items-center gap-4">
+                <span className="inline-flex h-[52px] w-[52px] items-center justify-center rounded-inset bg-danger-fill text-lg font-bold text-danger-text">
+                  {(hero.agentName || "?").slice(0, 1).toLowerCase()}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-lg font-bold tracking-[-0.02em] text-ink">{hero.agentName || hero.agentId}</p>
+                  <p className="truncate text-xs font-semibold text-danger-text">
+                    capability violation: {hero.attemptedCapability}
+                    {hero.registeredCapabilities?.length ? ` (registered: ${hero.registeredCapabilities.join(", ")})` : ""}
+                  </p>
+                </div>
+                {heroAgent && typeof heroAgent.trustScore === "number" && (
+                  <div className="text-right">
+                    <p className="text-[16px] font-bold tracking-[-0.02em] text-danger-text">{trustDisplay(heroAgent.trustScore)}</p>
+                    <p className="text-overline">Trust</p>
+                  </div>
+                )}
+              </div>
+              <div className="grid grid-cols-3 gap-2.5">
+                {[
+                  ["Severity", hero.severity],
+                  ["Blocked", relativeTime(hero.createdAt)],
+                  ["Status", hero.isBlocked ? "Contained" : "Not blocked"],
+                ].map(([k, v]) => (
+                  <div key={k} className="rounded-inset-sm border border-glass-inset-border bg-glass-inset-gray px-3 py-2.5">
+                    <p className="text-overline">{k}</p>
+                    <p className={cn("mt-0.5 text-[13px] font-bold", k === "Severity" && "capitalize", v === "Contained" ? "text-success-text" : "text-ink")}>{v}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-xs font-medium text-ink-secondary">
+                  {hero.isBlocked ? "The action was denied before it ran." : "The action was not blocked; review the agent's policy."}
+                  {typeof hero.trustScoreImpact === "number" && hero.trustScoreImpact !== 0 ? ` Trust impact ${hero.trustScoreImpact > 0 ? "+" : ""}${hero.trustScoreImpact.toFixed(2)}.` : ""}
+                </p>
+                {canOpenSecurity && (
+                  <Link href="/dashboard/security/violations" className="inline-flex h-9 items-center rounded-pill bg-brand px-5 text-[13px] font-bold text-white shadow-glow hover:bg-brand-hover">
+                    Review
+                  </Link>
+                )}
+              </div>
+            </div>
+          ) : lens.violations === null ? (
+            <div className="glass p-5 sm:p-6">
+              <CardTitle sub="They need the manager role; if you have it, refresh to retry.">Violations could not be loaded</CardTitle>
+            </div>
+          ) : (
+            <div className="glass p-5 sm:p-6">
+              <CardTitle sub="Denied actions appear here after the next refresh.">No violations recorded</CardTitle>
+            </div>
+          )}
+
+          <div className="glass p-5">
+            <CardTitle sub="Coverage of the controls that decide what an agent may do.">Policies and attestations</CardTitle>
+            {m ? (
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+                {[
+                  { label: "Trusted agents", value: `${m.agentsTrusted.toLocaleString()} of ${m.agentsMonitored.toLocaleString()}`, unit: "monitored", ok: m.agentsMonitored === 0 || m.agentsTrusted === m.agentsMonitored },
+                  { label: "MCP attestations", value: `${m.mcpServersVerified.toLocaleString()} of ${m.mcpServersTotal.toLocaleString()}`, unit: "verified", ok: m.mcpServersTotal === 0 || m.mcpServersVerified === m.mcpServersTotal },
+                  { label: "Open incidents", value: m.openIncidents.toLocaleString(), unit: m.openIncidents === 1 ? "incident" : "incidents", ok: m.openIncidents === 0 },
+                ].map((t) => (
+                  <div key={t.label} className="rounded-inset border border-glass-inset-border bg-glass-inset-gray p-3.5">
+                    <p className="text-xs font-semibold text-ink-secondary">{t.label}</p>
+                    <p className={cn("mt-1 text-[20px] font-bold tracking-[-0.02em]", t.ok ? "text-success-text" : "text-danger-text")}>
+                      {t.value} <span className="text-2xs font-semibold text-ink-tertiary">{t.unit}</span>
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <EmptyNote>Security metrics need the manager role. Ask an organization admin to change your role.</EmptyNote>
+            )}
+            {m && m.riskByCategory?.length > 0 && (
+              <div className="mt-4">
+                <p className="text-overline">Blocked by capability</p>
+                <ul className="mt-2 divide-y divide-divider">
+                  {m.riskByCategory.slice(0, 5).map((r) => (
+                    <li key={r.category} className="flex items-center justify-between py-2 text-xs">
+                      <span className="font-mono font-semibold text-ink">{r.category}</span>
+                      <span className="flex items-center gap-2">
+                        <span className="text-ink-secondary">{r.blocked.toLocaleString()} blocked</span>
+                        <StatusChip kind={r.riskLevel === "critical" || r.riskLevel === "high" ? "deny" : r.riskLevel === "medium" ? "pending" : "neutral"}>{r.riskLevel}</StatusChip>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="glass flex min-w-0 flex-col p-5">
+          <CardTitle
+            action={
+              <span className="inline-flex items-center gap-1.5 text-2xs font-semibold text-ink-secondary">
+                <span className="h-1.5 w-1.5 rounded-full bg-success shadow-[0_0_6px_rgba(52,199,89,0.7)]" aria-hidden="true" />
+                last 60 minutes
+              </span>
+            }
+          >
+            Verification stream
+          </CardTitle>
+          {lens.events === null ? (
+            <EmptyNote>The verification stream could not be loaded. Refresh to retry.</EmptyNote>
+          ) : events.length === 0 ? (
+            <EmptyNote>No verifications in the last hour. Actions your agents send through the SDK are checked against policy and land here.</EmptyNote>
+          ) : (
+            <ul className="mt-1 divide-y divide-divider">
+              {events.slice(0, 8).map((e) => {
+                const deny = e.status === "failed" || e.status === "denied" || e.status === "timeout";
+                return (
+                  <li key={e.id} className={cn("flex items-center gap-3 py-2.5", deny && "-mx-2 rounded-avatar bg-danger-fill px-2")}>
+                    <span className={cn("w-12 text-2xs font-semibold", deny ? "text-danger-text" : "text-ink-tertiary")}>{shortTime(e.startedAt || e.createdAt)}</span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[13px] font-bold text-ink">{e.agentName || e.agentId}</span>
+                      {deny && <span className="block truncate text-2xs font-semibold text-danger-text">{e.verificationType} failed</span>}
+                    </span>
+                    <StatusChip kind={deny ? "deny" : e.status === "pending" ? "pending" : "pass"}>{deny ? "Deny" : e.status === "pending" ? "Pending" : "Pass"}</StatusChip>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <p className="mt-auto pt-4 text-2xs text-ink-tertiary">Actions sent through the SDK are checked against policy. In monitoring mode a failed check is recorded and the action still runs.</p>
+          {canOpenSecurity && (
+            <Link href="/dashboard/security" className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-brand-text hover:underline">
+              Open Security <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/overview/shared.tsx
+++ b/apps/web/components/overview/shared.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import { formatDistanceToNowStrict } from "date-fns";
+import { cn } from "@/lib/utils";
+
+/** Presentation helpers shared by the overview lenses. Every number rendered through these comes from an endpoint. */
+
+export function relativeTime(iso?: string | null) {
+  if (!iso) return "";
+  try {
+    return formatDistanceToNowStrict(new Date(iso), { addSuffix: true });
+  } catch {
+    return "";
+  }
+}
+
+export function shortTime(iso?: string | null) {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return "";
+  if (ms < 60_000) return "now";
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export function trustDisplay(score: number | null | undefined) {
+  if (typeof score !== "number" || Number.isNaN(score)) return null;
+  return (score <= 1 ? score : score / 100).toFixed(2);
+}
+
+export function KpiTile({
+  label,
+  value,
+  delta,
+  tone = "default",
+  href,
+  size = "md",
+}: {
+  label: string;
+  value: string;
+  delta?: string;
+  tone?: "default" | "accent" | "alert" | "success";
+  href?: string;
+  size?: "md" | "sm";
+}) {
+  const body = (
+    <>
+      <p className={cn("font-semibold", size === "sm" ? "text-2xs" : "text-xs", tone === "alert" ? "text-danger-text" : "text-ink-secondary")}>{label}</p>
+      <p
+        className={cn(
+          "font-bold tracking-[-0.03em] leading-none",
+          size === "sm" ? "mt-1.5 text-[28px]" : "mt-2 text-[32px]",
+          tone === "accent" && "text-brand-text",
+          tone === "alert" && "text-danger-text",
+          tone === "success" && "text-success-text",
+          tone === "default" && "text-ink"
+        )}
+      >
+        {value}
+      </p>
+      {delta ? <p className={cn("mt-1 font-semibold text-ink-secondary", size === "sm" ? "text-2xs" : "text-xs")}>{delta}</p> : null}
+    </>
+  );
+  const cls = cn(tone === "alert" ? "glass-alert" : "glass", "block transition-transform", size === "sm" ? "rounded-card-sm p-4" : "p-5", href && "hover:-translate-y-0.5");
+  return href ? (
+    <Link href={href} className={cls}>
+      {body}
+    </Link>
+  ) : (
+    <div className={cls}>{body}</div>
+  );
+}
+
+export function StatusChip({ kind, children }: { kind: "pass" | "deny" | "pending" | "neutral"; children: React.ReactNode }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-pill border px-2.5 py-0.5 text-2xs font-bold",
+        kind === "pass" && "border-success-border bg-success-fill text-success-text",
+        kind === "deny" && "border-danger-border bg-danger-fill text-danger-text",
+        kind === "pending" && "border-warning-border bg-warning-fill text-warning-text",
+        kind === "neutral" && "border-glass-inset-border bg-glass-inset-gray text-ink-body"
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function CardTitle({ children, sub, action }: { children: React.ReactNode; sub?: string; action?: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <h3 className="text-[14px] font-bold tracking-[-0.02em] text-ink">{children}</h3>
+        {sub ? <p className="mt-0.5 text-xs text-ink-tertiary">{sub}</p> : null}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function EmptyNote({ children }: { children: React.ReactNode }) {
+  return <p className="mt-3 text-xs leading-relaxed text-ink-secondary">{children}</p>;
+}
+
+/**
+ * Recovery framing for the posture score. Withheld for now: a bare arithmetic delta
+ * names no action and leaks the hidden grade boundaries, so nothing renders it today. It
+ * returns once /security/metrics exposes the score components so the copy can name the lever
+ * ("+9 available by attesting 2 MCP servers"). Do not re-wire it to the next multiple of ten.
+ */
+export function postureDelta(_score: number) {
+  return "";
+}

--- a/apps/web/components/overview/types.ts
+++ b/apps/web/components/overview/types.ts
@@ -1,0 +1,97 @@
+import type { Agent } from "@/lib/api";
+
+export interface StatsData {
+  totalAgents: number;
+  verifiedAgents: number;
+  pendingAgents: number;
+  verificationRate: number;
+  avgTrustScore: number;
+  totalMcpServers: number;
+  activeMcpServers: number;
+  totalUsers: number;
+  activeUsers: number;
+  activeAlerts: number;
+  criticalAlerts: number;
+  securityIncidents: number;
+  organizationId: string;
+  /** Client-side index of the agents list, for lookups by id. */
+  agentsById?: Record<string, Agent>;
+}
+
+export interface VerificationStatistics {
+  totalVerifications: number;
+  successCount: number;
+  failedCount: number;
+  pendingCount: number;
+  uniqueAgentsVerified: number;
+}
+
+export interface VerificationActivityMonth {
+  month: string;
+  verified: number;
+  pending: number;
+  monthYear: string;
+}
+
+export interface SecurityMetrics {
+  securityScore: number;
+  securityStatus: string;
+  lastIncidentAt: string | null;
+  actionsBlocked: number;
+  actionsBlockedToday: number;
+  agentsMonitored: number;
+  agentsTrusted: number;
+  trustPercentage: number;
+  actionsToday: number;
+  requiresAttention: number;
+  averageTrustScore: number;
+  mcpServersTotal: number;
+  mcpServersVerified: number;
+  totalThreats: number;
+  activeThreats: number;
+  blockedThreats: number;
+  highSeverityCount: number;
+  openIncidents: number;
+  riskByCategory: Array<{ category: string; blocked: number; riskLevel: string }>;
+  recentBlockedActions: Array<{ id: string; agentId: string; agentName: string; attemptedCapability: string; details: string; trustImpact: number; createdAt: string }>;
+}
+
+export interface Violation {
+  id: string;
+  agentId: string;
+  agentName?: string;
+  attemptedCapability: string;
+  registeredCapabilities: string[];
+  severity: string;
+  trustScoreImpact: number;
+  isBlocked: boolean;
+  createdAt: string;
+}
+
+export interface VerificationEvent {
+  id: string;
+  agentId: string;
+  agentName?: string;
+  verificationType: string;
+  status: string;
+  trustScore: number;
+  startedAt: string;
+  createdAt: string;
+}
+
+export interface ComplianceStatus {
+  complianceLevel: string;
+  totalAgents: number;
+  verifiedAgents: number;
+  verificationRate: number;
+  averageTrustScore: number;
+  recentAuditCount: number;
+}
+
+/** Extra data the Security and Executive lenses read; null when the endpoint failed or the role may not read it. */
+export interface LensData {
+  security: SecurityMetrics | null;
+  violations: { violations: Violation[]; total: number } | null;
+  events: VerificationEvent[] | null;
+  compliance: ComplianceStatus | null;
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { toast } from "sonner";
+import { normalizeViolation, type SecurityViolation } from "./violations";
 
 const SESSION_EXPIRED_TOAST_ID = "session-expired";
 
@@ -2297,26 +2298,21 @@ class APIClient {
     limit: number = 50,
     offset: number = 0
   ): Promise<{
-    violations: Array<{
-      id: string;
-      agentId: string;
-      attemptedCapability: string;
-      registeredCapabilities: string[];
-      severity: string;
-      trustScoreImpact: number;
-      isBlocked: boolean;
-      sourceIp: string;
-      requestMetadata: Record<string, any>;
-      createdAt: string;
-      agentName?: string;
-    }>;
+    violations: SecurityViolation[];
     total: number;
     limit: number;
     offset: number;
   }> {
-    return this.request(
+    // The backend serializes violations with snake_case tags; consumers read camelCase.
+    const raw = await this.request<{ violations?: Array<Record<string, unknown>>; total?: number; limit?: number; offset?: number }>(
       `/api/v1/security/violations?limit=${limit}&offset=${offset}`
     );
+    return {
+      violations: (raw?.violations ?? []).map(normalizeViolation),
+      total: raw?.total ?? 0,
+      limit: raw?.limit ?? limit,
+      offset: raw?.offset ?? offset,
+    };
   }
 
   async getAgentKeyVault(agentId: string): Promise<any> {

--- a/apps/web/lib/violations.test.ts
+++ b/apps/web/lib/violations.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { normalizeViolation } from "@/lib/violations";
+
+// The exact wire shape of domain.CapabilityViolation (apps/backend/internal/domain/capability.go).
+const wire = {
+  id: "9c1f0c2e-1b7a-4c8e-9d1e-0a1b2c3d4e5f",
+  agent_id: "0a1b2c3d-4e5f-4a6b-8c7d-9e8f7a6b5c4d",
+  agent_name: "deploy-runner",
+  attempted_capability: "fs:write",
+  registered_capabilities: { "fs:read": true, "net:http": true },
+  severity: "high",
+  trust_score_impact: -5,
+  is_blocked: true,
+  source_ip: "10.0.0.7",
+  request_metadata: { path: "/etc/passwd" },
+  created_at: "2026-08-24T20:00:00Z",
+};
+
+describe("normalizeViolation", () => {
+  it("maps the backend's snake_case wire shape to the camelCase shape consumers read", () => {
+    const v = normalizeViolation(wire);
+    expect(v).toEqual({
+      id: wire.id,
+      agentId: wire.agent_id,
+      agentName: "deploy-runner",
+      attemptedCapability: "fs:write",
+      registeredCapabilities: ["fs:read", "net:http"],
+      severity: "high",
+      trustScoreImpact: -5,
+      isBlocked: true,
+      sourceIp: "10.0.0.7",
+      requestMetadata: { path: "/etc/passwd" },
+      createdAt: "2026-08-24T20:00:00Z",
+    });
+  });
+
+  it("keeps a blocked violation blocked (the field the hero card decides on)", () => {
+    expect(normalizeViolation({ ...wire, is_blocked: false }).isBlocked).toBe(false);
+    expect(normalizeViolation(wire).isBlocked).toBe(true);
+  });
+
+  it("passes an already camelCase payload through unchanged", () => {
+    const camel = normalizeViolation(wire);
+    expect(normalizeViolation(camel as unknown as Record<string, unknown>)).toEqual(camel);
+  });
+
+  it("accepts a capability list as well as a keyed object", () => {
+    expect(normalizeViolation({ ...wire, registered_capabilities: ["a", "b"] }).registeredCapabilities).toEqual(["a", "b"]);
+    expect(normalizeViolation({ ...wire, registered_capabilities: undefined }).registeredCapabilities).toEqual([]);
+  });
+});

--- a/apps/web/lib/violations.ts
+++ b/apps/web/lib/violations.ts
@@ -1,0 +1,51 @@
+/**
+ * Capability violations as the dashboard reads them.
+ *
+ * The backend serializes domain.CapabilityViolation with snake_case JSON tags
+ * (apps/backend/internal/domain/capability.go: agent_id, attempted_capability,
+ * registered_capabilities, trust_score_impact, is_blocked, source_ip, request_metadata,
+ * created_at) while every consumer in this app reads camelCase. The API client maps the
+ * wire shape here, once, so consumers see the declared shape whichever casing arrives.
+ */
+export interface SecurityViolation {
+  id: string;
+  agentId: string;
+  agentName?: string;
+  attemptedCapability: string;
+  registeredCapabilities: string[];
+  severity: string;
+  trustScoreImpact: number;
+  isBlocked: boolean;
+  sourceIp: string;
+  requestMetadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+type Raw = Record<string, unknown>;
+
+function pick<T>(raw: Raw, camel: string, snake: string): T | undefined {
+  return (raw[camel] !== undefined ? raw[camel] : raw[snake]) as T | undefined;
+}
+
+/** Registered capabilities arrive as an object keyed by capability name, or as a list. */
+function capabilityNames(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (value && typeof value === "object") return Object.keys(value as Record<string, unknown>);
+  return [];
+}
+
+export function normalizeViolation(raw: Raw): SecurityViolation {
+  return {
+    id: String(pick<string>(raw, "id", "id") ?? ""),
+    agentId: String(pick<string>(raw, "agentId", "agent_id") ?? ""),
+    agentName: pick<string>(raw, "agentName", "agent_name") ?? undefined,
+    attemptedCapability: String(pick<string>(raw, "attemptedCapability", "attempted_capability") ?? ""),
+    registeredCapabilities: capabilityNames(pick(raw, "registeredCapabilities", "registered_capabilities")),
+    severity: String(pick<string>(raw, "severity", "severity") ?? ""),
+    trustScoreImpact: Number(pick<number>(raw, "trustScoreImpact", "trust_score_impact") ?? 0),
+    isBlocked: Boolean(pick<boolean>(raw, "isBlocked", "is_blocked") ?? false),
+    sourceIp: String(pick<string>(raw, "sourceIp", "source_ip") ?? ""),
+    requestMetadata: (pick<Record<string, unknown>>(raw, "requestMetadata", "request_metadata") ?? {}) as Record<string, unknown>,
+    createdAt: String(pick<string>(raw, "createdAt", "created_at") ?? ""),
+  };
+}


### PR DESCRIPTION
Second of six stacked pull requests (Glasshouse; the whole change is #418). Stacked on the foundation PR.

## What this part contains

The overview rebuilt as a Glasshouse home: a hero sentence that states the fleet's condition, four tiles that each read one endpoint, the agents list with trust bars, a quickstart with the one install path that works (passing the dashboard origin to `aim-sdk login`, which otherwise defaults to the hosted service), and the verification series. With no agents it teaches the three commands instead of showing six zeros.

Security and Executive lenses read only endpoints the role's permission map already allows. A section the role may not read, or that failed to load, renders as unavailable rather than empty; violations carry no open/resolved state, so their count is labelled all-time; links into `/dashboard/security*` and `/dashboard/admin/alerts` are rendered only for roles the edge gate lets through; the role falls back to the token claim when `/users/me` fails.

The backend serializes capability violations with snake_case tags while every consumer read camelCase, so hero cards said "Not blocked" for blocked actions. The API client maps the wire shape once (`lib/violations.ts`, tested against the real handler shape), which also repairs the existing violations page.

## Verification

- `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch.
- Light and dark at 1440 and 375 px for each lens, with and without agents: no horizontal overflow, no page errors.
