### PR TITLE
Glasshouse auth pages and registration queue, with claims measured against the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Brings up `aim-server`, `aim-dashboard`, PostgreSQL, and Redis. Dashboard at `lo
 
 Production deployment (Azure, GCP, AWS): [infrastructure/DEPLOYMENT.md](infrastructure/DEPLOYMENT.md).
 
+New accounts wait for an administrator's approval. To bootstrap the first administrator, set `AIM_PLATFORM_ADMINS` (comma-separated emails) before starting the backend: accounts on that list are approved automatically and approve everyone else from the dashboard's admin area.
+
 ### From source
 
 Prerequisites: Docker, Go 1.22+, Node 20+, Python 3.11+.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -59,6 +59,12 @@ ENVIRONMENT=development                     # development | staging | production
 # Security Settings (Production)
 # -----------------------------------------------------------------------------
 # AIM_PUBLIC_URL=https://your-domain.com    # Public URL for SDK downloads
+# AIM_PLATFORM_ADMINS=you@example.com       # Comma-separated emails approved
+                                             # automatically at signup; each becomes
+                                             # admin of their own organization and can
+                                             # approve other accounts in the admin
+                                             # area. Empty (default): every new
+                                             # account waits for an existing admin.
 # CORS_ORIGINS=https://your-frontend.com    # Comma-separated allowed origins
 
 # -----------------------------------------------------------------------------

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,0 +1,2 @@
+// The registration review queue lives outside /dashboard but renders inside the same shell.
+export { default } from "@/app/dashboard/layout";

--- a/apps/web/app/admin/registrations/page.tsx
+++ b/apps/web/app/admin/registrations/page.tsx
@@ -72,153 +72,103 @@ export default function RegistrationsPage() {
     (req) => req.status === "rejected"
   ).length;
 
+  const tabs = (["pending", "approved", "rejected", "all"] as const).map((status) => ({
+    status,
+    label: status === "all" ? "All" : status.charAt(0).toUpperCase() + status.slice(1),
+    count: status === "pending" ? pendingCount : status === "approved" ? approvedCount : status === "rejected" ? rejectedCount : total,
+  }));
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
-                <UserPlus className="w-6 h-6 text-white" />
-              </div>
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">
-                  Registration Requests
-                </h1>
-                <p className="text-sm text-gray-600">
-                  Review and manage user registration requests
-                </p>
-              </div>
-            </div>
-
-            <button
-              onClick={fetchRequests}
-              disabled={loading}
-              className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50"
-            >
-              <RefreshCw
-                className={`w-4 h-4 ${loading ? "animate-spin" : ""}`}
-              />
-              <span>Refresh</span>
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white border border-gray-200 rounded-lg p-6">
-            <div className="text-sm text-gray-600 mb-1">Total Requests</div>
-            <div className="text-3xl font-bold text-gray-900">{total}</div>
-          </div>
-
-          <div className="bg-white border border-amber-200 rounded-lg p-6">
-            <div className="text-sm text-amber-700 mb-1">Pending Review</div>
-            <div className="text-3xl font-bold text-amber-600">
-              {pendingCount}
-            </div>
-          </div>
-
-          <div className="bg-white border border-green-200 rounded-lg p-6">
-            <div className="text-sm text-green-700 mb-1">Approved</div>
-            <div className="text-3xl font-bold text-green-600">
-              {approvedCount}
-            </div>
-          </div>
-
-          <div className="bg-white border border-red-200 rounded-lg p-6">
-            <div className="text-sm text-red-700 mb-1">Rejected</div>
-            <div className="text-3xl font-bold text-red-600">
-              {rejectedCount}
-            </div>
-          </div>
-        </div>
-
-        {/* Filter Tabs */}
-        <div className="bg-white border border-gray-200 rounded-lg p-1 mb-6 inline-flex">
-          {(["all", "pending", "approved", "rejected"] as const).map(
-            (status) => (
-              <button
-                key={status}
-                onClick={() => setFilter(status)}
-                className={`px-4 py-2 rounded-md font-medium text-sm transition-colors ${
-                  filter === status
-                    ? "bg-blue-600 text-white"
-                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-50"
-                }`}
-              >
-                {status.charAt(0).toUpperCase() + status.slice(1)}
-                {status !== "all" && (
-                  <span className="ml-2 text-xs opacity-75">
-                    (
-                    {status === "pending"
-                      ? pendingCount
-                      : status === "approved"
-                        ? approvedCount
-                        : rejectedCount}
-                    )
-                  </span>
-                )}
-              </button>
-            )
-          )}
-        </div>
-
-        {/* Error State */}
-        {error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6 flex items-center gap-3">
-            <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0" />
+    <main>
+      <div className="mx-auto max-w-5xl">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-inset-sm bg-brand-soft text-brand-text">
+              <UserPlus className="h-5 w-5" aria-hidden="true" />
+            </span>
             <div>
-              <p className="text-sm font-medium text-red-900">
-                Error loading requests
-              </p>
-              <p className="text-sm text-red-700">{error}</p>
+              <h1 className="text-headline">Registration requests</h1>
+              <p className="text-sm text-ink-secondary">People waiting for an administrator to let them in.</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={fetchRequests}
+            disabled={loading}
+            className="inline-flex h-9 items-center gap-2 rounded-pill border border-stroke bg-glass px-4 text-xs font-bold text-ink backdrop-blur-card hover:bg-glass-inset disabled:opacity-60"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} aria-hidden="true" />
+            Refresh
+          </button>
+        </div>
+
+        <div className="mt-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[
+            { label: "Total", value: total, tone: "text-ink" },
+            { label: "Pending review", value: pendingCount, tone: pendingCount > 0 ? "text-warning-text" : "text-ink" },
+            { label: "Approved", value: approvedCount, tone: "text-success-text" },
+            { label: "Rejected", value: rejectedCount, tone: rejectedCount > 0 ? "text-danger-text" : "text-ink" },
+          ].map((t) => (
+            <div key={t.label} className="glass p-4">
+              <p className="text-xs font-semibold text-ink-secondary">{t.label}</p>
+              <p className={`mt-1.5 text-[28px] font-bold leading-none tracking-[-0.03em] ${t.tone}`}>{t.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="glass-segment mt-5" role="tablist" aria-label="Filter requests">
+          {tabs.map((t) => (
+            <button
+              key={t.status}
+              type="button"
+              role="tab"
+              aria-selected={filter === t.status}
+              data-active={filter === t.status}
+              onClick={() => setFilter(t.status)}
+              className="glass-segment-item"
+            >
+              {t.label} <span className="opacity-70">({t.count})</span>
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="mt-5 flex items-center gap-3 rounded-card border border-danger-border bg-danger-fill p-4" role="alert">
+            <AlertCircle className="h-4 w-4 flex-shrink-0 text-danger-text" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-bold text-danger-text">Requests could not be loaded</p>
+              <p className="text-xs text-ink-body">{error}</p>
             </div>
           </div>
         )}
 
-        {/* Loading State */}
         {loading && (
-          <div className="flex items-center justify-center py-12">
-            <div className="flex items-center gap-3 text-gray-600">
-              <div className="w-6 h-6 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
-              <span>Loading registration requests...</span>
-            </div>
+          <div className="flex items-center justify-center gap-3 py-12 text-sm text-ink-secondary" aria-busy="true">
+            <span className="h-5 w-5 animate-spin rounded-full border-2 border-track border-t-brand" aria-hidden="true" />
+            Loading registration requests
           </div>
         )}
 
-        {/* Requests List */}
         {!loading && !error && (
-          <>
+          <div className="mt-5">
             {filteredRequests.length === 0 ? (
-              <div className="bg-white border border-gray-200 rounded-lg p-12 text-center">
-                <UserPlus className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">
-                  No {filter !== "all" && filter} registration requests
-                </h3>
-                <p className="text-gray-600">
-                  {filter === "pending"
-                    ? "There are no pending registration requests at the moment."
-                    : `No registration requests with status: ${filter}`}
+              <div className="glass p-10 text-center">
+                <UserPlus className="mx-auto mb-3 h-8 w-8 text-ink-tertiary" aria-hidden="true" />
+                <h3 className="text-[15px] font-bold text-ink">No {filter !== "all" ? filter : ""} registration requests</h3>
+                <p className="mt-1 text-xs text-ink-secondary">
+                  {filter === "pending" ? "Nobody is waiting for approval right now." : `There are no requests with status ${filter}.`}
                 </p>
               </div>
             ) : (
-              <div className="space-y-4">
+              <div className="space-y-3">
                 {filteredRequests.map((request) => (
-                  <RegistrationRequestCard
-                    key={request.id}
-                    request={request}
-                    onApproved={fetchRequests}
-                    onRejected={fetchRequests}
-                  />
+                  <RegistrationRequestCard key={request.id} request={request} onApproved={fetchRequests} onRejected={fetchRequests} />
                 ))}
               </div>
             )}
-          </>
+          </div>
         )}
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/app/auth/change-password/page.tsx
+++ b/apps/web/app/auth/change-password/page.tsx
@@ -3,14 +3,9 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import {
-  Shield,
-  Lock,
-  Eye,
-  EyeOff,
-  AlertCircle,
-  CheckCircle2,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, Eye, EyeOff, Lock, Shield } from "lucide-react";
+import { AimLogo } from "@/components/sidebar";
+import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 
@@ -145,215 +140,101 @@ export default function ChangePasswordPage() {
     ? validatePassword(formData.newPassword)
     : null;
 
+  const inputClass = (invalid: boolean) =>
+    `w-full rounded-inset border bg-glass-inset py-2.5 pl-10 pr-10 text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0 ${
+      invalid ? "border-danger" : "border-stroke"
+    }`;
+
+  const field = (
+    id: "currentPassword" | "newPassword" | "confirmPassword",
+    label: string,
+    placeholder: string,
+    shown: boolean,
+    toggle: () => void,
+    autoComplete: string
+  ) => (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-xs font-semibold text-ink-body">
+        {label}
+      </label>
+      <div className="relative">
+        <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-tertiary" aria-hidden="true" />
+        <input
+          id={id}
+          type={shown ? "text" : "password"}
+          autoComplete={autoComplete}
+          value={formData[id]}
+          onChange={(e) => setFormData({ ...formData, [id]: e.target.value })}
+          className={inputClass(!!errors[id])}
+          placeholder={placeholder}
+          aria-invalid={!!errors[id]}
+          aria-describedby={errors[id] ? `${id}-error` : undefined}
+        />
+        <button type="button" onClick={toggle} className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-tertiary hover:text-ink" aria-label={shown ? "Hide password" : "Show password"}>
+          {shown ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
+        </button>
+      </div>
+      {errors[id] && (
+        <p id={`${id}-error`} className="mt-1 flex items-center gap-1 text-xs font-semibold text-danger-text">
+          <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+          {errors[id]}
+        </p>
+      )}
+    </div>
+  );
+
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div className="w-full max-w-md">
-        {/* Logo and Branding */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-orange-600 to-red-600 rounded-2xl mb-4">
-            <Shield className="w-8 h-8 text-white" />
-          </div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Change Your Password
-          </h1>
-          <p className="text-gray-600">
-            Security policy requires you to set a new password
+        <div className="mb-6 flex flex-col items-center text-center">
+          <AimLogo size={48} className="shadow-[0_10px_26px_rgba(56,189,248,0.35)]" />
+          <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Set a new password</h1>
+          <p className="mt-1 text-sm text-ink-secondary">
+            Your account{userEmail ? ` (${userEmail})` : ""} needs a new password before you continue.
           </p>
         </div>
 
-        {/* Main Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          <div className="mb-6">
-            <p className="text-sm text-gray-600">
-              Changing password for: <span className="font-semibold text-gray-900">{userEmail}</span>
+        <div className="glass-chrome p-6 sm:p-8">
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            {field("currentPassword", "Current password", "Enter your current password", showCurrentPassword, () => setShowCurrentPassword((v) => !v), "current-password")}
+            {field("newPassword", "New password", "Enter a new password", showNewPassword, () => setShowNewPassword((v) => !v), "new-password")}
+            {formData.newPassword && passwordStrength && (
+              <ul className="rounded-inset bg-glass-inset-gray p-3 text-xs" aria-live="polite">
+                {passwordStrength.length === 0 ? (
+                  <li className="flex items-center gap-1.5 font-semibold text-success-text">
+                    <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    All requirements met
+                  </li>
+                ) : (
+                  passwordStrength.map((issue) => (
+                    <li key={issue} className="flex items-center gap-1.5 text-ink-secondary">
+                      <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden="true" />
+                      {issue}
+                    </li>
+                  ))
+                )}
+              </ul>
+            )}
+            {field("confirmPassword", "Confirm new password", "Enter it again", showConfirmPassword, () => setShowConfirmPassword((v) => !v), "new-password")}
+            <Button type="submit" disabled={isLoading} className="w-full" size="lg">
+              {isLoading ? "Saving..." : "Change password"}
+            </Button>
+          </form>
+
+          <div className="mt-5 flex gap-3 rounded-inset bg-brand-soft p-3.5">
+            <Shield className="mt-0.5 h-4 w-4 flex-shrink-0 text-brand-text" aria-hidden="true" />
+            <p className="text-xs leading-relaxed text-ink-body">
+              At least 8 characters with an uppercase letter, a lowercase letter, a number and a special character, and different from the current one.
             </p>
           </div>
 
-          {/* Password Change Form */}
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Current Password */}
-            <div>
-              <label
-                htmlFor="currentPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Current Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="currentPassword"
-                  type={showCurrentPassword ? "text" : "password"}
-                  value={formData.currentPassword}
-                  onChange={(e) =>
-                    setFormData({ ...formData, currentPassword: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-12 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.currentPassword ? "border-red-500" : "border-gray-300"
-                  }`}
-                  placeholder="Enter current password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowCurrentPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                  aria-label={showCurrentPassword ? "Hide password" : "Show password"}
-                >
-                  {showCurrentPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-              {errors.currentPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  {errors.currentPassword}
-                </p>
-              )}
-            </div>
-
-            {/* New Password */}
-            <div>
-              <label
-                htmlFor="newPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                New Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="newPassword"
-                  type={showNewPassword ? "text" : "password"}
-                  value={formData.newPassword}
-                  onChange={(e) =>
-                    setFormData({ ...formData, newPassword: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-12 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.newPassword ? "border-red-500" : "border-gray-300"
-                  }`}
-                  placeholder="Enter new password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowNewPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                  aria-label={showNewPassword ? "Hide password" : "Show password"}
-                >
-                  {showNewPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-              {errors.newPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  {errors.newPassword}
-                </p>
-              )}
-              {/* Password Strength Indicator */}
-              {formData.newPassword && passwordStrength && (
-                <div className="mt-2 space-y-1">
-                  <p className="text-xs font-medium text-gray-700">Password Requirements:</p>
-                  <div className="space-y-1">
-                    {passwordStrength.length === 0 ? (
-                      <p className="text-xs text-green-600 flex items-center gap-1">
-                        <CheckCircle2 className="h-3 w-3" />
-                        All requirements met
-                      </p>
-                    ) : (
-                      passwordStrength.map((issue, idx) => (
-                        <p key={idx} className="text-xs text-orange-600 flex items-center gap-1">
-                          <AlertCircle className="h-3 w-3" />
-                          {issue}
-                        </p>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Confirm Password */}
-            <div>
-              <label
-                htmlFor="confirmPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Confirm New Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  value={formData.confirmPassword}
-                  onChange={(e) =>
-                    setFormData({ ...formData, confirmPassword: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-12 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 ${
-                    errors.confirmPassword ? "border-red-500" : "border-gray-300"
-                  }`}
-                  placeholder="Confirm new password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                  aria-label={showConfirmPassword ? "Hide password" : "Show password"}
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-              {errors.confirmPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  {errors.confirmPassword}
-                </p>
-              )}
-            </div>
-
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="w-full py-3 px-4 bg-orange-600 text-white font-medium rounded-lg hover:bg-orange-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoading ? "Changing Password..." : "Change Password"}
-            </button>
-          </form>
-
-          {/* Info Box */}
-          <div className="bg-orange-50 border border-orange-100 rounded-lg p-4 mt-6">
-            <div className="flex gap-3">
-              <Shield className="w-5 h-5 text-orange-600 flex-shrink-0 mt-0.5" />
-              <div className="text-sm text-orange-900">
-                <p className="font-medium mb-1">Security Notice</p>
-                <p className="text-orange-700">
-                  Your new password must be strong and different from your current password. After changing, you'll be redirected to login with your new credentials.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Cancel Link */}
-          <div className="text-center pt-4 border-t border-gray-200 mt-6">
-            <Link
-              href="/auth/login"
-              className="text-gray-600 hover:text-gray-700 text-sm hover:underline"
-            >
-              Cancel and return to login
+          <p className="mt-5 border-t border-divider pt-4 text-center text-sm">
+            <Link href="/auth/login" className="font-semibold text-brand-text hover:underline">
+              Back to sign in
             </Link>
