### PR TITLE
Glasshouse agents, SDK and developer pages, teaching the pip path

### DIFF
--- a/apps/web/app/dashboard/agents/[id]/page.tsx
+++ b/apps/web/app/dashboard/agents/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowLeft,
@@ -232,7 +233,8 @@ export default function AgentDetailsPage({
     const token = api.getToken?.();
     if (!token) return;
     try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const role = (payload.role as any) || "viewer";
       setUserRole(role);
     } catch {}
@@ -311,9 +313,9 @@ export default function AgentDetailsPage({
 
   // Get trust score color
   const getTrustColor = (score: number): string => {
-    if (score >= 80) return "text-green-600 bg-green-500/10";
-    if (score >= 60) return "text-yellow-600 bg-yellow-500/10";
-    return "text-red-600 bg-red-500/10";
+    if (score >= 80) return "text-success-text bg-success-fill";
+    if (score >= 60) return "text-warning-text bg-warning-fill";
+    return "text-danger-text bg-danger-fill";
   };
 
   // Check if agent is verified
@@ -327,14 +329,14 @@ export default function AgentDetailsPage({
   const getStatusBadgeClass = (status: string): string => {
     switch (status) {
       case "verified":
-        return "bg-green-500/10 text-green-600";
+        return "bg-success-fill text-success-text";
       case "pending":
-        return "bg-yellow-500/10 text-yellow-600";
+        return "bg-warning-fill text-warning-text";
       case "suspended":
       case "revoked":
-        return "bg-red-500/10 text-red-600";
+        return "bg-danger-fill text-danger-text";
       default:
-        return "bg-gray-500/10 text-gray-600";
+        return "bg-glass-inset-gray text-ink-secondary";
     }
   };
 
@@ -475,7 +477,7 @@ export default function AgentDetailsPage({
                 <h1 className="text-3xl font-bold">{agent.name}</h1>
                 {isVerified && (
                   <span title="Verified">
-                    <Shield className="h-6 w-6 text-green-600" />
+                    <Shield className="h-6 w-6 text-success-text" />
                   </span>
                 )}
               </div>
@@ -516,7 +518,7 @@ export default function AgentDetailsPage({
               <Button
                 onClick={handleVerify}
                 disabled={verifying || isVerified}
-                className="bg-green-600 hover:bg-green-700"
+                className="rounded-pill"
               >
                 {verifying ? (
                   <>
@@ -526,7 +528,7 @@ export default function AgentDetailsPage({
                 ) : (
                   <>
                     <CheckCircle className="h-4 w-4 mr-1" />{" "}
-                    {isVerified ? "Verified" : "Verify Agent"}
+                    {isVerified ? "Verified" : "Verify agent"}
                   </>
                 )}
               </Button>
@@ -536,7 +538,7 @@ export default function AgentDetailsPage({
                 variant="outline"
                 onClick={() => setShowSuspendConfirm(true)}
                 disabled={suspending}
-                className="border-orange-500 text-orange-600 hover:bg-orange-50"
+                className="rounded-pill border-warning-border text-warning-text hover:bg-warning-fill"
               >
                 {suspending ? (
                   <>
@@ -555,7 +557,7 @@ export default function AgentDetailsPage({
                 variant="outline"
                 onClick={handleReactivate}
                 disabled={reactivating}
-                className="border-green-500 text-green-600 hover:bg-green-50"
+                className="rounded-pill border-success-border text-success-text hover:bg-success-fill"
               >
                 {reactivating ? (
                   <>
@@ -648,9 +650,9 @@ export default function AgentDetailsPage({
           <CardContent>
             <div className="text-2xl font-bold">
               {isVerified ? (
-                <Shield className="h-8 w-8 text-green-600" />
+                <Shield className="h-8 w-8 text-success-text" />
               ) : (
-                <AlertTriangle className="h-8 w-8 text-yellow-600" />
+                <AlertTriangle className="h-8 w-8 text-warning-text" />
               )}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -687,7 +689,7 @@ export default function AgentDetailsPage({
             <Tag className="h-4 w-4 mr-2" />
             Tags
           </TabsTrigger>
-          <TabsTrigger value="activity">Recent Activity</TabsTrigger>
+          <TabsTrigger value="activity">Recent activity</TabsTrigger>
           <TabsTrigger value="trust">
             <Shield className="h-4 w-4 mr-2" />
             Trust Score
@@ -698,7 +700,7 @@ export default function AgentDetailsPage({
         <TabsContent value="connections" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>MCP Server Connections</CardTitle>
+              <CardTitle>MCP server connections</CardTitle>
               <CardDescription>
                 Manage which MCP servers this agent can communicate with. Shows both manually connected servers and auto-detected servers from SDK runtime.
               </CardDescription>
@@ -707,7 +709,7 @@ export default function AgentDetailsPage({
               {/* Manually Connected Servers */}
               {connectedMCPServers.length > 0 && (
                 <div>
-                  <h3 className="text-sm font-semibold mb-3 text-muted-foreground">Manually Connected</h3>
+                  <h3 className="text-sm font-semibold mb-3 text-muted-foreground">Manually connected</h3>
                   <MCPServerList
                     agentId={agent.id}
                     mcpServers={connectedMCPServers}
@@ -727,7 +729,7 @@ export default function AgentDetailsPage({
               {/* Auto-Detected Servers */}
               {detectedMCPs.length > 0 && (
                 <div>
-                  <h3 className="text-sm font-semibold mb-3 text-muted-foreground">Auto-Detected by SDK</h3>
+                  <h3 className="text-sm font-semibold mb-3 text-muted-foreground">Auto-detected by SDK</h3>
                   <div className="grid gap-3">
                     {detectedMCPs.map((detection: any) => (
                       <div key={detection.name} className="p-4 rounded-lg border bg-card">
@@ -762,7 +764,7 @@ export default function AgentDetailsPage({
                   <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted mb-4">
                     <ExternalLink className="h-8 w-8 text-muted-foreground" />
                   </div>
-                  <h3 className="text-lg font-semibold mb-2">No MCP Servers Detected</h3>
+                  <h3 className="text-lg font-semibold mb-2">No MCP servers detected</h3>
                   <p className="text-sm text-muted-foreground max-w-md mx-auto mb-6">
                     This agent has no MCP servers connected or detected. Use the buttons above to add servers manually or install the AIM SDK to enable auto-detection.
                   </p>
@@ -979,29 +981,29 @@ export default function AgentDetailsPage({
                           <div key={event.id} className="relative pl-10">
                             {/* Timeline dot */}
                             <div className={`absolute left-2.5 w-3 h-3 rounded-full border-2 bg-background ${
-                              event.type === 'alert' ? 'border-red-500' :
-                              event.icon === 'trust_down' ? 'border-orange-500' :
-                              event.icon === 'trust_up' ? 'border-green-500' :
-                              event.type === 'verification' ? 'border-blue-500' :
-                              'border-gray-400'
+                              event.type === 'alert' ? 'border-danger' :
+                              event.icon === 'trust_down' ? 'border-warning' :
+                              event.icon === 'trust_up' ? 'border-success' :
+                              event.type === 'verification' ? 'border-brand' :
+                              'border-stroke'
                             }`} />
 
                             {/* Event card */}
                             <div className={`p-3 rounded-lg border ${
-                              event.type === 'alert' ? 'bg-red-50 dark:bg-red-950/20 border-red-200 dark:border-red-900' :
-                              event.icon === 'trust_down' ? 'bg-orange-50 dark:bg-orange-950/20 border-orange-200 dark:border-orange-900' :
-                              event.icon === 'trust_up' ? 'bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-900' :
-                              'bg-card'
+                              event.type === 'alert' ? 'bg-danger-fill border-danger-border' :
+                              event.icon === 'trust_down' ? 'bg-warning-fill border-warning-border' :
+                              event.icon === 'trust_up' ? 'bg-success-fill border-success-border' :
+                              'bg-glass-inset-gray border-divider'
                             }`}>
                               <div className="flex items-start justify-between gap-4">
                                 <div className="flex items-start gap-3">
                                   {/* Icon */}
                                   <div className={`mt-0.5 ${
-                                    event.type === 'alert' ? 'text-red-500' :
-                                    event.icon === 'trust_down' ? 'text-orange-500' :
-                                    event.icon === 'trust_up' ? 'text-green-500' :
-                                    event.type === 'verification' ? 'text-blue-500' :
-                                    'text-gray-500'
+                                    event.type === 'alert' ? 'text-danger-text' :
+                                    event.icon === 'trust_down' ? 'text-warning-text' :
+                                    event.icon === 'trust_up' ? 'text-success-text' :
+                                    event.type === 'verification' ? 'text-brand-text' :
+                                    'text-ink-secondary'
                                   }`}>
                                     {event.type === 'alert' && <AlertTriangle className="h-4 w-4" />}
                                     {event.icon === 'trust_down' && <TrendingDown className="h-4 w-4" />}
@@ -1078,7 +1080,7 @@ export default function AgentDetailsPage({
         <TabsContent value="details" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>Agent Details</CardTitle>
+              <CardTitle>Agent details</CardTitle>
               <CardDescription>
                 Detailed information about this agent
               </CardDescription>
@@ -1134,7 +1136,7 @@ export default function AgentDetailsPage({
                   </span>
                   <span className="col-span-2 text-sm">
                     {isVerified ? (
-                      <Badge className="bg-green-500/10 text-green-600">
+                      <Badge className="bg-success-fill text-success-text">
                         Verified
                       </Badge>
                     ) : (
@@ -1202,7 +1204,7 @@ export default function AgentDetailsPage({
                           <Button
                             variant="link"
                             size="sm"
-                            className="p-0 h-auto text-xs text-orange-600 justify-start"
+                            className="p-0 h-auto text-xs text-warning-text justify-start"
                             onClick={() => router.push(`/dashboard/api-keys?highlight=${agent.createdByApiKeyId}`)}
                           >
                             <KeyRound className="h-3 w-3 mr-1" />
@@ -1295,7 +1297,7 @@ export default function AgentDetailsPage({
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
+            <AlertDialogTitle>Delete agent</AlertDialogTitle>
             <AlertDialogDescription>
               This action cannot be undone. This will permanently delete the
               agent "{agent.name}" and remove associated data.
@@ -1305,7 +1307,7 @@ export default function AgentDetailsPage({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              className="bg-red-600 hover:bg-red-700"
+              className="rounded-pill bg-danger hover:brightness-95"
             >
               {deleting ? "Deleting..." : "Delete"}
             </AlertDialogAction>
@@ -1317,7 +1319,7 @@ export default function AgentDetailsPage({
       <AlertDialog open={showSuspendConfirm} onOpenChange={setShowSuspendConfirm}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Suspend Agent</AlertDialogTitle>
+            <AlertDialogTitle>Suspend agent</AlertDialogTitle>
             <AlertDialogDescription>
               This will temporarily suspend the agent "{agent.name}". The agent
               will be unable to authenticate or perform actions until
@@ -1328,7 +1330,7 @@ export default function AgentDetailsPage({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleSuspend}
-              className="bg-orange-600 hover:bg-orange-700"
+              className="rounded-pill bg-warning text-warning-foreground hover:opacity-90"
             >
               {suspending ? "Suspending..." : "Suspend"}
             </AlertDialogAction>

--- a/apps/web/app/dashboard/agents/[id]/success/page.tsx
+++ b/apps/web/app/dashboard/agents/[id]/success/page.tsx
@@ -28,6 +28,11 @@ export default function AgentSuccessPage() {
   const [loading, setLoading] = useState(true);
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [downloadingSDK, setDownloadingSDK] = useState<string | null>(null);
+  // `aim-sdk login` defaults to the hosted service; a self-hosted dashboard passes its own origin.
+  const [origin, setOrigin] = useState("");
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
   const [selectedLanguage, setSelectedLanguage] = useState<'python' | 'java'>('python');
 
   useEffect(() => {
@@ -115,7 +120,7 @@ export default function AgentSuccessPage() {
     return (
       <div className="max-w-4xl mx-auto mt-12">
         <div className="flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+          <div className="animate-spin rounded-pill h-12 w-12 border-b-2 border-brand"></div>
         </div>
       </div>
     );
@@ -126,7 +131,7 @@ export default function AgentSuccessPage() {
       <div className="max-w-4xl mx-auto mt-12">
         <Card>
           <CardContent className="pt-6">
-            <p className="text-center text-gray-600">Agent not found</p>
+            <p className="text-center text-ink-secondary">Agent not found</p>
           </CardContent>
         </Card>
       </div>
@@ -139,16 +144,16 @@ export default function AgentSuccessPage() {
       {/* Success Header */}
       <div className="text-center pt-8 pb-4">
         <div className="flex justify-center mb-4">
-          <div className="bg-green-100 p-4 rounded-full">
-            <CheckCircle className="h-16 w-16 text-green-600" />
+          <div className="bg-success-fill p-4 rounded-pill">
+            <CheckCircle className="h-16 w-16 text-success-text" />
           </div>
         </div>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
-          Agent Registered Successfully!
+        <h1 className="text-3xl font-bold text-ink mb-2">
+          Agent registered successfully
         </h1>
-        <p className="text-gray-600 max-w-2xl mx-auto">
+        <p className="text-ink-secondary max-w-2xl mx-auto">
           Your agent <span className="font-semibold">{agent.displayName}</span> has been registered with AIM.
-          Download the SDK to start building with automatic identity verification.
+          Connect it from your code with the steps below; actions it performs through the SDK are then verified against its identity.
         </p>
       </div>
 
@@ -156,17 +161,17 @@ export default function AgentSuccessPage() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <CheckCircle className="h-5 w-5 text-green-600" />
-            Agent Details
+            <CheckCircle className="h-5 w-5 text-success-text" />
+            Agent details
           </CardTitle>
           <CardDescription>Your agent has been created with these credentials</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Agent ID */}
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-glass-inset-gray rounded-inset">
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-700">Agent ID</p>
-              <p className="text-sm text-gray-600 font-mono break-all">{agent.id}</p>
+              <p className="text-sm font-medium text-ink-body">Agent ID</p>
+              <p className="text-sm text-ink-secondary font-mono break-all">{agent.id}</p>
             </div>
             <Button
               variant="ghost"
@@ -174,7 +179,7 @@ export default function AgentSuccessPage() {
               onClick={() => copyToClipboard(agent.id, 'agent_id')}
             >
               {copiedField === 'agent_id' ? (
-                <Check className="h-4 w-4 text-green-600" />
+                <Check className="h-4 w-4 text-success-text" />
               ) : (
                 <Copy className="h-4 w-4" />
               )}
@@ -182,19 +187,19 @@ export default function AgentSuccessPage() {
           </div>
 
           {/* Agent Name */}
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-glass-inset-gray rounded-inset">
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-700">Agent Name</p>
-              <p className="text-sm text-gray-600">{agent.name}</p>
+              <p className="text-sm font-medium text-ink-body">Agent name</p>
+              <p className="text-sm text-ink-secondary">{agent.name}</p>
             </div>
           </div>
 
           {/* Public Key */}
           {agent.publicKey && (
-            <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+            <div className="flex items-center justify-between p-3 bg-glass-inset-gray rounded-inset">
               <div className="flex-1">
-                <p className="text-sm font-medium text-gray-700">Public Key (Ed25519)</p>
-                <p className="text-sm text-gray-600 font-mono break-all truncate max-w-[500px]">
+                <p className="text-sm font-medium text-ink-body">Public key (Ed25519)</p>
+                <p className="text-sm text-ink-secondary font-mono break-all truncate max-w-[500px]">
                   {agent.publicKey}
                 </p>
               </div>
@@ -204,7 +209,7 @@ export default function AgentSuccessPage() {
                 onClick={() => copyToClipboard(agent.publicKey!, 'public_key')}
               >
                 {copiedField === 'public_key' ? (
-                  <Check className="h-4 w-4 text-green-600" />
+                  <Check className="h-4 w-4 text-success-text" />
                 ) : (
                   <Copy className="h-4 w-4" />
                 )}
@@ -213,10 +218,10 @@ export default function AgentSuccessPage() {
           )}
 
           {/* Status */}
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-glass-inset-gray rounded-inset">
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-700">Status</p>
-              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+              <p className="text-sm font-medium text-ink-body">Status</p>
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-pill border border-warning-border bg-warning-fill text-xs font-medium text-warning-text">
                 {agent.status}
               </span>
             </div>
@@ -232,126 +237,62 @@ export default function AgentSuccessPage() {
             Download SDK
           </CardTitle>
           <CardDescription>
-            Get started with the pre-configured SDK for your preferred language
+            Java: a package pre-configured for this agent. Python: the steps below, no download needed
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 gap-4">
-            {/* Python SDK - Production Ready */}
-            <div className="border-2 border-blue-500 rounded-lg p-6 bg-gradient-to-br from-blue-50 to-white">
-              <div className="flex flex-col h-full">
-                <div className="mb-4">
-                  <div className="flex items-center gap-3 mb-3">
-                    <div className="h-12 w-12 bg-blue-100 rounded-lg flex items-center justify-center">
-                      <Download className="h-6 w-6 text-blue-600" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-xl mb-1">Python SDK</h3>
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                        Production Ready
-                      </span>
-                    </div>
-                  </div>
-                  <p className="text-sm text-gray-700 mb-3">
-                    Official production-ready SDK with Ed25519 cryptographic signing, OAuth integration,
-                    automatic MCP detection, and secure keyring storage.
-                  </p>
-                  <div className="space-y-2 text-sm text-gray-600">
-                    <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span>Ed25519 cryptographic signing</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span>OAuth/OIDC integration (Google, Microsoft, Okta)</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span>Automatic MCP detection</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span>Secure keyring credential storage</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span>100% test coverage</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="mt-auto">
-                  <Button
-                    className="w-full bg-blue-600 hover:bg-blue-700"
-                    onClick={() => downloadSDK('python')}
-                    disabled={downloadingSDK !== null}
-                  >
-                    {downloadingSDK === 'python' ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Downloading...
-                      </>
-                    ) : (
-                      <>
-                        <Download className="h-4 w-4 mr-2" />
-                        Download Python SDK
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </div>
-
             {/* Java SDK - Production Ready */}
-            <div className="border-2 border-orange-500 rounded-lg p-6 bg-gradient-to-br from-orange-50 to-white">
+            <div className="rounded-card border border-stroke bg-glass-inset p-6">
               <div className="flex flex-col h-full">
                 <div className="mb-4">
                   <div className="flex items-center gap-3 mb-3">
-                    <div className="h-12 w-12 bg-orange-100 rounded-lg flex items-center justify-center">
-                      <Download className="h-6 w-6 text-orange-600" />
+                    <div className="h-12 w-12 bg-brand rounded-inset shadow-glow flex items-center justify-center">
+                      <Download className="h-6 w-6 text-ink-inverse" />
                     </div>
                     <div>
                       <h3 className="font-semibold text-xl mb-1">Java SDK</h3>
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                        Production Ready
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-pill border border-success-border bg-success-fill text-xs font-medium text-success-text">
+                        Production ready
                       </span>
                     </div>
                   </div>
-                  <p className="text-sm text-gray-700 mb-3">
-                    Enterprise-grade Java SDK with Ed25519 cryptographic signing, OAuth integration,
-                    AspectJ annotations, and seamless Spring Boot support.
+                  <p className="text-sm text-ink-body mb-3">
+                    Java SDK with Ed25519 cryptographic signing, OAuth integration,
+                    AspectJ annotations, and Spring Boot support.
                   </p>
-                  <div className="space-y-2 text-sm text-gray-600">
+                  <div className="space-y-2 text-sm text-ink-secondary">
                     <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <CheckCircle className="h-4 w-4 text-success-text" />
                       <span>Ed25519 cryptographic signing</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <CheckCircle className="h-4 w-4 text-success-text" />
                       <span>OAuth client credentials flow</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <CheckCircle className="h-4 w-4 text-success-text" />
                       <span>@SecureAction AspectJ annotations</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <CheckCircle className="h-4 w-4 text-success-text" />
                       <span>Spring Boot integration</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <CheckCircle className="h-4 w-4 text-success-text" />
                       <span>MCP server attestation</span>
                     </div>
                   </div>
                 </div>
                 <div className="mt-auto">
                   <Button
-                    className="w-full bg-orange-600 hover:bg-orange-700"
+                    className="w-full"
                     onClick={() => downloadSDK('java')}
                     disabled={downloadingSDK !== null}
                   >
                     {downloadingSDK === 'java' ? (
                       <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                        <div className="animate-spin rounded-pill h-4 w-4 border-b-2 border-current mr-2"></div>
                         Downloading...
                       </>
                     ) : (
@@ -365,15 +306,6 @@ export default function AgentSuccessPage() {
               </div>
             </div>
 
-            {/* Future SDKs Note */}
-            <div className="border border-gray-200 rounded-lg p-4 bg-gray-50">
-              <p className="text-sm text-gray-600 mb-2">
-                <strong>Future Releases:</strong> Go and JavaScript/TypeScript SDKs are planned for Q1-Q2 2026.
-              </p>
-              <p className="text-xs text-gray-500">
-                Python and Java SDKs provide complete feature parity and are production-ready for all use cases.
-              </p>
-            </div>
           </div>
         </CardContent>
       </Card>
@@ -383,7 +315,7 @@ export default function AgentSuccessPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Book className="h-5 w-5" />
-            Quick Start Guide
+            Quick start guide
           </CardTitle>
           <CardDescription>Get up and running in 3 steps</CardDescription>
         </CardHeader>
@@ -394,7 +326,6 @@ export default function AgentSuccessPage() {
               variant={selectedLanguage === 'python' ? 'default' : 'outline'}
               size="sm"
               onClick={() => setSelectedLanguage('python')}
-              className={selectedLanguage === 'python' ? 'bg-blue-600 hover:bg-blue-700' : ''}
             >
               Python
             </Button>
@@ -402,7 +333,6 @@ export default function AgentSuccessPage() {
               variant={selectedLanguage === 'java' ? 'default' : 'outline'}
               size="sm"
               onClick={() => setSelectedLanguage('java')}
-              className={selectedLanguage === 'java' ? 'bg-orange-600 hover:bg-orange-700' : ''}
             >
               Java
             </Button>
@@ -412,74 +342,66 @@ export default function AgentSuccessPage() {
             <div className="space-y-4">
               {/* Python Step 1 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-bold">
                   1
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Download and Extract SDK</h4>
-                  <p className="text-sm text-gray-600">
-                    Download the Python SDK above and extract the ZIP file to your project directory
+                  <h4 className="font-semibold mb-1">Install the SDK</h4>
+                  <p className="text-sm text-ink-secondary">
+                    From PyPI. For machines without registry access, use the offline install on the SDK page.
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
-                    <code>unzip aim-sdk-{agent.name}-python.zip</code>
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
+                    <code>pip install aim-sdk</code>
                   </pre>
                 </div>
               </div>
-
               {/* Python Step 2 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-bold">
                   2
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Install SDK</h4>
-                  <p className="text-sm text-gray-600">
-                    Install the SDK and its dependencies
+                  <h4 className="font-semibold mb-1">Sign in once</h4>
+                  <p className="text-sm text-ink-secondary">
+                    Links your machine to this account; no API key needed
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
-                    <code>pip install -e .</code>
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
+                    <code>{origin ? `aim-sdk login --url ${origin}` : "aim-sdk login"}</code>
                   </pre>
                 </div>
               </div>
-
               {/* Python Step 3 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-bold">
                   3
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Run Example</h4>
-                  <p className="text-sm text-gray-600">
-                    Test the automatic verification with the included example
+                  <h4 className="font-semibold mb-1">Connect this agent</h4>
+                  <p className="text-sm text-ink-secondary">
+                    Use this agent&apos;s identifier. The SDK creates a new key pair on this machine, stores it under ~/.aim/ and replaces the key created at registration, so no other copy of a private key has to exist.
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
-                    <code>python example.py</code>
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
+                    <code>{`from aim_sdk import secure
+
+agent = secure("${agent.id}")`}</code>
                   </pre>
                 </div>
               </div>
 
               {/* Python Example Code */}
               <div className="mt-6">
-                <h4 className="font-semibold mb-2">Example Usage</h4>
-                <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg text-xs overflow-x-auto">
-                  <code>{`from aim_sdk import AIMClient
-from aim_sdk.config import AGENT_ID, PUBLIC_KEY, PRIVATE_KEY, AIM_URL
+                <h4 className="font-semibold mb-2">Example usage</h4>
+                <pre className="glass-contrast p-4 rounded-inset font-mono text-xs text-ink-code overflow-x-auto">
+                  <code>{`from aim_sdk import secure
 
-# Initialize client with embedded credentials
-client = AIMClient(
-    agent_id=AGENT_ID,
-    public_key=PUBLIC_KEY,
-    private_key=PRIVATE_KEY,
-    aim_url=AIM_URL
-)
+agent = secure("${agent.id}")
 
-# Automatic verification with decorator
-@client.perform_action("read_database", resource="users_table")
+# Each call is verified against the agent's capabilities before it runs
+@agent.perform_action("read_database", resource="users_table")
 def get_users():
     # Your agent code here
     return database.query("SELECT * FROM users")
 
-# Just call the function - verification happens automatically!
 users = get_users()`}</code>
                 </pre>
               </div>
@@ -488,15 +410,15 @@ users = get_users()`}</code>
             <div className="space-y-4">
               {/* Java Step 1 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-orange-100 text-orange-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-semibold">
                   1
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Download and Extract SDK</h4>
-                  <p className="text-sm text-gray-600">
+                  <h4 className="font-semibold mb-1">Download and extract SDK</h4>
+                  <p className="text-sm text-ink-secondary">
                     Download the Java SDK above and extract the ZIP file to your project directory
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
                     <code>unzip aim-sdk-{agent.name}-java.zip</code>
                   </pre>
                 </div>
@@ -504,15 +426,15 @@ users = get_users()`}</code>
 
               {/* Java Step 2 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-orange-100 text-orange-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-semibold">
                   2
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Add to Your Project</h4>
-                  <p className="text-sm text-gray-600">
+                  <h4 className="font-semibold mb-1">Add to your project</h4>
+                  <p className="text-sm text-ink-secondary">
                     Add the SDK to your Maven or Gradle project
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
                     <code>{`<!-- Maven -->
 mvn install:install-file -Dfile=aim-sdk.jar \\
   -DgroupId=org.opena2a -DartifactId=aim-sdk \\
@@ -523,15 +445,15 @@ mvn install:install-file -Dfile=aim-sdk.jar \\
 
               {/* Java Step 3 */}
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-orange-100 text-orange-600 flex items-center justify-center font-semibold">
+                <div className="flex-shrink-0 w-8 h-8 rounded-pill bg-brand-soft text-brand-text flex items-center justify-center font-semibold">
                   3
                 </div>
                 <div>
-                  <h4 className="font-semibold mb-1">Run Example</h4>
-                  <p className="text-sm text-gray-600">
+                  <h4 className="font-semibold mb-1">Run example</h4>
+                  <p className="text-sm text-ink-secondary">
                     Compile and run the included example
                   </p>
-                  <pre className="mt-2 p-3 bg-gray-50 rounded text-xs overflow-x-auto">
+                  <pre className="mt-2 p-3 rounded-inset-sm bg-glass-inset-gray font-mono text-xs text-ink-body overflow-x-auto">
                     <code>mvn compile exec:java -Dexec.mainClass="BasicExample"</code>
                   </pre>
                 </div>
@@ -539,8 +461,8 @@ mvn install:install-file -Dfile=aim-sdk.jar \\
 
               {/* Java Example Code */}
               <div className="mt-6">
-                <h4 className="font-semibold mb-2">Example Usage</h4>
-                <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg text-xs overflow-x-auto">
+                <h4 className="font-semibold mb-2">Example usage</h4>
+                <pre className="glass-contrast p-4 rounded-inset font-mono text-xs text-ink-code overflow-x-auto">
                   <code>{`import org.opena2a.aim.client.AIMClient;
 import org.opena2a.aim.client.AgentType;
 import java.util.Arrays;
@@ -576,16 +498,16 @@ public class MyAgent {
       </Card>
 
       {/* Security Notice */}
-      <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded">
+      <div className="rounded-card border border-warning-border bg-warning-fill p-4">
         <div className="flex">
           <div className="flex-shrink-0">
-            <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+            <svg className="h-5 w-5 text-warning" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
             </svg>
           </div>
           <div className="ml-3">
-            <h3 className="text-sm font-medium text-yellow-800">Security Notice</h3>
-            <div className="mt-2 text-sm text-yellow-700">
+            <h3 className="text-sm font-medium text-warning-text">Security notice</h3>
+            <div className="mt-2 text-sm text-ink-body">
               <p>
                 The downloaded SDK contains your agent's <strong>private key</strong>. Never commit this file to version control
                 or share it publicly. Keep it secure and regenerate keys immediately if compromised.
@@ -601,18 +523,18 @@ public class MyAgent {
           variant="outline"
           onClick={() => router.push('/dashboard/agents')}
         >
-          View All Agents
+          View all agents
         </Button>
         <Button
           onClick={() => window.open('https://opena2a.org/docs', '_blank')}
         >
           <Book className="h-4 w-4 mr-2" />
-          View Documentation
+          View documentation
         </Button>
         <Button
           onClick={() => router.push('/dashboard')}
         >
-          Go to Dashboard
+          Go to dashboard
           <ArrowRight className="h-4 w-4 ml-2" />
         </Button>
       </div>

--- a/apps/web/app/dashboard/agents/page.tsx
+++ b/apps/web/app/dashboard/agents/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, Suspense, useMemo, useCallback } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Users,
@@ -31,37 +32,37 @@ import { AuthGuard } from "@/components/auth-guard";
 // Agent type display configuration
 const AGENT_TYPE_LABELS: Record<string, { label: string; color: string }> = {
   // LLM Providers
-  claude: { label: "Claude", color: "bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300" },
-  gpt: { label: "GPT", color: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300" },
-  gemini: { label: "Gemini", color: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300" },
-  llama: { label: "Llama", color: "bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300" },
-  mistral: { label: "Mistral", color: "bg-cyan-100 dark:bg-cyan-900/30 text-cyan-800 dark:text-cyan-300" },
-  cohere: { label: "Cohere", color: "bg-pink-100 dark:bg-pink-900/30 text-pink-800 dark:text-pink-300" },
+  claude: { label: "Claude", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  gpt: { label: "GPT", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  gemini: { label: "Gemini", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  llama: { label: "Llama", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  mistral: { label: "Mistral", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  cohere: { label: "Cohere", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Frameworks
-  langchain: { label: "LangChain", color: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300" },
-  llamaindex: { label: "LlamaIndex", color: "bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-300" },
-  langgraph: { label: "LangGraph", color: "bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-300" },
-  crewai: { label: "CrewAI", color: "bg-rose-100 dark:bg-rose-900/30 text-rose-800 dark:text-rose-300" },
-  autogen: { label: "AutoGen", color: "bg-sky-100 dark:bg-sky-900/30 text-sky-800 dark:text-sky-300" },
-  semantic_kernel: { label: "Semantic Kernel", color: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-300" },
-  haystack: { label: "Haystack", color: "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300" },
+  langchain: { label: "LangChain", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  llamaindex: { label: "LlamaIndex", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  langgraph: { label: "LangGraph", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  crewai: { label: "CrewAI", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  autogen: { label: "AutoGen", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  semantic_kernel: { label: "Semantic Kernel", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  haystack: { label: "Haystack", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Copilots & Assistants
-  copilot: { label: "Copilot", color: "bg-slate-100 dark:bg-slate-900/30 text-slate-800 dark:text-slate-300" },
-  assistant: { label: "Assistant", color: "bg-lime-100 dark:bg-lime-900/30 text-lime-800 dark:text-lime-300" },
-  chatbot: { label: "Chatbot", color: "bg-fuchsia-100 dark:bg-fuchsia-900/30 text-fuchsia-800 dark:text-fuchsia-300" },
+  copilot: { label: "Copilot", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  assistant: { label: "Assistant", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  chatbot: { label: "Chatbot", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Autonomous Agents
-  autogpt: { label: "AutoGPT", color: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300" },
-  babyagi: { label: "BabyAGI", color: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300" },
+  autogpt: { label: "AutoGPT", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  babyagi: { label: "BabyAGI", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Other
-  custom: { label: "Custom", color: "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300" },
+  custom: { label: "Custom", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Legacy
-  ai_agent: { label: "AI Agent", color: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300" },
+  ai_agent: { label: "AI Agent", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
 };
 
 // Get display info for an agent type
 function getAgentTypeDisplay(agentType: string | undefined): { label: string; color: string } {
   if (!agentType) return AGENT_TYPE_LABELS.custom;
-  return AGENT_TYPE_LABELS[agentType] || { label: agentType, color: "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300" };
+  return AGENT_TYPE_LABELS[agentType] || { label: agentType, color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" };
 }
 
 interface AgentStats {
@@ -73,26 +74,26 @@ interface AgentStats {
 
 function StatCard({ stat }: { stat: any }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className="flex-shrink-0">
-          <stat.icon className="h-6 w-6 text-gray-400" />
+          <stat.icon className="h-6 w-6 text-ink-tertiary" />
         </div>
         <div className="ml-5 w-0 flex-1">
           <dl>
-            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+            <dt className="text-sm font-medium text-ink-secondary truncate">
               {stat.name}
             </dt>
             <dd className="flex items-baseline">
-              <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              <div className="text-2xl font-semibold text-ink">
                 {stat.value}
               </div>
               {stat.change && (
                 <div
                   className={`ml-2 flex items-baseline text-sm font-semibold ${
                     stat.changeType === "positive"
-                      ? "text-green-600"
-                      : "text-red-600"
+                      ? "text-success-text"
+                      : "text-danger-text"
                   }`}
                 >
                   {stat.change}
@@ -110,20 +111,20 @@ function StatusBadge({ status }: { status: string }) {
   const getStatusStyles = (status: string) => {
     switch (status) {
       case "verified":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "border border-success-border bg-success-fill text-success-text";
       case "pending":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "border border-warning-border bg-warning-fill text-warning-text";
       case "suspended":
       case "revoked":
-        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+        return "border border-danger-border bg-danger-fill text-danger-text";
       default:
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "border border-glass-inset-border bg-glass-inset-gray text-ink-body";
     }
   };
 
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${getStatusStyles(status)}`}
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium capitalize ${getStatusStyles(status)}`}
     >
       {status}
     </span>
@@ -136,23 +137,23 @@ function TrustScoreBar({ score }: { score: number }) {
     score <= 1 ? Math.round(score * 100) : Math.round(score);
 
   const getScoreColor = (score: number) => {
-    if (score >= 80) return "bg-green-500";
-    if (score >= 60) return "bg-yellow-500";
-    return "bg-red-500";
+    if (score >= 80) return "bg-success";
+    if (score >= 60) return "bg-warning";
+    return "bg-danger";
   };
 
   const getScoreBadgeColor = (score: number) => {
     if (score >= 80)
-      return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+      return "border border-success-border bg-success-fill text-success-text";
     if (score >= 60)
-      return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
-    return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+      return "border border-warning-border bg-warning-fill text-warning-text";
+    return "border border-danger-border bg-danger-fill text-danger-text";
   };
 
   return (
     <div className="flex items-center gap-3">
       <div className="flex-1">
-        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+        <div className="w-full bg-track rounded-full h-2">
           <div
             className={`${getScoreColor(normalizedScore)} h-2 rounded-full transition-all duration-300`}
             style={{ width: `${normalizedScore}%` }}
@@ -172,8 +173,8 @@ function LoadingSpinner() {
   return (
     <div className="flex items-center justify-center min-h-[400px]">
       <div className="flex flex-col items-center gap-4">
-        <Loader2 className="h-12 w-12 text-blue-500 animate-spin" />
-        <p className="text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="h-12 w-12 text-brand-text animate-spin" />
+        <p className="text-sm text-ink-secondary">
           Loading agents...
         </p>
       </div>
@@ -191,14 +192,14 @@ function ErrorDisplay({
   return (
     <div className="flex items-center justify-center min-h-[400px]">
       <div className="flex flex-col items-center gap-4 max-w-md text-center">
-        <AlertCircle className="h-12 w-12 text-red-500" />
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          Failed to Load Agents
+        <AlertCircle className="h-12 w-12 text-danger-text" />
+        <h3 className="text-lg font-semibold text-ink">
+          Failed to load agents
         </h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
+        <p className="text-sm text-ink-secondary">{message}</p>
         <button
           onClick={onRetry}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          className="rounded-pill bg-brand px-4 py-2 text-white shadow-glow hover:bg-brand-hover transition-colors"
         >
           Retry
         </button>
@@ -238,7 +239,8 @@ function AgentsPageContent() {
     const token = api.getToken();
     if (token) {
       try {
-        const payload = JSON.parse(atob(token.split(".")[1]));
+        const payload = decodeJwtPayload(token);
+        if (!payload) throw new Error("token payload is not decodable");
         setUserRole((payload.role as UserRole) || "viewer");
       } catch (e) {
         console.error("Failed to decode JWT token:", e);
@@ -249,6 +251,13 @@ function AgentsPageContent() {
 
   // Get role-based permissions
   const permissions = getAgentPermissions(userRole);
+
+  // /dashboard/agents?register=1 (home CTA, mobile tab bar) opens the registration form for
+  // roles that may register; ?filter=pending (the Executive lens) preselects the status filter.
+  useEffect(() => {
+    if (searchParams.get("register") === "1" && permissions.canCreateAgent) setShowRegisterModal(true);
+    if (urlFilter === "pending") setStatusFilter("pending");
+  }, [searchParams, urlFilter, permissions.canCreateAgent]);
 
   const fetchAgents = async () => {
     try {
@@ -292,24 +301,24 @@ function AgentsPageContent() {
 
   const statCards = [
     {
-      name: "Total Agents",
+      name: "Total agents",
       value: stats.total.toLocaleString(),
       changeType: "positive",
       icon: Users,
     },
     {
-      name: "Verified Agents",
+      name: "Verified agents",
       value: stats.verified.toLocaleString(),
       changeType: "positive",
       icon: CheckCircle2,
     },
     {
-      name: "Pending Review",
+      name: "Pending review",
       value: stats.pending.toLocaleString(),
       icon: Clock,
     },
     {
-      name: "Avg Trust Score",
+      name: "Avg trust score",
       value: `${stats.avgTrustScore}%`,
       changeType: "positive",
       icon: Shield,
@@ -412,10 +421,10 @@ function AgentsPageContent() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Agent Registry
+          <h1 className="text-2xl font-bold text-ink">
+            Agent registry
           </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-1 text-sm text-ink-secondary">
             Manage and monitor all registered AI agents and MCP servers in your
             organization.
           </p>
@@ -423,10 +432,10 @@ function AgentsPageContent() {
         {permissions.canCreateAgent && (
           <button
             onClick={() => setShowRegisterModal(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            className="flex items-center gap-2 rounded-pill bg-brand px-4 py-2 text-white shadow-glow hover:bg-brand-hover transition-colors"
           >
             <Plus className="h-4 w-4" />
-            Create Agent
+            Create agent
           </button>
         )}
       </div>
@@ -439,26 +448,26 @@ function AgentsPageContent() {
       </div>
 
       {/* Filters */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
             <input
               type="text"
               placeholder="Search agents by name..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+              className="w-full pl-10 pr-4 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-brand text-ink placeholder:text-ink-tertiary"
             />
           </div>
           <div className="relative">
-            <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+            <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="pl-10 pr-8 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+              className="pl-10 pr-8 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-brand text-ink"
             >
-              <option value="all">All Status</option>
+              <option value="all">All statuses</option>
               <option value="verified">Verified</option>
               <option value="pending">Pending</option>
               <option value="suspended">Suspended</option>
@@ -469,51 +478,51 @@ function AgentsPageContent() {
       </div>
 
       {/* Agents Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Agent Name
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                  Agent name
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                   Type
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                   Version
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Trust Score
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                  Trust score
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Last Updated
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                  Last updated
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {paginatedAgents.map((agent) => (
                 <tr
                   key={agent?.id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+                  className="hover:bg-glass-inset-gray transition-colors cursor-pointer"
                   onClick={() => handleViewAgent(agent)}
                 >
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="flex-shrink-0 h-10 w-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-                        <Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                      <div className="flex-shrink-0 h-10 w-10 bg-brand-soft rounded-avatar flex items-center justify-center">
+                        <Users className="h-5 w-5 text-brand-text" />
                       </div>
                       <div className="ml-4">
-                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <div className="text-sm font-medium text-ink">
                           {agent?.displayName}
                         </div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">
+                        <div className="text-xs text-ink-secondary">
                           {agent?.name}
                         </div>
                       </div>
@@ -521,15 +530,15 @@ function AgentsPageContent() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAgentTypeDisplay(agent?.agentType).color}`}
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${getAgentTypeDisplay(agent?.agentType).color}`}
                     >
                       {getAgentTypeDisplay(agent?.agentType).label}
                     </span>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900 dark:text-gray-100">
+                    <div className="text-sm text-ink">
                       {agent?.version || (
-                        <span className="text-gray-400 dark:text-gray-500">—</span>
+                        <span className="text-ink-tertiary">—</span>
                       )}
                     </div>
                   </td>
@@ -542,7 +551,7 @@ function AgentsPageContent() {
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                    <div className="text-sm text-ink-secondary">
                       {agent?.updatedAt && formatDate(agent.updatedAt)}
                     </div>
                   </td>
@@ -554,7 +563,7 @@ function AgentsPageContent() {
                       {permissions.canViewAgent && (
                         <button
                           onClick={() => handleViewAgent(agent)}
-                          className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-brand-text transition-colors"
                           title="View details"
                         >
                           <Eye className="h-4 w-4" />
@@ -563,7 +572,7 @@ function AgentsPageContent() {
                       {permissions.canEditAgent && (
                         <button
                           onClick={() => handleEditAgent(agent)}
-                          className="p-1 text-gray-400 hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-warning-text transition-colors"
                           title="Edit agent"
                         >
                           <Edit className="h-4 w-4" />
@@ -572,7 +581,7 @@ function AgentsPageContent() {
                       {permissions.canDeleteAgent && (
                         <button
                           onClick={() => handleDeleteAgent(agent)}
-                          className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-danger-text transition-colors"
                           title="Delete agent"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -587,11 +596,11 @@ function AgentsPageContent() {
         </div>
         {filteredAgents.length === 0 && (
           <div className="text-center py-12">
-            <Users className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+            <Users className="mx-auto h-12 w-12 text-ink-tertiary" />
+            <h3 className="mt-2 text-sm font-medium text-ink">
               No agents found
             </h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               {searchTerm || statusFilter !== "all"
                 ? "Try adjusting your search or filters."
                 : "Get started by registering your first agent."}
@@ -600,25 +609,25 @@ function AgentsPageContent() {
         )}
         {/* Pagination Controls */}
         {filteredAgents.length > 0 && (
-          <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
-            <div className="text-sm text-gray-500 dark:text-gray-400">
+          <div className="px-6 py-4 border-t border-divider flex items-center justify-between">
+            <div className="text-sm text-ink-secondary">
               Showing {paginatedAgents.length} of {filteredAgents.length} agents
             </div>
             <div className="flex gap-2">
               {currentPage > 1 && (
                 <button
                   onClick={() => setCurrentPage(1)}
-                  className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  className="rounded-pill border border-stroke px-4 py-2 text-sm text-ink-body hover:text-ink hover:bg-glass-inset-gray transition-colors"
                 >
-                  Show Less
+                  Show less
                 </button>
               )}
               {hasMore && (
                 <button
                   onClick={() => setCurrentPage(currentPage + 1)}
-                  className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                  className="rounded-pill bg-brand px-4 py-2 text-sm text-white shadow-glow hover:bg-brand-hover transition-colors"
                 >
-                  Load More
+                  Load more
                 </button>
               )}
             </div>
@@ -657,7 +666,7 @@ function AgentsPageContent() {
 
       <ConfirmDialog
         isOpen={showDeleteConfirm}
-        title="Delete Agent"
+        title="Delete agent"
         message={`Are you sure you want to delete "${selectedAgent?.displayName}"? This action cannot be undone.`}
         confirmText="Delete"
         cancelText="Cancel"

--- a/apps/web/app/dashboard/api-keys/page.tsx
+++ b/apps/web/app/dashboard/api-keys/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useDebounce } from "@/hooks/use-debounce";
 import {
   Key,
@@ -27,26 +28,26 @@ interface APIKeyWithAgent extends APIKey {
 
 function StatCard({ stat }: { stat: any }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className="flex-shrink-0">
-          <stat.icon className="h-6 w-6 text-gray-400" />
+          <stat.icon className="h-6 w-6 text-ink-tertiary" />
         </div>
         <div className="ml-5 w-0 flex-1">
           <dl>
-            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+            <dt className="text-sm font-medium text-ink-secondary truncate">
               {stat.name}
             </dt>
             <dd className="flex items-baseline">
-              <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              <div className="text-2xl font-semibold text-ink">
                 {stat.value}
               </div>
               {stat.change && (
                 <div
                   className={`ml-2 flex items-baseline text-sm font-semibold ${
                     stat.changeType === "positive"
-                      ? "text-green-600"
-                      : "text-red-600"
+                      ? "text-success-text"
+                      : "text-danger-text"
                   }`}
                 >
                   {stat.change}
@@ -66,10 +67,10 @@ function APIKeysPageSkeleton() {
       {/* Header Skeleton */}
       <div className="flex items-center justify-between">
         <div>
-          <div className="h-8 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
-          <div className="h-4 w-64 bg-gray-200 dark:bg-gray-700 rounded mt-2"></div>
+          <div className="h-8 w-32 bg-track rounded"></div>
+          <div className="h-4 w-64 bg-track rounded mt-2"></div>
         </div>
-        <div className="h-10 w-36 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
+        <div className="h-10 w-36 bg-track rounded-pill"></div>
       </div>
 
       {/* Stats Cards Skeleton */}
@@ -77,13 +78,13 @@ function APIKeysPageSkeleton() {
         {[1, 2, 3, 4].map((i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+            className="glass p-6"
           >
             <div className="flex items-center">
-              <div className="h-6 w-6 bg-gray-200 dark:bg-gray-700 rounded"></div>
+              <div className="h-6 w-6 bg-track rounded"></div>
               <div className="ml-5 flex-1">
-                <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
-                <div className="h-8 w-12 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                <div className="h-4 w-20 bg-track rounded mb-2"></div>
+                <div className="h-8 w-12 bg-track rounded"></div>
               </div>
             </div>
           </div>
@@ -91,32 +92,32 @@ function APIKeysPageSkeleton() {
       </div>
 
       {/* Filters Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
-          <div className="flex-1 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
-          <div className="h-10 w-40 bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
+          <div className="flex-1 h-10 bg-track rounded-inset"></div>
+          <div className="h-10 w-40 bg-track rounded-lg"></div>
         </div>
       </div>
 
       {/* Table Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
                 {[1, 2, 3, 4, 5, 6, 7].map((i) => (
                   <th key={i} className="px-6 py-3">
-                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-20"></div>
+                    <div className="h-4 bg-track rounded w-20"></div>
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {[1, 2, 3, 4, 5].map((i) => (
                 <tr key={i}>
                   {[1, 2, 3, 4, 5, 6, 7].map((j) => (
                     <td key={j} className="px-6 py-4">
-                      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-24"></div>
+                      <div className="h-4 bg-track rounded w-24"></div>
                     </td>
                   ))}
                 </tr>
@@ -155,7 +156,8 @@ export default function APIKeysPage() {
     const token = api.getToken();
     if (token) {
       try {
-        const payload = JSON.parse(atob(token.split(".")[1]));
+        const payload = decodeJwtPayload(token);
+        if (!payload) throw new Error("token payload is not decodable");
         setUserRole((payload.role as UserRole) || "viewer");
       } catch (e) {
         console.error("Failed to decode JWT token:", e);
@@ -225,12 +227,12 @@ export default function APIKeysPage() {
 
   const statCards = [
     {
-      name: "Total Keys",
+      name: "Total keys",
       value: stats.total.toLocaleString(),
       icon: Key,
     },
     {
-      name: "Active Keys",
+      name: "Active keys",
       value: stats.active.toLocaleString(),
       changeType: "positive",
       icon: Check,
@@ -241,7 +243,7 @@ export default function APIKeysPage() {
       icon: Clock,
     },
     {
-      name: "Never Used",
+      name: "Never used",
       value: stats.neverUsed.toLocaleString(),
       icon: AlertCircle,
     },
@@ -392,20 +394,20 @@ export default function APIKeysPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-              API Keys
+            <h1 className="text-headline">
+              API keys
             </h1>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               Manage API keys for agent authentication and authorization.
             </p>
           </div>
           {permissions.canCreateAPIKey && (
             <button
               onClick={() => setShowCreateModal(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="inline-flex h-10 items-center gap-2 rounded-pill bg-brand px-5 text-sm font-bold text-white shadow-glow hover:bg-brand-hover transition-colors"
             >
               <Plus className="h-4 w-4" />
-              Create API Key
+              Create API key
             </button>
           )}
         </div>
@@ -418,87 +420,87 @@ export default function APIKeysPage() {
         </div>
 
         {/* Filters */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+        <div className="glass p-4">
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="flex-1 relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
               <input
                 type="text"
                 placeholder="Search by name, prefix, or agent..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                className="w-full pl-10 pr-4 py-2 rounded-inset border border-stroke bg-glass-inset text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
             <div className="relative">
-              <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+              <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-ink-tertiary" />
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value)}
-                className="pl-10 pr-8 py-2 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                className="pl-10 pr-8 py-2 rounded-inset border border-stroke bg-glass-inset text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring"
               >
-                <option value="all">All Status</option>
+                <option value="all">All statuses</option>
                 <option value="active">Active</option>
                 <option value="disabled">Disabled</option>
                 <option value="expired">Expired</option>
-                <option value="never-used">Never Used</option>
+                <option value="never-used">Never used</option>
               </select>
             </div>
           </div>
         </div>
 
         {/* API Keys Table */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="glass overflow-hidden">
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-50 dark:bg-gray-800">
+            <table className="min-w-full divide-y divide-divider">
+              <thead className="bg-glass-inset-gray">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-overline">
                     Name
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Key Prefix
+                  <th className="px-6 py-3 text-left text-overline">
+                    Key prefix
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-overline">
                     Agent
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Last Used
+                  <th className="px-6 py-3 text-left text-overline">
+                    Last used
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-overline">
                     Expires
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-overline">
                     Status
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-overline">
                     Actions
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+              <tbody className="divide-y divide-divider">
                 {filteredKeys?.map((key) => (
                   <tr
                     key={key?.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    className="hover:bg-glass-inset-gray transition-colors"
                   >
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      <div className="text-sm font-medium text-ink">
                         {key?.name}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="flex items-center gap-2">
-                        <code className="text-sm text-gray-600 dark:text-gray-400 font-mono">
+                        <code className="text-sm text-ink-code font-mono">
                           {key?.prefix}
                         </code>
                         <button
                           onClick={() => copyToClipboard(key?.prefix, key?.id)}
-                          className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-brand-text transition-colors"
                           title="Copy prefix"
                         >
                           {copiedId === key?.id ? (
-                            <Check className="h-4 w-4 text-green-600" />
+                            <Check className="h-4 w-4 text-success-text" />
                           ) : (
                             <Copy className="h-4 w-4" />
                           )}
@@ -506,30 +508,30 @@ export default function APIKeysPage() {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900 dark:text-gray-100">
+                      <div className="text-sm text-ink">
                         {key?.agentName || "Unknown"}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-500 dark:text-gray-400">
+                      <div className="text-sm text-ink-secondary">
                         {key?.lastUsedAt && formatDate(key.lastUsedAt)}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div
-                        className={`text-sm ${key?.expiresAt && isExpired(key.expiresAt) ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400"}`}
+                        className={`text-sm ${key?.expiresAt && isExpired(key.expiresAt) ? "text-danger-text" : "text-ink-secondary"}`}
                       >
                         {key?.expiresAt && formatDate(key.expiresAt)}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center rounded-pill px-2.5 py-0.5 text-xs font-semibold ${
                           !key?.isActive
-                            ? "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300"
+                            ? "border border-glass-inset-border bg-glass-inset-gray text-ink-secondary"
                             : key?.expiresAt && isExpired(key.expiresAt)
-                              ? "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300"
-                              : "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300"
+                              ? "border border-danger-border bg-danger-fill text-danger-text"
+                              : "border border-success-border bg-success-fill text-success-text"
                         }`}
                       >
                         {!key?.isActive
@@ -545,7 +547,7 @@ export default function APIKeysPage() {
                         (!key?.expiresAt || !isExpired(key.expiresAt)) ? (
                           <button
                             onClick={() => handleDisableKey(key)}
-                            className="p-1 text-gray-400 hover:text-orange-600 dark:hover:text-orange-400 transition-colors"
+                            className="p-1 text-ink-tertiary hover:text-warning-text transition-colors"
                             title="Disable key"
                           >
                             <Ban className="h-4 w-4" />
@@ -553,7 +555,7 @@ export default function APIKeysPage() {
                         ) : !key?.isActive && permissions.canDeleteAPIKey ? (
                           <button
                             onClick={() => handleDeleteKey(key)}
-                            className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                            className="p-1 text-ink-tertiary hover:text-danger-text transition-colors"
                             title="Delete key permanently"
                           >
                             <Trash2 className="h-4 w-4" />
@@ -568,11 +570,11 @@ export default function APIKeysPage() {
           </div>
           {filteredKeys.length === 0 && (
             <div className="text-center py-12">
-              <Key className="mx-auto h-12 w-12 text-gray-400" />
-              <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+              <Key className="mx-auto h-12 w-12 text-ink-tertiary" />
+              <h3 className="mt-2 text-sm font-medium text-ink">
                 No API keys found
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 {searchTerm || statusFilter !== "all"
                   ? "Try adjusting your search or filters."
                   : "Get started by creating your first API key."}
@@ -591,7 +593,7 @@ export default function APIKeysPage() {
 
         <ConfirmDialog
           isOpen={showDisableConfirm}
-          title="Disable API Key"
+          title="Disable API key"
           message={`Are you sure you want to disable "${selectedKey?.name}"? The key will be marked as inactive and cannot be used for authentication. You can delete it permanently later.`}
           confirmText="Disable"
           cancelText="Cancel"
@@ -608,7 +610,7 @@ export default function APIKeysPage() {
 
         <ConfirmDialog
           isOpen={showDeleteConfirm}
-          title="Delete API Key"
+          title="Delete API key"
           message={`Are you sure you want to permanently delete "${selectedKey?.name}"? This action cannot be undone.`}
           confirmText="Delete"
           cancelText="Cancel"

--- a/apps/web/app/dashboard/developers/page.tsx
+++ b/apps/web/app/dashboard/developers/page.tsx
@@ -180,7 +180,7 @@ function DevelopersPageContent() {
   const copyToClipboard = async (text: string, type: string) => {
     await navigator.clipboard.writeText(text);
     setCopiedCode(type);
-    toast.success("Copied to clipboard!");
+    toast.success("Copied to clipboard");
     setTimeout(() => setCopiedCode(null), 2000);
   };
 
@@ -313,17 +313,17 @@ function DevelopersPageContent() {
   const getMethodColor = (method: string) => {
     switch (method) {
       case "GET":
-        return "bg-blue-500";
+        return "border-transparent bg-brand-soft text-brand-text";
       case "POST":
-        return "bg-green-500";
+        return "border-success-border bg-success-fill text-success-text";
       case "PUT":
-        return "bg-yellow-500";
+        return "border-warning-border bg-warning-fill text-warning-text";
       case "DELETE":
-        return "bg-red-500";
+        return "border-danger-border bg-danger-fill text-danger-text";
       case "PATCH":
-        return "bg-purple-500";
+        return "border-stroke bg-glass-inset-gray text-ink";
       default:
-        return "bg-gray-500";
+        return "border-stroke bg-glass-inset-gray text-ink-secondary";
     }
   };
 
@@ -341,10 +341,10 @@ function DevelopersPageContent() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          API Documentation
+        <h1 className="text-headline">
+          API documentation
         </h1>
-        <p className="text-gray-600 dark:text-gray-400 mt-2">
+        <p className="text-ink-secondary mt-2">
           Complete AIM API reference with{" "}
           {apiDocumentation.reduce((sum, cat) => sum + cat.endpoints.length, 0)}{" "}
           endpoints
@@ -358,7 +358,7 @@ function DevelopersPageContent() {
             {/* Search Bar */}
             <div className="flex gap-2">
               <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
                 <Input
                   type="text"
                   placeholder="Search endpoints, tags, descriptions..."
@@ -383,17 +383,17 @@ function DevelopersPageContent() {
 
             {/* Advanced Filters */}
             {showFilters && (
-              <div className="flex flex-wrap gap-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <div className="flex flex-wrap gap-4 p-4 glass-inset rounded-inset">
                 <div className="flex-1 min-w-[200px]">
                   <label className="text-sm font-medium mb-2 block">
-                    HTTP Method
+                    HTTP method
                   </label>
                   <select
                     value={filterMethod}
                     onChange={(e) => setFilterMethod(e.target.value)}
-                    className="w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                    className="w-full px-3 py-2 rounded-inset-sm border border-stroke bg-glass text-ink"
                   >
-                    <option value="all">All Methods</option>
+                    <option value="all">All methods</option>
                     <option value="GET">GET</option>
                     <option value="POST">POST</option>
                     <option value="PUT">PUT</option>
@@ -404,15 +404,15 @@ function DevelopersPageContent() {
 
                 <div className="flex-1 min-w-[200px]">
                   <label className="text-sm font-medium mb-2 block">
-                    Required Role
+                    Required role
                   </label>
                   <select
                     value={filterRole}
                     onChange={(e) => setFilterRole(e.target.value)}
-                    className="w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                    className="w-full px-3 py-2 rounded-inset-sm border border-stroke bg-glass text-ink"
                   >
-                    <option value="all">All Roles</option>
-                    <option value="admin">Admin Only</option>
+                    <option value="all">All roles</option>
+                    <option value="admin">Admin only</option>
                     <option value="manager">Manager+</option>
                     <option value="member">Member+</option>
                     <option value="viewer">Viewer+</option>
@@ -423,7 +423,7 @@ function DevelopersPageContent() {
                   <div className="flex items-end">
                     <Button variant="ghost" onClick={clearFilters}>
                       <X className="h-4 w-4 mr-2" />
-                      Clear Filters
+                      Clear filters
                     </Button>
                   </div>
                 )}
@@ -431,7 +431,7 @@ function DevelopersPageContent() {
             )}
 
             {/* Results Count */}
-            <div className="text-sm text-gray-600 dark:text-gray-400">
+            <div className="text-sm text-ink-secondary">
               Showing <span className="font-semibold">{totalEndpoints}</span> of{" "}
               <span className="font-semibold">
                 {apiDocumentation.reduce(
@@ -463,10 +463,10 @@ function DevelopersPageContent() {
                     {/* Category Header */}
                     <button
                       onClick={() => toggleCategory(category.category)}
-                      className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                      className="w-full flex items-center justify-between p-2 rounded-nav hover:bg-glass-inset-gray transition-colors"
                     >
                       <div className="flex items-center gap-2">
-                        <Icon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                        <Icon className="h-4 w-4 text-brand-text" />
                         <span className="font-medium text-sm">
                           {category.category}
                         </span>
@@ -498,13 +498,13 @@ function DevelopersPageContent() {
                             }}
                             className={`w-full text-left p-2 rounded text-sm transition-colors ${
                               selectedEndpoint === endpoint
-                                ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
-                                : "hover:bg-gray-100 dark:hover:bg-gray-800"
+                                ? "bg-nav-active text-brand-text"
+                                : "hover:bg-glass-inset-gray"
                             }`}
                           >
                             <div className="flex items-center gap-2">
                               <Badge
-                                className={`${getMethodColor(endpoint.method)} text-white text-xs px-2 py-0`}
+                                className={`${getMethodColor(endpoint.method)} text-xs px-2 py-0`}
                               >
                                 {endpoint.method}
                               </Badge>
@@ -521,7 +521,7 @@ function DevelopersPageContent() {
               })}
 
               {filteredData.length === 0 && (
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-ink-tertiary">
                   <Search className="h-12 w-12 mx-auto mb-2 opacity-20" />
                   <p className="text-sm">No endpoints match your filters</p>
                 </div>
@@ -538,7 +538,7 @@ function DevelopersPageContent() {
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
                     <Badge
-                      className={`${getMethodColor(selectedEndpoint.method)} text-white`}
+                      className={getMethodColor(selectedEndpoint.method)}
                     >
                       {selectedEndpoint.method}
                     </Badge>
@@ -558,7 +558,7 @@ function DevelopersPageContent() {
                     {selectedEndpoint.requiresAuth && (
                       <Badge variant="destructive" className="text-xs">
                         <Lock className="h-3 w-3 mr-1" />
-                        Auth Required
+                        Auth required
                       </Badge>
                     )}
                     {selectedEndpoint.roleRequired && (
@@ -594,17 +594,17 @@ function DevelopersPageContent() {
                       <h3 className="text-sm font-semibold mb-2">
                         Authentication
                       </h3>
-                      <div className="flex items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                      <div className="flex items-center gap-2 p-3 glass-inset">
                         {selectedEndpoint.requiresAuth ? (
                           <>
-                            <Lock className="h-4 w-4 text-red-600" />
+                            <Lock className="h-4 w-4 text-danger-text" />
                             <span className="text-sm">
                               {selectedEndpoint.auth}
                             </span>
                           </>
                         ) : (
                           <>
-                            <Unlock className="h-4 w-4 text-green-600" />
+                            <Unlock className="h-4 w-4 text-success-text" />
                             <span className="text-sm">
                               No authentication required
                             </span>
@@ -617,7 +617,7 @@ function DevelopersPageContent() {
                     {selectedEndpoint.requestSchema && (
                       <div>
                         <h3 className="text-sm font-semibold mb-2">
-                          Request Body
+                          Request body
                         </h3>
                         <div className="space-y-2">
                           {Object.entries(
@@ -625,7 +625,7 @@ function DevelopersPageContent() {
                           ).map(([key, prop]) => (
                             <div
                               key={key}
-                              className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                              className="p-3 glass-inset"
                             >
                               <div className="flex items-center justify-between mb-1">
                                 <code className="text-sm font-mono">{key}</code>
@@ -643,11 +643,11 @@ function DevelopersPageContent() {
                                   )}
                                 </div>
                               </div>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                              <p className="text-sm text-ink-secondary">
                                 {prop.description}
                               </p>
                               {(prop as any).example && (
-                                <code className="text-xs text-gray-500 mt-1 block">
+                                <code className="text-xs text-ink-tertiary mt-1 block">
                                   Example:{" "}
                                   {JSON.stringify((prop as any).example)}
                                 </code>
@@ -662,7 +662,7 @@ function DevelopersPageContent() {
                     {selectedEndpoint.responseSchema && (
                       <div>
                         <h3 className="text-sm font-semibold mb-2">
-                          Response Body
+                          Response body
                         </h3>
                         <div className="space-y-2">
                           {Object.entries(
@@ -670,7 +670,7 @@ function DevelopersPageContent() {
                           ).map(([key, prop]) => (
                             <div
                               key={key}
-                              className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                              className="p-3 glass-inset"
                             >
                               <div className="flex items-center justify-between mb-1">
                                 <code className="text-sm font-mono">{key}</code>
@@ -678,11 +678,11 @@ function DevelopersPageContent() {
                                   {prop.type}
                                 </Badge>
                               </div>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                              <p className="text-sm text-ink-secondary">
                                 {prop.description}
                               </p>
                               {(prop as any).example && (
-                                <code className="text-xs text-gray-500 mt-1 block">
+                                <code className="text-xs text-ink-tertiary mt-1 block">
                                   Example:{" "}
                                   {JSON.stringify((prop as any).example)}
                                 </code>
@@ -700,7 +700,7 @@ function DevelopersPageContent() {
                         <div>
                           <div className="flex items-center justify-between mb-2">
                             <h3 className="text-sm font-semibold">
-                              Example Request
+                              Example request
                             </h3>
                             <Button
                               size="sm"
@@ -719,7 +719,7 @@ function DevelopersPageContent() {
                               )}
                             </Button>
                           </div>
-                          <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm">
+                          <pre className="glass-contrast p-4 rounded-inset overflow-x-auto text-sm">
                             <code>{selectedEndpoint.example}</code>
                           </pre>
                         </div>
@@ -729,11 +729,11 @@ function DevelopersPageContent() {
                   {/* Try it out Tab */}
                   <TabsContent value="try-it" className="space-y-4 mt-6">
                     {/* Authentication Status */}
-                    <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                    <div className="p-4 glass-inset">
                       {isAuthenticated ? (
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
-                            <CheckCircle className="h-5 w-5 text-green-600" />
+                            <CheckCircle className="h-5 w-5 text-success-text" />
                             <span className="font-medium">Authenticated</span>
                           </div>
                           <Button
@@ -751,9 +751,9 @@ function DevelopersPageContent() {
                       ) : (
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <AlertCircle className="h-5 w-5 text-yellow-600" />
+                            <AlertCircle className="h-5 w-5 text-warning-text" />
                             <span className="font-medium">
-                              Not Authenticated
+                              Not authenticated
                             </span>
                           </div>
                           {!showTokenInput ? (
@@ -761,7 +761,7 @@ function DevelopersPageContent() {
                               size="sm"
                               onClick={() => setShowTokenInput(true)}
                             >
-                              Add Token
+                              Add token
                             </Button>
                           ) : (
                             <div className="flex gap-2">
@@ -795,7 +795,7 @@ function DevelopersPageContent() {
                     {selectedEndpoint.method !== "GET" && (
                       <div>
                         <label className="text-sm font-semibold mb-2 block">
-                          Request Body
+                          Request body
                         </label>
                         <Textarea
                           value={requestBody}
@@ -819,14 +819,14 @@ function DevelopersPageContent() {
                       ) : (
                         <>
                           <Play className="h-4 w-4 mr-2" />
-                          Execute Request
+                          Execute request
                         </>
                       )}
                     </Button>
 
                     {/* Response Metadata */}
                     {responseMetadata && (
-                      <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                      <div className="p-4 glass-inset">
                         <div className="flex items-center justify-between">
                           <span className="text-sm font-medium">Response</span>
                           <div className="flex gap-2">
@@ -853,7 +853,7 @@ function DevelopersPageContent() {
                       <div>
                         <div className="flex items-center justify-between mb-2">
                           <h3 className="text-sm font-semibold">
-                            Response Body
+                            Response body
                           </h3>
                           <Button
                             size="sm"
@@ -872,7 +872,7 @@ function DevelopersPageContent() {
                             )}
                           </Button>
                         </div>
-                        <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm max-h-96">
+                        <pre className="glass-contrast p-4 rounded-inset overflow-x-auto text-sm max-h-96">
                           <code>{JSON.stringify(responseData, null, 2)}</code>
                         </pre>
                       </div>
@@ -880,14 +880,14 @@ function DevelopersPageContent() {
 
                     {/* Error Response */}
                     {executionError && (
-                      <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
+                      <div className="glass-alert p-4">
                         <div className="flex items-center gap-2 mb-2">
-                          <AlertCircle className="h-5 w-5 text-red-600" />
-                          <span className="font-semibold text-red-600">
+                          <AlertCircle className="h-5 w-5 text-danger-text" />
+                          <span className="font-semibold text-danger-text">
                             Error
                           </span>
                         </div>
-                        <pre className="text-sm text-red-800 dark:text-red-200 overflow-x-auto">
+                        <pre className="text-sm text-danger-text overflow-x-auto">
                           {executionError}
                         </pre>
                       </div>
@@ -914,7 +914,7 @@ function DevelopersPageContent() {
                           )}
                         </Button>
                       </div>
-                      <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm">
+                      <pre className="glass-contrast p-4 rounded-inset overflow-x-auto text-sm">
                         <code>{generateCurl()}</code>
                       </pre>
                     </div>
@@ -942,7 +942,7 @@ function DevelopersPageContent() {
                           )}
                         </Button>
                       </div>
-                      <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm">
+                      <pre className="glass-contrast p-4 rounded-inset overflow-x-auto text-sm">
                         <code>{`fetch('${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}${selectedEndpoint.path}', {
   method: '${selectedEndpoint.method}',
   headers: {
@@ -975,7 +975,7 @@ function DevelopersPageContent() {
                           )}
                         </Button>
                       </div>
-                      <pre className="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-x-auto text-sm">
+                      <pre className="glass-contrast p-4 rounded-inset overflow-x-auto text-sm">
                         <code>{`import requests
 
 url = '${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}${selectedEndpoint.path}'
@@ -992,7 +992,7 @@ print(response.json())`}</code>
             </Card>
           ) : (
             <Card className="h-full flex items-center justify-center min-h-[600px]">
-              <div className="text-center text-gray-500">
+              <div className="text-center text-ink-tertiary">
                 <BookOpen className="h-16 w-16 mx-auto mb-4 opacity-20" />
                 <p>Select an endpoint to view documentation</p>
               </div>

--- a/apps/web/app/dashboard/sdk-tokens/page.tsx
+++ b/apps/web/app/dashboard/sdk-tokens/page.tsx
@@ -129,8 +129,8 @@ export default function SDKTokensPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">SDK Tokens</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-ink">SDK tokens</h1>
+          <p className="text-sm text-ink-secondary mt-1">
             Manage your SDK authentication tokens and monitor their usage
           </p>
         </div>
@@ -139,7 +139,7 @@ export default function SDKTokensPage() {
             variant="outline"
             onClick={() => setIncludeRevoked(!includeRevoked)}
           >
-            {includeRevoked ? "Hide Revoked" : "Show Revoked"}
+            {includeRevoked ? "Hide revoked" : "Show revoked"}
           </Button>
           {activeTokens.length > 0 && (
             <Button
@@ -147,7 +147,7 @@ export default function SDKTokensPage() {
               onClick={() => setShowRevokeAllDialog(true)}
             >
               <Trash2 className="w-4 h-4 mr-2" />
-              Revoke All
+              Revoke all
             </Button>
           )}
         </div>
@@ -165,38 +165,38 @@ export default function SDKTokensPage() {
       <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">Active Tokens</CardTitle>
-            <Shield className="h-4 w-4 text-green-500" />
+            <CardTitle className="text-sm font-medium text-ink">Active tokens</CardTitle>
+            <Shield className="h-4 w-4 text-success-text" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{activeTokens.length}</div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Currently valid</p>
+            <div className="text-2xl font-bold text-ink">{activeTokens.length}</div>
+            <p className="text-xs text-ink-secondary">Currently valid</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">Total Usage</CardTitle>
-            <Key className="h-4 w-4 text-blue-500" />
+            <CardTitle className="text-sm font-medium text-ink">Total usage</CardTitle>
+            <Key className="h-4 w-4 text-brand-text" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            <div className="text-2xl font-bold text-ink">
               {tokens.reduce((sum, t) => sum + t.usageCount, 0)}
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">API requests</p>
+            <p className="text-xs text-ink-secondary">API requests</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">
-              Revoked Tokens
+            <CardTitle className="text-sm font-medium text-ink">
+              Revoked tokens
             </CardTitle>
-            <Trash2 className="h-4 w-4 text-red-500" />
+            <Trash2 className="h-4 w-4 text-danger-text" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{revokedTokens.length}</div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">No longer valid</p>
+            <div className="text-2xl font-bold text-ink">{revokedTokens.length}</div>
+            <p className="text-xs text-ink-secondary">No longer valid</p>
           </CardContent>
         </Card>
       </div>
@@ -205,9 +205,9 @@ export default function SDKTokensPage() {
       {tokens.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <Key className="h-12 w-12 text-gray-400 mb-4" />
-            <p className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No SDK tokens found</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 text-center max-w-md mb-4">
+            <Key className="h-12 w-12 text-ink-tertiary mb-4" />
+            <p className="text-lg font-medium text-ink mb-2">No SDK tokens found</p>
+            <p className="text-sm text-ink-secondary text-center max-w-md mb-4">
               Download the SDK to automatically generate an authentication token
             </p>
             <Button onClick={() => (window.location.href = "/dashboard/sdk")}>
@@ -229,12 +229,12 @@ export default function SDKTokensPage() {
                   <div className="flex items-start justify-between">
                     <div className="space-y-1">
                       <div className="flex items-center gap-2">
-                        <CardTitle className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                          {token.deviceName || "Unknown Device"}
+                        <CardTitle className="text-lg font-medium text-ink">
+                          {token.deviceName || "Unknown device"}
                         </CardTitle>
                         <Badge variant={status.color}>{status.label}</Badge>
                       </div>
-                      <CardDescription className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                      <CardDescription className="font-mono text-xs text-ink-secondary">
                         Token ID: {token.tokenId}
                       </CardDescription>
                     </div>
@@ -257,10 +257,10 @@ export default function SDKTokensPage() {
                   <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
                     {/* IP Address */}
                     <div className="flex items-start gap-2">
-                      <MapPin className="w-4 h-4 mt-0.5 text-muted-foreground" />
+                      <MapPin className="w-4 h-4 mt-0.5 text-ink-tertiary" />
                       <div>
-                        <p className="text-sm font-medium">IP Address</p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-sm font-medium text-ink">IP address</p>
+                        <p className="text-sm text-ink-body">
                           {token.lastIpAddress || token.ipAddress || "Unknown"}
                         </p>
                       </div>
@@ -268,11 +268,11 @@ export default function SDKTokensPage() {
 
                     {/* Device */}
                     <div className="flex items-start gap-2">
-                      <Monitor className="w-4 h-4 mt-0.5 text-muted-foreground" />
+                      <Monitor className="w-4 h-4 mt-0.5 text-ink-tertiary" />
                       <div>
-                        <p className="text-sm font-medium">User Agent</p>
+                        <p className="text-sm font-medium text-ink">User agent</p>
                         <p
-                          className="text-sm text-muted-foreground truncate max-w-[200px]"
+                          className="text-sm text-ink-body truncate max-w-[200px]"
                           title={token.userAgent}
                         >
                           {token.userAgent
@@ -284,10 +284,10 @@ export default function SDKTokensPage() {
 
                     {/* Last Used */}
                     <div className="flex items-start gap-2">
-                      <Clock className="w-4 h-4 mt-0.5 text-muted-foreground" />
+                      <Clock className="w-4 h-4 mt-0.5 text-ink-tertiary" />
                       <div>
-                        <p className="text-sm font-medium">Last Used</p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-sm font-medium text-ink">Last used</p>
+                        <p className="text-sm text-ink-body">
                           {token.lastUsedAt
                             ? formatDistanceToNow(new Date(token.lastUsedAt), {
                                 addSuffix: true,
@@ -299,10 +299,10 @@ export default function SDKTokensPage() {
 
                     {/* Usage Count */}
                     <div className="flex items-start gap-2">
-                      <Key className="w-4 h-4 mt-0.5 text-muted-foreground" />
+                      <Key className="w-4 h-4 mt-0.5 text-ink-tertiary" />
                       <div>
-                        <p className="text-sm font-medium">Usage Count</p>
-                        <p className="text-sm text-muted-foreground">
+                        <p className="text-sm font-medium text-ink">Usage count</p>
+                        <p className="text-sm text-ink-body">
                           {token.usageCount.toLocaleString()} requests
                         </p>
                       </div>
@@ -310,8 +310,8 @@ export default function SDKTokensPage() {
                   </div>
 
                   {/* Additional Info Row */}
-                  <div className="mt-4 pt-4 border-t flex items-center justify-between text-sm">
-                    <div className="flex items-center gap-6 text-muted-foreground">
+                  <div className="mt-4 pt-4 border-t border-divider flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-6 text-ink-secondary">
                       <span>
                         Created{" "}
                         {formatDistanceToNow(new Date(token.createdAt), {
@@ -326,7 +326,7 @@ export default function SDKTokensPage() {
                       </span>
                     </div>
                     {token.revokedAt && token.revokeReason && (
-                      <div className="text-red-600 text-sm">
+                      <div className="text-danger-text text-sm">
                         Revoked: {token.revokeReason}
                       </div>
                     )}
@@ -342,7 +342,7 @@ export default function SDKTokensPage() {
       <Dialog open={showRevokeDialog} onOpenChange={setShowRevokeDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Revoke SDK Token</DialogTitle>
+            <DialogTitle>Revoke SDK token</DialogTitle>
             <DialogDescription>
               This will immediately invalidate the token. Any applications using
               this token will lose access.
@@ -372,7 +372,7 @@ export default function SDKTokensPage() {
               onClick={handleRevokeToken}
               disabled={!revokeReason.trim() || revoking}
             >
-              {revoking ? "Revoking..." : "Revoke Token"}
+              {revoking ? "Revoking..." : "Revoke token"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -382,7 +382,7 @@ export default function SDKTokensPage() {
       <Dialog open={showRevokeAllDialog} onOpenChange={setShowRevokeAllDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Revoke All SDK Tokens</DialogTitle>
+            <DialogTitle>Revoke all SDK tokens</DialogTitle>
             <DialogDescription>
               This will immediately invalidate all {activeTokens.length} active
               tokens. This action cannot be undone.
@@ -421,7 +421,7 @@ export default function SDKTokensPage() {
             >
               {revoking
                 ? "Revoking..."
-                : `Revoke All ${activeTokens.length} Tokens`}
+                : `Revoke all ${activeTokens.length} tokens`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/app/dashboard/sdk/page.tsx
+++ b/apps/web/app/dashboard/sdk/page.tsx
@@ -185,21 +185,22 @@ export default function SDKDownloadPage() {
     <AuthGuard>
       <div className="container mx-auto py-8 px-4 max-w-4xl">
         <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-          Open Source Agent Security
+        <h1 className="text-3xl font-bold text-ink mb-2">
+          Open source agent security
         </h1>
-        <p className="text-gray-600 dark:text-gray-400 text-lg">
-          Secure your agents with minimal code. Zero configuration required.
+        <p className="text-ink-secondary text-lg">
+          Offline install path: download the SDK package for machines without registry access.
+          The supported path is <code className="font-mono text-base">pip install aim-sdk</code>.
         </p>
       </div>
 
       {/* Success message */}
       {success && (
-        <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-start gap-3">
-          <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+        <div className="mb-6 p-4 bg-success-fill border border-success-border rounded-card-sm flex items-start gap-3">
+          <CheckCircle className="h-5 w-5 text-success-text mt-0.5 flex-shrink-0" />
           <div>
-            <p className="font-medium text-green-900">SDK downloaded successfully!</p>
-            <p className="text-sm text-green-700 mt-1">
+            <p className="font-medium text-success-text">SDK downloaded</p>
+            <p className="text-sm text-ink-body mt-1">
               Follow the setup instructions below to get started.
             </p>
           </div>
@@ -208,11 +209,11 @@ export default function SDKDownloadPage() {
 
       {/* Error message */}
       {error && (
-        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-start gap-3">
-          <AlertCircle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+        <div className="glass-alert mb-6 p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-danger-text mt-0.5 flex-shrink-0" />
           <div>
-            <p className="font-medium text-red-900">Download failed</p>
-            <p className="text-sm text-red-700 mt-1">{error}</p>
+            <p className="font-medium text-danger-text">Download failed</p>
+            <p className="text-sm text-ink-body mt-1">{error}</p>
           </div>
         </div>
       )}
@@ -220,26 +221,23 @@ export default function SDKDownloadPage() {
       {/* SDK Cards - Python and Java */}
       <div className="mb-8 grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
         {/* Python SDK - Stable */}
-        <div className="bg-white border-2 border-blue-500 rounded-lg shadow-lg overflow-hidden">
+        <div className="glass overflow-hidden">
           <div className="p-6">
             <div className="flex items-center gap-4 mb-4">
-              <div className="h-14 w-14 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center shadow-lg">
+              <div className="h-14 w-14 bg-brand rounded-inset flex items-center justify-center shadow-glow">
                 <Code className="h-7 w-7 text-white" />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-gray-900">Python SDK</h2>
+                <h2 className="text-xl font-bold text-ink">Python SDK</h2>
                 <div className="flex items-center gap-2 mt-1">
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    ✅ Stable
-                  </span>
-                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-gray-100 text-gray-700">
-                    v1.15.0
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-pill text-xs font-medium bg-success-fill border border-success-border text-success-text">
+                    Stable
                   </span>
                 </div>
               </div>
             </div>
 
-            <p className="text-sm text-gray-700 mb-4">
+            <p className="text-sm text-ink-body mb-4">
               Official Python client with Ed25519 cryptographic verification, OAuth integration,
               automatic MCP detection, and secure keyring storage.
             </p>
@@ -247,7 +245,7 @@ export default function SDKDownloadPage() {
             <button
               onClick={() => handleDownload('python')}
               disabled={downloading && selectedSDK === 'python'}
-              className="w-full bg-blue-600 text-white px-4 py-2.5 rounded-lg font-medium hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors text-sm shadow-md"
+              className="w-full rounded-pill bg-brand text-white shadow-glow px-4 py-2.5 font-medium hover:bg-brand-hover disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors text-sm"
             >
               <Download className="h-4 w-4" />
               {downloading && selectedSDK === 'python' ? 'Downloading...' : 'Download Python SDK'}
@@ -256,26 +254,26 @@ export default function SDKDownloadPage() {
         </div>
 
         {/* Java SDK - New! */}
-        <div className="bg-white border-2 border-orange-500 rounded-lg shadow-lg overflow-hidden">
+        <div className="glass overflow-hidden">
           <div className="p-6">
             <div className="flex items-center gap-4 mb-4">
-              <div className="h-14 w-14 bg-gradient-to-br from-orange-500 to-red-600 rounded-lg flex items-center justify-center shadow-lg">
+              <div className="h-14 w-14 bg-brand rounded-inset flex items-center justify-center shadow-glow">
                 <Code className="h-7 w-7 text-white" />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-gray-900">Java SDK</h2>
+                <h2 className="text-xl font-bold text-ink">Java SDK</h2>
                 <div className="flex items-center gap-2 mt-1">
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-pill text-xs font-medium bg-warning-fill border border-warning-border text-warning-text">
                     New
                   </span>
-                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-gray-100 text-gray-700">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-glass-inset-gray text-ink-body">
                     v1.0.0
                   </span>
                 </div>
               </div>
             </div>
 
-            <p className="text-sm text-gray-700 mb-4">
+            <p className="text-sm text-ink-body mb-4">
               Java client with Maven support, AspectJ annotations, OkHttp,
               BouncyCastle cryptography, and Spring Boot integration.
             </p>
@@ -283,7 +281,7 @@ export default function SDKDownloadPage() {
             <button
               onClick={() => handleDownload('java')}
               disabled={downloading && selectedSDK === 'java'}
-              className="w-full bg-orange-600 text-white px-4 py-2.5 rounded-lg font-medium hover:bg-orange-700 disabled:bg-orange-400 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors text-sm shadow-md"
+              className="w-full rounded-pill bg-brand text-white shadow-glow px-4 py-2.5 font-medium hover:bg-brand-hover disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors text-sm"
             >
               <Download className="h-4 w-4" />
               {downloading && selectedSDK === 'java' ? 'Downloading...' : 'Download Java SDK'}
@@ -293,31 +291,31 @@ export default function SDKDownloadPage() {
       </div>
 
       {/* Setup Instructions */}
-      <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
+      <div className="glass overflow-hidden">
         <div className="p-6">
           <div className="flex items-center gap-2 mb-4">
-            <Terminal className="h-5 w-5 text-gray-700" />
-            <h3 className="text-lg font-semibold text-gray-900">Quick Start - See Results in 60 Seconds!</h3>
+            <Terminal className="h-5 w-5 text-ink-body" />
+            <h3 className="text-lg font-semibold text-ink">Quick start</h3>
           </div>
 
           {/* Language Tabs - Applies to all steps */}
           <div className="flex gap-2 mb-4">
             <button
               onClick={() => setSelectedCodeTab('python')}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              className={`px-4 py-2 rounded-pill text-sm font-medium transition-colors ${
                 selectedCodeTab === 'python'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-brand text-white shadow-glow'
+                  : 'bg-glass-inset-gray text-ink-body hover:bg-track'
               }`}
             >
               Python
             </button>
             <button
               onClick={() => setSelectedCodeTab('java')}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              className={`px-4 py-2 rounded-pill text-sm font-medium transition-colors ${
                 selectedCodeTab === 'java'
-                  ? 'bg-orange-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-brand text-white shadow-glow'
+                  : 'bg-glass-inset-gray text-ink-body hover:bg-track'
               }`}
             >
               Java
@@ -326,17 +324,17 @@ export default function SDKDownloadPage() {
 
           <div className="space-y-6">
             <div>
-              <h4 className="font-medium text-gray-900 mb-2">1. Extract & Install SDK</h4>
-              <div className="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+              <h4 className="font-medium text-ink mb-2">1. Extract and install the SDK</h4>
+              <div className="glass-contrast p-4 overflow-x-auto">
                 {selectedCodeTab === 'python' ? (
-                  <code className="text-sm text-green-400 font-mono">
+                  <code className="text-sm text-ink-code font-mono">
                     cd ~/projects  # or any folder you prefer<br />
                     unzip ~/Downloads/aim-sdk-python.zip<br />
                     cd aim-sdk-python<br />
                     pip install -e .
                   </code>
                 ) : (
-                  <code className="text-sm text-green-400 font-mono">
+                  <code className="text-sm text-ink-code font-mono">
                     cd ~/projects  # or any folder you prefer<br />
                     unzip ~/Downloads/aim-sdk-java.zip<br />
                     cd aim-sdk-java<br />
@@ -346,65 +344,65 @@ export default function SDKDownloadPage() {
               </div>
             </div>
 
-            <div className="bg-gradient-to-r from-green-50 to-emerald-50 border-2 border-green-300 rounded-lg p-4">
-              <h4 className="font-semibold text-green-900 mb-2">
-                2. Run the Demo Agent - Watch Dashboard Update Live!
+            <div className="bg-success-fill border border-success-border rounded-card-sm p-4">
+              <h4 className="font-semibold text-ink mb-2">
+                2. Run the demo agent
               </h4>
-              <div className="bg-gray-900 rounded-lg p-4 overflow-x-auto mb-2">
+              <div className="glass-contrast p-4 overflow-x-auto mb-2">
                 {selectedCodeTab === 'python' ? (
-                  <code className="text-sm text-green-400 font-mono">
+                  <code className="text-sm text-ink-code font-mono">
                     python demo_agent.py
                   </code>
                 ) : (
-                  <code className="text-sm text-green-400 font-mono">
+                  <code className="text-sm text-ink-code font-mono">
                     mvn exec:java -Dexec.mainClass="org.opena2a.aim.demo.DemoAgent"
                   </code>
                 )}
               </div>
-              <p className="text-sm text-green-800 mb-2">
+              <p className="text-sm text-ink-body mb-2">
                 The demo agent includes interactive actions you can trigger. Open your{' '}
-                <Link href="/dashboard/agents" className="underline font-medium">Agents Dashboard</Link>{' '}
-                side-by-side and watch it update in real-time as you perform actions!
+                <Link href="/dashboard/agents" className="underline font-medium text-brand-text">agents dashboard</Link>{' '}
+                side-by-side and watch it update as you perform actions.
               </p>
-              <p className="text-sm text-green-700">
+              <p className="text-sm text-ink-secondary">
                 <strong>Actions included:</strong> Weather checks, product searches, user lookups, notifications, and more - each with different risk levels so you can see how AIM monitors them differently.
               </p>
             </div>
 
             <div>
-              <h4 className="font-medium text-gray-900 mb-2">3. Build Your Own Agent</h4>
-              <div className="relative bg-black rounded-lg p-4 overflow-x-auto mb-2 border-2 border-primary/30">
+              <h4 className="font-medium text-ink mb-2">3. Build your own agent</h4>
+              <div className="glass-contrast relative p-4 overflow-x-auto mb-2">
                 <button
                   onClick={handleCopy}
-                  className="absolute top-3 right-3 p-2 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                  className="absolute top-3 right-3 p-2 rounded-md bg-glass-code hover:bg-glass-inset-gray text-ink-inverse-secondary hover:text-ink-inverse transition-colors"
                   title="Copy to clipboard"
                 >
-                  {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+                  {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
                 </button>
-                <pre className="text-sm text-green-400 font-mono whitespace-pre overflow-x-auto">
+                <pre className="text-sm text-ink-code font-mono whitespace-pre overflow-x-auto">
                   {currentSampleCode}
                 </pre>
               </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 flex items-start gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-ink-secondary flex items-start gap-2">
+                <CheckCircle className="h-4 w-4 text-success-text mt-0.5 flex-shrink-0" />
                 <span>
                   {selectedCodeTab === 'python'
-                    ? 'Click the copy button above or use the demo_agent.py file as a starting point!'
-                    : 'Add the SDK to your Maven pom.xml and use the examples as a starting point!'}
+                    ? 'Click the copy button above or use the demo_agent.py file as a starting point.'
+                    : 'Add the SDK to your Maven pom.xml and use the examples as a starting point.'}
                 </span>
               </p>
             </div>
 
             <div>
-              <h4 className="font-medium text-gray-900 mb-2">4. View Real-Time Security Analytics</h4>
-              <p className="text-gray-700 dark:text-gray-300 mb-3">
-                Monitor your agent&apos;s security posture, trust score, MCP connections, and behavior analytics in real-time.
+              <h4 className="font-medium text-ink mb-2">4. View security analytics</h4>
+              <p className="text-ink-body mb-3">
+                Monitor your agent&apos;s security posture, trust score, MCP connections, and behavior analytics.
               </p>
               <Link
                 href="/dashboard/agents"
-                className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+                className="inline-flex items-center gap-2 text-brand-text hover:underline font-medium"
               >
-                View Agents Dashboard →
+                View agents dashboard →
               </Link>
             </div>
           </div>

--- a/apps/web/app/dashboard/tags/page.tsx
+++ b/apps/web/app/dashboard/tags/page.tsx
@@ -121,11 +121,11 @@ export default function TagsPage() {
   };
 
   const categoryOptions: { value: TagCategory | "all"; label: string }[] = [
-    { value: "all", label: "All Categories" },
-    { value: "resource_type", label: "Resource Type" },
+    { value: "all", label: "All categories" },
+    { value: "resource_type", label: "Resource type" },
     { value: "environment", label: "Environment" },
-    { value: "agent_type", label: "Agent Type" },
-    { value: "data_classification", label: "Data Classification" },
+    { value: "agent_type", label: "Agent type" },
+    { value: "data_classification", label: "Data classification" },
     { value: "custom", label: "Custom" },
   ];
 
@@ -134,16 +134,16 @@ export default function TagsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Tags Management
+          <h1 className="text-2xl font-bold text-ink">
+            Tags
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-sm text-ink-secondary mt-1">
             Organize agents and MCP servers with tags
           </p>
         </div>
         <Button onClick={() => setIsCreateModalOpen(true)}>
           <Plus className="mr-2 h-4 w-4" />
-          Create Tag
+          Create tag
         </Button>
       </div>
 
@@ -151,23 +151,23 @@ export default function TagsPage() {
       <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">
-              Total Tags
+            <CardTitle className="text-sm font-medium text-ink">
+              Total tags
             </CardTitle>
-            <TagIcon className="h-4 w-4 text-gray-400" />
+            <TagIcon className="h-4 w-4 text-ink-tertiary" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="animate-pulse">
-                <div className="h-8 w-16 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
-                <div className="h-3 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                <div className="h-8 w-16 bg-track rounded mb-2"></div>
+                <div className="h-3 w-32 bg-track rounded"></div>
               </div>
             ) : (
               <>
-                <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                <div className="text-2xl font-bold text-ink">
                   {tags.length}
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-secondary">
                   Across all categories
                 </p>
               </>
@@ -177,23 +177,23 @@ export default function TagsPage() {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            <CardTitle className="text-sm font-medium text-ink">
               Categories
             </CardTitle>
-            <Filter className="h-4 w-4 text-gray-400" />
+            <Filter className="h-4 w-4 text-ink-tertiary" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="animate-pulse">
-                <div className="h-8 w-16 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
-                <div className="h-3 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                <div className="h-8 w-16 bg-track rounded mb-2"></div>
+                <div className="h-3 w-32 bg-track rounded"></div>
               </div>
             ) : (
               <>
-                <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                <div className="text-2xl font-bold text-ink">
                   {new Set(tags.map((t) => t.category)).size}
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-secondary">
                   Active tag categories
                 </p>
               </>
@@ -203,23 +203,23 @@ export default function TagsPage() {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium text-gray-900 dark:text-gray-100">
-              Filtered Results
+            <CardTitle className="text-sm font-medium text-ink">
+              Filtered results
             </CardTitle>
-            <Search className="h-4 w-4 text-gray-400" />
+            <Search className="h-4 w-4 text-ink-tertiary" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="animate-pulse">
-                <div className="h-8 w-16 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
-                <div className="h-3 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                <div className="h-8 w-16 bg-track rounded mb-2"></div>
+                <div className="h-3 w-32 bg-track rounded"></div>
               </div>
             ) : (
               <>
-                <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                <div className="text-2xl font-bold text-ink">
                   {filteredTags.length}
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-ink-secondary">
                   Matching current filters
                 </p>
               </>
@@ -231,10 +231,10 @@ export default function TagsPage() {
       {/* Filters */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg font-medium text-gray-900 dark:text-gray-100">
-            Filter Tags
+          <CardTitle className="text-lg font-medium text-ink">
+            Filter tags
           </CardTitle>
-          <CardDescription className="text-sm text-gray-500 dark:text-gray-400">
+          <CardDescription className="text-sm text-ink-secondary">
             Search and filter tags by category
           </CardDescription>
         </CardHeader>
@@ -242,7 +242,7 @@ export default function TagsPage() {
           <div className="flex gap-4">
             <div className="flex-1">
               <div className="relative">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-ink-tertiary" />
                 <Input
                   type="search"
                   placeholder="Search tags by key, value, or description..."

--- a/apps/web/app/dashboard/webhooks/page.tsx
+++ b/apps/web/app/dashboard/webhooks/page.tsx
@@ -200,7 +200,7 @@ export default function WebhooksPage() {
             {[...Array(4)].map((_, i) => (
               <div
                 key={i}
-                className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+                className="glass p-6"
               >
                 <div className="flex items-center">
                   <div className="flex-shrink-0">
@@ -215,7 +215,7 @@ export default function WebhooksPage() {
             ))}
           </div>
 
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <div className="glass">
             <div className="p-6">
               <div className="space-y-3">
                 {[...Array(5)].map((_, i) => (
@@ -234,11 +234,11 @@ export default function WebhooksPage() {
       <AuthGuard>
         <div className="space-y-6">
           <div className="text-center py-16">
-            <AlertCircle className="h-16 w-16 mx-auto mb-4 text-gray-400" />
-            <h2 className="text-2xl font-semibold mb-2 text-gray-900">Unable to Load Webhooks</h2>
-            <p className="text-gray-600">{error}</p>
+            <AlertCircle className="h-16 w-16 mx-auto mb-4 text-ink-tertiary" />
+            <h2 className="text-2xl font-semibold mb-2 text-ink">Unable to load webhooks</h2>
+            <p className="text-ink-secondary">{error}</p>
             <Button onClick={fetchWebhooks} className="mt-4">
-              Try Again
+              Try again
             </Button>
           </div>
         </div>
@@ -252,36 +252,36 @@ export default function WebhooksPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            <h1 className="text-2xl font-bold text-ink">
               Webhooks
             </h1>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               Manage webhook endpoints and monitor delivery status
             </p>
           </div>
           <button
             onClick={() => setShowCreateModal(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
           >
             <Plus className="h-4 w-4" />
-            Create Webhook
+            Create webhook
           </button>
         </div>
 
         {/* Summary Cards */}
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+          <div className="glass p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <Webhook className="h-6 w-6 text-gray-400" />
+                <Webhook className="h-6 w-6 text-ink-tertiary" />
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                    Total Webhooks
+                  <dt className="text-sm font-medium text-ink-secondary truncate">
+                    Total webhooks
                   </dt>
                   <dd className="flex items-baseline">
-                    <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                    <div className="text-2xl font-semibold text-ink">
                       {webhooks.length}
                     </div>
                   </dd>
@@ -290,18 +290,18 @@ export default function WebhooksPage() {
             </div>
           </div>
 
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+          <div className="glass p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <Power className="h-6 w-6 text-gray-400" />
+                <Power className="h-6 w-6 text-ink-tertiary" />
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                  <dt className="text-sm font-medium text-ink-secondary truncate">
                     Active
                   </dt>
                   <dd className="flex items-baseline">
-                    <div className="text-2xl font-semibold text-green-600 dark:text-green-400">
+                    <div className="text-2xl font-semibold text-success-text">
                       {webhooks.filter((w) => w.isActive).length}
                     </div>
                   </dd>
@@ -310,18 +310,18 @@ export default function WebhooksPage() {
             </div>
           </div>
 
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+          <div className="glass p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <CheckCircle className="h-6 w-6 text-gray-400" />
+                <CheckCircle className="h-6 w-6 text-ink-tertiary" />
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                    Total Successes
+                  <dt className="text-sm font-medium text-ink-secondary truncate">
+                    Total successes
                   </dt>
                   <dd className="flex items-baseline">
-                    <div className="text-2xl font-semibold text-green-600 dark:text-green-400">
+                    <div className="text-2xl font-semibold text-success-text">
                       {webhooks.reduce((sum, w) => sum + w.successCount, 0).toLocaleString()}
                     </div>
                   </dd>
@@ -330,18 +330,18 @@ export default function WebhooksPage() {
             </div>
           </div>
 
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+          <div className="glass p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <XCircle className="h-6 w-6 text-gray-400" />
+                <XCircle className="h-6 w-6 text-ink-tertiary" />
               </div>
               <div className="ml-5 w-0 flex-1">
                 <dl>
-                  <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                    Total Failures
+                  <dt className="text-sm font-medium text-ink-secondary truncate">
+                    Total failures
                   </dt>
                   <dd className="flex items-baseline">
-                    <div className="text-2xl font-semibold text-red-600 dark:text-red-400">
+                    <div className="text-2xl font-semibold text-danger-text">
                       {webhooks.reduce((sum, w) => sum + w.failureCount, 0).toLocaleString()}
                     </div>
                   </dd>
@@ -354,7 +354,7 @@ export default function WebhooksPage() {
         {/* Webhooks Table */}
         <Card>
           <CardHeader>
-            <CardTitle>Webhook Endpoints</CardTitle>
+            <CardTitle>Webhook endpoints</CardTitle>
             <CardDescription>
               Configure and monitor webhook endpoints for real-time event notifications
             </CardDescription>
@@ -369,7 +369,7 @@ export default function WebhooksPage() {
                 </p>
                 <Button onClick={() => setShowCreateModal(true)}>
                   <Plus className="h-4 w-4 mr-2" />
-                  Create Webhook
+                  Create webhook
                 </Button>
               </div>
             ) : (
@@ -380,8 +380,8 @@ export default function WebhooksPage() {
                     <TableHead>URL</TableHead>
                     <TableHead>Events</TableHead>
                     <TableHead>Status</TableHead>
-                    <TableHead>Success Rate</TableHead>
-                    <TableHead>Last Triggered</TableHead>
+                    <TableHead>Success rate</TableHead>
+                    <TableHead>Last triggered</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -402,7 +402,7 @@ export default function WebhooksPage() {
                               href={webhook.url}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="text-blue-600 hover:text-blue-800"
+                              className="text-brand-text hover:underline"
                             >
                               <ExternalLink className="h-3 w-3" />
                             </a>
@@ -424,12 +424,12 @@ export default function WebhooksPage() {
                         </TableCell>
                         <TableCell>
                           {webhook.isActive ? (
-                            <Badge className="bg-green-100 text-green-800 border-green-200">
+                            <Badge className="bg-success-fill text-success-text border-success-border">
                               <Power className="h-3 w-3 mr-1" />
                               Active
                             </Badge>
                           ) : (
-                            <Badge className="bg-gray-100 text-gray-800 border-gray-200">
+                            <Badge className="bg-glass-inset-gray text-ink-secondary border-divider">
                               <PowerOff className="h-3 w-3 mr-1" />
                               Inactive
                             </Badge>
@@ -437,16 +437,16 @@ export default function WebhooksPage() {
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-2">
-                            <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden w-20">
+                            <div className="flex-1 h-2 bg-track rounded-full overflow-hidden w-20">
                               <div
                                 className={`h-full rounded-full ${
                                   successRate >= 90
-                                    ? 'bg-green-500'
+                                    ? 'bg-success'
                                     : successRate >= 75
-                                      ? 'bg-blue-500'
+                                      ? 'bg-brand'
                                       : successRate >= 50
-                                        ? 'bg-yellow-500'
-                                        : 'bg-red-500'
+                                        ? 'bg-warning'
+                                        : 'bg-danger'
                                 }`}
                                 style={{ width: `${successRate}%` }}
                               />
@@ -472,7 +472,7 @@ export default function WebhooksPage() {
                           <div className="flex items-center justify-end gap-2">
                             <button
                               onClick={() => handleViewDetails(webhook)}
-                              className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                              className="p-1 text-ink-tertiary hover:text-brand-text transition-colors"
                               title="View details"
                             >
                               <Eye className="h-4 w-4" />
@@ -480,7 +480,7 @@ export default function WebhooksPage() {
                             <button
                               onClick={() => handleTestWebhook(webhook.id)}
                               disabled={testingWebhookId === webhook.id}
-                              className="p-1 text-gray-400 hover:text-green-600 dark:hover:text-green-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                              className="p-1 text-ink-tertiary hover:text-success-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                               title="Test webhook"
                             >
                               <TestTube className="h-4 w-4" />
@@ -489,7 +489,7 @@ export default function WebhooksPage() {
                               <button
                                 onClick={() => handleToggleWebhook(webhook)}
                                 disabled={togglingWebhookId === webhook.id}
-                                className="p-1 text-gray-400 hover:text-orange-600 dark:hover:text-orange-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="p-1 text-ink-tertiary hover:text-warning-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                 title="Disable webhook"
                               >
                                 <Ban className="h-4 w-4" />
@@ -497,7 +497,7 @@ export default function WebhooksPage() {
                             ) : (
                               <button
                                 onClick={() => setDeleteWebhookId(webhook.id)}
-                                className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                                className="p-1 text-ink-tertiary hover:text-danger-text transition-colors"
                                 title="Delete webhook permanently"
                               >
                                 <Trash2 className="h-4 w-4" />
@@ -541,7 +541,7 @@ export default function WebhooksPage() {
       <AlertDialog open={!!deleteWebhookId} onOpenChange={() => setDeleteWebhookId(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Webhook</AlertDialogTitle>
+            <AlertDialogTitle>Delete webhook</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete this webhook? This action cannot be undone, and the
               webhook will stop receiving events immediately.
@@ -551,7 +551,7 @@ export default function WebhooksPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDeleteWebhook}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-danger-strong text-white shadow-none hover:bg-danger-strong hover:brightness-95"
             >
               Delete
             </AlertDialogAction>

--- a/apps/web/components/agents/sdk-setup-guide.tsx
+++ b/apps/web/components/agents/sdk-setup-guide.tsx
@@ -31,8 +31,7 @@ export function SDKSetupGuide({ agentId, agentName, agentType }: SDKSetupGuidePr
 agent = secure("${agentId}")`;
 
   // Advanced Python example
-  const advancedCode = `# Download SDK from AIM Dashboard → Settings → SDK Download
-# Install dependencies: pip install keyring PyNaCl requests cryptography
+  const advancedCode = `# pip install aim-sdk
 
 from aim_sdk import AIMClient
 import os

--- a/apps/web/components/modals/agent-detail-modal.tsx
+++ b/apps/web/components/modals/agent-detail-modal.tsx
@@ -25,37 +25,37 @@ import { TagSelector } from "../ui/tag-selector";
 // Agent type display configuration
 const AGENT_TYPE_LABELS: Record<string, { label: string; color: string }> = {
   // LLM Providers
-  claude: { label: "Claude", color: "bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300" },
-  gpt: { label: "GPT", color: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300" },
-  gemini: { label: "Gemini", color: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300" },
-  llama: { label: "Llama", color: "bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300" },
-  mistral: { label: "Mistral", color: "bg-cyan-100 dark:bg-cyan-900/30 text-cyan-800 dark:text-cyan-300" },
-  cohere: { label: "Cohere", color: "bg-pink-100 dark:bg-pink-900/30 text-pink-800 dark:text-pink-300" },
+  claude: { label: "Claude", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  gpt: { label: "GPT", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  gemini: { label: "Gemini", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  llama: { label: "Llama", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  mistral: { label: "Mistral", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  cohere: { label: "Cohere", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Frameworks
-  langchain: { label: "LangChain", color: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300" },
-  llamaindex: { label: "LlamaIndex", color: "bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-300" },
-  langgraph: { label: "LangGraph", color: "bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-300" },
-  crewai: { label: "CrewAI", color: "bg-rose-100 dark:bg-rose-900/30 text-rose-800 dark:text-rose-300" },
-  autogen: { label: "AutoGen", color: "bg-sky-100 dark:bg-sky-900/30 text-sky-800 dark:text-sky-300" },
-  semantic_kernel: { label: "Semantic Kernel", color: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-300" },
-  haystack: { label: "Haystack", color: "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300" },
+  langchain: { label: "LangChain", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  llamaindex: { label: "LlamaIndex", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  langgraph: { label: "LangGraph", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  crewai: { label: "CrewAI", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  autogen: { label: "AutoGen", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  semantic_kernel: { label: "Semantic Kernel", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  haystack: { label: "Haystack", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Copilots & Assistants
-  copilot: { label: "Copilot", color: "bg-slate-100 dark:bg-slate-900/30 text-slate-800 dark:text-slate-300" },
-  assistant: { label: "Assistant", color: "bg-lime-100 dark:bg-lime-900/30 text-lime-800 dark:text-lime-300" },
-  chatbot: { label: "Chatbot", color: "bg-fuchsia-100 dark:bg-fuchsia-900/30 text-fuchsia-800 dark:text-fuchsia-300" },
+  copilot: { label: "Copilot", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  assistant: { label: "Assistant", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  chatbot: { label: "Chatbot", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Autonomous Agents
-  autogpt: { label: "AutoGPT", color: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300" },
-  babyagi: { label: "BabyAGI", color: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300" },
+  autogpt: { label: "AutoGPT", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
+  babyagi: { label: "BabyAGI", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Other
-  custom: { label: "Custom", color: "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300" },
+  custom: { label: "Custom", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
   // Legacy
-  ai_agent: { label: "AI Agent", color: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300" },
+  ai_agent: { label: "AI Agent", color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" },
 };
 
 // Get display info for an agent type
 function getAgentTypeDisplay(agentType: string | undefined): { label: string; color: string } {
   if (!agentType) return AGENT_TYPE_LABELS.custom;
-  return AGENT_TYPE_LABELS[agentType] || { label: agentType, color: "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300" };
+  return AGENT_TYPE_LABELS[agentType] || { label: agentType, color: "border border-glass-inset-border bg-glass-inset-gray text-ink-body" };
 }
 
 interface AgentDetailModalProps {
@@ -307,48 +307,48 @@ export function AgentDetailModal({
   const getStatusColor = (status: string) => {
     switch (status) {
       case "verified":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "border border-success-border bg-success-fill text-success-text";
       case "pending":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "border border-warning-border bg-warning-fill text-warning-text";
       case "suspended":
       case "revoked":
-        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+        return "border border-danger-border bg-danger-fill text-danger-text";
       default:
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "border border-glass-inset-border bg-glass-inset-gray text-ink-body";
     }
   };
 
   const getTrustScoreColor = (score: number) => {
-    if (score >= 80) return "text-green-600 dark:text-green-400";
-    if (score >= 60) return "text-yellow-600 dark:text-yellow-400";
-    return "text-red-600 dark:text-red-400";
+    if (score >= 80) return "text-success-text";
+    if (score >= 60) return "text-warning-text";
+    return "text-danger-text";
   };
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       style={{ margin: 0 }}
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
           <div className="flex items-center gap-3">
-            <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center">
+            <div className="w-12 h-12 bg-logo rounded-inset flex items-center justify-center">
               <Shield className="h-6 w-6 text-white" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              <h2 className="text-xl font-semibold text-ink">
                 {agent.displayName}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-secondary">
                 {agent.name}
               </p>
             </div>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="text-ink-tertiary hover:text-ink transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -359,18 +359,18 @@ export function AgentDetailModal({
           {/* Status and Trust Score */}
           <div className="flex items-center gap-4">
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+              <span className="text-sm text-ink-secondary block mb-1">
                 Status
               </span>
               <span
-                className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium capitalize ${getStatusColor(agent.status)}`}
+                className={`inline-flex items-center px-3 py-1 rounded-pill text-sm font-medium capitalize ${getStatusColor(agent.status)}`}
               >
                 {agent.status}
               </span>
             </div>
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
-                Trust Score
+              <span className="text-sm text-ink-secondary block mb-1">
+                Trust score
               </span>
               <span
                 className={`text-2xl font-bold ${getTrustScoreColor(agent.trustScore)}`}
@@ -382,11 +382,11 @@ export function AgentDetailModal({
               </span>
             </div>
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+              <span className="text-sm text-ink-secondary block mb-1">
                 Type
               </span>
               <span
-                className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getAgentTypeDisplay(agent.agentType).color}`}
+                className={`inline-flex items-center px-3 py-1 rounded-pill text-sm font-medium ${getAgentTypeDisplay(agent.agentType).color}`}
               >
                 {getAgentTypeDisplay(agent.agentType).label}
               </span>
@@ -396,10 +396,10 @@ export function AgentDetailModal({
           {/* Description */}
           {agent.description && (
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink mb-2">
                 Description
               </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-ink-body">
                 {agent.description}
               </p>
             </div>
@@ -407,11 +407,11 @@ export function AgentDetailModal({
 
           {/* Tags */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+            <h3 className="text-sm font-medium text-ink mb-3">
               Tags
             </h3>
             {loadingTags ? (
-              <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="text-sm text-ink-secondary">
                 Loading tags...
               </div>
             ) : (
@@ -426,12 +426,12 @@ export function AgentDetailModal({
 
           {/* Capabilities */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+            <h3 className="text-sm font-medium text-ink mb-3 flex items-center gap-2">
               <Key className="h-4 w-4" />
               Capabilities
             </h3>
             {loadingCapabilities ? (
-              <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="text-sm text-ink-secondary">
                 Loading capabilities...
               </div>
             ) : capabilities && capabilities.length > 0 ? (
@@ -439,16 +439,16 @@ export function AgentDetailModal({
                 {capabilities.map((capability) => (
                   <div
                     key={capability.id}
-                    className="inline-flex items-center gap-2 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-md"
+                    className="inline-flex items-center gap-2 px-3 py-2 bg-brand-soft border border-stroke rounded-inset-sm"
                   >
-                    <CheckCircle className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+                    <CheckCircle className="h-4 w-4 text-brand-text flex-shrink-0" />
                     <div>
-                      <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                      <p className="text-sm font-medium text-ink">
                         {capability.capabilityType}
                       </p>
                       {capability.capabilityScope &&
                         Object.keys(capability.capabilityScope).length > 0 && (
-                          <p className="text-xs text-blue-600 dark:text-blue-400">
+                          <p className="text-xs text-brand-text">
                             {Object.entries(capability.capabilityScope)
                               .map(([key, value]) => `${key}: ${value}`)
                               .join(", ")}
@@ -459,7 +459,7 @@ export function AgentDetailModal({
                 ))}
               </div>
             ) : (
-              <div className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <div className="text-sm text-ink-secondary italic">
                 No capabilities registered
               </div>
             )}
@@ -467,7 +467,7 @@ export function AgentDetailModal({
 
           {/* Talks To (MCP Servers) */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+            <h3 className="text-sm font-medium text-ink mb-3 flex items-center gap-2">
               <svg
                 className="h-4 w-4"
                 fill="none"
@@ -481,21 +481,21 @@ export function AgentDetailModal({
                   d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
                 />
               </svg>
-              Talks To (MCP Servers)
+              Talks to (MCP servers)
             </h3>
             {agent.talksTo && agent.talksTo.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {agent.talksTo.map((mcpServer, index) => (
                   <div
                     key={index}
-                    className="px-3 py-2 bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-md text-sm font-medium text-purple-900 dark:text-purple-100"
+                    className="px-3 py-2 border border-glass-inset-border bg-glass-inset-gray text-ink-body rounded-inset-sm text-sm font-medium"
                   >
                     {mcpServer}
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <div className="text-sm text-ink-secondary italic">
                 No MCP servers configured
               </div>
             )}
@@ -504,39 +504,39 @@ export function AgentDetailModal({
           {/* Details Grid */}
           <div className="grid grid-cols-2 gap-6">
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink mb-2">
                 Version
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100 font-mono">
+              <p className="text-sm text-ink font-mono">
                 {agent.version}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink mb-2">
                 Organization ID
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100 font-mono">
+              <p className="text-sm text-ink font-mono">
                 {agent.organizationId}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <h3 className="text-sm font-medium text-ink mb-2 flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 Created
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100">
+              <p className="text-sm text-ink">
                 {formatDate(agent.createdAt)}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <h3 className="text-sm font-medium text-ink mb-2 flex items-center gap-2">
                 <Clock className="h-4 w-4" />
-                Last Updated
+                Last updated
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100">
+              <p className="text-sm text-ink">
                 {formatDate(agent.updatedAt)}
               </p>
             </div>
@@ -544,28 +544,28 @@ export function AgentDetailModal({
 
           {/* Audit History */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-              Recent Activity
+            <h3 className="text-sm font-medium text-ink mb-3">
+              Recent activity
             </h3>
             <div className="space-y-2">
-              <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+              <div className="flex items-center gap-3 p-3 glass-inset">
+                <CheckCircle className="h-4 w-4 text-success-text" />
                 <div className="flex-1">
-                  <p className="text-sm text-gray-900 dark:text-gray-100">
+                  <p className="text-sm text-ink">
                     Agent registered
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-ink-secondary">
                     {formatDate(agent.createdAt)}
                   </p>
                 </div>
               </div>
-              <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <CheckCircle className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+              <div className="flex items-center gap-3 p-3 glass-inset">
+                <CheckCircle className="h-4 w-4 text-brand-text" />
                 <div className="flex-1">
-                  <p className="text-sm text-gray-900 dark:text-gray-100">
+                  <p className="text-sm text-ink">
                     Agent updated
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                  <p className="text-xs text-ink-secondary">
                     {formatDate(agent.updatedAt)}
                   </p>
                 </div>
@@ -575,11 +575,11 @@ export function AgentDetailModal({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-divider">
           {onDelete && (
             <button
               onClick={() => onDelete(agent)}
-              className="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors flex items-center gap-2"
+              className="px-4 py-2 text-sm font-medium text-danger-text hover:bg-danger-fill rounded-pill transition-colors flex items-center gap-2"
             >
               <Trash2 className="h-4 w-4" />
               Delete
@@ -588,10 +588,10 @@ export function AgentDetailModal({
           {onEdit && (
             <button
               onClick={() => onEdit(agent)}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+              className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors flex items-center gap-2"
             >
               <Edit className="h-4 w-4" />
-              Edit Agent
+              Edit agent
             </button>
           )}
         </div>

--- a/apps/web/components/modals/create-api-key-modal.tsx
+++ b/apps/web/components/modals/create-api-key-modal.tsx
@@ -23,7 +23,6 @@ interface CreateAPIKeyModalProps {
 interface FormData {
   name: string;
   agentId: string;
-  expiresIn: string;
 }
 
 export function CreateAPIKeyModal({
@@ -42,7 +41,6 @@ export function CreateAPIKeyModal({
   const [formData, setFormData] = useState<FormData>({
     name: "",
     agentId: "",
-    expiresIn: "90",
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -74,10 +72,9 @@ export function CreateAPIKeyModal({
 
     try {
       const result = await api.createAPIKey(formData.agentId, formData.name);
-      console.log("API Key creation result:", result);
 
       if (!result.apiKey) {
-        console.error("No API key in response:", result);
+        console.error("No API key in response");
         throw new Error("API key not returned from server");
       }
 
@@ -104,7 +101,6 @@ export function CreateAPIKeyModal({
     setFormData({
       name: "",
       agentId: "",
-      expiresIn: "90",
     });
     setErrors({});
     setError(null);
@@ -150,36 +146,24 @@ export function CreateAPIKeyModal({
     }
   };
 
-  const getExpirationDate = () => {
-    const days = parseInt(formData.expiresIn);
-    if (days === 0) return "Never";
-    const date = new Date();
-    date.setDate(date.getDate() + days);
-    return date.toLocaleDateString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-  };
-
   if (!isOpen) return null;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       style={{ margin: 0 }}
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {success ? "API Key Created Successfully" : "Create API Key"}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
+          <h2 className="text-xl font-semibold text-ink">
+            {success ? "API key created successfully" : "Create API key"}
           </h2>
           <button
             onClick={handleClose}
             disabled={loading}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            className="text-ink-tertiary hover:text-ink transition-colors disabled:opacity-50"
           >
             <X className="h-5 w-5" />
           </button>
@@ -190,33 +174,33 @@ export function CreateAPIKeyModal({
           {/* Show API Key (only after creation) */}
           {success && apiKey && (
             <div className="space-y-4">
-              <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+              <div className="p-4 bg-success-fill border border-success-border rounded-inset">
                 <div className="flex items-start gap-3">
-                  <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+                  <CheckCircle className="h-5 w-5 text-success-text flex-shrink-0 mt-0.5" />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-green-800 dark:text-green-300">
-                      API Key Created Successfully
+                    <p className="text-sm font-medium text-success-text">
+                      API key created successfully
                     </p>
-                    <p className="text-xs text-green-700 dark:text-green-400 mt-1">
+                    <p className="text-xs text-success-text mt-1">
                       Make sure to copy your API key now. You won't be able to
-                      see it again!
+                      see it again.
                     </p>
                   </div>
                 </div>
               </div>
 
               {/* Critical Warning */}
-              <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border-2 border-yellow-400 dark:border-yellow-600 rounded-lg">
+              <div className="p-4 bg-warning-fill border border-warning-border rounded-inset">
                 <div className="flex items-start gap-3">
-                  <AlertCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" />
+                  <AlertCircle className="h-5 w-5 text-warning-text flex-shrink-0 mt-0.5" />
                   <div className="flex-1">
-                    <p className="text-sm font-bold text-yellow-900 dark:text-yellow-300">
-                      ⚠️ IMPORTANT: Copy the Full API Key Now!
+                    <p className="text-sm font-bold text-warning-text">
+                      Important: copy the full API key now
                     </p>
-                    <p className="text-xs text-yellow-800 dark:text-yellow-400 mt-1">
+                    <p className="text-xs text-warning-text mt-1">
                       <strong className="block mt-1">
                         You must copy the entire key below - it will never be
-                        shown again!
+                        shown again.
                       </strong>
                     </p>
                   </div>
@@ -224,17 +208,17 @@ export function CreateAPIKeyModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Your Complete API Key ({apiKey.length} characters)
+                <label className="block text-sm font-medium text-ink-body mb-2">
+                  Your complete API key ({apiKey.length} characters)
                 </label>
                 <div className="relative">
-                  <div className="flex items-center gap-2 p-3 bg-gray-100 dark:bg-gray-800 border-2 border-blue-500 dark:border-blue-400 rounded-lg font-mono text-sm">
-                    <code className="flex-1 overflow-x-auto break-all text-gray-900 dark:text-gray-100">
+                  <div className="flex items-center gap-2 p-3 bg-glass-inset border border-brand rounded-inset font-mono text-sm">
+                    <code className="flex-1 overflow-x-auto break-all text-ink">
                       {showKey ? apiKey : "•".repeat(apiKey.length)}
                     </code>
                     <button
                       onClick={() => setShowKey(!showKey)}
-                      className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors flex-shrink-0"
+                      className="p-1 text-ink-tertiary hover:text-ink transition-colors flex-shrink-0"
                       title={showKey ? "Hide key" : "Show key"}
                     >
                       {showKey ? (
@@ -245,34 +229,34 @@ export function CreateAPIKeyModal({
                     </button>
                     <button
                       onClick={copyToClipboard}
-                      className="flex items-center gap-1 px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex-shrink-0"
+                      className="flex items-center gap-1 px-3 py-1 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors flex-shrink-0"
                     >
                       {copied ? (
                         <>
                           <Check className="h-4 w-4" />
-                          <span className="text-xs font-bold">Copied!</span>
+                          <span className="text-xs font-bold">Copied</span>
                         </>
                       ) : (
                         <>
                           <Copy className="h-4 w-4" />
                           <span className="text-xs font-bold">
-                            Copy Full Key
+                            Copy full key
                           </span>
                         </>
                       )}
                     </button>
                   </div>
                 </div>
-                <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                  💡 Tip: Save this key in a secure location (e.g., environment
+                <p className="mt-2 text-xs text-ink-tertiary">
+                  Tip: save this key in a secure location (e.g., environment
                   variables, password manager)
                 </p>
               </div>
 
-              <div className="flex items-center justify-end pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-end pt-4 border-t border-divider">
                 <button
                   onClick={handleClose}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+                  className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
                 >
                   Done
                 </button>
@@ -285,10 +269,10 @@ export function CreateAPIKeyModal({
             <form onSubmit={handleSubmit} className="space-y-4">
               {/* Error Message */}
               {error && (
-                <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-3">
-                  <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+                <div className="p-4 bg-danger-fill border border-danger-border rounded-inset flex items-center gap-3">
+                  <AlertCircle className="h-5 w-5 text-danger-text" />
                   <div className="flex-1">
-                    <p className="text-sm text-red-800 dark:text-red-300">
+                    <p className="text-sm text-danger-text">
                       {error}
                     </p>
                   </div>
@@ -297,8 +281,8 @@ export function CreateAPIKeyModal({
 
               {/* Key Name */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Key Name <span className="text-red-500">*</span>
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Key name <span className="text-danger-text">*</span>
                 </label>
                 <input
                   type="text"
@@ -307,32 +291,28 @@ export function CreateAPIKeyModal({
                     setFormData({ ...formData, name: e.target.value })
                   }
                   placeholder="e.g., Production API Key"
-                  className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${
-                    errors.name
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                  className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${
+                    errors.name ? "border-danger" : "border-stroke"
                   }`}
                   disabled={loading}
                 />
                 {errors.name && (
-                  <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+                  <p className="mt-1 text-xs text-danger-text">{errors.name}</p>
                 )}
               </div>
 
               {/* Agent Selection */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Agent <span className="text-red-500">*</span>
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Agent <span className="text-danger-text">*</span>
                 </label>
                 <select
                   value={formData.agentId}
                   onChange={(e) =>
                     setFormData({ ...formData, agentId: e.target.value })
                   }
-                  className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${
-                    errors.agentId
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                  className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink ${
+                    errors.agentId ? "border-danger" : "border-stroke"
                   }`}
                   disabled={loading}
                 >
@@ -344,51 +324,30 @@ export function CreateAPIKeyModal({
                   ))}
                 </select>
                 {errors.agentId && (
-                  <p className="mt-1 text-xs text-red-500">{errors.agentId}</p>
+                  <p className="mt-1 text-xs text-danger-text">{errors.agentId}</p>
                 )}
               </div>
 
-              {/* Expiration */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Expiration
-                </label>
-                <select
-                  value={formData.expiresIn}
-                  onChange={(e) =>
-                    setFormData({ ...formData, expiresIn: e.target.value })
-                  }
-                  className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
-                  disabled={loading}
-                >
-                  <option value="30">30 days</option>
-                  <option value="90">90 days</option>
-                  <option value="180">180 days</option>
-                  <option value="365">1 year</option>
-                  <option value="0">Never</option>
-                </select>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Expires on: {getExpirationDate()}
-                </p>
-              </div>
+              {/* Lifetime: the backend issues every key for 90 days (api_key_handler.go). */}
+              <p className="text-xs text-ink-tertiary">Keys expire 90 days after they are created.</p>
 
               {/* Footer */}
-              <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-end gap-3 pt-4 border-t border-divider">
                 <button
                   type="button"
                   onClick={handleClose}
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50"
+                  className="px-4 py-2 text-sm font-medium text-ink-body hover:bg-glass-inset-gray rounded-pill transition-colors disabled:opacity-50"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+                  className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
                   {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-                  Create API Key
+                  Create API key
                 </button>
               </div>
             </form>

--- a/apps/web/components/modals/create-tag-modal.tsx
+++ b/apps/web/components/modals/create-tag-modal.tsx
@@ -27,7 +27,7 @@ interface FormData {
 
 const TAG_CATEGORIES: { value: TagCategory; label: string }[] = [
   { value: "environment", label: "Environment" },
-  { value: "data_classification", label: "Data Classification" },
+  { value: "data_classification", label: "Data classification" },
   { value: "custom", label: "Custom" },
 ];
 
@@ -39,7 +39,7 @@ const PRESET_COLORS = [
   { hex: "#8B5CF6", name: "Purple" },
   { hex: "#EC4899", name: "Pink" },
   { hex: "#06B6D4", name: "Cyan" },
-  { hex: "#DC2626", name: "Dark Red" },
+  { hex: "#DC2626", name: "Dark red" },
   { hex: "#6B7280", name: "Gray" },
 ];
 
@@ -111,7 +111,7 @@ export function CreateTagModal({
       setSuccess(true);
 
       // Show success toast
-      toast.success("Tag Created Successfully", {
+      toast.success("Tag created successfully", {
         description: `Custom tag "${tagData.key}:${tagData.value}" has been created and is now available.`,
       });
 
@@ -136,7 +136,7 @@ export function CreateTagModal({
       setError(errorMessage);
 
       // Show error toast
-      toast.error("Tag Creation Failed", {
+      toast.error("Tag creation failed", {
         description: errorMessage,
         action: {
           label: "Retry",
@@ -205,19 +205,19 @@ export function CreateTagModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Create Custom Tag
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
+          <h2 className="text-xl font-semibold text-ink">
+            Create custom tag
           </h2>
           <button
             onClick={handleClose}
             disabled={loading}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            className="text-ink-tertiary hover:text-ink transition-colors disabled:opacity-50"
           >
             <X className="h-5 w-5" />
           </button>
@@ -227,14 +227,14 @@ export function CreateTagModal({
         <div className="p-6">
           {/* Success Message */}
           {success && (
-            <div className="mb-6 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+            <div className="mb-6 p-4 bg-success-fill border border-success-border rounded-inset">
               <div className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+                <CheckCircle className="h-5 w-5 text-success-text flex-shrink-0 mt-0.5" />
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-green-800 dark:text-green-300">
-                    Tag Created Successfully
+                  <p className="text-sm font-medium text-success-text">
+                    Tag created successfully
                   </p>
-                  <p className="text-xs text-green-700 dark:text-green-400 mt-1">
+                  <p className="text-xs text-ink-body mt-1">
                     Your custom tag "{getTagPreview()}" has been created and is
                     now available.
                   </p>
@@ -248,10 +248,10 @@ export function CreateTagModal({
             <form onSubmit={handleSubmit} className="space-y-4">
               {/* Error Message */}
               {error && (
-                <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg flex items-center gap-3">
-                  <AlertCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+                <div className="p-4 bg-warning-fill border border-warning-border rounded-inset flex items-center gap-3">
+                  <AlertCircle className="h-5 w-5 text-warning-text" />
                   <div className="flex-1">
-                    <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                    <p className="text-sm text-warning-text">
                       {error}
                     </p>
                   </div>
@@ -260,12 +260,12 @@ export function CreateTagModal({
 
               {/* Tag Preview */}
               {getTagPreview() && (
-                <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                <div className="p-3 bg-glass-inset-gray border border-divider rounded-inset">
+                  <p className="text-xs text-ink-tertiary mb-1">
                     Preview:
                   </p>
                   <div
-                    className="inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium text-white"
+                    className="inline-flex items-center gap-1.5 px-2 py-1 rounded-pill text-xs font-medium text-white"
                     style={{ backgroundColor: formData.color }}
                   >
                     {getTagPreview()}
@@ -275,8 +275,8 @@ export function CreateTagModal({
 
               {/* Tag Key */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Tag Key <span className="text-red-500">*</span>
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Tag key <span className="text-danger-text">*</span>
                 </label>
                 <input
                   type="text"
@@ -285,17 +285,17 @@ export function CreateTagModal({
                     setFormData({ ...formData, key: e.target.value })
                   }
                   placeholder="e.g., team, region, project"
-                  className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${
+                  className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${
                     errors.key
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                      ? "border-danger"
+                      : "border-stroke"
                   }`}
                   disabled={loading}
                 />
                 {errors.key && (
-                  <p className="mt-1 text-xs text-red-500">{errors.key}</p>
+                  <p className="mt-1 text-xs text-danger-text">{errors.key}</p>
                 )}
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-xs text-ink-tertiary">
                   The category or type of tag (lowercase, alphanumeric,
                   underscores only)
                 </p>
@@ -303,8 +303,8 @@ export function CreateTagModal({
 
               {/* Tag Value */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Tag Value <span className="text-red-500">*</span>
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Tag value <span className="text-danger-text">*</span>
                 </label>
                 <input
                   type="text"
@@ -313,17 +313,17 @@ export function CreateTagModal({
                     setFormData({ ...formData, value: e.target.value })
                   }
                   placeholder="e.g., backend, us-east, customer-portal"
-                  className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${
+                  className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${
                     errors.value
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                      ? "border-danger"
+                      : "border-stroke"
                   }`}
                   disabled={loading}
                 />
                 {errors.value && (
-                  <p className="mt-1 text-xs text-red-500">{errors.value}</p>
+                  <p className="mt-1 text-xs text-danger-text">{errors.value}</p>
                 )}
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-xs text-ink-tertiary">
                   The specific value for this tag (lowercase, alphanumeric,
                   underscores/hyphens)
                 </p>
@@ -331,8 +331,8 @@ export function CreateTagModal({
 
               {/* Category */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Category <span className="text-red-500">*</span>
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Category <span className="text-danger-text">*</span>
                 </label>
                 <select
                   value={formData.category}
@@ -342,10 +342,10 @@ export function CreateTagModal({
                       category: e.target.value as TagCategory,
                     })
                   }
-                  className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${
+                  className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink ${
                     errors.category
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                      ? "border-danger"
+                      : "border-stroke"
                   }`}
                   disabled={loading}
                 >
@@ -356,14 +356,14 @@ export function CreateTagModal({
                   ))}
                 </select>
                 {errors.category && (
-                  <p className="mt-1 text-xs text-red-500">{errors.category}</p>
+                  <p className="mt-1 text-xs text-danger-text">{errors.category}</p>
                 )}
               </div>
 
               {/* Description */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Description (Optional)
+                <label className="block text-sm font-medium text-ink-body mb-1">
+                  Description (optional)
                 </label>
                 <textarea
                   value={formData.description}
@@ -372,14 +372,14 @@ export function CreateTagModal({
                   }
                   placeholder="What does this tag represent?"
                   rows={2}
-                  className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                  className="w-full px-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary"
                   disabled={loading}
                 />
               </div>
 
               {/* Color */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label className="block text-sm font-medium text-ink-body mb-2">
                   Color
                 </label>
                 <div className="grid grid-cols-5 gap-2">
@@ -390,9 +390,9 @@ export function CreateTagModal({
                       onClick={() =>
                         setFormData({ ...formData, color: preset.hex })
                       }
-                      className={`h-10 rounded-lg transition-all ${
+                      className={`h-10 rounded-inset transition-all ${
                         formData.color === preset.hex
-                          ? "ring-2 ring-offset-2 ring-blue-500 scale-105"
+                          ? "ring-2 ring-offset-2 ring-offset-page ring-ring scale-105"
                           : "hover:scale-105"
                       }`}
                       style={{ backgroundColor: preset.hex }}
@@ -404,22 +404,22 @@ export function CreateTagModal({
               </div>
 
               {/* Footer */}
-              <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-end gap-3 pt-4 border-t border-divider">
                 <button
                   type="button"
                   onClick={handleClose}
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50"
+                  className="px-4 py-2 text-sm font-medium text-ink-body hover:bg-glass-inset-gray rounded-pill transition-colors disabled:opacity-50"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+                  className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
                   {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-                  Create Tag
+                  Create tag
                 </button>
               </div>
             </form>

--- a/apps/web/components/modals/register-agent-modal.test.ts
+++ b/apps/web/components/modals/register-agent-modal.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { registrationDefaults } from "@/components/modals/register-agent-modal";
+
+/**
+ * Regression for the silent-forever-pending defect: the backend's shouldAutoVerifyAgent
+ * refuses agents whose name, displayName or description is empty, so the browser payload
+ * must always carry all three, non-empty like the defaults the Python SDK's secure() sends
+ * (sdk/python/aim_sdk/client.py, "Prepare registration request"). The description states
+ * the real origin (the dashboard), not the SDK.
+ */
+describe("registrationDefaults", () => {
+  it("fills displayName, description and version for a minimal form", () => {
+    const p = registrationDefaults({ name: "my-first-agent", displayName: "", description: "", version: "" });
+    expect(p.name).toBe("my-first-agent");
+    expect(p.displayName).toBe("my-first-agent");
+    expect(p.description).toBe("Agent my-first-agent registered from the AIM dashboard");
+    expect(p.version).toBe("1.0.0");
+    for (const v of Object.values(p)) expect(v).not.toBe("");
+  });
+
+  it("keeps what the user typed", () => {
+    const p = registrationDefaults({ name: "billing", displayName: "Billing bot", description: "Reconciles invoices", version: "2.1.0" });
+    expect(p).toEqual({ name: "billing", displayName: "Billing bot", description: "Reconciles invoices", version: "2.1.0" });
+  });
+});

--- a/apps/web/components/modals/register-agent-modal.tsx
+++ b/apps/web/components/modals/register-agent-modal.tsx
@@ -81,11 +81,29 @@ const CAPABILITY_PATTERN = /^[a-z][a-z0-9]*:[a-z][a-z0-9_]*$/;
 
 // Risk level colors for capability badges
 const RISK_LEVEL_COLORS: Record<string, string> = {
-  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-  medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
-  high: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
-  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  low: "bg-success-fill text-success-text",
+  medium: "bg-warning-fill text-warning-text",
+  high: "bg-danger-fill text-danger-text",
+  critical: "bg-danger-fill text-danger-text border border-danger-border",
 };
+
+
+/**
+ * Fills the fields the backend's auto-verify predicate requires (shouldAutoVerifyAgent:
+ * name, displayName, description all non-empty) the way the Python SDK's secure() does
+ * (client.py: displayName defaults to the name, description to a generated sentence,
+ * version to 1.0.0), so an agent registered from this form and one registered by the SDK
+ * get the same verification outcome. The description names where the agent came from.
+ */
+export function registrationDefaults(form: { name: string; displayName: string; description: string; version: string }) {
+  const name = form.name.trim();
+  return {
+    name,
+    displayName: form.displayName.trim() || name,
+    description: form.description.trim() || `Agent ${name} registered from the AIM dashboard`,
+    version: form.version.trim() || "1.0.0",
+  };
+}
 
 export function RegisterAgentModal({
   isOpen,
@@ -307,13 +325,10 @@ export function RegisterAgentModal({
         "Agent name must be lowercase alphanumeric with dashes/underscores";
     }
 
-    if (!formData.displayName.trim()) {
-      newErrors.displayName = "Display name is required";
-    }
+    // Display name is optional: registrationDefaults() fills it the way the SDK does,
+    // so both registration paths satisfy the auto-verify field checks.
 
-    if (!formData.version.trim()) {
-      newErrors.version = "Version is required";
-    } else if (!/^\d+\.\d+\.\d+$/.test(formData.version)) {
+    if (formData.version.trim() && !/^\d+\.\d+\.\d+$/.test(formData.version)) {
       newErrors.version = "Version must be in format X.Y.Z (e.g., 1.0.0)";
     }
 
@@ -329,10 +344,8 @@ export function RegisterAgentModal({
       newErrors.documentationUrl = "Must be a valid HTTP(S) URL";
     }
 
-    // Require at least 1 capability
-    if (formData.capabilities.length === 0) {
-      newErrors.capabilities = "At least one capability is required";
-    }
+    // Capabilities are optional: the SDK detects them at runtime, and a hand-typed
+    // capability string is the worst jargon wall at first contact.
 
     setErrors(newErrors);
     if (Object.keys(newErrors).length > 0) {
@@ -374,11 +387,12 @@ export function RegisterAgentModal({
     try {
       // Send snake_case to match backend JSON tags
       const agentData: any = {
-        name: formData.name,
-        displayName: formData.displayName,
-        description: formData.description,
+        // Defaults apply only at registration; an edit sends what was typed, so a cleared
+        // field is cleared rather than refilled.
+        ...(editMode
+          ? { name: formData.name.trim(), displayName: formData.displayName.trim(), description: formData.description.trim(), version: formData.version.trim() }
+          : registrationDefaults(formData)),
         agentType: formData.agentType,
-        version: formData.version,
       };
 
       // Add optional fields only if they have values
@@ -647,20 +661,20 @@ export function RegisterAgentModal({
 
   return (
     <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       style={{ margin: 0 }}
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {editMode ? "Edit Agent" : "Register New Agent"}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
+          <h2 className="text-xl font-semibold text-ink">
+            {editMode ? "Edit agent" : "Register new agent"}
           </h2>
           <button
             onClick={handleClose}
             disabled={loading}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            className="text-ink-tertiary hover:text-ink transition-colors disabled:opacity-50"
           >
             <X className="h-5 w-5" />
           </button>
@@ -682,67 +696,67 @@ export function RegisterAgentModal({
           {success && !editMode && createdAgent && (
             <div className="space-y-4">
               {/* Success Banner */}
-              <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg flex items-center gap-3">
-                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
-                <p className="text-sm text-green-800 dark:text-green-300">
-                  Agent registered successfully! Cryptographic keys and API key generated
+              <div className="p-4 bg-success-fill border border-success-border rounded-inset flex items-center gap-3">
+                <CheckCircle className="h-5 w-5 text-success-text" />
+                <p className="text-sm text-success-text">
+                  Agent registered. Cryptographic keys and an API key were generated
                   automatically.
                 </p>
               </div>
 
               {/* ✅ API KEY DISPLAY - Show immediately after creation */}
               {createdApiKey && (
-                <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border-2 border-yellow-400 dark:border-yellow-600 rounded-lg space-y-3">
+                <div className="p-4 bg-warning-fill border border-warning-border rounded-inset space-y-3">
                   <div>
-                    <p className="text-sm font-bold text-yellow-900 dark:text-yellow-300">
-                      🔑 Your API Key (for Manual Integration)
+                    <p className="text-sm font-bold text-warning-text">
+                      Your API key (for manual integration)
                     </p>
-                    <p className="text-xs text-yellow-800 dark:text-yellow-400 mt-1">
+                    <p className="text-xs text-warning-text mt-1">
                       SDK users can skip this. Only needed for manual API calls. You can always create a new key later.
                     </p>
                   </div>
 
                   <div>
-                    <label className="block text-xs font-medium text-yellow-800 dark:text-yellow-300 mb-1">
-                      Your API Key
+                    <label className="block text-xs font-medium text-warning-text mb-1">
+                      Your API key
                     </label>
                     <div className="flex gap-2">
                       <input
                         type={showPrivateKey ? "text" : "password"}
                         value={createdApiKey.key}
                         readOnly
-                        className="flex-1 px-3 py-2 bg-white dark:bg-gray-900 border-2 border-yellow-500 dark:border-yellow-600 rounded text-xs font-mono text-gray-900 dark:text-gray-100"
+                        className="flex-1 px-3 py-2 bg-glass-inset border border-warning-border rounded-inset-sm text-xs font-mono text-ink"
                       />
                       <button
                         type="button"
                         onClick={() => setShowPrivateKey(!showPrivateKey)}
-                        className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                        className="px-3 py-2 bg-glass-inset-gray hover:bg-track rounded-inset-sm transition-colors"
                       >
                         {showPrivateKey ? (
-                          <EyeOff className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                          <EyeOff className="h-4 w-4 text-ink-secondary" />
                         ) : (
-                          <Eye className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                          <Eye className="h-4 w-4 text-ink-secondary" />
                         )}
                       </button>
                       <button
                         type="button"
                         onClick={() => copyToClipboard(createdApiKey.key, "api_key")}
-                        className="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white rounded transition-colors flex items-center gap-2"
+                        className="px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors flex items-center gap-2"
                       >
                         {copiedField === "api_key" ? (
                           <>
                             <CheckCircle className="h-4 w-4" />
-                            <span className="text-xs font-bold">Copied!</span>
+                            <span className="text-xs font-bold">Copied</span>
                           </>
                         ) : (
                           <>
                             <Copy className="h-4 w-4" />
-                            <span className="text-xs font-bold">Copy Key</span>
+                            <span className="text-xs font-bold">Copy key</span>
                           </>
                         )}
                       </button>
                     </div>
-                    <p className="mt-1 text-xs text-yellow-700 dark:text-yellow-400">
+                    <p className="mt-1 text-xs text-warning-text">
                       Key: {createdApiKey.name} • Expires: {createdApiKey.expiresAt ? new Date(createdApiKey.expiresAt).toLocaleDateString() : "Never"}
                     </p>
                   </div>
@@ -752,22 +766,22 @@ export function RegisterAgentModal({
               {/* Integration Method Selection - Show if no method chosen yet */}
               {!integrationMethod && (
                 <div className="space-y-3">
-                  <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
-                    🎯 Choose Your Integration Method
+                  <h4 className="text-sm font-semibold text-ink">
+                    Choose your integration method
                   </h4>
 
                   {/* Manual Integration Option - Primary */}
                   <button
                     onClick={handleManualIntegration}
-                    className="w-full p-4 border-2 border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:border-blue-300 dark:hover:border-blue-700 transition-colors text-left"
+                    className="w-full p-4 border border-brand-soft bg-brand-soft rounded-inset hover:border-brand transition-colors text-left"
                   >
                     <div className="flex items-start gap-3">
-                      <Code className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
+                      <Code className="h-5 w-5 text-brand-text mt-0.5 flex-shrink-0" />
                       <div className="flex-1">
-                        <h5 className="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-1">
-                          🔧 Manual Integration (Recommended for Dashboard Agents)
+                        <h5 className="text-sm font-semibold text-ink mb-1">
+                          Manual integration (recommended for dashboard agents)
                         </h5>
-                        <p className="text-xs text-blue-800 dark:text-blue-200">
+                        <p className="text-xs text-ink-body">
                           Use <strong>any programming language</strong> (Python, Rust,
                           Ruby, PHP, Java, etc.). Get your API key and credentials.
                         </p>
@@ -778,15 +792,15 @@ export function RegisterAgentModal({
                   {/* SDK Integration Option - Secondary */}
                   <button
                     onClick={() => setIntegrationMethod("sdk")}
-                    className="w-full p-4 border-2 border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 rounded-lg hover:border-gray-300 dark:hover:border-gray-600 transition-colors text-left"
+                    className="w-full p-4 border border-divider bg-glass-inset-gray rounded-inset hover:border-stroke transition-colors text-left"
                   >
                     <div className="flex items-start gap-3">
-                      <Package className="h-5 w-5 text-gray-600 dark:text-gray-400 mt-0.5 flex-shrink-0" />
+                      <Package className="h-5 w-5 text-ink-secondary mt-0.5 flex-shrink-0" />
                       <div className="flex-1">
-                        <h5 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                          📦 Using Python SDK?
+                        <h5 className="text-sm font-semibold text-ink mb-1">
+                          Using the Python SDK?
                         </h5>
-                        <p className="text-xs text-gray-700 dark:text-gray-300">
+                        <p className="text-xs text-ink-body">
                           The SDK auto-registers agents with local credentials.
                           See how to create agents directly via SDK code.
                         </p>
@@ -798,14 +812,14 @@ export function RegisterAgentModal({
 
               {/* SDK Integration Section - Show if SDK method chosen */}
               {integrationMethod === "sdk" && (
-                <div className="p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg space-y-4">
+                <div className="p-4 bg-warning-fill border border-warning-border rounded-inset space-y-4">
                   <div className="flex items-start gap-3">
-                    <AlertCircle className="h-5 w-5 text-amber-600 dark:text-amber-400 mt-0.5" />
+                    <AlertCircle className="h-5 w-5 text-warning-text mt-0.5" />
                     <div className="flex-1">
-                      <h4 className="text-sm font-semibold text-amber-900 dark:text-amber-100 mb-1">
-                        SDK Creates Agents Automatically
+                      <h4 className="text-sm font-semibold text-ink mb-1">
+                        The SDK creates agents automatically
                       </h4>
-                      <p className="text-xs text-amber-800 dark:text-amber-200 mb-3">
+                      <p className="text-xs text-ink-body mb-3">
                         The Python SDK generates local cryptographic keys and auto-registers agents.
                         Dashboard-created agents use server-side keys which won't work with the SDK.
                       </p>
@@ -814,11 +828,11 @@ export function RegisterAgentModal({
 
                   {/* Python Code Example */}
                   <div>
-                    <p className="text-xs font-medium text-amber-900 dark:text-amber-100 mb-2">
+                    <p className="text-xs font-medium text-ink mb-2">
                       Create your agent directly in Python code:
                     </p>
                     <div className="relative">
-                      <pre className="p-3 bg-gray-900 dark:bg-black text-green-400 text-xs font-mono rounded-lg overflow-x-auto whitespace-pre-wrap">
+                      <pre className="glass-contrast p-3 text-ink-code text-xs font-mono rounded-inset overflow-x-auto whitespace-pre-wrap">
 {`from aim_sdk import secure, AgentType
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -943,12 +957,12 @@ print(f"Result: {result}")
 # )`;
                           copyToClipboard(pythonCode, "python_code");
                         }}
-                        className="absolute top-2 right-2 px-2 py-1 bg-gray-700 hover:bg-gray-600 text-white text-xs rounded transition-colors flex items-center gap-1"
+                        className="absolute top-2 right-2 px-2 py-1 rounded-pill bg-glass-code text-ink-inverse hover:bg-track text-xs transition-colors flex items-center gap-1"
                       >
                         {copiedField === "python_code" ? (
                           <>
                             <CheckCircle className="h-3 w-3" />
-                            Copied!
+                            Copied
                           </>
                         ) : (
                           <>
@@ -961,11 +975,11 @@ print(f"Result: {result}")
                   </div>
 
                   {/* SDK Download Link and Documentation */}
-                  <div className="pt-3 border-t border-amber-200 dark:border-amber-700">
+                  <div className="pt-3 border-t border-warning-border">
                     <div className="flex flex-wrap gap-2 mb-2">
                       <a
                         href="/dashboard/sdk"
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover text-sm font-medium transition-colors"
                       >
                         <Package className="h-4 w-4" />
                         Download Python SDK
@@ -974,14 +988,14 @@ print(f"Result: {result}")
                         href="https://opena2a.org/docs/integration/python"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white text-sm font-medium rounded-lg transition-colors"
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-pill bg-brand-soft text-brand-text hover:brightness-95 text-sm font-medium transition-colors"
                       >
                         <ExternalLink className="h-4 w-4" />
-                        SDK Documentation
+                        SDK documentation
                       </a>
                     </div>
-                    <p className="text-xs text-amber-700 dark:text-amber-300">
-                      After downloading, run: <code className="bg-amber-100 dark:bg-amber-900 px-1 rounded">pip install -e .</code>
+                    <p className="text-xs text-ink-body">
+                      The supported install is <code className="bg-glass-inset-gray px-1 rounded">pip install aim-sdk</code>; the download is for machines without registry access.
                     </p>
                   </div>
 
@@ -989,7 +1003,7 @@ print(f"Result: {result}")
                   <div className="text-center pt-2">
                     <button
                       onClick={() => setIntegrationMethod(null)}
-                      className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 underline"
+                      className="text-xs text-ink-secondary hover:text-ink underline"
                     >
                       ← Choose a different integration method
                     </button>
@@ -999,20 +1013,20 @@ print(f"Result: {result}")
 
               {/* Manual Integration Section - Show if manual method chosen */}
               {integrationMethod === "manual" && (
-                <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg space-y-4">
+                <div className="glass-inset p-4 space-y-4">
                   <div className="flex items-start gap-3">
-                    <Code className="h-5 w-5 text-gray-600 dark:text-gray-400 mt-0.5" />
+                    <Code className="h-5 w-5 text-ink-secondary mt-0.5" />
                     <div className="flex-1">
-                      <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                        🔑 Agent Credentials & API Access
+                      <h4 className="text-sm font-semibold text-ink mb-1">
+                        Agent credentials and API access
                       </h4>
-                      <p className="text-xs text-gray-700 dark:text-gray-300 mb-4">
+                      <p className="text-xs text-ink-body mb-4">
                         Use these credentials to integrate AIM with any
                         programming language. Keep your private key secure.
                       </p>
 
                       {loadingKeys ? (
-                        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                        <div className="flex items-center gap-2 text-sm text-ink-secondary">
                           <Loader2 className="h-4 w-4 animate-spin" />
                           Loading credentials...
                         </div>
@@ -1020,7 +1034,7 @@ print(f"Result: {result}")
                         <div className="space-y-3">
                           {/* Agent ID */}
                           <div>
-                            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            <label className="block text-xs font-medium text-ink-body mb-1">
                               Agent ID
                             </label>
                             <div className="flex gap-2">
@@ -1028,19 +1042,19 @@ print(f"Result: {result}")
                                 type="text"
                                 value={createdAgent.id}
                                 readOnly
-                                className="flex-1 px-3 py-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs font-mono"
+                                className="flex-1 px-3 py-2 bg-glass-inset border border-stroke rounded-inset-sm text-xs font-mono text-ink"
                               />
                               <button
                                 type="button"
                                 onClick={() =>
                                   copyToClipboard(createdAgent.id, "agent_id")
                                 }
-                                className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                                className="px-3 py-2 bg-glass-inset-gray hover:bg-track rounded-inset-sm transition-colors"
                               >
                                 {copiedField === "agent_id" ? (
-                                  <CheckCircle className="h-4 w-4 text-green-600" />
+                                  <CheckCircle className="h-4 w-4 text-success-text" />
                                 ) : (
-                                  <Copy className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                  <Copy className="h-4 w-4 text-ink-secondary" />
                                 )}
                               </button>
                             </div>
@@ -1048,15 +1062,15 @@ print(f"Result: {result}")
 
                           {/* ✅ Pre-filled Curl Command for Verification */}
                           {createdApiKey && formData.capabilities.length > 0 && (
-                            <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                            <div className="pt-3 border-t border-divider">
                               <div className="flex items-center gap-2 mb-2">
-                                <Terminal className="h-4 w-4 text-green-600 dark:text-green-400" />
-                                <label className="text-xs font-medium text-gray-700 dark:text-gray-300">
-                                  Verify Your Agent (Ready to Copy & Paste)
+                                <Terminal className="h-4 w-4 text-success-text" />
+                                <label className="text-xs font-medium text-ink-body">
+                                  Verify your agent (ready to copy and paste)
                                 </label>
                               </div>
                               <div className="relative">
-                                <pre className="p-3 bg-gray-900 dark:bg-black text-green-400 text-xs font-mono rounded-lg overflow-x-auto whitespace-pre-wrap break-all">
+                                <pre className="glass-contrast p-3 text-ink-code text-xs font-mono rounded-inset overflow-x-auto whitespace-pre-wrap break-all">
 {`curl -X POST "${typeof window !== 'undefined' ? window.location.origin.replace('-frontend', '-backend').replace(':3000', ':8080') : 'http://localhost:8080'}/api/v1/agents/${createdAgent.id}/verify-capability" \\
   -H "Authorization: Bearer ${createdApiKey.key}" \\
   -H "Content-Type: application/json" \\
@@ -1068,12 +1082,12 @@ print(f"Result: {result}")
                                     const curlCmd = `curl -X POST "${typeof window !== 'undefined' ? window.location.origin.replace('-frontend', '-backend').replace(':3000', ':8080') : 'http://localhost:8080'}/api/v1/agents/${createdAgent.id}/verify-capability" \\\n  -H "Authorization: Bearer ${createdApiKey.key}" \\\n  -H "Content-Type: application/json" \\\n  -d '{"capability": "${formData.capabilities[0]}", "resource": "test.resource"}'`;
                                     copyToClipboard(curlCmd, "curl_cmd");
                                   }}
-                                  className="absolute top-2 right-2 px-2 py-1 bg-gray-700 hover:bg-gray-600 text-white text-xs rounded transition-colors flex items-center gap-1"
+                                  className="absolute top-2 right-2 px-2 py-1 rounded-pill bg-glass-code text-ink-inverse hover:bg-track text-xs transition-colors flex items-center gap-1"
                                 >
                                   {copiedField === "curl_cmd" ? (
                                     <>
                                       <CheckCircle className="h-3 w-3" />
-                                      Copied!
+                                      Copied
                                     </>
                                   ) : (
                                     <>
@@ -1083,63 +1097,63 @@ print(f"Result: {result}")
                                   )}
                                 </button>
                               </div>
-                              <p className="mt-2 text-xs text-gray-600 dark:text-gray-300">
-                                Run this command in your terminal to verify your agent can use the <code className="bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 px-1.5 py-0.5 rounded font-semibold">{formData.capabilities[0]}</code> capability.
+                              <p className="mt-2 text-xs text-ink-secondary">
+                                Run this command in your terminal to verify your agent can use the <code className="bg-brand-soft text-brand-text px-1.5 py-0.5 rounded font-semibold">{formData.capabilities[0]}</code> capability.
                               </p>
                             </div>
                           )}
 
                           {/* API Documentation Link */}
-                          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                          <div className="pt-3 border-t border-divider">
                             <a
                               href="https://opena2a.org/docs/api/rest"
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="inline-flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                              className="inline-flex items-center gap-2 text-sm text-brand-text hover:underline"
                             >
                               <ExternalLink className="h-4 w-4" />
-                              View Full API Documentation →
+                              View full API documentation
                             </a>
                           </div>
 
                           {/* Advanced: Cryptographic Keys (Collapsible) */}
-                          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                          <div className="pt-3 border-t border-divider">
                             <button
                               type="button"
                               onClick={() => setShowAdvancedKeys(!showAdvancedKeys)}
-                              className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                              className="flex items-center gap-2 text-xs text-ink-tertiary hover:text-ink"
                             >
                               <ChevronDown className={`h-3 w-3 transition-transform ${showAdvancedKeys ? 'rotate-180' : ''}`} />
-                              Advanced: Cryptographic Keys (Ed25519)
+                              Advanced: cryptographic keys (Ed25519)
                             </button>
 
                             {showAdvancedKeys && (
-                              <div className="mt-3 space-y-3 p-3 bg-gray-100 dark:bg-gray-900 rounded-lg">
-                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                              <div className="mt-3 space-y-3 p-3 glass-inset">
+                                <p className="text-xs text-ink-tertiary">
                                   For custom integrations with request signing. Most users don't need these.
                                 </p>
 
                                 {/* Public Key */}
                                 <div>
-                                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                    Public Key
+                                  <label className="block text-xs font-medium text-ink-body mb-1">
+                                    Public key
                                   </label>
                                   <div className="flex gap-2">
                                     <input
                                       type="text"
                                       value={agentKeys.publicKey}
                                       readOnly
-                                      className="flex-1 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded text-xs font-mono"
+                                      className="flex-1 px-3 py-2 bg-glass-inset border border-stroke rounded-inset-sm text-xs font-mono text-ink"
                                     />
                                     <button
                                       type="button"
                                       onClick={() => copyToClipboard(agentKeys.publicKey, "public_key")}
-                                      className="px-3 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded transition-colors"
+                                      className="px-3 py-2 bg-glass-inset-gray hover:bg-track rounded-inset-sm transition-colors"
                                     >
                                       {copiedField === "public_key" ? (
-                                        <CheckCircle className="h-4 w-4 text-green-600" />
+                                        <CheckCircle className="h-4 w-4 text-success-text" />
                                       ) : (
-                                        <Copy className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                        <Copy className="h-4 w-4 text-ink-secondary" />
                                       )}
                                     </button>
                                   </div>
@@ -1147,36 +1161,36 @@ print(f"Result: {result}")
 
                                 {/* Private Key */}
                                 <div>
-                                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                    Private Key - ⚠️ Keep Secret
+                                  <label className="block text-xs font-medium text-ink-body mb-1">
+                                    Private key (keep secret)
                                   </label>
                                   <div className="flex gap-2">
                                     <input
                                       type={showPrivateKey ? "text" : "password"}
                                       value={agentKeys.privateKey}
                                       readOnly
-                                      className="flex-1 px-3 py-2 bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800 rounded text-xs font-mono"
+                                      className="flex-1 px-3 py-2 bg-glass-inset border border-danger-border rounded-inset-sm text-xs font-mono text-ink"
                                     />
                                     <button
                                       type="button"
                                       onClick={() => setShowPrivateKey(!showPrivateKey)}
-                                      className="px-3 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded transition-colors"
+                                      className="px-3 py-2 bg-glass-inset-gray hover:bg-track rounded-inset-sm transition-colors"
                                     >
                                       {showPrivateKey ? (
-                                        <EyeOff className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                        <EyeOff className="h-4 w-4 text-ink-secondary" />
                                       ) : (
-                                        <Eye className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                        <Eye className="h-4 w-4 text-ink-secondary" />
                                       )}
                                     </button>
                                     <button
                                       type="button"
                                       onClick={() => copyToClipboard(agentKeys.privateKey, "private_key")}
-                                      className="px-3 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded transition-colors"
+                                      className="px-3 py-2 bg-glass-inset-gray hover:bg-track rounded-inset-sm transition-colors"
                                     >
                                       {copiedField === "private_key" ? (
-                                        <CheckCircle className="h-4 w-4 text-green-600" />
+                                        <CheckCircle className="h-4 w-4 text-success-text" />
                                       ) : (
-                                        <Copy className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                        <Copy className="h-4 w-4 text-ink-secondary" />
                                       )}
                                     </button>
                                   </div>
@@ -1186,7 +1200,7 @@ print(f"Result: {result}")
                           </div>
                         </div>
                       ) : (
-                        <p className="text-sm text-red-600 dark:text-red-400">
+                        <p className="text-sm text-danger-text">
                           Failed to load credentials. Please try again from the
                           agent details page.
                         </p>
@@ -1198,7 +1212,7 @@ print(f"Result: {result}")
                   <div className="text-center">
                     <button
                       onClick={() => setIntegrationMethod(null)}
-                      className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 underline"
+                      className="text-xs text-ink-secondary hover:text-ink underline"
                     >
                       ← Choose a different integration method
                     </button>
@@ -1211,7 +1225,7 @@ print(f"Result: {result}")
                 <div className="text-center">
                   <button
                     onClick={handleSkipSDK}
-                    className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 underline"
+                    className="text-xs text-ink-secondary hover:text-ink underline"
                   >
                     Done (you can access credentials later from agent details)
                   </button>
@@ -1224,11 +1238,11 @@ print(f"Result: {result}")
           {error && (
             <div
               ref={errorBannerRef}
-              className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-3"
+              className="glass-alert p-4 flex items-center gap-3"
             >
-              <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+              <AlertCircle className="h-5 w-5 text-danger-text" />
               <div className="flex-1">
-                <p className="text-sm text-red-800 dark:text-red-300">
+                <p className="text-sm text-danger-text">
                   {error}
                 </p>
               </div>
@@ -1240,14 +1254,14 @@ print(f"Result: {result}")
             <>
               {/* Basic Information */}
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
-                  Basic Information
+                <h3 className="text-overline">
+                  Basic information
                 </h3>
 
                 {/* Agent Name */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Agent Name <span className="text-red-500">*</span>
+                  <label className="block text-sm font-medium text-ink-body mb-1">
+                    Agent name <span className="text-danger-text">*</span>
                   </label>
                   <input
                     ref={nameRef}
@@ -1257,28 +1271,28 @@ print(f"Result: {result}")
                       setFormData({ ...formData, name: e.target.value })
                     }
                     placeholder="e.g., claude-assistant"
-                    className={`w-full px-3 py-2 border rounded-lg focus:outline-none text-gray-900 dark:text-gray-100 ${
+                    className={`w-full px-3 py-2 border rounded-inset focus:outline-none text-ink placeholder:text-ink-tertiary ${
                       // Styling for normal/active state
                       loading || success || editMode
-                        ? "bg-gray-200 dark:bg-gray-700 cursor-not-allowed border-gray-300 dark:border-gray-600 focus:ring-0"
-                        : "bg-gray-50 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 border-gray-200 dark:border-gray-700"
+                        ? "bg-track cursor-not-allowed border-stroke focus:ring-0"
+                        : "bg-glass-inset focus:ring-2 focus:ring-ring border-stroke"
                       } ${
                       // Styling for error state (overrides normal/active styling if present)
                       errors.name
-                        ? "border-red-500"
+                        ? "border-danger"
                         : ""
                       }`}
                     disabled={loading || success || editMode}
                   />
                   {errors.name && (
-                    <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+                    <p className="mt-1 text-xs text-danger-text">{errors.name}</p>
                   )}
                 </div>
 
                 {/* Display Name */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Display Name <span className="text-red-500">*</span>
+                  <label className="block text-sm font-medium text-ink-body mb-1">
+                    Display name
                   </label>
                   <input
                     ref={displayNameRef}
@@ -1288,14 +1302,14 @@ print(f"Result: {result}")
                       setFormData({ ...formData, displayName: e.target.value })
                     }
                     placeholder="e.g., Claude AI Assistant"
-                    className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.displayName
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                    className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.displayName
+                      ? "border-danger"
+                      : "border-stroke"
                       }`}
                     disabled={loading || success}
                   />
                   {errors.displayName && (
-                    <p className="mt-1 text-xs text-red-500">
+                    <p className="mt-1 text-xs text-danger-text">
                       {errors.displayName}
                     </p>
                   )}
@@ -1303,7 +1317,7 @@ print(f"Result: {result}")
 
                 {/* Description */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label className="block text-sm font-medium text-ink-body mb-1">
                     Description
                   </label>
                   <textarea
@@ -1314,7 +1328,7 @@ print(f"Result: {result}")
                     }
                     placeholder="Brief description of what this agent does..."
                     rows={3}
-                    className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                    className="w-full px-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary"
                     disabled={loading || success}
                   />
                 </div>
@@ -1322,8 +1336,8 @@ print(f"Result: {result}")
                 {/* Agent Type and Version */}
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Agent Type <span className="text-red-500">*</span>
+                    <label className="block text-sm font-medium text-ink-body mb-1">
+                      Agent type <span className="text-danger-text">*</span>
                     </label>
                     <select
                       value={formData.agentType}
@@ -1333,7 +1347,7 @@ print(f"Result: {result}")
                           agentType: e.target.value as AgentType,
                         })
                       }
-                      className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                      className="w-full px-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary"
                       disabled={loading || success}
                     >
                       {AGENT_TYPE_CATEGORIES.map((category) => (
@@ -1346,14 +1360,14 @@ print(f"Result: {result}")
                         </optgroup>
                       ))}
                     </select>
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-ink-tertiary">
                       {AGENT_TYPE_OPTIONS.find(o => o.value === formData.agentType)?.description}
                     </p>
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Version <span className="text-red-500">*</span>
+                    <label className="block text-sm font-medium text-ink-body mb-1">
+                      Version
                     </label>
                     <input
                       ref={versionRef}
@@ -1363,14 +1377,14 @@ print(f"Result: {result}")
                         setFormData({ ...formData, version: e.target.value })
                       }
                       placeholder="1.0.0"
-                      className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.version
-                        ? "border-red-500"
-                        : "border-gray-200 dark:border-gray-700"
+                      className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.version
+                        ? "border-danger"
+                        : "border-stroke"
                         }`}
                       disabled={loading || success}
                     />
                     {errors.version && (
-                      <p className="mt-1 text-xs text-red-500">
+                      <p className="mt-1 text-xs text-danger-text">
                         {errors.version}
                       </p>
                     )}
@@ -1380,13 +1394,13 @@ print(f"Result: {result}")
 
               {/* Additional Resources */}
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
-                  Additional Resources (Optional)
+                <h3 className="text-overline">
+                  Additional resources (optional)
                 </h3>
 
                 {/* Repository URL */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label className="block text-sm font-medium text-ink-body mb-1">
                     Repository URL
                   </label>
                   <input
@@ -1400,14 +1414,14 @@ print(f"Result: {result}")
                       })
                     }
                     placeholder="https://github.com/yourusername/your-agent"
-                    className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.repositoryUrl
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                    className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.repositoryUrl
+                      ? "border-danger"
+                      : "border-stroke"
                       }`}
                     disabled={loading || success}
                   />
                   {errors.repositoryUrl && (
-                    <p className="mt-1 text-xs text-red-500">
+                    <p className="mt-1 text-xs text-danger-text">
                       {errors.repositoryUrl}
                     </p>
                   )}
@@ -1415,7 +1429,7 @@ print(f"Result: {result}")
 
                 {/* Documentation URL */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label className="block text-sm font-medium text-ink-body mb-1">
                     Documentation URL
                   </label>
                   <input
@@ -1429,14 +1443,14 @@ print(f"Result: {result}")
                       })
                     }
                     placeholder="https://docs.example.com/agents/your-agent"
-                    className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.documentationUrl
-                      ? "border-red-500"
-                      : "border-gray-200 dark:border-gray-700"
+                    className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.documentationUrl
+                      ? "border-danger"
+                      : "border-stroke"
                       }`}
                     disabled={loading || success}
                   />
                   {errors.documentationUrl && (
-                    <p className="mt-1 text-xs text-red-500">
+                    <p className="mt-1 text-xs text-danger-text">
                       {errors.documentationUrl}
                     </p>
                   )}
@@ -1446,21 +1460,21 @@ print(f"Result: {result}")
               {/* Capabilities */}
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Capabilities <span className="text-red-500">*</span>
+                  <label className="block text-sm font-medium text-ink-body mb-2">
+                    Capabilities
                   </label>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                    Select at least one capability this agent has. These define what
-                    actions the agent can perform. Format: <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">namespace:action</code>
+                  <p className="text-xs text-ink-tertiary mb-3">
+                    Optional: the SDK detects capabilities when the agent runs. Add any you want
+                    recorded now. Format: <code className="bg-glass-inset-gray px-1 rounded">namespace:action</code>
                   </p>
                   {errors.capabilities && (
-                    <p className="text-xs text-red-500 mb-2">{errors.capabilities}</p>
+                    <p className="text-xs text-danger-text mb-2">{errors.capabilities}</p>
                   )}
                 </div>
 
                 {/* Loading state */}
                 {loadingCapabilities ? (
-                  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 py-4">
+                  <div className="flex items-center gap-2 text-sm text-ink-secondary py-4">
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Loading capabilities...
                   </div>
@@ -1471,25 +1485,25 @@ print(f"Result: {result}")
                       {mergedCapabilities.map((capability) => (
                         <label
                           key={capability.type}
-                          className="flex items-start gap-2 p-2 rounded border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer"
+                          className="flex items-start gap-2 p-2 rounded-inset-sm border border-divider hover:bg-glass-inset-gray cursor-pointer"
                         >
                           <input
                             type="checkbox"
                             checked={formData.capabilities.includes(capability.type)}
                             onChange={() => toggleCapability(capability.type)}
-                            className="mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                            className="mt-1 rounded border-stroke text-brand focus:ring-ring"
                             disabled={loading || success}
                           />
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2">
-                              <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                              <span className="text-sm font-medium text-ink truncate">
                                 {capability.name}
                               </span>
                               <span className={`text-xs px-1.5 py-0.5 rounded ${RISK_LEVEL_COLORS[capability.riskLevel]}`}>
                                 {capability.riskLevel}
                               </span>
                             </div>
-                            <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+                            <span className="text-xs text-ink-tertiary font-mono">
                               {capability.type}
                             </span>
                           </div>
@@ -1498,11 +1512,11 @@ print(f"Result: {result}")
                     </div>
 
                     {/* Custom capability input */}
-                    <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        Add Custom Capability
+                    <div className="pt-3 border-t border-divider">
+                      <label className="block text-sm font-medium text-ink-body mb-2">
+                        Add custom capability
                       </label>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                      <p className="text-xs text-ink-tertiary mb-2">
                         Define custom capabilities for your organization. Reserved namespaces: {reservedNamespaces.join(", ")}
                       </p>
                       <div className="flex gap-2">
@@ -1519,8 +1533,8 @@ print(f"Result: {result}")
                             e.key === "Enter" && (e.preventDefault(), addCustomCapability())
                           }
                           placeholder="e.g., payment:process or email:send"
-                          className={`flex-1 px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 font-mono text-sm ${
-                            customCapabilityError ? "border-red-500" : "border-gray-200 dark:border-gray-700"
+                          className={`flex-1 px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary font-mono text-sm ${
+                            customCapabilityError ? "border-danger" : "border-stroke"
                           }`}
                           disabled={loading || success}
                         />
@@ -1528,14 +1542,14 @@ print(f"Result: {result}")
                           type="button"
                           onClick={addCustomCapability}
                           disabled={!customCapability.trim() || loading || success}
-                          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+                          className="px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
                         >
                           <Plus className="h-4 w-4" />
                           Add
                         </button>
                       </div>
                       {customCapabilityError && (
-                        <p className="mt-1 text-xs text-red-500">{customCapabilityError}</p>
+                        <p className="mt-1 text-xs text-danger-text">{customCapabilityError}</p>
                       )}
                     </div>
                   </>
@@ -1544,10 +1558,10 @@ print(f"Result: {result}")
 
               {/* MCP Servers Communication */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  MCP Servers (Talks To)
+                <label className="block text-sm font-medium text-ink-body mb-2">
+                  MCP servers (talks to)
                 </label>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                <p className="text-xs text-ink-tertiary mb-3">
                   Select MCP servers this agent communicates with. Choose from registered servers or discovered MCPs.
                 </p>
 
@@ -1556,7 +1570,7 @@ print(f"Result: {result}")
                   <div className="flex gap-2 mb-3">
                     <div className="relative flex-1">
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <Search className="h-4 w-4 text-gray-400" />
+                        <Search className="h-4 w-4 text-ink-tertiary" />
                       </div>
                       <input
                         ref={mcpInputRef}
@@ -1574,7 +1588,7 @@ print(f"Result: {result}")
                           }
                         }}
                         placeholder="Search or type MCP server name..."
-                        className="w-full pl-10 pr-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                        className="w-full pl-10 pr-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary"
                         disabled={loading || success}
                       />
                     </div>
@@ -1582,7 +1596,7 @@ print(f"Result: {result}")
                       type="button"
                       onClick={() => addMcpServer()}
                       disabled={!newMcpServer.trim() || loading || success}
-                      className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+                      className="px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
                     >
                       <Plus className="h-4 w-4" />
                       Add
@@ -1593,11 +1607,11 @@ print(f"Result: {result}")
                   {showMcpDropdown && !loading && !success && (
                     <div
                       ref={mcpDropdownRef}
-                      className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+                      className="glass absolute z-50 w-full mt-1 rounded-inset max-h-60 overflow-y-auto"
                       style={{ top: "calc(100% - 12px)" }}
                     >
                       {loadingMcpSuggestions ? (
-                        <div className="p-3 text-center text-gray-500 dark:text-gray-400">
+                        <div className="p-3 text-center text-ink-tertiary">
                           <Loader2 className="h-4 w-4 animate-spin mx-auto mb-1" />
                           <span className="text-sm">Loading MCP servers...</span>
                         </div>
@@ -1606,34 +1620,34 @@ print(f"Result: {result}")
                           {/* Registered MCPs Section */}
                           {filteredMcpSuggestions.filter(s => s.isRegistered).length > 0 && (
                             <>
-                              <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-                                Registered MCP Servers
+                              <div className="px-3 py-2 text-xs font-semibold text-ink-tertiary bg-glass-inset-gray border-b border-divider">
+                                Registered MCP servers
                               </div>
                               {filteredMcpSuggestions.filter(s => s.isRegistered).map((suggestion) => (
                                 <button
                                   key={suggestion.id}
                                   type="button"
                                   onClick={() => addMcpServer(suggestion.name)}
-                                  className="w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3 border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                                  className="w-full px-3 py-2 text-left hover:bg-glass-inset-gray flex items-center gap-3 border-b border-divider last:border-b-0"
                                 >
-                                  <Server className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" />
+                                  <Server className="h-4 w-4 text-success-text flex-shrink-0" />
                                   <div className="flex-1 min-w-0">
                                     <div className="flex items-center gap-2">
-                                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                      <span className="text-sm font-medium text-ink truncate">
                                         {suggestion.name}
                                       </span>
                                       <span className={`text-xs px-1.5 py-0.5 rounded ${
                                         suggestion.status === "verified"
-                                          ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                                          ? "bg-success-fill text-success-text"
                                           : suggestion.status === "active"
-                                          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-                                          : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                                          ? "bg-brand-soft text-brand-text"
+                                          : "bg-glass-inset-gray text-ink-secondary"
                                       }`}>
                                         {suggestion.status}
                                       </span>
                                     </div>
                                     {suggestion.url && (
-                                      <span className="text-xs text-gray-500 dark:text-gray-400 truncate block">
+                                      <span className="text-xs text-ink-tertiary truncate block">
                                         {suggestion.url}
                                       </span>
                                     )}
@@ -1646,28 +1660,28 @@ print(f"Result: {result}")
                           {/* Discovered MCPs Section */}
                           {filteredMcpSuggestions.filter(s => s.isDiscovered).length > 0 && (
                             <>
-                              <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-                                Discovered (Not Registered)
+                              <div className="px-3 py-2 text-xs font-semibold text-ink-tertiary bg-glass-inset-gray border-b border-divider">
+                                Discovered (not registered)
                               </div>
                               {filteredMcpSuggestions.filter(s => s.isDiscovered).map((suggestion) => (
                                 <button
                                   key={suggestion.id}
                                   type="button"
                                   onClick={() => addMcpServer(suggestion.name)}
-                                  className="w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3 border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                                  className="w-full px-3 py-2 text-left hover:bg-glass-inset-gray flex items-center gap-3 border-b border-divider last:border-b-0"
                                 >
-                                  <Server className="h-4 w-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+                                  <Server className="h-4 w-4 text-warning-text flex-shrink-0" />
                                   <div className="flex-1 min-w-0">
                                     <div className="flex items-center gap-2">
-                                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                      <span className="text-sm font-medium text-ink truncate">
                                         {suggestion.name}
                                       </span>
-                                      <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                                      <span className="text-xs px-1.5 py-0.5 rounded bg-warning-fill text-warning-text">
                                         discovered
                                       </span>
                                     </div>
                                     {suggestion.url && (
-                                      <span className="text-xs text-gray-500 dark:text-gray-400 truncate block">
+                                      <span className="text-xs text-ink-tertiary truncate block">
                                         {suggestion.url}
                                       </span>
                                     )}
@@ -1678,7 +1692,7 @@ print(f"Result: {result}")
                           )}
                         </>
                       ) : (
-                        <div className="p-3 text-center text-gray-500 dark:text-gray-400">
+                        <div className="p-3 text-center text-ink-tertiary">
                           <span className="text-sm">
                             {mcpSuggestions.length === 0
                               ? "No MCP servers found. Type a name to add manually."
@@ -1693,34 +1707,34 @@ print(f"Result: {result}")
                 {/* Selected MCP Servers List */}
                 {formData.talksTo.length > 0 && (
                   <div className="space-y-2 mt-3">
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-                      Selected MCP Servers ({formData.talksTo.length})
+                    <div className="text-xs font-medium text-ink-tertiary mb-1">
+                      Selected MCP servers ({formData.talksTo.length})
                     </div>
                     {formData.talksTo.map((server) => {
                       const suggestion = mcpSuggestions.find(s => s.name === server);
                       return (
                         <div
                           key={server}
-                          className="flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded"
+                          className="glass-inset flex items-center justify-between p-2"
                         >
                           <div className="flex items-center gap-2">
                             <Server className={`h-4 w-4 ${
                               suggestion?.isRegistered
-                                ? "text-green-600 dark:text-green-400"
+                                ? "text-success-text"
                                 : suggestion?.isDiscovered
-                                ? "text-yellow-600 dark:text-yellow-400"
-                                : "text-gray-400"
+                                ? "text-warning-text"
+                                : "text-ink-tertiary"
                             }`} />
-                            <span className="text-sm text-gray-700 dark:text-gray-300">
+                            <span className="text-sm text-ink-body">
                               {server}
                             </span>
                             {suggestion?.isRegistered && (
-                              <span className="text-xs px-1.5 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-success-fill text-success-text">
                                 registered
                               </span>
                             )}
                             {suggestion?.isDiscovered && (
-                              <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-warning-fill text-warning-text">
                                 discovered
                               </span>
                             )}
@@ -1729,7 +1743,7 @@ print(f"Result: {result}")
                             type="button"
                             onClick={() => removeMcpServer(server)}
                             disabled={loading || success}
-                            className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+                            className="text-danger-text hover:text-danger disabled:opacity-50"
                           >
                             <Trash2 className="h-4 w-4" />
                           </button>
@@ -1743,13 +1757,13 @@ print(f"Result: {result}")
           )}
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-divider">
             {success && !editMode ? (
               // Show Done button after successful registration
               <button
                 type="button"
                 onClick={handleSkipSDK}
-                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+                className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors flex items-center gap-2"
               >
                 <CheckCircle className="h-4 w-4" />
                 Done
@@ -1761,7 +1775,7 @@ print(f"Result: {result}")
                   type="button"
                   onClick={handleClose}
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50"
+                  className="px-4 py-2 text-sm font-medium text-ink-body hover:bg-glass-inset-gray rounded-pill transition-colors disabled:opacity-50"
                 >
                   Cancel
                 </button>
@@ -1769,10 +1783,10 @@ print(f"Result: {result}")
                   type="submit"
                   disabled={loading || success || JSON.stringify(formData) === JSON.stringify(initialFormData)}
                   className=
-                  "px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+                  "px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
                   {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-                  {editMode ? "Update Agent" : "Register Agent"}
+                  {editMode ? "Update agent" : "Register agent"}
                 </button>
               </>
             )}


### PR DESCRIPTION
Fourth of six stacked pull requests (Glasshouse; the whole change is #418). Stacked on the auth PR.

## What this part contains

Agents, agent detail, API keys, SDK, SDK tokens, developers, webhooks, tags, the registration form and the creation modals on the semantic tokens.

The agent success page teaches the pip path: its example imported `aim_sdk.config`, a module that exists only in the per-agent ZIP; it now uses `secure()` and the `perform_action` decorator. The Python ZIP card leaves that page because `secure("<id>")` generates a new key pair on the machine and replaces the one stored at registration, which invalidated a ZIP downloaded from the same page; the step says so, and stale sentences about planned SDKs, coverage and parity go along with a hardcoded SDK version badge.

The registration form no longer marks display name, version and capabilities as required, fills the auto-verify fields the way the SDK's `secure()` does at registration only (an edit sends what was typed), describes a browser-registered agent as registered from the dashboard, and opens from `?register=1` only for roles that may register agents; `?filter=pending` preselects the status filter. The API key modal states the fixed 90-day lifetime instead of a selector the backend ignores and no longer logs the plaintext key.

## Verification

- `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch.
- Light and dark at 1440 and 375 px on agents, API keys and the success page: no horizontal overflow, no page errors.
