### PR TITLE
Glasshouse security surfaces with distinct severities and honest wording

### DIFF
--- a/apps/web/app/dashboard/security/page.tsx
+++ b/apps/web/app/dashboard/security/page.tsx
@@ -105,11 +105,11 @@ function SecurityScoreGauge({ score, grade, status }: { score: number; grade: st
   const strokeDashoffset = circumference - (score / 100) * circumference;
 
   const getScoreColor = () => {
-    if (score >= 90) return { stroke: "#22c55e", bg: "bg-green-50 dark:bg-green-900/20", text: "text-green-600 dark:text-green-400" };
-    if (score >= 80) return { stroke: "#84cc16", bg: "bg-lime-50 dark:bg-lime-900/20", text: "text-lime-600 dark:text-lime-400" };
-    if (score >= 70) return { stroke: "#eab308", bg: "bg-yellow-50 dark:bg-yellow-900/20", text: "text-yellow-600 dark:text-yellow-400" };
-    if (score >= 60) return { stroke: "#f97316", bg: "bg-orange-50 dark:bg-orange-900/20", text: "text-orange-600 dark:text-orange-400" };
-    return { stroke: "#ef4444", bg: "bg-red-50 dark:bg-red-900/20", text: "text-red-600 dark:text-red-400" };
+    if (score >= 90) return { stroke: "var(--green)", bg: "bg-success-fill", text: "text-success-text" };
+    if (score >= 80) return { stroke: "var(--green)", bg: "bg-success-fill", text: "text-success-text" };
+    if (score >= 70) return { stroke: "var(--amber)", bg: "bg-warning-fill", text: "text-warning-text" };
+    if (score >= 60) return { stroke: "var(--amber)", bg: "bg-warning-fill", text: "text-warning-text" };
+    return { stroke: "var(--brand)", bg: "bg-brand-soft", text: "text-brand-text" };
   };
 
   const colors = getScoreColor();
@@ -123,9 +123,8 @@ function SecurityScoreGauge({ score, grade, status }: { score: number; grade: st
           cy="50"
           r="45"
           fill="none"
-          stroke="currentColor"
+          stroke="var(--track)"
           strokeWidth="8"
-          className="text-gray-200 dark:text-gray-700"
         />
         {/* Progress circle */}
         <circle
@@ -143,7 +142,7 @@ function SecurityScoreGauge({ score, grade, status }: { score: number; grade: st
       </svg>
       <div className="absolute flex flex-col items-center">
         <span className={`text-3xl font-bold ${colors.text}`}>{score}</span>
-        <span className="text-xs text-gray-500 dark:text-gray-400">/100</span>
+        <span className="text-xs text-ink-secondary">/100</span>
       </div>
     </div>
   );
@@ -165,39 +164,39 @@ function StatCard({
   variant?: "default" | "success" | "warning" | "danger";
 }) {
   const variantStyles = {
-    default: "from-gray-50 to-white dark:from-gray-800 dark:to-gray-800 border-gray-200 dark:border-gray-700",
-    success: "from-green-50 to-white dark:from-green-900/20 dark:to-gray-800 border-green-200 dark:border-green-800",
-    warning: "from-amber-50 to-white dark:from-amber-900/20 dark:to-gray-800 border-amber-200 dark:border-amber-800",
-    danger: "from-red-50 to-white dark:from-red-900/20 dark:to-gray-800 border-red-200 dark:border-red-800",
+    default: "glass",
+    success: "glass border-success-border",
+    warning: "glass border-warning-border",
+    danger: "glass-alert",
   };
 
   const iconStyles = {
-    default: "text-gray-600 dark:text-gray-400",
-    success: "text-green-600 dark:text-green-400",
-    warning: "text-amber-600 dark:text-amber-400",
-    danger: "text-red-600 dark:text-red-400",
+    default: "text-ink-secondary",
+    success: "text-success-text",
+    warning: "text-warning-text",
+    danger: "text-danger-text",
   };
 
   return (
-    <div className={`bg-gradient-to-br ${variantStyles[variant]} rounded-xl border p-5 shadow-sm hover:shadow-md transition-shadow`}>
+    <div className={`${variantStyles[variant]} p-5 transition-shadow`}>
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">
+          <p className="text-xs font-medium text-ink-secondary uppercase tracking-wide">{label}</p>
+          <p className="text-2xl font-bold text-ink mt-1">
             {typeof value === 'number' ? value.toLocaleString() : value}
           </p>
           {subValue && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{subValue}</p>
+            <p className="text-xs text-ink-secondary mt-1">{subValue}</p>
           )}
         </div>
-        <div className={`p-2 rounded-lg bg-white/50 dark:bg-gray-900/50 ${iconStyles[variant]}`}>
+        <div className={`p-2 rounded-lg bg-glass-inset-gray ${iconStyles[variant]}`}>
           <Icon className="h-5 w-5" />
         </div>
       </div>
       {trend && (
         <div className="mt-2 flex items-center text-xs">
-          <TrendingUp className="h-3 w-3 mr-1 text-green-500" />
-          <span className="text-green-600 dark:text-green-400">{trend}</span>
+          <TrendingUp className="h-3 w-3 mr-1 text-success-text" />
+          <span className="text-success-text">{trend}</span>
         </div>
       )}
     </div>
@@ -217,43 +216,43 @@ function BlockedActionCard({ action }: { action: any }) {
   const CategoryIcon = getCategoryIcon(action.attemptedCapability);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition-all">
+    <div className="glass-inset border border-divider p-4 transition-all">
       <div className="flex items-start gap-3">
-        <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30">
-          <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+        <div className="p-2 rounded-lg bg-danger-fill">
+          <XCircle className="h-5 w-5 text-danger-text" />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300">
-              BLOCKED
+            <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-danger-fill text-danger-text">
+              Blocked
             </span>
-            <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            <span className="text-sm font-medium text-ink truncate">
               {action.agentName}
             </span>
           </div>
           <div className="flex items-center gap-2 mt-1.5">
-            <CategoryIcon className="h-4 w-4 text-gray-400" />
-            <span className="text-sm text-gray-700 dark:text-gray-300 font-mono">
+            <CategoryIcon className="h-4 w-4 text-ink-tertiary" />
+            <span className="text-sm text-ink-body font-mono">
               {action.attemptedCapability}
             </span>
           </div>
           <div className="flex items-center justify-between mt-2">
-            <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-3 text-xs text-ink-secondary">
               <span className="flex items-center gap-1">
                 <Clock className="h-3 w-3" />
                 {formatRelativeTime(action.createdAt)}
               </span>
               {action.trustImpact !== 0 && (
-                <span className="text-red-600 dark:text-red-400">
+                <span className="text-danger-text">
                   Trust {action.trustImpact > 0 ? "+" : ""}{action.trustImpact}%
                 </span>
               )}
             </div>
             <Link
               href={`/dashboard/agents?id=${action.agentId}`}
-              className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+              className="text-xs text-brand-text hover:underline flex items-center gap-1"
             >
-              Review Agent <ChevronRight className="h-3 w-3" />
+              Review agent <ChevronRight className="h-3 w-3" />
             </Link>
           </div>
         </div>
@@ -271,17 +270,17 @@ function RiskCategoryBar({ category, blocked, riskLevel, maxBlocked }: {
   const width = maxBlocked > 0 ? (blocked / maxBlocked) * 100 : 0;
 
   const riskColors = {
-    high: "bg-red-500",
-    medium: "bg-orange-500",
-    low: "bg-yellow-500",
-    secure: "bg-green-500",
+    high: "bg-danger",
+    medium: "bg-warning",
+    low: "bg-track",
+    secure: "bg-success",
   };
 
   const riskLabels = {
-    high: { text: "High Risk", class: "text-red-600 dark:text-red-400" },
-    medium: { text: "Medium", class: "text-orange-600 dark:text-orange-400" },
-    low: { text: "Low", class: "text-yellow-600 dark:text-yellow-400" },
-    secure: { text: "Secure", class: "text-green-600 dark:text-green-400" },
+    high: { text: "High risk", class: "text-danger-text" },
+    medium: { text: "Medium", class: "text-warning-text" },
+    low: { text: "Low", class: "text-ink-secondary" },
+    secure: { text: "Secure", class: "text-success-text" },
   };
 
   const label = riskLabels[riskLevel as keyof typeof riskLabels] || riskLabels.secure;
@@ -289,13 +288,13 @@ function RiskCategoryBar({ category, blocked, riskLevel, maxBlocked }: {
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-sm">
-        <span className="text-gray-700 dark:text-gray-300">{category}</span>
+        <span className="text-ink-body">{category}</span>
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-900 dark:text-white">{blocked}</span>
+          <span className="font-medium text-ink">{blocked}</span>
           <span className={`text-xs ${label.class}`}>{label.text}</span>
         </div>
       </div>
-      <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+      <div className="h-2 bg-track rounded-full overflow-hidden">
         <div
           className={`h-full ${riskColors[riskLevel as keyof typeof riskColors] || riskColors.secure} rounded-full transition-all duration-500`}
           style={{ width: `${width}%` }}
@@ -309,12 +308,12 @@ function SecurityPageSkeleton() {
   return (
     <div className="space-y-6">
       {/* Hero Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+      <div className="glass p-6">
         <div className="flex items-center gap-8">
-          <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-32 w-32 rounded-full"></div>
+          <div className="animate-pulse bg-track h-32 w-32 rounded-full"></div>
           <div className="flex-1 space-y-3">
-            <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-48 rounded"></div>
-            <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-96 rounded"></div>
+            <div className="animate-pulse bg-track h-6 w-48 rounded"></div>
+            <div className="animate-pulse bg-track h-4 w-96 rounded"></div>
           </div>
         </div>
       </div>
@@ -322,10 +321,10 @@ function SecurityPageSkeleton() {
       {/* Stats Skeleton */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+          <div key={i} className="glass p-5">
             <div className="animate-pulse space-y-3">
-              <div className="bg-gray-200 dark:bg-gray-700 h-4 w-24 rounded"></div>
-              <div className="bg-gray-200 dark:bg-gray-700 h-8 w-16 rounded"></div>
+              <div className="bg-track h-4 w-24 rounded"></div>
+              <div className="bg-track h-8 w-16 rounded"></div>
             </div>
           </div>
         ))}
@@ -340,23 +339,23 @@ function ErrorDisplay({ message, onRetry }: { message: string; onRetry: () => vo
   return (
     <div className="flex items-center justify-center min-h-[400px]">
       <div className="flex flex-col items-center gap-4 max-w-md text-center px-4">
-        <Shield className={`h-16 w-16 ${is403 ? "text-amber-500" : "text-red-500"}`} />
+        <Shield className={`h-16 w-16 ${is403 ? "text-warning" : "text-danger"}`} />
         <div className="space-y-2">
-          <h3 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {is403 ? "Access Restricted" : "Failed to Load Security Data"}
+          <h3 className="text-2xl font-bold text-ink">
+            {is403 ? "Access restricted" : "Failed to load security data"}
           </h3>
           {is403 ? (
-            <p className="text-base text-gray-600 dark:text-gray-400">
+            <p className="text-base text-ink-secondary">
               Security monitoring is only available to Admin and Manager roles.
             </p>
           ) : (
-            <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
+            <p className="text-sm text-ink-secondary">{message}</p>
           )}
         </div>
         {!is403 && (
           <button
             onClick={onRetry}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            className="px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
           >
             Retry
           </button>
@@ -417,11 +416,12 @@ export default function SecurityPage() {
   // Calculate insight text for protection
   const protectionInsight = useMemo(() => {
     if (!metrics) return null;
+    // Both numbers come from the same 30-day timeline so the ratio stays within 0-100.
     const totalActions = metrics.protectionTimeline?.reduce((sum, d) => sum + d.actions, 0) || 0;
-    const totalBlocked = metrics.actionsBlocked || 0;
-    if (totalActions === 0) return "No agent actions recorded yet.";
-    const authorizedRate = ((totalActions - totalBlocked) / totalActions * 100).toFixed(1);
-    return `${authorizedRate}% of agent actions were authorized. AIM blocked ${totalBlocked} unauthorized attempt${totalBlocked !== 1 ? 's' : ''}.`;
+    const totalBlocked = metrics.protectionTimeline?.reduce((sum, d) => sum + d.blocked, 0) || 0;
+    if (totalActions === 0) return "No agent actions recorded in the last 30 days.";
+    const authorizedRate = Math.min(100, Math.max(0, ((totalActions - totalBlocked) / totalActions) * 100)).toFixed(1);
+    return `${authorizedRate}% of agent actions in the last 30 days were authorized. AIM denied ${totalBlocked} of them.`;
   }, [metrics]);
 
   // Get max blocked for category chart scaling
@@ -439,10 +439,10 @@ export default function SecurityPage() {
   }
 
   const statusIndicator = metrics?.securityStatus === "Secure" || metrics?.securityStatus === "Good"
-    ? { color: "bg-green-500", text: "All Systems Operational" }
+    ? { color: "bg-success", text: "All systems operational" }
     : metrics?.securityStatus === "Needs Attention"
-    ? { color: "bg-yellow-500", text: "Needs Attention" }
-    : { color: "bg-red-500", text: "Action Required" };
+    ? { color: "bg-warning", text: "Needs attention" }
+    : { color: "bg-danger", text: "Action required" };
 
   return (
     <AuthGuard>
@@ -450,7 +450,7 @@ export default function SecurityPage() {
         {/* ============================================ */}
         {/* HERO SECTION - Security Command Center */}
         {/* ============================================ */}
-        <div className="bg-gradient-to-br from-slate-50 to-white dark:from-gray-800 dark:to-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden">
+        <div className="glass overflow-hidden">
           <div className="p-6 md:p-8">
             <div className="flex flex-col md:flex-row md:items-center gap-6">
               {/* Security Score Gauge */}
@@ -465,20 +465,20 @@ export default function SecurityPage() {
               {/* Status Content */}
               <div className="flex-1">
                 <div className="flex items-center gap-3 mb-2">
-                  <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-                    Your AI Fleet
+                  <h1 className="text-2xl font-bold text-ink">
+                    Your AI fleet
                   </h1>
                   <div className="flex items-center gap-2">
                     <span className={`w-2 h-2 rounded-full ${statusIndicator.color} animate-pulse`}></span>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">{statusIndicator.text}</span>
+                    <span className="text-sm text-ink-secondary">{statusIndicator.text}</span>
                   </div>
                 </div>
-                <p className="text-gray-600 dark:text-gray-400">
-                  <span className="font-medium text-gray-900 dark:text-white">{metrics?.agentsMonitored || 0}</span> agents
+                <p className="text-ink-secondary">
+                  <span className="font-medium text-ink">{metrics?.agentsMonitored || 0}</span> agents
                   <span className="mx-1">+</span>
-                  <span className="font-medium text-gray-900 dark:text-white">{metrics?.mcpServersTotal || 0}</span> MCP servers monitored
+                  <span className="font-medium text-ink">{metrics?.mcpServersTotal || 0}</span> MCP servers monitored
                   <span className="mx-2">•</span>
-                  <span className="font-medium text-gray-900 dark:text-white">{metrics?.actionsBlocked || 0}</span> threats blocked
+                  <span className="font-medium text-ink">{metrics?.actionsBlocked || 0}</span> actions denied
                   {metrics?.lastIncidentAt && (
                     <>
                       <span className="mx-2">•</span>
@@ -492,7 +492,7 @@ export default function SecurityPage() {
                   {(metrics?.requiresAttention || 0) > 0 && (
                     <Link
                       href="/dashboard/admin/alerts"
-                      className="inline-flex items-center gap-2 px-4 py-2 bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 rounded-lg hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors text-sm font-medium"
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-warning-fill text-warning-text rounded-pill hover:bg-warning-border transition-colors text-sm font-medium"
                     >
                       <Bell className="h-4 w-4" />
                       {metrics?.requiresAttention} items need attention
@@ -501,10 +501,10 @@ export default function SecurityPage() {
                   )}
                   <Link
                     href="/dashboard/agents"
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-sm font-medium"
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-glass-inset-gray text-ink-body rounded-pill hover:bg-track transition-colors text-sm font-medium"
                   >
                     <Bot className="h-4 w-4" />
-                    View All Agents
+                    View all agents
                     <ChevronRight className="h-4 w-4" />
                   </Link>
                 </div>
@@ -519,35 +519,35 @@ export default function SecurityPage() {
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
           <StatCard
             icon={Shield}
-            label="Actions Blocked"
+            label="Actions blocked"
             value={metrics?.actionsBlocked || 0}
             subValue={`${metrics?.actionsBlockedToday || 0} today`}
             variant="success"
           />
           <StatCard
             icon={Bot}
-            label="Agents Monitored"
+            label="Agents monitored"
             value={metrics?.agentsMonitored || 0}
             subValue={`${metrics?.trustPercentage || 0}% trusted`}
             variant="default"
           />
           <StatCard
             icon={Server}
-            label="MCP Servers"
+            label="MCP servers"
             value={metrics?.mcpServersTotal || 0}
             subValue={`${metrics?.mcpTrustPercentage || 0}% verified`}
             variant="default"
           />
           <StatCard
             icon={Zap}
-            label="Actions Today"
+            label="Actions today"
             value={metrics?.actionsToday || 0}
             subValue="processed by agents"
             variant="default"
           />
           <StatCard
             icon={Bell}
-            label="Requires Attention"
+            label="Requires attention"
             value={metrics?.requiresAttention || 0}
             subValue="pending items"
             variant={(metrics?.requiresAttention || 0) > 10 ? "warning" : "default"}
@@ -559,71 +559,72 @@ export default function SecurityPage() {
         {/* ============================================ */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Protection Timeline */}
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+          <div className="glass p-6">
             <div className="flex items-center justify-between mb-4">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Protection Timeline</h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">Last 30 days</p>
+                <h3 className="text-lg font-semibold text-ink">Protection timeline</h3>
+                <p className="text-sm text-ink-secondary">Last 30 days</p>
               </div>
-              <Activity className="h-5 w-5 text-gray-400" />
+              <Activity className="h-5 w-5 text-ink-tertiary" />
             </div>
             <div className="h-64">
               <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart data={metrics?.protectionTimeline || []}>
                   <defs>
                     <linearGradient id="actionsGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.2}/>
-                      <stop offset="95%" stopColor="#3b82f6" stopOpacity={0}/>
+                      <stop offset="5%" stopColor="var(--brand)" stopOpacity={0.2}/>
+                      <stop offset="95%" stopColor="var(--brand)" stopOpacity={0}/>
                     </linearGradient>
                   </defs>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-                  <XAxis dataKey="date" stroke="#9CA3AF" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
-                  <YAxis stroke="#9CA3AF" tick={{ fontSize: 11 }} />
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-divider" />
+                  <XAxis dataKey="date" stroke="var(--text-tertiary)" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
+                  <YAxis stroke="var(--text-tertiary)" tick={{ fontSize: 11 }} />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "white",
-                      border: "1px solid #e5e7eb",
-                      borderRadius: "0.5rem",
-                      boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+                      backgroundColor: "var(--glass-fill)",
+                      border: "1px solid var(--glass-border)",
+                      borderRadius: "12px",
+                      boxShadow: "var(--shadow-card)",
+                      color: "var(--text-primary)",
                     }}
                   />
                   <Area
                     type="monotone"
                     dataKey="actions"
                     fill="url(#actionsGradient)"
-                    stroke="#3b82f6"
+                    stroke="var(--brand)"
                     strokeWidth={2}
                     name="Actions"
                   />
                   <Line
                     type="monotone"
                     dataKey="blocked"
-                    stroke="#ef4444"
+                    stroke="var(--red)"
                     strokeWidth={2}
                     name="Blocked"
-                    dot={{ fill: "#ef4444", strokeWidth: 2, r: 3 }}
+                    dot={{ fill: "var(--red)", strokeWidth: 2, r: 3 }}
                   />
                 </ComposedChart>
               </ResponsiveContainer>
             </div>
             {/* Insight Box */}
             {protectionInsight && (
-              <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-                <p className="text-sm text-blue-800 dark:text-blue-300">
-                  <span className="font-medium">💡 Insight:</span> {protectionInsight}
+              <div className="mt-4 p-3 bg-brand-soft rounded-inset border border-stroke">
+                <p className="text-sm text-brand-text">
+                  <span className="font-medium">Insight:</span> {protectionInsight}
                 </p>
               </div>
             )}
           </div>
 
           {/* Risk by Category */}
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+          <div className="glass p-6">
             <div className="flex items-center justify-between mb-4">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Risk by Category</h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">Blocked actions by type</p>
+                <h3 className="text-lg font-semibold text-ink">Risk by category</h3>
+                <p className="text-sm text-ink-secondary">Blocked actions by type</p>
               </div>
-              <Shield className="h-5 w-5 text-gray-400" />
+              <Shield className="h-5 w-5 text-ink-tertiary" />
             </div>
             <div className="space-y-4">
               {metrics?.riskByCategory && metrics.riskByCategory.length > 0 ? (
@@ -638,17 +639,17 @@ export default function SecurityPage() {
                 ))
               ) : (
                 <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <CheckCircle className="h-12 w-12 text-green-500 mb-3" />
-                  <p className="text-sm text-gray-600 dark:text-gray-400">No blocked actions detected</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">All agent actions are within authorized capabilities</p>
+                  <CheckCircle className="h-12 w-12 text-success mb-3" />
+                  <p className="text-sm text-ink-secondary">No blocked actions detected</p>
+                  <p className="text-xs text-ink-tertiary mt-1">All agent actions are within authorized capabilities</p>
                 </div>
               )}
             </div>
             {/* Risk Insight */}
             {metrics?.riskByCategory && metrics.riskByCategory.length > 0 && (
-              <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
-                <p className="text-sm text-amber-800 dark:text-amber-300">
-                  <span className="font-medium">⚠️ Recommendation:</span> Review agents attempting{" "}
+              <div className="mt-4 p-3 bg-warning-fill rounded-inset border border-warning-border">
+                <p className="text-sm text-warning-text">
+                  <span className="font-medium">Recommendation:</span> Review agents attempting{" "}
                   <span className="font-medium">{metrics.riskByCategory[0]?.category}</span> actions.
                 </p>
               </div>
@@ -659,22 +660,22 @@ export default function SecurityPage() {
         {/* ============================================ */}
         {/* BLOCKED ACTIONS */}
         {/* ============================================ */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+        <div className="glass">
+          <div className="p-6 border-b border-divider">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                  <Shield className="h-5 w-5 text-green-600" />
-                  Blocked Actions
+                <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                  <Shield className="h-5 w-5 text-success-text" />
+                  Denied actions
                 </h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  AIM prevented these unauthorized attempts
+                <p className="text-sm text-ink-secondary mt-1">
+                  Actions AIM denied. Whether the agent ran them anyway is self-reported; AIM does not observe execution.
                 </p>
               </div>
               {(metrics?.actionsBlocked || 0) > 10 && (
                 <Link
                   href="/dashboard/security/violations"
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                  className="text-sm text-brand-text hover:underline flex items-center gap-1"
                 >
                   View all <ChevronRight className="h-4 w-4" />
                 </Link>
@@ -690,11 +691,11 @@ export default function SecurityPage() {
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12 text-center">
-                <div className="p-4 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
-                  <CheckCircle className="h-8 w-8 text-green-600 dark:text-green-400" />
+                <div className="p-4 rounded-full bg-success-fill mb-4">
+                  <CheckCircle className="h-8 w-8 text-success-text" />
                 </div>
-                <h4 className="text-lg font-medium text-gray-900 dark:text-white">All Clear</h4>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                <h4 className="text-lg font-medium text-ink">All clear</h4>
+                <p className="text-sm text-ink-secondary mt-1">
                   No unauthorized actions have been blocked recently
                 </p>
               </div>
@@ -707,51 +708,45 @@ export default function SecurityPage() {
         {/* ============================================ */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Requires Attention */}
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="glass">
+            <div className="p-6 border-b border-divider">
               <div className="flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                    <Bell className="h-5 w-5 text-amber-500" />
-                    Requires Your Attention
+                  <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                    <Bell className="h-5 w-5 text-warning" />
+                    Requires your attention
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-sm text-ink-secondary mt-1">
                     {metrics?.requiresAttention || 0} pending items
                   </p>
                 </div>
                 <Link
                   href="/dashboard/admin/alerts"
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                  className="text-sm text-brand-text hover:underline flex items-center gap-1"
                 >
                   View all <ChevronRight className="h-4 w-4" />
                 </Link>
               </div>
             </div>
-            <div className="divide-y divide-gray-200 dark:divide-gray-700 max-h-[400px] overflow-y-auto">
+            <div className="divide-y divide-divider max-h-[400px] overflow-y-auto">
               {/* Capability Requests */}
               {capabilityRequests.slice(0, 3).map((req) => (
-                <div key={req.id} className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                <div key={req.id} className="p-4 hover:bg-glass-inset-gray transition-colors">
                   <div className="flex items-start gap-3">
-                    <div className="p-1.5 rounded-full bg-amber-100 dark:bg-amber-900/30">
-                      <Clock className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+                    <div className="p-1.5 rounded-full bg-warning-fill">
+                      <Clock className="h-4 w-4 text-warning-text" />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
-                        Capability Request
+                      <p className="text-sm font-medium text-ink">
+                        Capability request
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      <p className="text-xs text-ink-secondary truncate">
                         {req.agentName || "Agent"} wants <span className="font-mono">{req.requestedCapability}</span>
                       </p>
                       <div className="flex gap-2 mt-2">
-                        <button className="px-2 py-1 text-xs font-medium rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50 transition-colors">
-                          Approve
-                        </button>
-                        <button className="px-2 py-1 text-xs font-medium rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors">
-                          Deny
-                        </button>
                         <Link
                           href={`/dashboard/admin/capability-requests?id=${req.id}`}
-                          className="px-2 py-1 text-xs font-medium rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                          className="px-2 py-1 text-xs font-medium rounded bg-glass-inset-gray text-ink-body hover:bg-track transition-colors"
                         >
                           Review
                         </Link>
@@ -763,29 +758,29 @@ export default function SecurityPage() {
 
               {/* Unacknowledged Alerts */}
               {alerts.filter(a => !a.isAcknowledged).slice(0, 3).map((alert) => (
-                <div key={alert.id} className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                <div key={alert.id} className="p-4 hover:bg-glass-inset-gray transition-colors">
                   <div className="flex items-start gap-3">
                     <div className={`p-1.5 rounded-full ${
                       alert.severity === 'critical' || alert.severity === 'high'
-                        ? 'bg-red-100 dark:bg-red-900/30'
-                        : 'bg-amber-100 dark:bg-amber-900/30'
+                        ? 'bg-danger-fill'
+                        : 'bg-warning-fill'
                     }`}>
                       <AlertTriangle className={`h-4 w-4 ${
                         alert.severity === 'critical' || alert.severity === 'high'
-                          ? 'text-red-600 dark:text-red-400'
-                          : 'text-amber-600 dark:text-amber-400'
+                          ? 'text-danger-text'
+                          : 'text-warning-text'
                       }`} />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                      <p className="text-sm font-medium text-ink truncate">
                         {alert.title}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-xs text-ink-secondary">
                         {formatRelativeTime(alert.createdAt)}
                       </p>
                       <Link
-                        href={`/dashboard/admin/alerts?id=${alert.id}`}
-                        className="mt-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                        href={`/dashboard/admin/alerts?selected=${alert.id}`}
+                        className="mt-1 text-xs text-brand-text hover:underline"
                       >
                         Investigate →
                       </Link>
@@ -797,75 +792,75 @@ export default function SecurityPage() {
               {/* Empty State */}
               {capabilityRequests.length === 0 && alerts.filter(a => !a.isAcknowledged).length === 0 && (
                 <div className="p-8 text-center">
-                  <CheckCircle className="h-12 w-12 mx-auto mb-3 text-green-500" />
-                  <p className="text-sm text-gray-500 dark:text-gray-400">All caught up!</p>
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">No pending items require your attention</p>
+                  <CheckCircle className="h-12 w-12 mx-auto mb-3 text-success" />
+                  <p className="text-sm text-ink-secondary">All caught up</p>
+                  <p className="text-xs text-ink-tertiary mt-1">No pending items require your attention</p>
                 </div>
               )}
             </div>
           </div>
 
           {/* Security Alerts (for legacy compatibility) */}
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-            <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="glass">
+            <div className="p-6 border-b border-divider">
               <div className="flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                    <AlertTriangle className="h-5 w-5 text-red-500" />
-                    Security Alerts
+                  <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                    <AlertTriangle className="h-5 w-5 text-danger" />
+                    Security alerts
                   </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-sm text-ink-secondary mt-1">
                     {alertCounts.unacknowledged} unacknowledged of {alertCounts.all} total
                   </p>
                 </div>
                 <Link
                   href="/dashboard/admin/alerts"
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                  className="text-sm text-brand-text hover:underline flex items-center gap-1"
                 >
                   View all <ChevronRight className="h-4 w-4" />
                 </Link>
               </div>
             </div>
-            <div className="divide-y divide-gray-200 dark:divide-gray-700 max-h-[400px] overflow-y-auto">
+            <div className="divide-y divide-divider max-h-[400px] overflow-y-auto">
               {alerts.length > 0 ? (
                 alerts.map((alert) => (
-                  <div key={alert.id} className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                  <div key={alert.id} className="p-4 hover:bg-glass-inset-gray transition-colors">
                     <div className="flex items-start gap-3">
                       <div className={`p-1.5 rounded-full ${
-                        alert.severity === 'critical' ? 'bg-red-100 dark:bg-red-900/30' :
-                        alert.severity === 'high' ? 'bg-orange-100 dark:bg-orange-900/30' :
-                        alert.severity === 'medium' ? 'bg-yellow-100 dark:bg-yellow-900/30' :
-                        'bg-blue-100 dark:bg-blue-900/30'
+                        alert.severity === 'critical' ? 'bg-danger-strong' :
+                        alert.severity === 'high' ? 'bg-danger-fill' :
+                        alert.severity === 'medium' ? 'bg-warning-fill' :
+                        'bg-brand-soft'
                       }`}>
                         <AlertTriangle className={`h-4 w-4 ${
-                          alert.severity === 'critical' ? 'text-red-600 dark:text-red-400' :
-                          alert.severity === 'high' ? 'text-orange-600 dark:text-orange-400' :
-                          alert.severity === 'medium' ? 'text-yellow-600 dark:text-yellow-400' :
-                          'text-blue-600 dark:text-blue-400'
+                          alert.severity === 'critical' ? 'text-white' :
+                          alert.severity === 'high' ? 'text-danger-text' :
+                          alert.severity === 'medium' ? 'text-warning-text' :
+                          'text-brand-text'
                         }`} />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                          <p className="text-sm font-medium text-ink truncate">
                             {alert.title}
                           </p>
                           <span className={`text-xs px-2 py-0.5 rounded-full capitalize ${
-                            alert.severity === 'critical' ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300' :
-                            alert.severity === 'high' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300' :
-                            alert.severity === 'medium' ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300' :
-                            'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                            alert.severity === 'critical' ? 'bg-danger-fill text-danger-text border border-danger-strong font-bold' :
+                            alert.severity === 'high' ? 'bg-danger-fill text-danger-text' :
+                            alert.severity === 'medium' ? 'bg-warning-fill text-warning-text' :
+                            'bg-brand-soft text-brand-text'
                           }`}>
                             {alert.severity}
                           </span>
                         </div>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                        <p className="text-xs text-ink-secondary truncate mt-0.5">
                           {alert.description}
                         </p>
                         <div className="flex items-center gap-2 mt-1">
-                          <Clock className="h-3 w-3 text-gray-400" />
-                          <span className="text-xs text-gray-400">{formatDateTime(alert.createdAt)}</span>
+                          <Clock className="h-3 w-3 text-ink-tertiary" />
+                          <span className="text-xs text-ink-tertiary">{formatDateTime(alert.createdAt)}</span>
                           {!alert.isAcknowledged && (
-                            <span className="text-xs px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded">
+                            <span className="text-xs px-1.5 py-0.5 bg-warning-fill text-warning-text rounded">
                               Unacknowledged
                             </span>
                           )}
@@ -876,8 +871,8 @@ export default function SecurityPage() {
                 ))
               ) : (
                 <div className="p-8 text-center">
-                  <CheckCircle className="h-12 w-12 mx-auto mb-3 text-green-500" />
-                  <p className="text-sm text-gray-500 dark:text-gray-400">No security alerts</p>
+                  <CheckCircle className="h-12 w-12 mx-auto mb-3 text-success" />
+                  <p className="text-sm text-ink-secondary">No security alerts</p>
                 </div>
               )}
             </div>

--- a/apps/web/app/dashboard/security/violations/page.tsx
+++ b/apps/web/app/dashboard/security/violations/page.tsx
@@ -60,28 +60,29 @@ function getCategoryIcon(capability: string) {
 function getSeverityStyles(severity: string) {
   switch (severity.toLowerCase()) {
     case "critical":
+      // Critical carries a solid danger border so it reads differently from high.
       return {
-        bg: "bg-red-100 dark:bg-red-900/30",
-        text: "text-red-700 dark:text-red-300",
-        border: "border-red-200 dark:border-red-800",
+        bg: "bg-danger-fill",
+        text: "text-danger-text",
+        border: "border-danger-strong",
       };
     case "high":
       return {
-        bg: "bg-orange-100 dark:bg-orange-900/30",
-        text: "text-orange-700 dark:text-orange-300",
-        border: "border-orange-200 dark:border-orange-800",
+        bg: "bg-danger-fill",
+        text: "text-danger-text",
+        border: "border-danger-border",
       };
     case "medium":
       return {
-        bg: "bg-yellow-100 dark:bg-yellow-900/30",
-        text: "text-yellow-700 dark:text-yellow-300",
-        border: "border-yellow-200 dark:border-yellow-800",
+        bg: "bg-warning-fill",
+        text: "text-warning-text",
+        border: "border-warning-border",
       };
     default:
       return {
-        bg: "bg-blue-100 dark:bg-blue-900/30",
-        text: "text-blue-700 dark:text-blue-300",
-        border: "border-blue-200 dark:border-blue-800",
+        bg: "bg-brand-soft",
+        text: "text-brand-text",
+        border: "border-stroke",
       };
   }
 }
@@ -91,47 +92,47 @@ function ViolationCard({ violation }: { violation: Violation }) {
   const severityStyles = getSeverityStyles(violation.severity);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition-all">
+    <div className="glass p-4 hover:-translate-y-0.5 transition-transform">
       <div className="flex items-start gap-4">
         {/* Status Icon */}
-        <div className={`p-2 rounded-lg ${violation.isBlocked ? "bg-red-100 dark:bg-red-900/30" : "bg-yellow-100 dark:bg-yellow-900/30"}`}>
+        <div className={`p-2 rounded-inset-sm ${violation.isBlocked ? "bg-danger-fill" : "bg-warning-fill"}`}>
           {violation.isBlocked ? (
-            <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+            <XCircle className="h-5 w-5 text-danger-text" />
           ) : (
-            <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <AlertTriangle className="h-5 w-5 text-warning-text" />
           )}
         </div>
 
         {/* Content */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap mb-2">
-            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+            <span className={`text-xs font-semibold px-2 py-0.5 rounded-pill border ${
               violation.isBlocked
-                ? "bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300"
-                : "bg-yellow-100 dark:bg-yellow-900/50 text-yellow-700 dark:text-yellow-300"
+                ? "bg-danger-fill border-danger-border text-danger-text"
+                : "bg-warning-fill border-warning-border text-warning-text"
             }`}>
-              {violation.isBlocked ? "BLOCKED" : "ALLOWED"}
+              {violation.isBlocked ? "Blocked" : "Allowed"}
             </span>
-            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${severityStyles.bg} ${severityStyles.text}`}>
-              {violation.severity.toUpperCase()}
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-pill border ${severityStyles.bg} ${severityStyles.text} ${severityStyles.border}`}>
+              {violation.severity.charAt(0).toUpperCase() + violation.severity.slice(1).toLowerCase()}
             </span>
             <Link
               href={`/dashboard/agents/${violation.agentId}`}
-              className="text-sm font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 truncate"
+              className="text-sm font-medium text-ink hover:text-brand-text truncate"
             >
               {violation.agentName || violation.agentId.slice(0, 8)}
             </Link>
           </div>
 
           <div className="flex items-center gap-2 mb-2">
-            <CategoryIcon className="h-4 w-4 text-gray-400" />
-            <span className="text-sm font-mono text-gray-700 dark:text-gray-300">
+            <CategoryIcon className="h-4 w-4 text-ink-tertiary" />
+            <span className="text-sm font-mono text-ink-body">
               {violation.attemptedCapability}
             </span>
           </div>
 
           <div className="flex items-center justify-between mt-3">
-            <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-4 text-xs text-ink-secondary">
               <span className="flex items-center gap-1">
                 <Clock className="h-3 w-3" />
                 {formatRelativeTime(violation.createdAt)}
@@ -143,16 +144,16 @@ function ViolationCard({ violation }: { violation: Violation }) {
                 </span>
               )}
               {violation.trustScoreImpact !== 0 && (
-                <span className={violation.trustScoreImpact < 0 ? "text-red-600 dark:text-red-400" : "text-green-600 dark:text-green-400"}>
+                <span className={violation.trustScoreImpact < 0 ? "text-danger-text" : "text-success-text"}>
                   Trust {violation.trustScoreImpact > 0 ? "+" : ""}{violation.trustScoreImpact}%
                 </span>
               )}
             </div>
             <Link
               href={`/dashboard/agents/${violation.agentId}`}
-              className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+              className="text-xs text-brand-text hover:underline flex items-center gap-1"
             >
-              View Agent <ChevronRight className="h-3 w-3" />
+              View agent <ChevronRight className="h-3 w-3" />
             </Link>
           </div>
         </div>
@@ -165,13 +166,13 @@ function ViolationsPageSkeleton() {
   return (
     <div className="space-y-4">
       {[...Array(5)].map((_, i) => (
-        <div key={i} className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div key={i} className="glass p-4">
           <div className="flex items-start gap-4">
-            <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-10 rounded-lg"></div>
+            <div className="animate-pulse bg-track h-10 w-10 rounded-inset-sm"></div>
             <div className="flex-1 space-y-3">
-              <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-48 rounded"></div>
-              <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-64 rounded"></div>
-              <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-3 w-32 rounded"></div>
+              <div className="animate-pulse bg-track h-4 w-48 rounded"></div>
+              <div className="animate-pulse bg-track h-4 w-64 rounded"></div>
+              <div className="animate-pulse bg-track h-3 w-32 rounded"></div>
             </div>
           </div>
         </div>
@@ -237,48 +238,48 @@ export default function ViolationsPage() {
           <div className="flex items-center gap-4">
             <Link
               href="/dashboard/security"
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              className="p-2 rounded-nav hover:bg-nav-active transition-colors"
             >
-              <ChevronLeft className="h-5 w-5 text-gray-500" />
+              <ChevronLeft className="h-5 w-5 text-ink-secondary" />
             </Link>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-                <Shield className="h-6 w-6 text-green-600" />
-                Capability Violations
+              <h1 className="text-2xl font-bold tracking-[-0.02em] text-ink flex items-center gap-2">
+                <Shield className="h-6 w-6 text-success-text" />
+                Capability violations
               </h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              <p className="text-sm text-ink-secondary mt-1">
                 All blocked and flagged agent actions
               </p>
             </div>
           </div>
           <div className="text-right">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{total}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">total violations</p>
+            <p className="text-2xl font-bold tracking-[-0.02em] text-ink">{total}</p>
+            <p className="text-sm text-ink-secondary">total violations</p>
           </div>
         </div>
 
         {/* Filters */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+        <div className="glass p-4">
           <div className="flex flex-col sm:flex-row gap-4">
             {/* Search */}
             <div className="flex-1 relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
               <input
                 type="text"
                 placeholder="Search by capability or agent..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full pl-10 pr-4 py-2 border border-stroke rounded-inset bg-glass-inset text-sm text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0"
               />
             </div>
 
             {/* Status Filter */}
             <div className="flex items-center gap-2">
-              <Filter className="h-4 w-4 text-gray-400" />
+              <Filter className="h-4 w-4 text-ink-tertiary" />
               <select
                 value={filterBlocked}
                 onChange={(e) => setFilterBlocked(e.target.value as any)}
-                className="px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="px-3 py-2 border border-stroke rounded-inset bg-glass-inset text-sm text-ink focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0"
               >
                 <option value="all">All ({violations.length})</option>
                 <option value="blocked">Blocked ({blockedCount})</option>
@@ -292,23 +293,23 @@ export default function ViolationsPage() {
         {loading ? (
           <ViolationsPageSkeleton />
         ) : error ? (
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-8 text-center">
-            <AlertTriangle className="h-12 w-12 mx-auto text-red-500 mb-4" />
-            <p className="text-gray-600 dark:text-gray-400">{error}</p>
+          <div className="glass-alert p-8 text-center">
+            <AlertTriangle className="h-12 w-12 mx-auto text-danger-text mb-4" />
+            <p className="text-ink-body">{error}</p>
             <button
               onClick={fetchViolations}
-              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="mt-4 px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
             >
               Retry
             </button>
           </div>
         ) : filteredViolations.length === 0 ? (
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-12 text-center">
-            <div className="p-4 rounded-full bg-green-100 dark:bg-green-900/30 inline-block mb-4">
-              <CheckCircle className="h-8 w-8 text-green-600 dark:text-green-400" />
+          <div className="glass p-12 text-center">
+            <div className="p-4 rounded-pill bg-success-fill inline-block mb-4">
+              <CheckCircle className="h-8 w-8 text-success-text" />
             </div>
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white">No Violations Found</h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            <h3 className="text-lg font-medium text-ink">No violations found</h3>
+            <p className="text-sm text-ink-secondary mt-1">
               {searchQuery || filterBlocked !== "all"
                 ? "No violations match your filters"
                 : "All agent actions are within authorized capabilities"}
@@ -324,25 +325,25 @@ export default function ViolationsPage() {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="flex items-center justify-between bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+          <div className="glass flex items-center justify-between px-4 py-3">
+            <p className="text-sm text-ink-secondary">
               Showing {(page - 1) * pageSize + 1} to {Math.min(page * pageSize, total)} of {total} violations
             </p>
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="p-2 rounded-nav text-ink-secondary hover:bg-nav-active disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 <ChevronLeft className="h-5 w-5" />
               </button>
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+              <span className="text-sm text-ink-body">
                 Page {page} of {totalPages}
               </span>
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
-                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="p-2 rounded-nav text-ink-secondary hover:bg-nav-active disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 <ChevronRight className="h-5 w-5" />
               </button>

--- a/apps/web/components/agent/trust-score-breakdown.tsx
+++ b/apps/web/components/agent/trust-score-breakdown.tsx
@@ -84,66 +84,66 @@ interface TrustScoreHistory {
 const factorMetadata = {
   verificationStatus: {
     icon: Shield,
-    label: 'Verification Status',
+    label: 'Verification status',
     description: 'Ed25519 signature verification for all actions',
-    color: 'text-blue-600',
-    bgColor: 'bg-blue-500/10',
+    color: 'text-brand-text',
+    bgColor: 'bg-brand-soft',
   },
   uptime: {
     icon: Activity,
-    label: 'Uptime & Availability',
+    label: 'Uptime & availability',
     description: 'Health check responsiveness over time',
-    color: 'text-green-600',
-    bgColor: 'bg-green-500/10',
+    color: 'text-success-text',
+    bgColor: 'bg-success-fill',
   },
   successRate: {
     icon: CheckCircle,
-    label: 'Action Success Rate',
+    label: 'Action success rate',
     description: 'Percentage of actions that complete successfully',
-    color: 'text-emerald-600',
-    bgColor: 'bg-emerald-500/10',
+    color: 'text-success-text',
+    bgColor: 'bg-success-fill',
   },
   securityAlerts: {
     icon: AlertTriangle,
-    label: 'Security Alerts',
+    label: 'Security alerts',
     description: 'Active security alerts by severity (critical, high, medium, low)',
-    color: 'text-orange-600',
-    bgColor: 'bg-orange-500/10',
+    color: 'text-warning-text',
+    bgColor: 'bg-warning-fill',
   },
   compliance: {
     icon: FileCheck,
-    label: 'Compliance Score',
+    label: 'Compliance score',
     description: 'SOC 2, HIPAA, GDPR adherence',
-    color: 'text-purple-600',
-    bgColor: 'bg-purple-500/10',
+    color: 'text-brand-text',
+    bgColor: 'bg-brand-soft',
   },
   age: {
     icon: Clock,
-    label: 'Age & History',
+    label: 'Age & history',
     description: 'How long agent has been operating successfully (<7d, 7-30d, 30-90d, 90d+)',
-    color: 'text-cyan-600',
-    bgColor: 'bg-cyan-500/10',
+    color: 'text-ink-secondary',
+    bgColor: 'bg-glass-inset-gray',
   },
   driftDetection: {
     icon: TrendingUp,
-    label: 'Drift Detection',
+    label: 'Drift detection',
     description: 'Behavioral pattern changes and anomaly detection',
-    color: 'text-indigo-600',
-    bgColor: 'bg-indigo-500/10',
+    color: 'text-brand-text',
+    bgColor: 'bg-brand-soft',
   },
   userFeedback: {
     icon: ThumbsUp,
-    label: 'User Feedback',
+    label: 'User feedback',
     description: 'Explicit user ratings and feedback',
-    color: 'text-pink-600',
-    bgColor: 'bg-pink-500/10',
+    color: 'text-ink-secondary',
+    bgColor: 'bg-glass-inset-gray',
   },
   executionIsolation: {
     icon: Box,
-    label: 'Execution Isolation',
+    label: 'Execution isolation',
     description: 'Self-reported runtime isolation posture (sandbox, network, filesystem, process). Defaults to a low baseline until the agent reports it.',
-    color: 'text-teal-600',
-    bgColor: 'bg-teal-500/10',
+    color: 'text-brand-text',
+    bgColor: 'bg-brand-soft',
   },
 };
 
@@ -153,10 +153,10 @@ const factorMetadata = {
 // shipped server-side before this map was updated).
 const fallbackFactorMetadata = {
   icon: Shield,
-  label: 'Trust Factor',
+  label: 'Trust factor',
   description: 'Contributing trust factor',
-  color: 'text-gray-600',
-  bgColor: 'bg-gray-500/10',
+  color: 'text-ink-secondary',
+  bgColor: 'bg-glass-inset-gray',
 } as const;
 
 export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScoreUpdate }: TrustScoreBreakdownProps) {
@@ -205,22 +205,22 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
   }, [agentId]);
 
   const getScoreColor = (score: number): string => {
-    if (score >= 0.95) return 'text-green-600';
-    if (score >= 0.75) return 'text-yellow-600';
-    return 'text-red-600';
+    if (score >= 0.95) return 'text-success-text';
+    if (score >= 0.75) return 'text-warning-text';
+    return 'text-danger-text';
   };
 
   const getProgressColor = (score: number): string => {
-    if (score >= 0.95) return 'bg-green-600';
-    if (score >= 0.75) return 'bg-yellow-600';
-    return 'bg-red-600';
+    if (score >= 0.95) return 'bg-success';
+    if (score >= 0.75) return 'bg-warning';
+    return 'bg-danger';
   };
 
   if (loading) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Trust Score Breakdown</CardTitle>
+          <CardTitle>Trust score breakdown</CardTitle>
           <CardDescription>Loading trust score analysis...</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -239,11 +239,11 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Trust Score Breakdown</CardTitle>
+          <CardTitle>Trust score breakdown</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-center py-8 text-muted-foreground">
-            <AlertTriangle className="h-12 w-12 mx-auto mb-3 text-yellow-600" />
+          <div className="text-center py-8 text-ink-secondary">
+            <AlertTriangle className="h-12 w-12 mx-auto mb-3 text-warning-text" />
             <p>{error || 'No trust score data available'}</p>
           </div>
         </CardContent>
@@ -257,7 +257,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
         {/* Overall Score Card */}
         <Card>
           <CardHeader>
-            <CardTitle>Overall Trust Score</CardTitle>
+            <CardTitle>Overall trust score</CardTitle>
             <CardDescription>
               Weighted average of 9 behavioral and security factors
             </CardDescription>
@@ -268,11 +268,11 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                 <div className={`text-4xl font-bold ${getScoreColor(breakdown.overall)}`}>
                   {(breakdown.overall * 100).toFixed(1)}%
                 </div>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="text-sm text-ink-secondary mt-1">
                   Confidence: {(breakdown.confidence * 100).toFixed(1)}%
                 </p>
               </div>
-              <div className="text-right text-sm text-muted-foreground">
+              <div className="text-right text-sm text-ink-secondary">
                 <p>Last calculated:</p>
                 <p>{new Date(breakdown.calculatedAt).toLocaleString()}</p>
               </div>
@@ -287,7 +287,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
         {/* Individual Factors */}
         <Card>
           <CardHeader>
-            <CardTitle>Factor Breakdown</CardTitle>
+            <CardTitle>Factor breakdown</CardTitle>
             <CardDescription>
               Individual components contributing to the overall trust score
             </CardDescription>
@@ -300,18 +300,18 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
               const contribution = breakdown.contributions[key as keyof typeof breakdown.contributions];
 
               return (
-                <div key={key} className="group p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 transition-all">
+                <div key={key} className="group p-4 rounded-panel border border-divider hover:border-brand transition-all">
                   <div className="flex items-start justify-between mb-3">
                     <div className="flex items-start gap-3 flex-1">
-                      <div className={`p-2.5 rounded-lg ${metadata.bgColor} transition-transform group-hover:scale-110`}>
+                      <div className={`p-2.5 rounded-inset-sm ${metadata.bgColor} transition-transform group-hover:scale-110`}>
                         <Icon className={`h-5 w-5 ${metadata.color}`} />
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="font-semibold text-base">{metadata.label}</span>
+                          <span className="font-semibold text-base text-ink">{metadata.label}</span>
                           <Tooltip>
                             <TooltipTrigger>
-                              <Info className="h-3.5 w-3.5 text-muted-foreground hover:text-blue-600 transition-colors" />
+                              <Info className="h-3.5 w-3.5 text-ink-tertiary hover:text-brand-text transition-colors" />
                             </TooltipTrigger>
                             <TooltipContent side="top" className="max-w-xs">
                               <p>{metadata.description}</p>
@@ -322,14 +322,14 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                         {/* Visual weight and contribution indicators */}
                         <div className="flex items-center gap-4 mt-2">
                           <div className="flex items-center gap-1.5">
-                            <div className="text-xs font-medium text-gray-500 dark:text-gray-400">Weight</div>
-                            <div className="px-2 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-xs font-semibold text-gray-700 dark:text-gray-300">
+                            <div className="text-xs font-medium text-ink-tertiary">Weight</div>
+                            <div className="px-2 py-0.5 rounded-md bg-glass-inset-gray text-xs font-semibold text-ink-body">
                               {(weight * 100).toFixed(0)}%
                             </div>
                           </div>
                           <div className="flex items-center gap-1.5">
-                            <div className="text-xs font-medium text-gray-500 dark:text-gray-400">Impact</div>
-                            <div className="px-2 py-0.5 rounded-md bg-blue-50 dark:bg-blue-950 text-xs font-semibold text-blue-700 dark:text-blue-300">
+                            <div className="text-xs font-medium text-ink-tertiary">Impact</div>
+                            <div className="px-2 py-0.5 rounded-md bg-brand-soft text-xs font-semibold text-brand-text">
                               +{(contribution * 100).toFixed(1)}%
                             </div>
                           </div>
@@ -342,7 +342,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                       <div className={`text-2xl font-bold ${getScoreColor(value)}`}>
                         {(value * 100).toFixed(1)}%
                       </div>
-                      <div className="text-xs text-muted-foreground mt-0.5">
+                      <div className="text-xs text-ink-tertiary mt-0.5">
                         score
                       </div>
                     </div>
@@ -350,12 +350,12 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
 
                   {/* Progress bar with gradient */}
                   <div className="relative">
-                    <div className="h-2.5 w-full bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                    <div className="h-2.5 w-full bg-track rounded-full overflow-hidden">
                       <div
                         className={`h-full rounded-full transition-all ${
-                          value >= 0.95 ? 'bg-gradient-to-r from-green-500 to-green-600' :
-                          value >= 0.75 ? 'bg-gradient-to-r from-yellow-500 to-yellow-600' :
-                          'bg-gradient-to-r from-red-500 to-red-600'
+                          value >= 0.95 ? 'bg-success' :
+                          value >= 0.75 ? 'bg-warning' :
+                          'bg-danger'
                         }`}
                         style={{ width: `${value * 100}%` }}
                       />
@@ -372,7 +372,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <History className="h-5 w-5" />
-              Trust Score History
+              Trust score history
             </CardTitle>
             <CardDescription>
               Historical changes in trust score over time
@@ -384,7 +384,7 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                 <Skeleton className="h-64 w-full" />
               </div>
             ) : historyError || !history || history.history.length === 0 ? (
-              <div className="text-center py-12 text-muted-foreground">
+              <div className="text-center py-12 text-ink-secondary">
                 <History className="h-12 w-12 mx-auto mb-3 opacity-50" />
                 <p>{historyError || 'No historical data available yet'}</p>
                 <p className="text-xs mt-2">Trust score changes will appear here over time</p>
@@ -404,30 +404,32 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                       }))}
                       margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
                     >
-                      <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--divider)" />
                       <XAxis
                         dataKey="timestamp"
-                        className="text-xs text-muted-foreground"
+                        stroke="var(--stroke)"
+                        tick={{ fill: 'var(--text-tertiary)', fontSize: 11 }}
                       />
                       <YAxis
                         domain={[0, 100]}
-                        className="text-xs text-muted-foreground"
-                        label={{ value: 'Trust Score (%)', angle: -90, position: 'insideLeft' }}
+                        stroke="var(--stroke)"
+                        tick={{ fill: 'var(--text-tertiary)', fontSize: 11 }}
+                        label={{ value: 'Trust score (%)', angle: -90, position: 'insideLeft', fill: 'var(--text-tertiary)', fontSize: 11 }}
                       />
                       <RechartsTooltip
                         content={({ active, payload }: { active?: boolean; payload?: any[] }) => {
                           if (active && payload && payload.length) {
                             const data = payload[0].payload;
                             return (
-                              <div className="bg-white dark:bg-gray-800 p-3 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
+                              <div className="glass p-3 text-ink">
                                 <p className="font-semibold">{data.fullTimestamp}</p>
                                 <p className="text-sm mt-1">
                                   Score: <span className="font-semibold">{data.score}%</span>
                                 </p>
-                                <p className="text-xs text-muted-foreground mt-1">
+                                <p className="text-xs text-ink-secondary mt-1">
                                   Reason: {data.reason}
                                 </p>
-                                <p className="text-xs text-muted-foreground">
+                                <p className="text-xs text-ink-secondary">
                                   By: {data.changedBy}
                                 </p>
                               </div>
@@ -440,40 +442,40 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                       <Line
                         type="monotone"
                         dataKey="score"
-                        stroke="#3b82f6"
+                        stroke="var(--brand)"
                         strokeWidth={2}
                         dot={{ r: 4 }}
                         activeDot={{ r: 6 }}
-                        name="Trust Score (%)"
+                        name="Trust score (%)"
                       />
                     </LineChart>
                   </ResponsiveContainer>
                 </div>
 
                 {/* History Table */}
-                <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                <div className="border border-divider rounded-panel overflow-hidden">
                   <div className="max-h-96 overflow-y-auto">
                     <table className="w-full">
-                      <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0">
+                      <thead className="bg-glass-inset-gray sticky top-0">
                         <tr>
-                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                            Date & Time
+                          <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                            Date & time
                           </th>
-                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                            Trust Score
+                          <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                            Trust score
                           </th>
-                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                          <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                             Reason
                           </th>
-                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                            Changed By
+                          <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                            Changed by
                           </th>
                         </tr>
                       </thead>
-                      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+                      <tbody className="divide-y divide-divider">
                         {history.history.map((entry, index) => (
-                          <tr key={index} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                            <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                          <tr key={index} className="hover:bg-glass-inset-gray">
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-ink">
                               {new Date(entry.timestamp).toLocaleString()}
                             </td>
                             <td className="px-4 py-3 whitespace-nowrap">
@@ -481,10 +483,10 @@ export function TrustScoreBreakdown({ agentId, userRole = "viewer", onTrustScore
                                 {(entry.trustScore * 100).toFixed(1)}%
                               </span>
                             </td>
-                            <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                            <td className="px-4 py-3 text-sm text-ink-secondary">
                               {entry.reason}
                             </td>
-                            <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-ink-secondary">
                               {entry.changedBy}
                             </td>
                           </tr>

--- a/apps/web/components/alerts/alert-detail-panel.tsx
+++ b/apps/web/components/alerts/alert-detail-panel.tsx
@@ -49,12 +49,12 @@ interface AlertDetailPanelProps {
 }
 
 const severityColors: Record<string, string> = {
-  low: "bg-gray-100 text-gray-800 border-gray-300",
-  info: "bg-blue-100 text-blue-800 border-blue-300",
-  medium: "bg-yellow-100 text-yellow-800 border-yellow-300",
-  warning: "bg-yellow-100 text-yellow-800 border-yellow-300",
-  high: "bg-orange-100 text-orange-800 border-orange-300",
-  critical: "bg-red-100 text-red-800 border-red-300",
+  low: "border-glass-inset-border bg-glass-inset-gray text-ink-body",
+  info: "border-transparent bg-brand-soft text-brand-text",
+  medium: "border-warning-border bg-warning-fill text-warning-text",
+  warning: "border-warning-border bg-warning-fill text-warning-text",
+  high: "border-danger-border bg-danger-fill text-danger-text",
+  critical: "border-danger-strong bg-danger-fill text-danger-text font-bold",
 };
 
 interface VerificationEvent {
@@ -211,14 +211,14 @@ export function AlertDetailPanel({
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/20 z-40 transition-opacity"
+        className="fixed inset-0 z-40 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm transition-opacity"
         onClick={onClose}
       />
 
       {/* Panel */}
-      <div className="fixed right-0 top-0 h-full w-full max-w-xl bg-white shadow-2xl z-50 overflow-y-auto animate-in slide-in-from-right duration-200">
+      <div className="fixed right-0 top-0 h-full w-full max-w-xl bg-glass-chrome border-l border-glass-chrome-border shadow-chrome backdrop-blur-chrome z-50 overflow-y-auto animate-in slide-in-from-right duration-200">
         {/* Header */}
-        <div className="sticky top-0 bg-white border-b px-6 py-4 flex items-start justify-between">
+        <div className="sticky top-0 bg-glass-chrome backdrop-blur-chrome border-b border-divider px-6 py-4 flex items-start justify-between">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <Badge
@@ -231,7 +231,7 @@ export function AlertDetailPanel({
                 {alert.alertType.replace(/_/g, " ")}
               </Badge>
             </div>
-            <h2 className="text-lg font-semibold truncate">{alert.title}</h2>
+            <h2 className="text-lg font-semibold text-ink truncate">{alert.title}</h2>
           </div>
           <Button variant="ghost" size="icon" onClick={onClose} className="ml-2">
             <X className="h-5 w-5" />
@@ -242,19 +242,19 @@ export function AlertDetailPanel({
         <div className="p-6 space-y-6">
           {/* Agent Info */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-ink-tertiary uppercase tracking-wide flex items-center gap-2">
               <User className="h-4 w-4" />
-              Agent Information
+              Agent information
             </h3>
-            <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+            <div className="bg-glass-inset-gray rounded-inset p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Agent Name</span>
-                <span className="font-medium">{alert.agentName || "Unknown"}</span>
+                <span className="text-sm text-ink-secondary">Agent name</span>
+                <span className="font-medium text-ink">{alert.agentName || "Unknown"}</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Agent ID</span>
+                <span className="text-sm text-ink-secondary">Agent ID</span>
                 <div className="flex items-center gap-2">
-                  <code className="text-xs bg-gray-200 px-2 py-1 rounded font-mono">
+                  <code className="text-xs bg-glass-inset-gray text-ink px-2 py-1 rounded font-mono">
                     {alert.resourceId}
                   </code>
                   <Button
@@ -264,7 +264,7 @@ export function AlertDetailPanel({
                     onClick={() => copyToClipboard(alert.resourceId, "agentId")}
                   >
                     {copiedField === "agentId" ? (
-                      <Check className="h-3 w-3 text-green-600" />
+                      <Check className="h-3 w-3 text-success-text" />
                     ) : (
                       <Copy className="h-3 w-3" />
                     )}
@@ -274,8 +274,8 @@ export function AlertDetailPanel({
               {/* Show current trust score (freshly fetched) */}
               {currentTrustScore !== null && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Current Trust Score</span>
-                  <span className="font-medium">
+                  <span className="text-sm text-ink-secondary">Current trust score</span>
+                  <span className="font-medium text-ink">
                     {(currentTrustScore * 100).toFixed(1)}%
                   </span>
                 </div>
@@ -284,8 +284,8 @@ export function AlertDetailPanel({
               {metadata.trustScore !== undefined && currentTrustScore !== null &&
                Math.abs((metadata.trustScore * 100) - (currentTrustScore * 100)) > 1 && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Trust Score at Alert Time</span>
-                  <span className="font-medium text-gray-500">
+                  <span className="text-sm text-ink-secondary">Trust score at alert time</span>
+                  <span className="font-medium text-ink-tertiary">
                     {(metadata.trustScore * 100).toFixed(0)}%
                   </span>
                 </div>
@@ -293,8 +293,8 @@ export function AlertDetailPanel({
               {/* Fallback: show historical score if current couldn't be fetched */}
               {metadata.trustScore !== undefined && currentTrustScore === null && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Trust Score at Alert Time</span>
-                  <span className="font-medium">
+                  <span className="text-sm text-ink-secondary">Trust score at alert time</span>
+                  <span className="font-medium text-ink">
                     {(metadata.trustScore * 100).toFixed(0)}%
                   </span>
                 </div>
@@ -303,11 +303,11 @@ export function AlertDetailPanel({
               {/* Creator Info */}
               {agentDetails?.createdByName && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Created By</span>
-                  <span className="font-medium">
+                  <span className="text-sm text-ink-secondary">Created by</span>
+                  <span className="font-medium text-ink">
                     {agentDetails.createdByName}
                     {agentDetails.createdByEmail && (
-                      <span className="text-gray-500 text-xs ml-1">({agentDetails.createdByEmail})</span>
+                      <span className="text-ink-tertiary text-xs ml-1">({agentDetails.createdByEmail})</span>
                     )}
                   </span>
                 </div>
@@ -316,27 +316,27 @@ export function AlertDetailPanel({
               {/* SDK Token Info */}
               {agentDetails?.createdBySdkTokenId && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">SDK Token</span>
+                  <span className="text-sm text-ink-secondary">SDK token</span>
                   <div className="flex items-center gap-2">
                     <Link
                       href={`/dashboard/sdk-tokens?highlight=${agentDetails.createdBySdkTokenId}`}
-                      className="text-xs text-primary hover:underline flex items-center gap-1"
+                      className="text-xs text-brand-text hover:underline flex items-center gap-1"
                     >
                       <KeyRound className="h-3 w-3" />
-                      View Token
+                      View token
                     </Link>
                     {!revokeSuccess ? (
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-6 text-xs text-red-600 hover:text-red-700 hover:bg-red-50 px-2"
+                        className="h-6 text-xs text-danger-text hover:bg-danger-fill px-2"
                         onClick={() => setShowRevokeConfirm(true)}
                       >
                         <Ban className="h-3 w-3 mr-1" />
                         Revoke
                       </Button>
                     ) : (
-                      <Badge variant="outline" className="text-xs text-green-600 border-green-300">
+                      <Badge variant="outline" className="text-xs text-success-text border-success-border">
                         <Check className="h-3 w-3 mr-1" />
                         Revoked
                       </Badge>
@@ -350,14 +350,14 @@ export function AlertDetailPanel({
           {/* SDK Token Revoke Confirmation */}
           {showRevokeConfirm && agentDetails?.createdBySdkTokenId && (
             <section className="space-y-3">
-              <div className="p-4 bg-red-50 rounded-lg border border-red-200">
+              <div className="glass-alert p-4">
                 <div className="flex items-start gap-3">
-                  <Ban className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
+                  <Ban className="h-5 w-5 text-danger-text flex-shrink-0 mt-0.5" />
                   <div className="flex-1">
-                    <h4 className="text-sm font-medium text-red-900 mb-1">
-                      Confirm SDK Token Revocation
+                    <h4 className="text-sm font-medium text-danger-text mb-1">
+                      Confirm SDK token revocation
                     </h4>
-                    <p className="text-xs text-red-800 mb-3">
+                    <p className="text-xs text-danger-text mb-3">
                       This will immediately revoke the SDK token used to create this agent.
                       Any applications using this token will no longer be able to authenticate.
                     </p>
@@ -377,7 +377,7 @@ export function AlertDetailPanel({
                         ) : (
                           <>
                             <Ban className="h-3 w-3 mr-1" />
-                            Yes, Revoke Token
+                            Yes, revoke token
                           </>
                         )}
                       </Button>
@@ -398,36 +398,36 @@ export function AlertDetailPanel({
 
           {/* Alert Details */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-ink-tertiary uppercase tracking-wide flex items-center gap-2">
               <AlertTriangle className="h-4 w-4" />
-              Alert Details
+              Alert details
             </h3>
-            <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+            <div className="bg-glass-inset-gray rounded-inset p-4 space-y-3">
               <div>
-                <span className="text-sm text-gray-600">Description</span>
-                <p className="mt-1 text-sm">{alert.description}</p>
+                <span className="text-sm text-ink-secondary">Description</span>
+                <p className="mt-1 text-sm text-ink-body">{alert.description}</p>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Created</span>
-                <span className="text-sm">{formatDateTime(alert.createdAt)}</span>
+                <span className="text-sm text-ink-secondary">Created</span>
+                <span className="text-sm text-ink">{formatDateTime(alert.createdAt)}</span>
               </div>
               {alert.isAcknowledged && alert.acknowledgedAt && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Acknowledged</span>
-                  <span className="text-sm text-green-600">
+                  <span className="text-sm text-ink-secondary">Acknowledged</span>
+                  <span className="text-sm text-success-text">
                     {formatDateTime(alert.acknowledgedAt)}
                   </span>
                 </div>
               )}
               {metadata.policyName && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Policy</span>
+                  <span className="text-sm text-ink-secondary">Policy</span>
                   <Badge variant="outline">{metadata.policyName}</Badge>
                 </div>
               )}
               {metadata.enforcement && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-gray-600">Enforcement</span>
+                  <span className="text-sm text-ink-secondary">Enforcement</span>
                   <Badge
                     variant={metadata.isBlocked ? "destructive" : "secondary"}
                   >
@@ -440,21 +440,21 @@ export function AlertDetailPanel({
 
           {/* Verification History */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-ink-tertiary uppercase tracking-wide flex items-center gap-2">
               <Clock className="h-4 w-4" />
-              Verification History
+              Verification history
             </h3>
 
             {loadingData ? (
-              <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+              <div className="bg-glass-inset-gray rounded-inset p-4 space-y-3">
                 <Skeleton className="h-4 w-full" />
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-4 w-1/2" />
               </div>
             ) : verificationHistory.length > 0 ? (
-              <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+              <div className="bg-glass-inset-gray rounded-inset p-4 space-y-3">
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm text-gray-600">Recent Verifications</span>
+                  <span className="text-sm text-ink-secondary">Recent verifications</span>
                   <Badge variant="outline" className="text-xs">
                     {verificationHistory.length} events
                   </Badge>
@@ -467,12 +467,12 @@ export function AlertDetailPanel({
                     return (
                       <div
                         key={event.id}
-                        className={`p-3 rounded-lg border ${
+                        className={`p-3 rounded-inset border ${
                           isDenied
-                            ? "bg-red-50 border-red-200"
+                            ? "bg-danger-fill border-danger-border"
                             : isSuccess
-                            ? "bg-green-50 border-green-200"
-                            : "bg-gray-50 border-gray-200"
+                            ? "bg-success-fill border-success-border"
+                            : "bg-glass-inset-gray border-stroke"
                         }`}
                       >
                         <div className="flex items-center justify-between mb-1">
@@ -483,11 +483,11 @@ export function AlertDetailPanel({
                             >
                               {isDenied ? "DENIED" : isSuccess ? "ALLOWED" : event.status.toUpperCase()}
                             </Badge>
-                            <span className="text-xs font-medium text-gray-600">
+                            <span className="text-xs font-medium text-ink-secondary">
                               {event.verificationType}
                             </span>
                           </div>
-                          <span className="text-xs text-gray-400">
+                          <span className="text-xs text-ink-tertiary">
                             {formatDateTime(event.createdAt)}
                           </span>
                         </div>
@@ -495,17 +495,17 @@ export function AlertDetailPanel({
                         {(event.action || event.resource) && (
                           <div className="mt-2 space-y-1">
                             {event.action && (
-                              <p className="text-sm text-gray-700">
-                                <span className="text-gray-500">Capability:</span>{" "}
-                                <code className="text-xs bg-white px-1.5 py-0.5 rounded border">
+                              <p className="text-sm text-ink-body">
+                                <span className="text-ink-tertiary">Capability:</span>{" "}
+                                <code className="text-xs bg-glass text-ink px-1.5 py-0.5 rounded border border-stroke">
                                   {event.action}
                                 </code>
                               </p>
                             )}
                             {event.resource && (
-                              <p className="text-sm text-gray-700">
-                                <span className="text-gray-500">Resource:</span>{" "}
-                                <code className="text-xs bg-white px-1.5 py-0.5 rounded border">
+                              <p className="text-sm text-ink-body">
+                                <span className="text-ink-tertiary">Resource:</span>{" "}
+                                <code className="text-xs bg-glass text-ink px-1.5 py-0.5 rounded border border-stroke">
                                   {event.resource}
                                 </code>
                               </p>
@@ -514,7 +514,7 @@ export function AlertDetailPanel({
                         )}
 
                         {isDenied && event.reason && (
-                          <p className="text-sm text-red-600 mt-2">
+                          <p className="text-sm text-danger-text mt-2">
                             <span className="font-medium">Denied:</span> {event.reason}
                           </p>
                         )}
@@ -538,12 +538,12 @@ export function AlertDetailPanel({
                           execution-outcome follow-up.
                         */}
                         {event.executed !== undefined && (
-                          <div className={`mt-2 p-2 rounded text-xs ${
+                          <div className={`mt-2 p-2 rounded-inset-sm text-xs ${
                             event.executed
                               ? isDenied
-                                ? "bg-yellow-50 border border-yellow-200 text-yellow-700"
-                                : "bg-green-50 border border-green-200 text-green-700"
-                              : "bg-gray-50 border border-gray-200 text-gray-700"
+                                ? "bg-warning-fill border border-warning-border text-warning-text"
+                                : "bg-success-fill border border-success-border text-success-text"
+                              : "bg-glass-inset-gray border border-stroke text-ink-body"
                           }`}>
                             <span className="font-medium">
                               {event.executed ? (
@@ -556,7 +556,7 @@ export function AlertDetailPanel({
                                 "Agent reported: action not executed"
                               )}
                             </span>
-                            <p className="mt-1 text-gray-500">
+                            <p className="mt-1 text-ink-secondary">
                               Self-reported by the agent. AIM does not independently observe
                               execution, so this is not a record of enforcement.
                               {event.strictMode !== undefined && (
@@ -565,12 +565,12 @@ export function AlertDetailPanel({
                               )}
                             </p>
                             {event.executionError && (
-                              <p className="mt-1 text-red-600">Reported error: {event.executionError}</p>
+                              <p className="mt-1 text-danger-text">Reported error: {event.executionError}</p>
                             )}
                           </div>
                         )}
 
-                        <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                        <div className="flex items-center gap-4 mt-2 text-xs text-ink-tertiary">
                           <span>Trust: {(event.trustScore * 100).toFixed(0)}%</span>
                           {event.durationMs > 0 && <span>{event.durationMs}ms</span>}
                           {event.initiatorIp && <span>IP: {event.initiatorIp}</span>}
@@ -581,8 +581,8 @@ export function AlertDetailPanel({
                 </div>
               </div>
             ) : (
-              <div className="bg-gray-50 rounded-lg p-4">
-                <p className="text-sm text-gray-500">
+              <div className="bg-glass-inset-gray rounded-inset p-4">
+                <p className="text-sm text-ink-secondary">
                   No verification events recorded for this agent.
                 </p>
               </div>
@@ -597,17 +597,17 @@ export function AlertDetailPanel({
             if (contextEntries.length === 0) return null;
             return (
               <section className="space-y-3">
-                <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-ink-tertiary uppercase tracking-wide flex items-center gap-2">
                   <Shield className="h-4 w-4" />
                   Context
                 </h3>
-                <div className="bg-gray-50 rounded-lg p-4 space-y-2">
+                <div className="bg-glass-inset-gray rounded-inset p-4 space-y-2">
                   {contextEntries.map(([key, value]) => (
                     <div key={key} className="flex items-center justify-between">
-                      <span className="text-sm text-gray-600 capitalize">
+                      <span className="text-sm text-ink-secondary capitalize">
                         {key.replace(/([A-Z])/g, " $1").trim()}
                       </span>
-                      <span className="text-sm font-medium">
+                      <span className="text-sm font-medium text-ink">
                         {typeof value === "object" ? JSON.stringify(value) : String(value)}
                       </span>
                     </div>
@@ -619,7 +619,7 @@ export function AlertDetailPanel({
         </div>
 
         {/* Footer Actions */}
-        <div className="sticky bottom-0 bg-white border-t px-6 py-4 flex gap-3">
+        <div className="sticky bottom-0 bg-glass-chrome backdrop-blur-chrome border-t border-divider px-6 py-4 flex gap-3">
           {!alert.isAcknowledged ? (
             <Button
               className="flex-1"
@@ -630,7 +630,7 @@ export function AlertDetailPanel({
           ) : (
             <Button
               variant="outline"
-              className="flex-1 border-green-500 text-green-600 hover:bg-green-50"
+              className="flex-1 border-success-border text-success-text hover:bg-success-fill"
               onClick={() => onResolve(alert.id)}
             >
               Resolve
@@ -639,7 +639,7 @@ export function AlertDetailPanel({
           <Link href={`/dashboard/agents/${alert.resourceId}`} className="flex-1">
             <Button variant="outline" className="w-full">
               <ExternalLink className="h-4 w-4 mr-2" />
-              View Agent
+              View agent
             </Button>
           </Link>
         </div>

--- a/apps/web/components/analytics/activity-timeline.tsx
+++ b/apps/web/components/analytics/activity-timeline.tsx
@@ -78,27 +78,27 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'success':
-        return <CheckCircle className="h-5 w-5 text-green-600" />;
+        return <CheckCircle className="h-5 w-5 text-success-text" />;
       case 'failure':
-        return <XCircle className="h-5 w-5 text-red-600" />;
+        return <XCircle className="h-5 w-5 text-danger-text" />;
       case 'pending':
-        return <Clock className="h-5 w-5 text-yellow-600" />;
+        return <Clock className="h-5 w-5 text-warning-text" />;
       default:
-        return <Activity className="h-5 w-5 text-gray-600" />;
+        return <Activity className="h-5 w-5 text-ink-secondary" />;
     }
   };
 
   const getStatusBadge = (status: string) => {
     const variants = {
-      success: 'bg-green-100 text-green-800 border-green-200',
-      failure: 'bg-red-100 text-red-800 border-red-200',
-      pending: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+      success: 'bg-success-fill text-success-text border-success-border',
+      failure: 'bg-danger-fill text-danger-text border-danger-border',
+      pending: 'bg-warning-fill text-warning-text border-warning-border',
     };
 
     return (
       <Badge
         variant="outline"
-        className={variants[status as keyof typeof variants] || 'bg-gray-100 text-gray-800'}
+        className={variants[status as keyof typeof variants] || 'bg-glass-inset-gray text-ink-body border-stroke'}
       >
         {status}
       </Badge>
@@ -109,7 +109,7 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Agent Activity Timeline</CardTitle>
+          <CardTitle>Agent activity timeline</CardTitle>
           <CardDescription>Loading activity data...</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -131,15 +131,15 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Agent Activity Timeline</CardTitle>
+          <CardTitle>Agent activity timeline</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-center py-8 text-muted-foreground">
-            <AlertCircle className="h-12 w-12 mx-auto mb-3 text-yellow-600" />
+          <div className="text-center py-8 text-ink-secondary">
+            <AlertCircle className="h-12 w-12 mx-auto mb-3 text-warning-text" />
             <p>{error || 'No activity data available'}</p>
             <Button onClick={handleRefresh} className="mt-4" variant="outline">
               <RefreshCw className="h-4 w-4 mr-2" />
-              Try Again
+              Try again
             </Button>
           </div>
         </CardContent>
@@ -151,8 +151,8 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-          Agent Activity Timeline
+        <h2 className="text-2xl font-semibold tracking-[-0.02em] text-ink">
+          Agent activity timeline
         </h2>
         <Button
           variant="outline"
@@ -177,18 +177,18 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
       {/* Summary Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
         {/* Total Activities */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="glass p-6">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <Activity className="h-6 w-6 text-gray-400" />
+              <Activity className="h-6 w-6 text-ink-tertiary" />
             </div>
             <div className="ml-5 w-0 flex-1">
               <dl>
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                  Total Activities
+                <dt className="text-sm font-medium text-ink-secondary truncate">
+                  Total activities
                 </dt>
                 <dd className="flex items-baseline">
-                  <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                  <div className="text-2xl font-semibold text-ink">
                     {data.summary.totalActivities}
                   </div>
                 </dd>
@@ -198,18 +198,18 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
         </div>
 
         {/* Successful */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="glass p-6">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <CheckCircle className="h-6 w-6 text-green-600" />
+              <CheckCircle className="h-6 w-6 text-success-text" />
             </div>
             <div className="ml-5 w-0 flex-1">
               <dl>
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                <dt className="text-sm font-medium text-ink-secondary truncate">
                   Successful
                 </dt>
                 <dd className="flex items-baseline">
-                  <div className="text-2xl font-semibold text-green-600">
+                  <div className="text-2xl font-semibold text-success-text">
                     {data.summary.successCount}
                   </div>
                 </dd>
@@ -219,18 +219,18 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
         </div>
 
         {/* Failed */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="glass p-6">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <XCircle className="h-6 w-6 text-red-600" />
+              <XCircle className="h-6 w-6 text-danger-text" />
             </div>
             <div className="ml-5 w-0 flex-1">
               <dl>
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                <dt className="text-sm font-medium text-ink-secondary truncate">
                   Failed
                 </dt>
                 <dd className="flex items-baseline">
-                  <div className="text-2xl font-semibold text-red-600">
+                  <div className="text-2xl font-semibold text-danger-text">
                     {data.summary.failureCount}
                   </div>
                 </dd>
@@ -240,18 +240,18 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
         </div>
 
         {/* Success Rate */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="glass p-6">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <TrendingUp className="h-6 w-6 text-gray-400" />
+              <TrendingUp className="h-6 w-6 text-ink-tertiary" />
             </div>
             <div className="ml-5 w-0 flex-1">
               <dl>
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                  Success Rate
+                <dt className="text-sm font-medium text-ink-secondary truncate">
+                  Success rate
                 </dt>
                 <dd className="flex items-baseline">
-                  <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                  <div className="text-2xl font-semibold text-ink">
                     {data.summary.successRate.toFixed(1)}%
                   </div>
                 </dd>
@@ -262,13 +262,13 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
       </div>
 
       {/* Timeline */}
-      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
-        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-          Recent Activity
+      <div className="glass p-6">
+        <h3 className="text-lg font-medium text-ink mb-4">
+          Recent activity
         </h3>
         {data.activities.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-            <Activity className="h-12 w-12 mx-auto mb-3 text-gray-400" />
+          <div className="text-center py-8 text-ink-secondary">
+            <Activity className="h-12 w-12 mx-auto mb-3 text-ink-tertiary" />
             <p>No activities recorded yet</p>
           </div>
         ) : (
@@ -277,7 +277,7 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
               <Link
                 key={`${activity.agentId}-${activity.timestamp}-${index}`}
                 href={`/dashboard/agents/${activity.agentId}`}
-                className="flex gap-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors cursor-pointer group"
+                className="flex gap-4 p-4 rounded-inset border border-divider bg-glass-inset-gray hover:bg-brand-soft hover:border-brand-text/30 transition-colors cursor-pointer group"
               >
                 {/* Status Icon */}
                 <div className="flex-shrink-0 mt-1">
@@ -288,31 +288,31 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-start justify-between gap-4 mb-1">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-semibold text-sm text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      <span className="font-semibold text-sm text-ink group-hover:text-brand-text transition-colors">
                         {activity.agentName}
                       </span>
-                      <span className="text-sm text-gray-600 dark:text-gray-400">
+                      <span className="text-sm text-ink-body">
                         {activity.action}
                       </span>
                       {getStatusBadge(activity.status)}
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      <span className="text-xs text-ink-secondary whitespace-nowrap">
                         {formatDistanceToNow(new Date(activity.timestamp), {
                           addSuffix: true,
                         })}
                       </span>
-                      <ExternalLink className="h-3 w-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                      <ExternalLink className="h-3 w-3 text-ink-tertiary opacity-0 group-hover:opacity-100 transition-opacity" />
                     </div>
                   </div>
 
                   {activity.details && (
-                    <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                    <p className="text-xs text-ink-body mt-1">
                       {activity.details}
                     </p>
                   )}
 
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 font-mono">
+                  <div className="text-xs text-ink-secondary mt-1 font-mono">
                     Agent ID: {activity.agentId}
                   </div>
                 </div>
@@ -328,7 +328,7 @@ export function ActivityTimeline({ defaultLimit = 50 }: ActivityTimelineProps) {
               variant="outline"
               onClick={() => setLimit(limit + 50)}
             >
-              Load More Activities
+              Load more activities
             </Button>
           </div>
         )}

--- a/apps/web/components/modals/threat-detail-modal.tsx
+++ b/apps/web/components/modals/threat-detail-modal.tsx
@@ -30,6 +30,7 @@ import Link from "next/link";
 import { formatDateTime } from "@/lib/date-utils";
 import { api, Agent } from "@/lib/api";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 
 interface SecurityThreat {
   id: string;
@@ -63,21 +64,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   malicious_agent: [
     {
       priority: "critical",
-      action: "Revoke SDK Token Immediately",
+      action: "Revoke SDK token immediately",
       description: "Prevent further unauthorized access by revoking the token used to create this agent",
       link: "/dashboard/sdk-tokens",
       icon: Ban,
     },
     {
       priority: "high",
-      action: "Block Agent & Investigate",
+      action: "Block agent & investigate",
       description: "Suspend the agent and review all recent activity for signs of compromise",
       link: "/dashboard/agents/{id}",
       icon: UserX,
     },
     {
       priority: "medium",
-      action: "Review Violation History",
+      action: "Review violation history",
       description: "Check the compliance logs for patterns of malicious behavior",
       link: "/dashboard/admin/compliance",
       icon: FileWarning,
@@ -86,21 +87,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   unauthorized_access: [
     {
       priority: "high",
-      action: "Review Agent Capabilities",
+      action: "Review agent capabilities",
       description: "Compare the attempted action against the agent's registered capabilities",
       link: "/dashboard/agents/{id}",
       icon: Shield,
     },
     {
       priority: "medium",
-      action: "Approve or Deny Capability",
+      action: "Approve or deny capability",
       description: "If legitimate, grant the capability through the requests dashboard",
       link: "/dashboard/admin/capability-requests",
       icon: CheckCircle2,
     },
     {
       priority: "low",
-      action: "Monitor for Patterns",
+      action: "Monitor for patterns",
       description: "Watch for recurring unauthorized access attempts from this agent",
       link: "/dashboard/security",
       icon: Eye,
@@ -109,21 +110,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   configuration_drift: [
     {
       priority: "high",
-      action: "Compare Configurations",
+      action: "Compare configurations",
       description: "Review registered vs detected MCP servers and capabilities",
       link: "/dashboard/agents/{id}",
       icon: RefreshCw,
     },
     {
       priority: "medium",
-      action: "Update Registration",
+      action: "Update registration",
       description: "If drift is legitimate, update the agent's registered configuration",
       link: "/dashboard/agents/{id}",
       icon: Settings,
     },
     {
       priority: "low",
-      action: "Review Drift Policy",
+      action: "Review drift policy",
       description: "Adjust drift detection sensitivity in security policies",
       link: "/dashboard/security/policies",
       icon: FileText,
@@ -132,21 +133,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   suspicious_activity: [
     {
       priority: "high",
-      action: "Review Recent Activity",
+      action: "Review recent activity",
       description: "Examine the agent's recent actions for anomalous patterns",
       link: "/dashboard/agents/{id}",
       icon: Activity,
     },
     {
       priority: "medium",
-      action: "Check Trust Score Trend",
+      action: "Check trust score trend",
       description: "Review how the agent's trust score has changed over time",
       link: "/dashboard/agents/{id}",
       icon: Activity,
     },
     {
       priority: "low",
-      action: "Adjust Monitoring Threshold",
+      action: "Adjust monitoring threshold",
       description: "Fine-tune what qualifies as suspicious activity",
       link: "/dashboard/security/policies",
       icon: Settings,
@@ -155,21 +156,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   credential_leak: [
     {
       priority: "critical",
-      action: "Rotate All Credentials",
+      action: "Rotate all credentials",
       description: "Immediately rotate API keys and tokens associated with this agent",
       link: "/dashboard/sdk-tokens",
       icon: RefreshCw,
     },
     {
       priority: "high",
-      action: "Revoke Compromised Tokens",
+      action: "Revoke compromised tokens",
       description: "Revoke any tokens that may have been exposed",
       link: "/dashboard/sdk-tokens",
       icon: Ban,
     },
     {
       priority: "medium",
-      action: "Audit Access Logs",
+      action: "Audit access logs",
       description: "Review who accessed what with the compromised credentials",
       link: "/dashboard/admin/compliance",
       icon: Database,
@@ -178,21 +179,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
   certificate_expiry: [
     {
       priority: "high",
-      action: "Renew Certificate",
+      action: "Renew certificate",
       description: "Generate and deploy a new certificate before expiration",
       link: "/dashboard/agents/{id}",
       icon: RefreshCw,
     },
     {
       priority: "medium",
-      action: "Update Agent Config",
+      action: "Update agent config",
       description: "Ensure the agent is configured to use the new certificate",
       link: "/dashboard/agents/{id}",
       icon: Settings,
     },
     {
       priority: "low",
-      action: "Set Up Auto-Renewal",
+      action: "Set up auto-renewal",
       description: "Configure automatic certificate renewal to prevent future issues",
       link: "/dashboard/settings",
       icon: Clock,
@@ -204,21 +205,21 @@ const THREAT_RECOMMENDATIONS: Record<string, RecommendationItem[]> = {
 const DEFAULT_RECOMMENDATIONS: RecommendationItem[] = [
   {
     priority: "high",
-    action: "Investigate the Threat",
+    action: "Investigate the threat",
     description: "Review agent activity logs and audit trail for suspicious patterns",
     link: "/dashboard/admin/compliance",
     icon: Eye,
   },
   {
     priority: "medium",
-    action: "Verify Agent Configuration",
+    action: "Verify agent configuration",
     description: "Ensure agent capabilities match its registered scope",
     link: "/dashboard/agents/{id}",
     icon: Shield,
   },
   {
     priority: "low",
-    action: "Monitor Trust Score",
+    action: "Monitor trust score",
     description: "Watch for trust score changes that may indicate ongoing issues",
     link: "/dashboard/security",
     icon: Activity,
@@ -280,52 +281,52 @@ export default function ThreatDetailModal({
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case "critical":
-        return "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400";
+        return "bg-danger-fill text-danger-text border border-danger-strong font-bold";
       case "high":
-        return "bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400";
+        return "bg-danger-fill text-danger-text";
       case "medium":
-        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400";
+        return "bg-warning-fill text-warning-text";
       case "low":
-        return "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400";
+        return "bg-brand-soft text-brand-text";
       default:
-        return "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400";
+        return "bg-glass-inset-gray text-ink-body";
     }
   };
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
       case "critical":
-        return "bg-red-50 border-red-200 dark:bg-red-900/10 dark:border-red-800";
+        return "bg-danger-fill border-danger-strong";
       case "high":
-        return "bg-orange-50 border-orange-200 dark:bg-orange-900/10 dark:border-orange-800";
+        return "bg-danger-fill border-danger-border";
       case "medium":
-        return "bg-yellow-50 border-yellow-200 dark:bg-yellow-900/10 dark:border-yellow-800";
+        return "bg-warning-fill border-warning-border";
       case "low":
-        return "bg-blue-50 border-blue-200 dark:bg-blue-900/10 dark:border-blue-800";
+        return "bg-brand-soft border-stroke";
       default:
-        return "bg-gray-50 border-gray-200 dark:bg-gray-900/10 dark:border-gray-700";
+        return "bg-glass-inset-gray border-glass-inset-border";
     }
   };
 
   const getPriorityIconColor = (priority: string) => {
     switch (priority) {
       case "critical":
-        return "text-red-600 dark:text-red-400";
+        return "text-danger-text";
       case "high":
-        return "text-orange-600 dark:text-orange-400";
+        return "text-danger-text";
       case "medium":
-        return "text-yellow-600 dark:text-yellow-400";
+        return "text-warning-text";
       case "low":
-        return "text-blue-600 dark:text-blue-400";
+        return "text-brand-text";
       default:
-        return "text-gray-600 dark:text-gray-400";
+        return "text-ink-body";
     }
   };
 
   const getStatusColor = (isBlocked: boolean) => {
     return isBlocked
-      ? "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400"
-      : "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400";
+      ? "bg-success-fill text-success-text"
+      : "bg-danger-fill text-danger-text";
   };
 
   // Check if source is an IP address or UUID
@@ -360,28 +361,28 @@ export default function ThreatDetailModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between p-6 border-b border-divider">
           <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-lg ${getSeverityColor(threat.severity)}`}>
+            <div className={`p-2 rounded-inset-sm ${getSeverityColor(threat.severity)}`}>
               <AlertTriangle className="h-5 w-5" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                Threat Details
+              <h2 className="text-xl font-semibold text-ink">
+                Threat details
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-secondary">
                 {threat.threatType.replace(/_/g, " ")}
               </p>
             </div>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            className="text-ink-tertiary hover:text-ink transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -390,41 +391,41 @@ export default function ThreatDetailModal({
         {/* Body with Tabs */}
         <div className="p-6">
           {/* Quick Actions Bar */}
-          <div className="flex flex-col gap-3 p-4 bg-blue-50 dark:bg-blue-900/10 rounded-lg border border-blue-200 dark:border-blue-800 mb-6">
+          <div className="flex flex-col gap-3 p-4 bg-brand-soft rounded-inset border border-stroke mb-6">
             <div className="flex items-center gap-2">
-              <Zap className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                Quick Actions
+              <Zap className="h-5 w-5 text-brand-text" />
+              <span className="text-sm font-medium text-ink">
+                Quick actions
               </span>
             </div>
             <div className="flex items-center gap-2 flex-wrap">
               <Link
                 href={`/dashboard/agents?search=${threat.targetId}`}
-                className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 bg-white dark:bg-gray-800 border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                className="inline-flex items-center gap-1 rounded-pill border border-stroke bg-glass px-3 py-1.5 text-xs font-medium text-brand-text transition-colors hover:bg-brand-soft"
               >
                 <User className="h-3 w-3" />
-                View Agent
+                View agent
                 <ExternalLink className="h-3 w-3" />
               </Link>
               <Link
                 href={`/dashboard/agents/${threat.targetId}`}
-                className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 bg-white dark:bg-gray-800 border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                className="inline-flex items-center gap-1 rounded-pill border border-stroke bg-glass px-3 py-1.5 text-xs font-medium text-brand-text transition-colors hover:bg-brand-soft"
               >
                 <Activity className="h-3 w-3" />
-                Agent Details
+                Agent details
                 <ExternalLink className="h-3 w-3" />
               </Link>
               <Link
                 href="/dashboard/admin/compliance"
-                className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 bg-white dark:bg-gray-800 border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                className="inline-flex items-center gap-1 rounded-pill border border-stroke bg-glass px-3 py-1.5 text-xs font-medium text-brand-text transition-colors hover:bg-brand-soft"
               >
                 <FileText className="h-3 w-3" />
-                Audit Log
+                Audit log
                 <ExternalLink className="h-3 w-3" />
               </Link>
 
               {loadingAgent ? (
-                <span className="inline-flex items-center gap-1 px-3 py-1.5 text-xs text-gray-500">
+                <span className="inline-flex items-center gap-1 px-3 py-1.5 text-xs text-ink-secondary">
                   <Loader2 className="h-3 w-3 animate-spin" />
                   Loading...
                 </span>
@@ -432,22 +433,22 @@ export default function ThreatDetailModal({
                 <>
                   <Link
                     href={`/dashboard/sdk-tokens?highlight=${agent.createdBySdkTokenId}`}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-purple-700 dark:text-purple-300 bg-white dark:bg-gray-800 border border-purple-300 dark:border-purple-700 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors"
+                    className="inline-flex items-center gap-1 rounded-pill border border-stroke bg-glass px-3 py-1.5 text-xs font-medium text-brand-text transition-colors hover:bg-brand-soft"
                   >
                     <KeyRound className="h-3 w-3" />
-                    SDK Token
+                    SDK token
                     <ExternalLink className="h-3 w-3" />
                   </Link>
                   {!revokeSuccess ? (
                     <button
                       onClick={() => setShowRevokeConfirm(true)}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 bg-white dark:bg-gray-800 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                      className="inline-flex items-center gap-1 rounded-pill border border-danger-border bg-glass px-3 py-1.5 text-xs font-medium text-danger-text transition-colors hover:bg-danger-fill"
                     >
                       <Ban className="h-3 w-3" />
-                      Revoke Token
+                      Revoke token
                     </button>
                   ) : (
-                    <span className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/20 border border-green-300 dark:border-green-700 rounded-lg">
+                    <span className="inline-flex items-center gap-1 rounded-pill border border-success-border bg-success-fill px-3 py-1.5 text-xs font-medium text-success-text">
                       <Shield className="h-3 w-3" />
                       Revoked
                     </span>
@@ -459,14 +460,14 @@ export default function ThreatDetailModal({
 
           {/* SDK Token Revoke Confirmation */}
           {showRevokeConfirm && (
-            <div className="p-4 bg-red-50 dark:bg-red-900/10 rounded-lg border border-red-200 dark:border-red-800 mb-6">
+            <div className="glass-alert p-4 mb-6">
               <div className="flex items-start gap-3">
-                <Ban className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                <Ban className="h-5 w-5 text-danger-text flex-shrink-0 mt-0.5" />
                 <div className="flex-1">
-                  <h4 className="text-sm font-medium text-red-900 dark:text-red-100 mb-1">
-                    Confirm SDK Token Revocation
+                  <h4 className="text-sm font-medium text-danger-text mb-1">
+                    Confirm SDK token revocation
                   </h4>
-                  <p className="text-xs text-red-800 dark:text-red-200 mb-3">
+                  <p className="text-xs text-ink-body mb-3">
                     This will immediately revoke the SDK token. Any applications using this token will no longer authenticate.
                     {agent?.createdByName && (
                       <span className="block mt-1 font-medium">
@@ -478,7 +479,7 @@ export default function ThreatDetailModal({
                     <button
                       onClick={handleRevokeSDKToken}
                       disabled={revokingToken}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+                      className="inline-flex items-center gap-1 rounded-pill bg-danger px-3 py-1.5 text-xs font-medium text-danger-foreground transition-colors hover:brightness-95 disabled:opacity-50"
                     >
                       {revokingToken ? (
                         <>
@@ -488,13 +489,13 @@ export default function ThreatDetailModal({
                       ) : (
                         <>
                           <Ban className="h-3 w-3" />
-                          Revoke Token
+                          Revoke token
                         </>
                       )}
                     </button>
                     <button
                       onClick={() => setShowRevokeConfirm(false)}
-                      className="px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                      className="rounded-pill border border-stroke bg-glass px-3 py-1.5 text-xs font-medium text-ink-body transition-colors hover:bg-glass-inset-gray"
                     >
                       Cancel
                     </button>
@@ -513,7 +514,7 @@ export default function ThreatDetailModal({
               </TabsTrigger>
               <TabsTrigger value="source" className="flex items-center gap-1.5">
                 <Globe className="h-4 w-4" />
-                Source & Target
+                Source & target
               </TabsTrigger>
               <TabsTrigger value="recommendations" className="flex items-center gap-1.5">
                 <Zap className="h-4 w-4" />
@@ -525,20 +526,20 @@ export default function ThreatDetailModal({
             <TabsContent value="overview" className="space-y-4">
               {/* Threat ID & Severity */}
               <div className="grid grid-cols-2 gap-4">
-                <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <div className="glass-inset p-3">
+                  <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
                     Threat ID
                   </label>
-                  <p className="mt-1 text-sm text-gray-900 dark:text-white font-mono break-all">
+                  <p className="mt-1 text-sm text-ink font-mono break-all">
                     {threat.id}
                   </p>
                 </div>
-                <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <div className="glass-inset p-3">
+                  <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
                     Severity
                   </label>
                   <p className="mt-1">
-                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-full uppercase ${getSeverityColor(threat.severity)}`}>
+                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-pill uppercase ${getSeverityColor(threat.severity)}`}>
                       {threat.severity}
                     </span>
                   </p>
@@ -546,42 +547,42 @@ export default function ThreatDetailModal({
               </div>
 
               {/* Threat Type */}
-              <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  Threat Type
+              <div className="glass-inset p-3">
+                <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
+                  Threat type
                 </label>
-                <p className="mt-1 text-sm text-gray-900 dark:text-white font-semibold capitalize">
+                <p className="mt-1 text-sm text-ink font-semibold capitalize">
                   {threat.threatType.replace(/_/g, " ")}
                 </p>
               </div>
 
               {/* Description */}
-              <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              <div className="glass-inset p-3">
+                <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
                   Description
                 </label>
-                <p className="mt-1 text-sm text-gray-900 dark:text-white leading-relaxed">
+                <p className="mt-1 text-sm text-ink leading-relaxed">
                   {threat.description}
                 </p>
               </div>
 
               {/* Status & Detection Time */}
               <div className="grid grid-cols-2 gap-4">
-                <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <div className="glass-inset p-3">
+                  <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
                     Status
                   </label>
                   <p className="mt-1">
-                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-full uppercase ${getStatusColor(threat.isBlocked)}`}>
+                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-pill uppercase ${getStatusColor(threat.isBlocked)}`}>
                       {threat.isBlocked ? "Blocked" : "Active"}
                     </span>
                   </p>
                 </div>
-                <div className="p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
-                  <label className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                    Detected At
+                <div className="glass-inset p-3">
+                  <label className="text-xs font-medium text-ink-tertiary uppercase tracking-wide">
+                    Detected at
                   </label>
-                  <p className="mt-1 text-sm text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm text-ink">
                     {formatDateTime(threat.createdAt)}
                   </p>
                 </div>
@@ -591,70 +592,70 @@ export default function ThreatDetailModal({
             {/* Source & Target Tab */}
             <TabsContent value="source" className="space-y-4">
               {/* Source Information */}
-              <div className="p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-slate-200 dark:border-slate-700">
+              <div className="p-4 bg-glass-inset-gray rounded-inset border border-stroke">
                 <div className="flex items-center gap-2 mb-3">
-                  <Globe className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                  <span className="font-medium text-gray-900 dark:text-white">Source Information</span>
+                  <Globe className="h-5 w-5 text-ink-secondary" />
+                  <span className="font-medium text-ink">Source information</span>
                 </div>
 
                 {threat.source ? (
                   <div className="space-y-3">
                     {isIPAddress(threat.source) ? (
                       <div className="flex items-center gap-3">
-                        <span className="px-2 py-0.5 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded text-xs font-medium">
-                          IP Address
+                        <span className="px-2 py-0.5 bg-brand-soft text-brand-text rounded-inset-sm text-xs font-medium">
+                          IP address
                         </span>
-                        <span className="font-mono text-sm text-gray-900 dark:text-white">
+                        <span className="font-mono text-sm text-ink">
                           {threat.source}
                         </span>
                       </div>
                     ) : isUUID(threat.source) ? (
                       <>
                         <div className="flex items-center gap-3">
-                          <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded text-xs font-medium">
+                          <span className="px-2 py-0.5 bg-brand-soft text-brand-text rounded-inset-sm text-xs font-medium">
                             Agent ID
                           </span>
-                          <span className="font-mono text-sm text-gray-900 dark:text-white">
+                          <span className="font-mono text-sm text-ink">
                             {threat.source}
                           </span>
                         </div>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                        <p className="text-xs text-ink-secondary flex items-center gap-1">
                           <Lock className="h-3 w-3" />
                           Source IP not captured for this event
                         </p>
                       </>
                     ) : (
                       <div className="flex items-center gap-3">
-                        <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-xs font-medium">
+                        <span className="px-2 py-0.5 bg-glass-inset-gray text-ink-body rounded-inset-sm text-xs font-medium">
                           Source
                         </span>
-                        <span className="font-mono text-sm text-gray-900 dark:text-white">
+                        <span className="font-mono text-sm text-ink">
                           {threat.source}
                         </span>
                       </div>
                     )}
                   </div>
                 ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-ink-secondary">
                     Source information not available
                   </p>
                 )}
               </div>
 
               {/* Target Information */}
-              <div className="p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-slate-200 dark:border-slate-700">
+              <div className="p-4 bg-glass-inset-gray rounded-inset border border-stroke">
                 <div className="flex items-center gap-2 mb-3">
-                  <Target className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                  <span className="font-medium text-gray-900 dark:text-white">Affected Target</span>
+                  <Target className="h-5 w-5 text-ink-secondary" />
+                  <span className="font-medium text-ink">Affected target</span>
                 </div>
 
                 <div className="space-y-3">
                   {/* Agent Name - prioritize fetched agent data over threat.targetName which may be truncated ID */}
                   <div className="flex items-center gap-3">
-                    <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded text-xs font-medium">
+                    <span className="px-2 py-0.5 bg-brand-soft text-brand-text rounded-inset-sm text-xs font-medium">
                       Agent
                     </span>
-                    <span className="font-medium text-gray-900 dark:text-white">
+                    <span className="font-medium text-ink">
                       {agent?.name || agent?.displayName || (
                         // If threat.targetName looks like UUID/truncated ID, show loading; otherwise show it
                         threat.targetName && !threat.targetName.match(/^[0-9a-f-]+\.{0,3}$/i)
@@ -666,10 +667,10 @@ export default function ThreatDetailModal({
 
                   {/* Agent ID - show full UUID for reference */}
                   <div className="flex items-center gap-3">
-                    <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded text-xs font-medium">
+                    <span className="px-2 py-0.5 bg-glass-inset-gray text-ink-secondary rounded-inset-sm text-xs font-medium">
                       ID
                     </span>
-                    <span className="font-mono text-xs text-gray-600 dark:text-gray-400">
+                    <span className="font-mono text-xs text-ink-secondary">
                       {threat.targetId}
                     </span>
                   </div>
@@ -678,13 +679,13 @@ export default function ThreatDetailModal({
                     <>
                       {agent.trustScore !== undefined && (
                         <div className="flex items-center gap-3">
-                          <span className="px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded text-xs font-medium">
-                            Trust Score
+                          <span className="px-2 py-0.5 bg-warning-fill text-warning-text rounded-inset-sm text-xs font-medium">
+                            Trust score
                           </span>
                           <span className={`font-semibold ${
-                            agent.trustScore >= 0.7 ? "text-green-600 dark:text-green-400" :
-                            agent.trustScore >= 0.4 ? "text-yellow-600 dark:text-yellow-400" :
-                            "text-red-600 dark:text-red-400"
+                            agent.trustScore >= 0.7 ? "text-success-text" :
+                            agent.trustScore >= 0.4 ? "text-warning-text" :
+                            "text-danger-text"
                           }`}>
                             {Math.round((agent.trustScore <= 1 ? agent.trustScore * 100 : agent.trustScore))}%
                           </span>
@@ -692,13 +693,13 @@ export default function ThreatDetailModal({
                       )}
                       {agent.status && (
                         <div className="flex items-center gap-3">
-                          <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded text-xs font-medium">
+                          <span className="px-2 py-0.5 bg-glass-inset-gray text-ink-secondary rounded-inset-sm text-xs font-medium">
                             Status
                           </span>
                           <span className={`font-medium capitalize ${
-                            agent.status === "verified" ? "text-green-600 dark:text-green-400" :
-                            agent.status === "suspended" ? "text-red-600 dark:text-red-400" :
-                            "text-gray-600 dark:text-gray-400"
+                            agent.status === "verified" ? "text-success-text" :
+                            agent.status === "suspended" ? "text-danger-text" :
+                            "text-ink-secondary"
                           }`}>
                             {agent.status}
                           </span>
@@ -711,12 +712,12 @@ export default function ThreatDetailModal({
 
               {/* Additional Metadata */}
               {threat.metadata && Object.keys(threat.metadata).length > 0 && (
-                <div className="p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-slate-200 dark:border-slate-700">
+                <div className="p-4 bg-glass-inset-gray rounded-inset border border-stroke">
                   <div className="flex items-center gap-2 mb-3">
-                    <Server className="h-5 w-5 text-slate-600 dark:text-slate-400" />
-                    <span className="font-medium text-gray-900 dark:text-white">Additional Details</span>
+                    <Server className="h-5 w-5 text-ink-secondary" />
+                    <span className="font-medium text-ink">Additional details</span>
                   </div>
-                  <pre className="text-xs text-gray-700 dark:text-gray-300 font-mono overflow-x-auto bg-white dark:bg-gray-800 p-3 rounded border border-gray-200 dark:border-gray-700">
+                  <pre className="text-xs text-ink-body font-mono overflow-x-auto bg-glass p-3 rounded-inset-sm border border-stroke">
                     {JSON.stringify(threat.metadata, null, 2)}
                   </pre>
                 </div>
@@ -726,9 +727,9 @@ export default function ThreatDetailModal({
             {/* Recommendations Tab */}
             <TabsContent value="recommendations" className="space-y-3">
               <div className="flex items-center gap-2 mb-4">
-                <AlertTriangle className="h-5 w-5 text-amber-500" />
-                <span className="text-sm font-medium text-gray-900 dark:text-white">
-                  Recommended Actions for <span className="capitalize">{threat.threatType.replace(/_/g, " ")}</span>
+                <AlertTriangle className="h-5 w-5 text-warning" />
+                <span className="text-sm font-medium text-ink">
+                  Recommended actions for <span className="capitalize">{threat.threatType.replace(/_/g, " ")}</span>
                 </span>
               </div>
 
@@ -737,35 +738,35 @@ export default function ThreatDetailModal({
                 return (
                   <div
                     key={index}
-                    className={`p-4 rounded-lg border ${getPriorityColor(rec.priority)}`}
+                    className={`p-4 rounded-inset border ${getPriorityColor(rec.priority)}`}
                   >
                     <div className="flex items-start gap-3">
-                      <div className={`p-1.5 rounded ${getPriorityColor(rec.priority)}`}>
+                      <div className={`p-1.5 rounded-inset-sm ${getPriorityColor(rec.priority)}`}>
                         <IconComponent className={`h-4 w-4 ${getPriorityIconColor(rec.priority)}`} />
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className={`px-1.5 py-0.5 text-xs font-semibold uppercase rounded ${
-                            rec.priority === "critical" ? "bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-200" :
-                            rec.priority === "high" ? "bg-orange-200 text-orange-800 dark:bg-orange-800 dark:text-orange-200" :
-                            rec.priority === "medium" ? "bg-yellow-200 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200" :
-                            "bg-blue-200 text-blue-800 dark:bg-blue-800 dark:text-blue-200"
+                          <span className={`px-1.5 py-0.5 text-xs font-semibold uppercase rounded-inset-sm ${
+                            rec.priority === "critical" ? "bg-danger-fill text-danger-text" :
+                            rec.priority === "high" ? "bg-warning-fill text-warning-text" :
+                            rec.priority === "medium" ? "bg-warning-fill text-warning-text" :
+                            "bg-brand-soft text-brand-text"
                           }`}>
                             {rec.priority}
                           </span>
-                          <span className="font-medium text-gray-900 dark:text-white">
+                          <span className="font-medium text-ink">
                             {rec.action}
                           </span>
                         </div>
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                        <p className="text-sm text-ink-secondary mb-2">
                           {rec.description}
                         </p>
                         {rec.link && (
                           <Link
                             href={resolveLink(rec.link)}
-                            className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                            className="inline-flex items-center gap-1 text-xs font-medium text-brand-text hover:underline"
                           >
-                            Take Action
+                            Take action
                             <ExternalLink className="h-3 w-3" />
                           </Link>
                         )}
@@ -777,15 +778,15 @@ export default function ThreatDetailModal({
 
               {/* Additional SDK Token Warning */}
               {agent?.createdBySdkTokenId && !revokeSuccess && (
-                <div className="p-4 bg-red-50 dark:bg-red-900/10 rounded-lg border border-red-200 dark:border-red-800">
+                <div className="glass-alert p-4">
                   <div className="flex items-start gap-3">
-                    <KeyRound className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0" />
+                    <KeyRound className="h-5 w-5 text-danger-text flex-shrink-0" />
                     <div>
-                      <p className="text-sm font-medium text-red-900 dark:text-red-100">
-                        SDK Token Available for Revocation
+                      <p className="text-sm font-medium text-danger-text">
+                        SDK token available for revocation
                       </p>
-                      <p className="text-xs text-red-800 dark:text-red-200 mt-1">
-                        If this agent is compromised, you can immediately revoke its SDK token using the Quick Actions above.
+                      <p className="text-xs text-ink-body mt-1">
+                        If this agent is compromised, you can immediately revoke its SDK token using the quick actions above.
                       </p>
                     </div>
                   </div>
@@ -796,13 +797,10 @@ export default function ThreatDetailModal({
         </div>
 
         {/* Footer */}
-        <div className="flex justify-end p-6 border-t border-gray-200 dark:border-gray-700">
-          <button
-            onClick={onClose}
-            className="px-6 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
-          >
+        <div className="flex justify-end p-6 border-t border-divider">
+          <Button onClick={onClose} className="px-6">
             Close
-          </button>
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fifth of six stacked pull requests (Glasshouse; the whole change is #418). Stacked on the agents PR.

## What this part contains

The security overview, violations, the threat detail modal, the alert detail panel, the trust breakdown and the activity timeline on the semantic tokens; the score ring's low band renders in the brand colour with the recovery delta instead of a red wall.

"Threats blocked" and "AIM prevented these unauthorized attempts" described a deny decision as observed prevention; the copy says denied and carries the same self-reporting caveat the alert panel shows. The protection ratio takes both numbers from the same 30-day window and is clamped. Critical, high, medium and low render distinctly in every severity map. Dead Approve and Deny buttons on pending capability requests are removed in favour of the working Review link; the Investigate link uses the query key the alerts page reads.

## Verification

- `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch.
- Light and dark at 1440 and 375 px on the security and violations pages: no horizontal overflow, no page errors.