-          </div>
+          </p>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/app/auth/forgot-password/page.tsx
+++ b/apps/web/app/auth/forgot-password/page.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Shield, Mail, AlertCircle, CheckCircle2, ArrowLeft } from "lucide-react";
+import { AlertCircle, ArrowLeft, CheckCircle2, Mail, Shield } from "lucide-react";
+import { AimLogo } from "@/components/sidebar";
+import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 
@@ -54,171 +56,113 @@ export default function ForgotPasswordPage() {
     }
   };
 
+  const inputClass = (invalid: boolean) =>
+    `w-full rounded-inset border bg-glass-inset py-2.5 pl-10 pr-4 text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0 ${
+      invalid ? "border-danger" : "border-stroke"
+    }`;
+
   if (isSubmitted) {
     return (
-      <div className="min-h-screen bg-white flex items-center justify-center p-4">
+      <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
         <div className="w-full max-w-md">
-          {/* Logo and Branding */}
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-green-600 to-emerald-600 rounded-2xl mb-4">
-              <CheckCircle2 className="w-8 h-8 text-white" />
-            </div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              Check Your Email
-            </h1>
-            <p className="text-gray-600">
-              We've sent you password reset instructions
+          <div className="mb-6 flex flex-col items-center text-center">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-success-fill text-success-text">
+              <CheckCircle2 className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Check your email</h1>
+            <p className="mt-1 text-sm text-ink-secondary">
+              If an account exists for <span className="font-semibold text-ink">{email}</span>, a reset link is on its way.
             </p>
           </div>
 
-          {/* Success Card */}
-          <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-            <div className="text-center space-y-4">
-              <div className="bg-green-50 border border-green-100 rounded-lg p-4">
-                <p className="text-sm text-green-900">
-                  If an account exists for <strong>{email}</strong>, you will
-                  receive an email with instructions to reset your password.
-                </p>
-              </div>
-
-              <div className="text-left space-y-2 text-sm text-gray-600">
-                <p className="font-medium text-gray-900">Next steps:</p>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>Check your email inbox for a message from Agent Identity Management</li>
-                  <li>Click the password reset link in the email</li>
-                  <li>The link will expire in 24 hours for security</li>
-                  <li>Check your spam folder if you don't see it</li>
-                </ul>
-              </div>
-
-              <div className="pt-4 space-y-3">
-                <Link
-                  href="/auth/login"
-                  className="block w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
-                >
-                  Return to Login
-                </Link>
-                <button
-                  onClick={() => {
-                    setIsSubmitted(false);
-                    setEmail("");
-                  }}
-                  className="block w-full py-3 px-4 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition-colors text-center"
-                >
-                  Send Another Email
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Help Text */}
-          <div className="mt-6 text-center text-sm text-gray-600">
-            <p>
-              Didn't receive an email?{" "}
+          <div className="glass-chrome p-6 sm:p-8">
+            <p className="text-sm font-bold text-ink">Next steps</p>
+            <ul className="mt-2 space-y-1.5 text-xs text-ink-body">
+              <li>Open the message from Agent Identity Management and follow the reset link.</li>
+              <li>The link expires after 24 hours and works once; request another if it has expired.</li>
+              <li>Check your spam folder if nothing arrives.</li>
+            </ul>
+            <div className="mt-6 flex flex-col gap-2">
+              <Link href="/auth/login" className="inline-flex h-11 items-center justify-center rounded-pill bg-brand text-sm font-bold text-white shadow-glow hover:bg-brand-hover">
+                Back to sign in
+              </Link>
               <button
+                type="button"
                 onClick={() => {
                   setIsSubmitted(false);
                   setEmail("");
                 }}
-                className="text-blue-600 hover:underline font-medium"
+                className="inline-flex h-11 items-center justify-center rounded-pill border border-stroke bg-glass text-sm font-bold text-ink hover:bg-glass-inset"
               >
-                Try again
+                Send another email
               </button>
-            </p>
+            </div>
           </div>
         </div>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div className="w-full max-w-md">
-        {/* Logo and Branding */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-600 to-purple-600 rounded-2xl mb-4">
-            <Shield className="w-8 h-8 text-white" />
-          </div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Forgot Password?
-          </h1>
-          <p className="text-gray-600">
-            No worries, we'll send you reset instructions
-          </p>
+        <div className="mb-6 flex flex-col items-center text-center">
+          <AimLogo size={48} className="shadow-[0_10px_26px_rgba(56,189,248,0.35)]" />
+          <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Forgot your password?</h1>
+          <p className="mt-1 text-sm text-ink-secondary">Enter your email and we will send a reset link.</p>
         </div>
 
-        {/* Main Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="glass-chrome p-6 sm:p-8">
+          <form onSubmit={handleSubmit} className="space-y-5" noValidate>
             <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Email Address
+              <label htmlFor="email" className="mb-1 block text-xs font-semibold text-ink-body">
+                Email address
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-tertiary" aria-hidden="true" />
                 <input
                   id="email"
                   type="email"
+                  autoComplete="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   onBlur={validateEmail}
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    error ? "border-red-500" : "border-gray-300"
-                  }`}
+                  className={inputClass(!!error)}
                   placeholder="you@example.com"
                   autoFocus
+                  aria-invalid={!!error}
+                  aria-describedby={error ? "email-error" : "email-hint"}
                 />
               </div>
-              {error && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
+              {error ? (
+                <p id="email-error" className="mt-1 flex items-center gap-1 text-xs font-semibold text-danger-text">
+                  <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   {error}
                 </p>
+              ) : (
+                <p id="email-hint" className="mt-1 text-xs text-ink-tertiary">The address you sign in with.</p>
               )}
-              <p className="mt-2 text-xs text-gray-500">
-                Enter the email address associated with your account
-              </p>
             </div>
-
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoading ? "Sending..." : "Send Reset Link"}
-            </button>
+            <Button type="submit" disabled={isLoading} className="w-full" size="lg">
+              {isLoading ? "Sending..." : "Send reset link"}
+            </Button>
           </form>
 
-          {/* Security Info */}
-          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 mt-6">
-            <div className="flex gap-3">
-              <Shield className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
-              <div className="text-sm text-blue-900">
-                <p className="font-medium mb-1">Secure Reset Process</p>
-                <p className="text-blue-700">
-                  For security, we don't reveal whether an email exists in our
-                  system. You'll only receive an email if your account is
-                  registered.
-                </p>
-              </div>
-            </div>
+          <div className="mt-5 flex gap-3 rounded-inset bg-brand-soft p-3.5">
+            <Shield className="mt-0.5 h-4 w-4 flex-shrink-0 text-brand-text" aria-hidden="true" />
+            <p className="text-xs leading-relaxed text-ink-body">
+              The response does not say whether an account exists. A message is sent only to registered accounts.
+            </p>
           </div>
 
-          {/* Back to Login */}
-          <div className="text-center pt-6 border-t border-gray-200 mt-6">
-            <Link
-              href="/auth/login"
-              className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 font-medium hover:underline"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Back to Login
+          <p className="mt-5 border-t border-divider pt-4 text-center text-sm">
+            <Link href="/auth/login" className="inline-flex items-center gap-1.5 font-semibold text-brand-text hover:underline">
+              <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              Back to sign in
             </Link>
-          </div>
+          </p>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -3,23 +3,17 @@
 import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import {
-  CheckCircle2,
-  Shield,
-  Users,
-  Lock,
-  Mail,
-  AlertCircle,
-  Eye,
-  EyeOff,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, Eye, EyeOff, Lock, Mail } from "lucide-react";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
+import { AimLogo } from "@/components/sidebar";
+import { Button } from "@/components/ui/button";
+import { safeReturnUrl } from "@/lib/return-url";
 
 function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const returnUrl = searchParams.get("returnUrl") || "/dashboard";
+  const returnUrl = safeReturnUrl(searchParams.get("returnUrl"));
   const [isLoadingPassword, setIsLoadingPassword] = useState(false);
   const [formData, setFormData] = useState({
     email: "",
@@ -74,8 +68,8 @@ function LoginPageContent() {
       if (response.success) {
         if (response.isApproved) {
           // User is approved, redirect to return URL or dashboard
-          toast.success("Login successful!");
-          router.push(decodeURIComponent(returnUrl));
+          toast.success("Signed in");
+          router.push(returnUrl);
         } else {
           // User exists but not approved yet - redirect to pending page
           toast.info("Your account is pending admin approval.");
@@ -95,7 +89,7 @@ function LoginPageContent() {
       }
 
       // Show toast notification with the exact backend error
-      toast.error("Login Failed", {
+      toast.error("Could not sign in", {
         description: errorMessage,
         duration: 5000,
       });
@@ -106,159 +100,114 @@ function LoginPageContent() {
     }
   };
 
+  const inputClass = (invalid: boolean) =>
+    `w-full rounded-inset border bg-glass-inset py-2.5 pl-10 pr-10 text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0 ${
+      invalid ? "border-danger" : "border-stroke"
+    }`;
+
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div className="w-full max-w-md">
-        {/* Logo and Branding */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-20 h-20 mb-4">
-            <img
-              src="/opena2a-logo.svg"
-              alt="OpenA2A Logo"
-              className="w-full h-full object-contain"
-            />
-          </div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Welcome Back
-          </h1>
-          <p className="text-sm text-blue-600 font-medium mb-1">AIM for a better security</p>
-          <p className="text-gray-600">
-            Sign in to manage your AI agents and MCP servers
-          </p>
+        <div className="mb-6 flex flex-col items-center text-center">
+          <AimLogo size={48} className="shadow-[0_10px_26px_rgba(56,189,248,0.35)]" />
+          <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Welcome back</h1>
+          <p className="mt-1 text-sm text-ink-secondary">Sign in to manage your agents and MCP servers.</p>
         </div>
 
-        {/* Main Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-6">
-            Sign in to your account
-          </h2>
-
-          {/* Email/Password Form */}
-          <form onSubmit={handlePasswordLogin} className="space-y-4 mb-6">
+        <div className="glass-chrome p-6 sm:p-8">
+          <form onSubmit={handlePasswordLogin} className="space-y-4" noValidate>
             <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Email Address
+              <label htmlFor="email" className="mb-1 block text-xs font-semibold text-ink-body">
+                Email address
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-tertiary" aria-hidden="true" />
                 <input
                   id="email"
                   type="email"
+                  autoComplete="email"
                   value={formData.email}
-                  onChange={(e) =>
-                    setFormData({ ...formData, email: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.email ? "border-red-500" : "border-gray-300"
-                  }`}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  className={inputClass(!!errors.email)}
                   placeholder="you@example.com"
+                  aria-invalid={!!errors.email}
+                  aria-describedby={errors.email ? "email-error" : undefined}
                 />
               </div>
               {errors.email && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
+                <p id="email-error" className="mt-1 flex items-center gap-1 text-xs font-semibold text-danger-text">
+                  <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   {errors.email}
                 </p>
               )}
             </div>
 
             <div>
-              <div className="flex items-center justify-between mb-1">
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-gray-700"
-                >
+              <div className="mb-1 flex items-center justify-between">
+                <label htmlFor="password" className="block text-xs font-semibold text-ink-body">
                   Password
                 </label>
-                <Link
-                  href="/auth/forgot-password"
-                  className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
-                >
+                <Link href="/auth/forgot-password" className="text-xs font-semibold text-brand-text hover:underline">
                   Forgot password?
                 </Link>
               </div>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-tertiary" aria-hidden="true" />
                 <input
                   id="password"
                   type={showPassword ? "text" : "password"}
+                  autoComplete="current-password"
                   value={formData.password}
-                  onChange={(e) =>
-                    setFormData({ ...formData, password: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.password ? "border-red-500" : "border-gray-300"
-                  }`}
+                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                  className={inputClass(!!errors.password)}
                   placeholder="Enter your password"
+                  aria-invalid={!!errors.password}
+                  aria-describedby={errors.password ? "password-error" : undefined}
                 />
                 <button
                   type="button"
-                  onClick={() => setShowPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-tertiary hover:text-ink"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
-                  {showPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
+                  {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                 </button>
               </div>
               {errors.password && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
+                <p id="password-error" className="mt-1 flex items-center gap-1 text-xs font-semibold text-danger-text">
+                  <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   {errors.password}
                 </p>
               )}
             </div>
 
-            <button
-              type="submit"
-              disabled={isLoadingPassword}
-              className="w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoadingPassword ? "Signing in..." : "Sign In"}
-            </button>
+            <Button type="submit" disabled={isLoadingPassword} className="w-full" size="lg">
+              {isLoadingPassword ? "Signing in..." : "Sign in"}
+            </Button>
           </form>
 
-          {/* Info Box */}
-          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 mt-6">
-            <div className="flex gap-3">
-              <CheckCircle2 className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
-              <div className="text-sm text-blue-900">
-                <p className="font-medium mb-1">Secure Authentication</p>
-                <p className="text-blue-700">
-                  Your credentials are encrypted and protected. All new registrations require admin approval for enhanced security.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* New User Link */}
-          <div className="text-center pt-4 border-t border-gray-200 mt-6">
-            <p className="text-gray-600">
-              Don't have an account?{" "}
-              <Link
-                href="/auth/register"
-                className="text-blue-600 hover:text-blue-700 font-medium hover:underline"
-              >
-                Sign Up
-              </Link>
+          <div className="mt-5 flex gap-3 rounded-inset bg-brand-soft p-3.5">
+            <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-brand-text" aria-hidden="true" />
+            <p className="text-xs leading-relaxed text-ink-body">
+              New accounts are reviewed by an administrator before they can sign in. Passwords are stored as bcrypt hashes, never in plain text.
             </p>
           </div>
-        </div>
 
+          <p className="mt-5 border-t border-divider pt-4 text-center text-sm text-ink-secondary">
+            Don&apos;t have an account?{" "}
+            <Link href="/auth/register" className="font-semibold text-brand-text hover:underline">
+              Create one
+            </Link>
+          </p>
+        </div>
       </div>
-    </div>
+    </main>
   );
 }
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center text-sm text-ink-secondary">Loading...</div>}>
       <LoginPageContent />
     </Suspense>
   );

--- a/apps/web/app/auth/register/page.tsx
+++ b/apps/web/app/auth/register/page.tsx
@@ -119,7 +119,7 @@ export default function RegisterPage() {
       });
 
       if (response.success) {
-        toast.success("Registration successful! Awaiting admin approval.");
+        toast.success("Registration successful. Awaiting admin approval.");
         // Redirect to pending page with request ID
         router.push(
           `/auth/registration-pending?request_id=${response.requestId}`
@@ -142,27 +142,26 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
+    <div className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div className="w-full max-w-md">
         {/* Logo and Title */}
         <div className="text-center mb-8">
           <div className="flex justify-center mb-4">
-            <div className="w-16 h-16 bg-gradient-to-br from-blue-600 to-purple-600 rounded-2xl flex items-center justify-center shadow-lg">
-              <Shield className="w-10 h-10 text-white" />
+            <div className="w-16 h-16 bg-logo rounded-card flex items-center justify-center shadow-glow">
+              <Shield className="w-10 h-10 text-ink-inverse" />
             </div>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          <h1 className="text-3xl font-bold tracking-[-0.03em] text-ink mb-2">
             Welcome to AIM
           </h1>
-          <p className="text-sm text-blue-600 font-medium mb-1">AIM for a better security</p>
-          <p className="text-gray-600">
+          <p className="text-ink-secondary">
             Sign up to manage AI agents and MCP servers
           </p>
         </div>
 
         {/* Registration Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          <h2 className="text-xl font-semibold text-gray-900 mb-6 text-center">
+        <div className="glass-chrome p-8">
+          <h2 className="text-xl font-semibold text-ink mb-6 text-center">
             Create your account
           </h2>
 
@@ -171,12 +170,12 @@ export default function RegisterPage() {
             <div>
               <label
                 htmlFor="email"
-                className="block text-sm font-medium text-gray-700 mb-1"
+                className="block text-sm font-medium text-ink-body mb-1"
               >
-                Email Address
+                Email address
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
                 <input
                   id="email"
                   type="email"
@@ -184,14 +183,14 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, email: e.target.value })
                   }
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.email ? "border-red-500" : "border-gray-300"
+                  className={`w-full pl-10 pr-4 py-2 rounded-inset border bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.email ? "border-danger" : "border-stroke"
                   }`}
                   placeholder="you@example.com"
                 />
               </div>
               {errors.email && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                   <AlertCircle className="h-4 w-4" />
                   {errors.email}
                 </p>
@@ -202,12 +201,12 @@ export default function RegisterPage() {
               <div>
                 <label
                   htmlFor="firstName"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-ink-body mb-1"
                 >
-                  First Name
+                  First name
                 </label>
                 <div className="relative">
-                  <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                  <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
                   <input
                     id="firstName"
                     type="text"
@@ -215,14 +214,14 @@ export default function RegisterPage() {
                     onChange={(e) =>
                       setFormData({ ...formData, firstName: e.target.value })
                     }
-                    className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                      errors.firstName ? "border-red-500" : "border-gray-300"
+                    className={`w-full pl-10 pr-4 py-2 rounded-inset border bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring ${
+                      errors.firstName ? "border-danger" : "border-stroke"
                     }`}
                     placeholder="John"
                   />
                 </div>
                 {errors.firstName && (
-                  <p className="mt-1 text-sm text-red-600">
+                  <p className="mt-1 text-sm text-danger-text">
                     {errors.firstName}
                   </p>
                 )}
@@ -231,9 +230,9 @@ export default function RegisterPage() {
               <div>
                 <label
                   htmlFor="lastName"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-ink-body mb-1"
                 >
-                  Last Name
+                  Last name
                 </label>
                 <input
                   id="lastName"
@@ -242,13 +241,13 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, lastName: e.target.value })
                   }
-                  className={`w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.lastName ? "border-red-500" : "border-gray-300"
+                  className={`w-full px-4 py-2 rounded-inset border bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.lastName ? "border-danger" : "border-stroke"
                   }`}
                   placeholder="Doe"
                 />
                 {errors.lastName && (
-                  <p className="mt-1 text-sm text-red-600">{errors.lastName}</p>
+                  <p className="mt-1 text-sm text-danger-text">{errors.lastName}</p>
                 )}
               </div>
             </div>
@@ -256,12 +255,12 @@ export default function RegisterPage() {
             <div>
               <label
                 htmlFor="password"
-                className="block text-sm font-medium text-gray-700 mb-1"
+                className="block text-sm font-medium text-ink-body mb-1"
               >
                 Password
               </label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
                 <input
                   id="password"
                   type={showPassword ? "text" : "password"}
@@ -269,15 +268,15 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, password: e.target.value })
                   }
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.password ? "border-red-500" : "border-gray-300"
+                  className={`w-full pl-10 pr-4 py-2 rounded-inset border bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.password ? "border-danger" : "border-stroke"
                   }`}
                   placeholder="Min. 8 characters, uppercase, lowercase, number, special char"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-tertiary hover:text-ink"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? (
@@ -288,13 +287,13 @@ export default function RegisterPage() {
                 </button>
               </div>
               {errors.password && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                   <AlertCircle className="h-4 w-4" />
                   {errors.password}
                 </p>
               )}
               {!errors.password && (
-                <p className="mt-1 text-xs text-gray-500">
+                <p className="mt-1 text-xs text-ink-tertiary">
                   Must be 8+ characters with uppercase, lowercase, number &
                   special character
                 </p>
@@ -304,12 +303,12 @@ export default function RegisterPage() {
             <div>
               <label
                 htmlFor="confirmPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
+                className="block text-sm font-medium text-ink-body mb-1"
               >
-                Confirm Password
+                Confirm password
               </label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
                 <input
                   id="confirmPassword"
                   type={showConfirm ? "text" : "password"}
@@ -320,17 +319,17 @@ export default function RegisterPage() {
                       confirmPassword: e.target.value,
                     })
                   }
-                  className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  className={`w-full pl-10 pr-4 py-2 rounded-inset border bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring ${
                     errors.confirmPassword
-                      ? "border-red-500"
-                      : "border-gray-300"
+                      ? "border-danger"
+                      : "border-stroke"
                   }`}
                   placeholder="Re-enter password"
                 />
                 <button
                   type="button"
                   onClick={() => setShowConfirm((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-tertiary hover:text-ink"
                   aria-label={showConfirm ? "Hide password" : "Show password"}
                 >
                   {showConfirm ? (
@@ -341,22 +340,22 @@ export default function RegisterPage() {
                 </button>
               </div>
               {errors.confirmPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                   <AlertCircle className="h-4 w-4" />
                   {errors.confirmPassword}
                 </p>
               )}
             </div>
 
-            <div className="pt-2 border-t border-gray-200 space-y-4">
-              <p className="text-sm text-gray-600">
+            <div className="pt-2 border-t border-divider space-y-4">
+              <p className="text-sm text-ink-secondary">
                 A few quick questions so we can improve AIM:
               </p>
 
               <div>
                 <label
                   htmlFor="role"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-ink-body mb-1"
                 >
                   What best describes you?
                 </label>
@@ -366,9 +365,9 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, role: e.target.value })
                   }
-                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.role ? "border-red-500" : "border-gray-300"
-                  } ${formData.role ? "text-gray-900" : "text-gray-400"}`}
+                  className={`w-full px-4 py-2 rounded-inset border bg-glass-inset focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.role ? "border-danger" : "border-stroke"
+                  } ${formData.role ? "text-ink" : "text-ink-tertiary"}`}
                 >
                   <option value="" disabled>
                     Select an option
@@ -380,7 +379,7 @@ export default function RegisterPage() {
                   ))}
                 </select>
                 {errors.role && (
-                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                  <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                     <AlertCircle className="h-4 w-4" />
                     {errors.role}
                   </p>
@@ -390,7 +389,7 @@ export default function RegisterPage() {
               <div>
                 <label
                   htmlFor="primaryUseCase"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-ink-body mb-1"
                 >
                   What will you use AIM for?
                 </label>
@@ -400,9 +399,9 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, primaryUseCase: e.target.value })
                   }
-                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.primaryUseCase ? "border-red-500" : "border-gray-300"
-                  } ${formData.primaryUseCase ? "text-gray-900" : "text-gray-400"}`}
+                  className={`w-full px-4 py-2 rounded-inset border bg-glass-inset focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.primaryUseCase ? "border-danger" : "border-stroke"
+                  } ${formData.primaryUseCase ? "text-ink" : "text-ink-tertiary"}`}
                 >
                   <option value="" disabled>
                     Select an option
@@ -414,7 +413,7 @@ export default function RegisterPage() {
                   ))}
                 </select>
                 {errors.primaryUseCase && (
-                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                  <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                     <AlertCircle className="h-4 w-4" />
                     {errors.primaryUseCase}
                   </p>
@@ -424,7 +423,7 @@ export default function RegisterPage() {
               <div>
                 <label
                   htmlFor="referralSource"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-ink-body mb-1"
                 >
                   How did you hear about AIM?
                 </label>
@@ -434,9 +433,9 @@ export default function RegisterPage() {
                   onChange={(e) =>
                     setFormData({ ...formData, referralSource: e.target.value })
                   }
-                  className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.referralSource ? "border-red-500" : "border-gray-300"
-                  } ${formData.referralSource ? "text-gray-900" : "text-gray-400"}`}
+                  className={`w-full px-4 py-2 rounded-inset border bg-glass-inset focus:outline-none focus:ring-2 focus:ring-ring ${
+                    errors.referralSource ? "border-danger" : "border-stroke"
+                  } ${formData.referralSource ? "text-ink" : "text-ink-tertiary"}`}
                 >
                   <option value="" disabled>
                     Select an option
@@ -448,7 +447,7 @@ export default function RegisterPage() {
                   ))}
                 </select>
                 {errors.referralSource && (
-                  <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
+                  <p className="mt-1 text-sm text-danger-text flex items-center gap-1">
                     <AlertCircle className="h-4 w-4" />
                     {errors.referralSource}
                   </p>
@@ -459,43 +458,31 @@ export default function RegisterPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full py-3 px-4 rounded-pill bg-brand text-ink-inverse font-medium shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isLoading ? "Creating Account..." : "Create Account"}
+              {isLoading ? "Creating account..." : "Create account"}
             </button>
           </form>
 
           {/* Info Box */}
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-            <p className="text-sm text-blue-800">
-              <strong>Note:</strong> After you sign up, an administrator will
-              review and approve your account. You'll receive an email
-              notification once your account is ready.
+          <div className="rounded-inset bg-brand-soft p-4">
+            <p className="text-sm text-ink-body">
+              <strong>Note:</strong> After you sign up, an administrator reviews
+              your account before you can sign in. Until then the sign-in page
+              will tell you the request is still pending.
             </p>
           </div>
 
           {/* Footer */}
-          <div className="mt-6 text-center text-sm text-gray-600">
+          <div className="mt-6 text-center text-sm text-ink-secondary">
             Already have an account?{" "}
             <Link
               href="/auth/login"
-              className="text-blue-600 hover:text-blue-700 font-medium"
+              className="font-semibold text-brand-text hover:underline"
             >
               Sign in
             </Link>
           </div>
-        </div>
-
-        {/* Additional Info */}
-        <div className="mt-6 text-center text-xs text-gray-500">
-          By signing up, you agree to our{" "}
-          <a href="/terms" className="text-blue-600 hover:underline">
-            Terms of Service
-          </a>{" "}
-          and{" "}
-          <a href="/privacy" className="text-blue-600 hover:underline">
-            Privacy Policy
-          </a>
         </div>
       </div>
     </div>

--- a/apps/web/app/auth/registration-pending/page.tsx
+++ b/apps/web/app/auth/registration-pending/page.tsx
@@ -1,138 +1,98 @@
-'use client'
+"use client";
 
-import { useSearchParams } from 'next/navigation'
-import { Shield, CheckCircle, Mail, Clock } from 'lucide-react'
-import Link from 'next/link'
-import { Suspense } from 'react'
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { CheckCircle2, Clock, Mail } from "lucide-react";
+import { AimLogo } from "@/components/sidebar";
 
 function RegistrationPendingContent() {
-  const searchParams = useSearchParams()
-  const requestId = searchParams.get('request_id')
-  const supportEmail = process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'info@opena2a.org'
+  const searchParams = useSearchParams();
+  const requestId = searchParams.get("request_id");
+  const supportEmail = process.env.NEXT_PUBLIC_SUPPORT_EMAIL || "info@opena2a.org";
 
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
-      <div className="w-full max-w-2xl">
-        {/* Logo */}
-        <div className="text-center mb-8">
-          <div className="flex justify-center mb-4">
-            <div className="w-16 h-16 bg-gradient-to-br from-blue-600 to-purple-600 rounded-2xl flex items-center justify-center shadow-lg">
-              <Shield className="w-10 h-10 text-white" />
-            </div>
-          </div>
-          <h1 className="text-3xl font-bold text-gray-900">
-            AIM - Agent Identity Management
-          </h1>
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
+      <div className="w-full max-w-xl">
+        <div className="mb-6 flex flex-col items-center text-center">
+          <AimLogo size={48} className="shadow-[0_10px_26px_rgba(56,189,248,0.35)]" />
+          <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Your request is in.</h1>
+          <p className="mt-1 text-sm text-ink-secondary">An administrator reviews new accounts before they can sign in.</p>
         </div>
 
-        {/* Success Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          {/* Success Icon */}
-          <div className="flex justify-center mb-6">
-            <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center">
-              <CheckCircle className="w-12 h-12 text-green-600" />
+        <div className="glass-chrome p-6 sm:p-8">
+          <div className="flex items-start gap-3 rounded-inset bg-success-fill p-4">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-success-text" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-bold text-ink">Registration submitted</p>
+              {requestId && (
+                <p className="mt-1 text-xs text-ink-secondary">
+                  Request ID <span className="break-all font-mono text-ink">{requestId}</span>
+                </p>
+              )}
             </div>
           </div>
 
-          {/* Title */}
-          <h2 className="text-2xl font-bold text-gray-900 text-center mb-4">
-            Registration Submitted Successfully!
-          </h2>
-
-          {/* Description */}
-          <p className="text-gray-600 text-center mb-8">
-            Your account request has been submitted and is now pending administrator approval.
-          </p>
-
-          {/* Request ID */}
-          {requestId && (
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
-              <p className="text-sm text-gray-600 mb-1">Request ID:</p>
-              <p className="font-mono text-sm text-gray-900 break-all">
-                {requestId}
-              </p>
-            </div>
-          )}
-
-          {/* Next Steps */}
-          <div className="space-y-4 mb-8">
-            <h3 className="font-semibold text-gray-900 text-lg">What happens next?</h3>
-
-            <div className="flex items-start gap-3">
-              <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                <Clock className="w-4 h-4 text-blue-600" />
-              </div>
+          <h2 className="mt-6 text-[15px] font-bold tracking-[-0.02em] text-ink">What happens next</h2>
+          <ol className="mt-3 space-y-3">
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-brand-soft text-brand-text">
+                <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
               <div>
-                <h4 className="font-medium text-gray-900">Administrator Review</h4>
-                <p className="text-sm text-gray-600">
-                  An administrator will review your registration request. This typically takes 1-2 business days.
-                </p>
+                <p className="text-sm font-bold text-ink">An administrator reviews the request</p>
+                <p className="text-xs text-ink-secondary">Approval happens in this AIM deployment's admin area; the time it takes depends on your administrator.</p>
               </div>
-            </div>
-
-            <div className="flex items-start gap-3">
-              <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                <Mail className="w-4 h-4 text-purple-600" />
-              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-brand-soft text-brand-text">
+                <Mail className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
               <div>
-                <h4 className="font-medium text-gray-900">Email Notification</h4>
-                <p className="text-sm text-gray-600">
-                  You'll receive an email notification once your account has been approved or if additional information is needed.
-                </p>
+                <p className="text-sm font-bold text-ink">Check back by signing in</p>
+                <p className="text-xs text-ink-secondary">Once approved, signing in takes you straight to your dashboard. Until then the sign-in page will tell you the request is still pending. If the request is declined you will not receive a message; contact the administrator if you have not been approved.</p>
               </div>
-            </div>
+            </li>
+          </ol>
 
-            <div className="flex items-start gap-3">
-              <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                <CheckCircle className="w-4 h-4 text-green-600" />
-              </div>
-              <div>
-                <h4 className="font-medium text-gray-900">Access Granted</h4>
-                <p className="text-sm text-gray-600">
-                  Once approved, you'll be able to sign in and start using AIM to manage your AI agents and MCP servers.
-                </p>
-              </div>
-            </div>
+          <div className="mt-5 rounded-inset bg-glass-inset-gray px-4 py-3">
+            <p className="text-xs leading-relaxed text-ink-secondary">
+              Running this deployment yourself? Accounts whose email is listed in the{" "}
+              <code className="font-mono text-ink">AIM_PLATFORM_ADMINS</code> environment variable
+              (comma-separated, for example{" "}
+              <code className="font-mono text-ink">AIM_PLATFORM_ADMINS=you@example.com</code>) are
+              approved automatically and become administrators of their own organization.
+              Administrators approve everyone else under Organization &gt; Registrations in the dashboard.
+            </p>
           </div>
 
-          {/* Action Buttons */}
-          <div className="flex flex-col gap-3">
-            <Link
-              href="/auth/login"
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-lg transition-colors text-center"
-            >
-              Go to Sign In
+          <div className="mt-6 flex flex-col gap-2 sm:flex-row">
+            <Link href="/auth/login" className="inline-flex h-11 flex-1 items-center justify-center rounded-pill bg-brand text-sm font-bold text-white shadow-glow hover:bg-brand-hover">
+              Go to sign in
             </Link>
-
             <a
-              href={`mailto:${supportEmail}?subject=AIM Account Registration - Urgent`}
-              className="w-full border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-3 px-6 rounded-lg transition-colors text-center"
+              href={`mailto:${supportEmail}?subject=${encodeURIComponent("AIM account registration")}`}
+              className="inline-flex h-11 flex-1 items-center justify-center rounded-pill border border-stroke bg-glass text-sm font-bold text-ink hover:bg-glass-inset"
             >
-              Contact Administrator
+              Contact the administrator
             </a>
           </div>
         </div>
-
-        {/* Footer */}
-        <div className="mt-6 text-center text-sm text-gray-500">
-          Need help?{' '}
-          <a href="/support" className="text-blue-600 hover:underline">
-            Contact Support
-          </a>
-        </div>
       </div>
-    </div>
-  )
+    </main>
+  );
 }
 
 export default function RegistrationPendingPage() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center" aria-busy="true">
+          <span className="h-8 w-8 animate-spin rounded-full border-2 border-track border-t-brand" aria-label="Loading" />
+        </div>
+      }
+    >
       <RegistrationPendingContent />
     </Suspense>
-  )
+  );
 }

--- a/apps/web/app/auth/reset-password/page.tsx
+++ b/apps/web/app/auth/reset-password/page.tsx
@@ -3,15 +3,9 @@
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import {
-  Shield,
-  Lock,
-  AlertCircle,
-  CheckCircle2,
-  Eye,
-  EyeOff,
-  XCircle,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, Eye, EyeOff, Lock, Shield, XCircle } from "lucide-react";
+import { AimLogo } from "@/components/sidebar";
+import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 
@@ -44,9 +38,10 @@ function ResetPasswordPageContent() {
       newErrors.newPassword = "Password is required";
     } else if (formData.newPassword.length < 8) {
       newErrors.newPassword = "Password must be at least 8 characters";
-    } else if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(formData.newPassword)) {
+    } else if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?])/.test(formData.newPassword)) {
+      // The same rule the backend enforces (infrastructure/auth/password.go ValidatePassword).
       newErrors.newPassword =
-        "Password must contain uppercase, lowercase, and number";
+        "Password must contain an uppercase letter, a lowercase letter, a number and a special character";
     }
 
     if (!formData.confirmPassword) {
@@ -76,8 +71,8 @@ function ResetPasswordPageContent() {
 
       if (response.success) {
         setIsSuccess(true);
-        toast.success("Password reset successful!", {
-          description: "You can now log in with your new password.",
+        toast.success("Password updated", {
+          description: "Sign in with your new password.",
         });
 
         // Redirect to login after 3 seconds
@@ -104,7 +99,7 @@ function ResetPasswordPageContent() {
         setTokenValid(false);
       }
 
-      toast.error("Password Reset Failed", {
+      toast.error("Could not reset the password", {
         description: errorMessage,
         duration: 5000,
       });
@@ -115,262 +110,138 @@ function ResetPasswordPageContent() {
     }
   };
 
+  const inputClass = (invalid: boolean) =>
+    `w-full rounded-inset border bg-glass-inset py-2.5 pl-10 pr-10 text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0 ${
+      invalid ? "border-danger" : "border-stroke"
+    }`;
+
   // Invalid or missing token
   if (!tokenValid) {
     return (
-      <div className="min-h-screen bg-white flex items-center justify-center p-4">
+      <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
         <div className="w-full max-w-md">
-          {/* Logo and Branding */}
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-red-600 to-orange-600 rounded-2xl mb-4">
-              <XCircle className="w-8 h-8 text-white" />
-            </div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              Invalid Reset Link
-            </h1>
-            <p className="text-gray-600">
-              This password reset link is invalid or has expired
-            </p>
+          <div className="mb-6 flex flex-col items-center text-center">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-danger-fill text-danger-text">
+              <XCircle className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">This reset link no longer works</h1>
+            <p className="mt-1 text-sm text-ink-secondary">Reset links expire 24 hours after they are sent and work once.</p>
           </div>
-
-          {/* Error Card */}
-          <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-            <div className="text-center space-y-4">
-              <div className="bg-red-50 border border-red-100 rounded-lg p-4">
-                <p className="text-sm text-red-900">
-                  The password reset link you used is either invalid or has
-                  expired. Password reset links are valid for 24 hours.
-                </p>
-              </div>
-
-              <div className="text-left space-y-2 text-sm text-gray-600">
-                <p className="font-medium text-gray-900">What to do next:</p>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>Request a new password reset link</li>
-                  <li>Check that you used the latest email</li>
-                  <li>Make sure you clicked the link within 24 hours</li>
-                </ul>
-              </div>
-
-              <div className="pt-4 space-y-3">
-                <Link
-                  href="/auth/forgot-password"
-                  className="block w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
-                >
-                  Request New Reset Link
-                </Link>
-                <Link
-                  href="/auth/login"
-                  className="block w-full py-3 px-4 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition-colors text-center"
-                >
-                  Back to Login
-                </Link>
-              </div>
+          <div className="glass-chrome p-6 sm:p-8">
+            <p className="text-sm font-bold text-ink">What to do</p>
+            <ul className="mt-2 space-y-1.5 text-xs text-ink-body">
+              <li>Request a new link and open the most recent email.</li>
+              <li>Use the link within 24 hours of receiving it.</li>
+            </ul>
+            <div className="mt-6 flex flex-col gap-2">
+              <Link href="/auth/forgot-password" className="inline-flex h-11 items-center justify-center rounded-pill bg-brand text-sm font-bold text-white shadow-glow hover:bg-brand-hover">
+                Request a new link
+              </Link>
+              <Link href="/auth/login" className="inline-flex h-11 items-center justify-center rounded-pill border border-stroke bg-glass text-sm font-bold text-ink hover:bg-glass-inset">
+                Back to sign in
+              </Link>
             </div>
           </div>
         </div>
-      </div>
+      </main>
     );
   }
 
   // Success state
   if (isSuccess) {
     return (
-      <div className="min-h-screen bg-white flex items-center justify-center p-4">
+      <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
         <div className="w-full max-w-md">
-          {/* Logo and Branding */}
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-green-600 to-emerald-600 rounded-2xl mb-4">
-              <CheckCircle2 className="w-8 h-8 text-white" />
-            </div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              Password Reset Successful!
-            </h1>
-            <p className="text-gray-600">
-              Your password has been updated securely
-            </p>
+          <div className="mb-6 flex flex-col items-center text-center">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-success-fill text-success-text">
+              <CheckCircle2 className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Password updated</h1>
+            <p className="mt-1 text-sm text-ink-secondary">You can sign in with the new password now.</p>
           </div>
-
-          {/* Success Card */}
-          <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-            <div className="text-center space-y-4">
-              <div className="bg-green-50 border border-green-100 rounded-lg p-4">
-                <p className="text-sm text-green-900">
-                  Your password has been successfully reset. You can now log in
-                  with your new password.
-                </p>
-              </div>
-
-              <p className="text-sm text-gray-600">
-                Redirecting to login page in 3 seconds...
-              </p>
-
-              <Link
-                href="/auth/login"
-                className="block w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
-              >
-                Go to Login Now
-              </Link>
-            </div>
+          <div className="glass-chrome p-6 text-center sm:p-8" role="status" aria-live="polite">
+            <p className="text-xs text-ink-secondary">Taking you to sign in in a few seconds.</p>
+            <Link href="/auth/login" className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-pill bg-brand text-sm font-bold text-white shadow-glow hover:bg-brand-hover">
+              Go to sign in now
+            </Link>
           </div>
         </div>
-      </div>
+      </main>
     );
   }
 
+  const passwordField = (
+    id: "newPassword" | "confirmPassword",
+    label: string,
+    placeholder: string,
+    shown: boolean,
+    toggle: () => void,
+    hint?: string
+  ) => (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-xs font-semibold text-ink-body">
+        {label}
+      </label>
+      <div className="relative">
+        <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-tertiary" aria-hidden="true" />
+        <input
+          id={id}
+          type={shown ? "text" : "password"}
+          autoComplete="new-password"
+          value={formData[id]}
+          onChange={(e) => setFormData({ ...formData, [id]: e.target.value })}
+          className={inputClass(!!errors[id])}
+          placeholder={placeholder}
+          autoFocus={id === "newPassword"}
+          aria-invalid={!!errors[id]}
+          aria-describedby={errors[id] ? `${id}-error` : hint ? `${id}-hint` : undefined}
+        />
+        <button type="button" onClick={toggle} className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-tertiary hover:text-ink" aria-label={shown ? "Hide password" : "Show password"}>
+          {shown ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
+        </button>
+      </div>
+      {errors[id] ? (
+        <p id={`${id}-error`} className="mt-1 flex items-center gap-1 text-xs font-semibold text-danger-text">
+          <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+          {errors[id]}
+        </p>
+      ) : hint ? (
+        <p id={`${id}-hint`} className="mt-1 text-xs text-ink-tertiary">{hint}</p>
+      ) : null}
+    </div>
+  );
+
   // Reset password form
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
+    <main className="glass-page relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div className="w-full max-w-md">
-        {/* Logo and Branding */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-600 to-purple-600 rounded-2xl mb-4">
-            <Shield className="w-8 h-8 text-white" />
-          </div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Reset Your Password
-          </h1>
-          <p className="text-gray-600">
-            Choose a strong password for your account
-          </p>
+        <div className="mb-6 flex flex-col items-center text-center">
+          <AimLogo size={48} className="shadow-[0_10px_26px_rgba(56,189,248,0.35)]" />
+          <h1 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-ink">Choose a new password</h1>
+          <p className="mt-1 text-sm text-ink-secondary">At least 8 characters with an uppercase letter, a lowercase letter, a number and a special character.</p>
         </div>
 
-        {/* Main Card */}
-        <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8">
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div>
-              <label
-                htmlFor="newPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                New Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="newPassword"
-                  type={showNewPassword ? "text" : "password"}
-                  value={formData.newPassword}
-                  onChange={(e) =>
-                    setFormData({ ...formData, newPassword: e.target.value })
-                  }
-                  className={`w-full pl-10 pr-12 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.newPassword ? "border-red-500" : "border-gray-300"
-                  }`}
-                  placeholder="Enter new password"
-                  autoFocus
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowNewPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                  aria-label={showNewPassword ? "Hide password" : "Show password"}
-                >
-                  {showNewPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-              {errors.newPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  {errors.newPassword}
-                </p>
-              )}
-              <p className="mt-1 text-xs text-gray-500">
-                Must be at least 8 characters with uppercase, lowercase, and
-                number
-              </p>
-            </div>
-
-            <div>
-              <label
-                htmlFor="confirmPassword"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                Confirm Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  value={formData.confirmPassword}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      confirmPassword: e.target.value,
-                    })
-                  }
-                  className={`w-full pl-10 pr-12 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                    errors.confirmPassword
-                      ? "border-red-500"
-                      : "border-gray-300"
-                  }`}
-                  placeholder="Confirm new password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword((s) => !s)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                  aria-label={
-                    showConfirmPassword ? "Hide password" : "Show password"
-                  }
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="h-5 w-5" />
-                  ) : (
-                    <Eye className="h-5 w-5" />
-                  )}
-                </button>
-              </div>
-              {errors.confirmPassword && (
-                <p className="mt-1 text-sm text-red-600 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  {errors.confirmPassword}
-                </p>
-              )}
-            </div>
-
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="w-full py-3 px-4 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoading ? "Resetting Password..." : "Reset Password"}
-            </button>
+        <div className="glass-chrome p-6 sm:p-8">
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            {passwordField("newPassword", "New password", "Enter a new password", showNewPassword, () => setShowNewPassword((v) => !v))}
+            {passwordField("confirmPassword", "Confirm password", "Enter it again", showConfirmPassword, () => setShowConfirmPassword((v) => !v))}
+            <Button type="submit" disabled={isLoading} className="w-full" size="lg">
+              {isLoading ? "Saving..." : "Set new password"}
+            </Button>
           </form>
-
-          {/* Security Info */}
-          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 mt-6">
-            <div className="flex gap-3">
-              <Shield className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
-              <div className="text-sm text-blue-900">
-                <p className="font-medium mb-1">Secure Password Reset</p>
-                <p className="text-blue-700">
-                  Your password is encrypted using industry-standard bcrypt
-                  hashing. This link expires in 24 hours.
-                </p>
-              </div>
-            </div>
+          <div className="mt-5 flex gap-3 rounded-inset bg-brand-soft p-3.5">
+            <Shield className="mt-0.5 h-4 w-4 flex-shrink-0 text-brand-text" aria-hidden="true" />
+            <p className="text-xs leading-relaxed text-ink-body">Passwords are stored as bcrypt hashes. This reset link expires 24 hours after it was sent and works once.</p>
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }
 
 export default function ResetPasswordPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="min-h-screen flex items-center justify-center">
-          Loading...
-        </div>
-      }
-    >
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center text-sm text-ink-secondary">Loading...</div>}>
       <ResetPasswordPageContent />
     </Suspense>
   );

--- a/apps/web/components/admin/registration-request-card.tsx
+++ b/apps/web/components/admin/registration-request-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { CheckCircle, XCircle, User, Mail, Shield, Calendar, AlertCircle } from 'lucide-react'
+import { AlertCircle, Calendar, CheckCircle, Mail, XCircle } from 'lucide-react'
 import { api } from '@/lib/api'
 
 interface RegistrationRequest {
@@ -35,12 +35,6 @@ interface RegistrationRequestCardProps {
   onRejected?: () => void
 }
 
-const providerColors = {
-  google: 'bg-blue-100 text-blue-700',
-  microsoft: 'bg-gray-800 text-white',
-  okta: 'bg-blue-600 text-white',
-  local: 'bg-gray-100 text-gray-700',
-}
 
 // Human-readable labels for the signup questionnaire slugs
 // (vocabulary defined in backend domain/signup_profile.go)
@@ -122,192 +116,165 @@ export function RegistrationRequestCard({ request, onApproved, onRejected }: Reg
     })
   }
 
+  const provider = request.oauthProvider ?? 'local'
+  const providerLabel = provider === 'local' ? 'Email and password' : provider.charAt(0).toUpperCase() + provider.slice(1)
+
   return (
     <>
-      <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow">
+      <div className="glass p-5">
         <div className="flex items-start gap-4">
-          {/* Profile Picture */}
           <div className="flex-shrink-0">
             {request.profilePictureUrl ? (
-              <img
-                src={request.profilePictureUrl}
-                alt={fullName}
-                className="w-16 h-16 rounded-full object-cover"
-              />
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={request.profilePictureUrl} alt="" className="h-12 w-12 rounded-full object-cover" />
             ) : (
-              <div className="w-16 h-16 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center">
-                <User className="w-8 h-8 text-white" />
-              </div>
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[#a78bfa] to-[#6366f1] text-sm font-bold text-white" aria-hidden="true">
+                {fullName.slice(0, 1).toUpperCase()}
+              </span>
             )}
           </div>
 
-          {/* Content */}
-          <div className="flex-grow min-w-0">
-            {/* Name and Provider */}
-            <div className="flex items-start justify-between gap-4 mb-3">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-1">
-                  {fullName}
-                </h3>
-                <div className="flex items-center gap-2 text-sm text-gray-600">
-                  <Mail className="w-4 h-4" />
+          <div className="min-w-0 flex-grow">
+            <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h3 className="truncate text-[15px] font-bold tracking-[-0.02em] text-ink">{fullName}</h3>
+                <p className="flex items-center gap-1.5 text-xs text-ink-secondary">
+                  <Mail className="h-3.5 w-3.5 text-ink-tertiary" aria-hidden="true" />
                   <span className="truncate">{request.email}</span>
-                </div>
+                </p>
               </div>
-
-              <span className={`px-3 py-1 rounded-full text-xs font-medium ${providerColors[request.oauthProvider ?? 'local']}`}>
-                {(request.oauthProvider ?? 'local').toUpperCase()}
+              <span className="inline-flex rounded-pill border border-glass-inset-border bg-glass-inset-gray px-2.5 py-0.5 text-2xs font-bold text-ink-body">
+                {providerLabel}
               </span>
             </div>
 
-            {/* Metadata */}
-            <div className="grid grid-cols-2 gap-3 mb-4 text-sm">
-              <div className="flex items-center gap-2 text-gray-600">
-                <Calendar className="w-4 h-4" />
-                <span>Requested {formatDate(request.requestedAt)}</span>
-              </div>
-
-              <div className="flex items-center gap-2">
-                {request.oauthEmailVerified ? (
-                  <>
-                    <CheckCircle className="w-4 h-4 text-green-600" />
-                    <span className="text-green-700 font-medium">Email Verified</span>
-                  </>
-                ) : (
-                  <>
-                    <AlertCircle className="w-4 h-4 text-amber-600" />
-                    <span className="text-amber-700">Email Not Verified</span>
-                  </>
-                )}
-              </div>
+            <div className="mb-3 flex flex-wrap gap-x-5 gap-y-1.5 text-xs">
+              <span className="inline-flex items-center gap-1.5 text-ink-secondary">
+                <Calendar className="h-3.5 w-3.5 text-ink-tertiary" aria-hidden="true" />
+                Requested {formatDate(request.requestedAt)}
+              </span>
+              {request.oauthEmailVerified ? (
+                <span className="inline-flex items-center gap-1.5 font-semibold text-success-text">
+                  <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  Email verified by the provider
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1.5 font-semibold text-warning-text">
+                  <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  Email not verified
+                </span>
+              )}
             </div>
 
-            {/* Signup Profile Answers */}
             {profileEntries.length > 0 && (
-              <div className="flex flex-wrap gap-2 mb-4">
+              <div className="mb-3 flex flex-wrap gap-2">
                 {profileEntries.map((entry) => (
-                  <span
-                    key={entry.label}
-                    className="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-50 border border-gray-200 rounded-full text-xs"
-                  >
-                    <span className="text-gray-500">{entry.label}:</span>
-                    <span className="font-medium text-gray-800">{entry.value}</span>
+                  <span key={entry.label} className="inline-flex items-center gap-1.5 rounded-pill bg-glass-inset-gray px-2.5 py-1 text-2xs">
+                    <span className="text-ink-tertiary">{entry.label}</span>
+                    <span className="font-bold text-ink">{entry.value}</span>
                   </span>
                 ))}
               </div>
             )}
 
-            {/* Error Message */}
             {error && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800">
+              <div className="mb-3 rounded-inset border border-danger-border bg-danger-fill p-3 text-xs font-semibold text-danger-text" role="alert">
                 {error}
               </div>
             )}
 
-            {/* Action Buttons */}
             {request.status === 'pending' && (
-              <div className="flex gap-3">
+              <div className="flex flex-wrap gap-2">
                 <button
+                  type="button"
                   onClick={handleApprove}
                   disabled={isApproving || isRejecting}
-                  className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-pill bg-brand px-4 text-xs font-bold text-white shadow-glow hover:bg-brand-hover disabled:opacity-50"
                 >
                   {isApproving ? (
                     <>
-                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                      <span>Approving...</span>
+                      <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" aria-hidden="true" />
+                      Approving...
                     </>
                   ) : (
                     <>
-                      <CheckCircle className="w-4 h-4" />
-                      <span>Approve</span>
+                      <CheckCircle className="h-4 w-4" aria-hidden="true" />
+                      Approve
                     </>
                   )}
                 </button>
-
                 <button
+                  type="button"
                   onClick={() => setShowRejectModal(true)}
                   disabled={isApproving || isRejecting}
-                  className="flex-1 flex items-center justify-center gap-2 bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-pill border border-danger-border bg-danger-fill px-4 text-xs font-bold text-danger-text hover:brightness-95 disabled:opacity-50"
                 >
-                  <XCircle className="w-4 h-4" />
-                  <span>Reject</span>
+                  <XCircle className="h-4 w-4" aria-hidden="true" />
+                  Reject
                 </button>
               </div>
             )}
 
-            {/* Status Badge for Reviewed Requests */}
             {request.status !== 'pending' && (
-              <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg ${
-                request.status === 'approved' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+              <div className={`inline-flex items-center gap-2 rounded-pill border px-3 py-1 text-xs font-bold ${
+                request.status === 'approved' ? 'border-success-border bg-success-fill text-success-text' : 'border-danger-border bg-danger-fill text-danger-text'
               }`}>
-                {request.status === 'approved' ? (
-                  <CheckCircle className="w-4 h-4" />
-                ) : (
-                  <XCircle className="w-4 h-4" />
-                )}
-                <span className="font-medium capitalize">{request.status}</span>
-                {request.reviewedAt && (
-                  <span className="text-sm">on {formatDate(request.reviewedAt)}</span>
-                )}
+                {request.status === 'approved' ? <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" /> : <XCircle className="h-3.5 w-3.5" aria-hidden="true" />}
+                <span className="capitalize">{request.status}</span>
+                {request.reviewedAt && <span className="font-medium opacity-80">on {formatDate(request.reviewedAt)}</span>}
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {/* Rejection Modal */}
       {showRejectModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">
-              Reject Registration Request
-            </h3>
-
-            <p className="text-sm text-gray-600 mb-4">
-              Please provide a reason for rejecting {fullName}'s registration request.
-              This will be sent to the user via email.
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="reject-title">
+          <div className="glass-chrome w-full max-w-md p-6">
+            <h3 id="reject-title" className="text-[17px] font-bold tracking-[-0.02em] text-ink">Reject this request</h3>
+            <p className="mt-1 text-xs text-ink-secondary">
+              Give a reason for rejecting {fullName}. A reason is required and is kept with the request.
             </p>
-
+            <label htmlFor="reject-reason" className="sr-only">Rejection reason</label>
             <textarea
+              id="reject-reason"
               value={rejectionReason}
               onChange={(e) => setRejectionReason(e.target.value)}
-              placeholder="e.g., Email address does not match company domain"
+              placeholder="e.g. Email address is not on the company domain"
               rows={4}
-              className="w-full border border-gray-300 rounded-lg p-3 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+              className="mt-4 w-full rounded-inset border border-stroke bg-glass-inset p-3 text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring"
             />
-
             {error && (
-              <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800">
+              <div className="mt-3 rounded-inset border border-danger-border bg-danger-fill p-3 text-xs font-semibold text-danger-text" role="alert">
                 {error}
               </div>
             )}
-
-            <div className="mt-6 flex gap-3">
+            <div className="mt-5 flex gap-3">
               <button
+                type="button"
                 onClick={() => {
                   setShowRejectModal(false)
                   setRejectionReason('')
                   setError(null)
                 }}
                 disabled={isRejecting}
-                className="flex-1 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded-lg transition-colors"
+                className="inline-flex h-10 flex-1 items-center justify-center rounded-pill border border-stroke bg-glass text-sm font-bold text-ink hover:bg-glass-inset"
               >
                 Cancel
               </button>
-
               <button
+                type="button"
                 onClick={handleReject}
                 disabled={isRejecting || !rejectionReason.trim()}
-                className="flex-1 bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-pill bg-danger text-sm font-bold text-white hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isRejecting ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  <>
+                    <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" aria-hidden="true" />
                     Rejecting...
-                  </span>
+                  </>
                 ) : (
-                  'Reject Request'
+                  'Reject request'
                 )}
               </button>
             </div>

--- a/apps/web/lib/return-url.test.ts
+++ b/apps/web/lib/return-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { safeReturnUrl } from "@/lib/return-url";
+
+describe("safeReturnUrl", () => {
+  it("follows a same-origin path", () => {
+    expect(safeReturnUrl("/dashboard/agents")).toBe("/dashboard/agents");
+    expect(safeReturnUrl("%2Fadmin%2Fregistrations")).toBe("/admin/registrations");
+  });
+
+  it("refuses anything that could leave the origin", () => {
+    for (const bad of ["https://evil.example/", "//evil.example/x", "/\\evil.example", "javascript:alert(1)", "%ZZ", ""]) {
+      expect(safeReturnUrl(bad), bad).toBe("/dashboard");
+    }
+    expect(safeReturnUrl(null)).toBe("/dashboard");
+  });
+});

--- a/apps/web/lib/return-url.ts
+++ b/apps/web/lib/return-url.ts
@@ -1,0 +1,14 @@
+/**
+ * The path to follow after sign-in. Only a same-origin path is accepted; a full URL, a
+ * protocol-relative URL, a backslash escape or an undecodable value lands on the dashboard.
+ */
+export function safeReturnUrl(raw: string | null): string {
+  if (!raw) return "/dashboard";
+  let value: string;
+  try {
+    value = decodeURIComponent(raw);
+  } catch {
+    return "/dashboard";
+  }
+  return value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\") ? value : "/dashboard";
+}


### PR DESCRIPTION
Third of six stacked pull requests (Glasshouse; the whole change is #418). Stacked on the overview PR.

## What this part contains

Sign-in, sign-up, registration-pending, forgot-password, reset-password and change-password on the frosted-glass system, with every claim checked against the handler the page actually calls: reset links last 24 hours and work once (`RegistrationService` behind `/api/v1/public/*`), the password rule includes the special character the backend requires, approval is a human action and the pages no longer promise timing or mail the deployment may not send, the login note stops calling a bcrypt hash encryption, the forgot-password note says only that the response does not reveal whether an account exists. Sign-in follows `returnUrl` only for same-origin paths (`lib/return-url.ts`, tested).

The registration queue (`/admin/registrations`) renders inside the dashboard shell; the reject dialog no longer claims the reason is shown to other administrators or mailed. `AIM_PLATFORM_ADMINS` is documented where a self-hosting operator first needs it (registration-pending page, backend env template, README). Links to `/terms` and `/privacy`, which this build does not ship, are removed.

## Verification

- `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch.
- Light and dark at 1440 and 375 px on every auth page and the registration queue: no horizontal overflow, no page errors.
