### PR TITLE
Refuse a registration nobody in the deployment could approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Brings up `aim-server`, `aim-dashboard`, PostgreSQL, and Redis. Dashboard at `lo
 
 Production deployment (Azure, GCP, AWS): [infrastructure/DEPLOYMENT.md](infrastructure/DEPLOYMENT.md).
 
-New accounts wait for an administrator's approval. To bootstrap the first administrator, set `AIM_PLATFORM_ADMINS` (comma-separated emails) before starting the backend: accounts on that list are approved automatically and approve everyone else from the dashboard's admin area.
+New accounts wait for an administrator's approval. To bootstrap the first administrator, set `AIM_PLATFORM_ADMINS` (comma-separated emails) before starting the backend: accounts on that list are approved automatically and approve everyone else from the dashboard's admin area. Until a listed address has registered, or some administrator exists, other sign-ups are refused with an error that says so; nothing is queued. The backend logs how the variable was read at startup, so a mistyped entry is visible there.
 
 ### From source
 

--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -103,6 +103,9 @@ func main() {
 	}
 	log.Println("✅ Database migrations completed successfully")
 
+	// Report how AIM_PLATFORM_ADMINS was read; a mistyped entry is visible, not silent.
+	application.ReportPlatformAdminAllowlist()
+
 	// Override default admin password if ADMIN_PASSWORD env var is set
 	if err := applyAdminPasswordOverride(db); err != nil {
 		log.Printf("⚠️  Failed to apply admin password override: %v", err)
@@ -352,8 +355,8 @@ func main() {
 	// message, a ±30s window and revocation enforcement; the handlers add the
 	// agent-ownership check, because the group authenticates *an* agent and also
 	// falls through to JWT for human callers (pqc_agent_auth.go:39-41, :50-52).
-	sdkAPI.Post("/verifications/:id/result", h.Verification.SubmitVerificationResult)        // Withdrawn: 403 for every caller
-	sdkAPI.Post("/verifications/:id/execution-status", h.Verification.UpdateExecutionStatus) // Agent-owned execution report
+	sdkAPI.Post("/verifications/:id/result", h.Verification.SubmitVerificationResult)              // Withdrawn: 403 for every caller
+	sdkAPI.Post("/verifications/:id/execution-status", h.Verification.UpdateExecutionStatus)       // Agent-owned execution report
 	sdkAPI.Get("/agents/:identifier", h.Agent.GetAgentByIdentifier)                                // Get agent by ID or name (SDK)
 	sdkAPI.Post("/agents/:id/capabilities", h.Capability.GrantCapability)                          // SDK capability reporting (legacy)
 	sdkAPI.Post("/agents/:id/capabilities/register", h.Capability.RegisterCapability)              // SDK capability registration (respects enforcement mode)
@@ -1766,8 +1769,8 @@ func setupRoutes(v1 fiber.Router, h *Handlers, services *Services, jwtService *a
 	verifications := v1.Group("/verifications")
 	verifications.Use(middleware.AuthMiddleware(jwtService))
 	verifications.Use(middleware.RateLimitMiddleware())
-	verifications.Post("/", h.Verification.CreateVerification)                 // Request verification for agent action
-	verifications.Get("/:id", h.Verification.GetVerification)                  // Get verification status by ID
+	verifications.Post("/", h.Verification.CreateVerification) // Request verification for agent action
+	verifications.Get("/:id", h.Verification.GetVerification)  // Get verification status by ID
 	// REMOVED: `verifications.Post("/:id/result", ...)`. This mount authenticated a
 	// JWT user but the handler had no ownership check, so any authenticated user of
 	// any organization could rewrite any verification by UUID. It is deleted rather

--- a/apps/backend/internal/application/admin_service_test.go
+++ b/apps/backend/internal/application/admin_service_test.go
@@ -126,6 +126,10 @@ func (m *MockUserRepoForAdmin) CountActiveUsers(orgID uuid.UUID, withinMinutes i
 	return count, nil
 }
 
+func (m *MockUserRepoForAdmin) CountByRoleAndStatus(role domain.UserRole, status domain.UserStatus) (int, error) {
+	return 0, nil
+}
+
 // MockOrgRepository implements OrganizationRepository for admin service tests
 type MockOrgRepository struct {
 	orgs       map[uuid.UUID]*domain.Organization

--- a/apps/backend/internal/application/auth_service_test.go
+++ b/apps/backend/internal/application/auth_service_test.go
@@ -89,6 +89,11 @@ func (m *MockUserRepository) CountActiveUsers(orgID uuid.UUID, withinMinutes int
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockUserRepository) CountByRoleAndStatus(role domain.UserRole, status domain.UserStatus) (int, error) {
+	args := m.Called(role, status)
+	return args.Int(0), args.Error(1)
+}
+
 // MockOrganizationRepository for testing
 type MockOrganizationRepository struct {
 	mock.Mock

--- a/apps/backend/internal/application/mocks_test.go
+++ b/apps/backend/internal/application/mocks_test.go
@@ -665,6 +665,11 @@ func (m *SharedMockUserRepository) CountActiveUsers(orgID uuid.UUID, withinMinut
 	return args.Int(0), args.Error(1)
 }
 
+func (m *SharedMockUserRepository) CountByRoleAndStatus(role domain.UserRole, status domain.UserStatus) (int, error) {
+	args := m.Called(role, status)
+	return args.Int(0), args.Error(1)
+}
+
 // SharedMockOrganizationRepository is a mock implementation of OrganizationRepository
 type SharedMockOrganizationRepository struct {
 	mock.Mock

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -682,7 +682,7 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 // platformAdminAllowlist returns the non-empty, lower-cased, trimmed entries of
 // AIM_PLATFORM_ADMINS; an unset, empty or separator-only variable yields no entries.
 func platformAdminAllowlist() []string {
-	var entries []string
+	entries := make([]string, 0)
 	for _, entry := range strings.Split(os.Getenv("AIM_PLATFORM_ADMINS"), ",") {
 		if e := strings.ToLower(strings.TrimSpace(entry)); e != "" {
 			entries = append(entries, e)

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -18,6 +18,8 @@ var (
 	ErrRegistrationNotPending    = errors.New("registration request is not pending")
 	ErrUserAlreadyExists         = errors.New("user with this email already exists")
 	ErrRegistrationRequestExists = errors.New("registration request with this email already exists")
+	// ErrNoAdministrators: the request would wait for an approval nobody in this deployment can give.
+	ErrNoAdministrators = errors.New("no administrator can approve a registration request in this deployment")
 )
 
 // RegistrationRepository defines the interface for registration data persistence
@@ -94,6 +96,19 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 	// (see PR-B) and team creation is an explicit user action (see PR-C).
 	emailDomain := extractEmailDomain(email)
 	shouldAutoApprove := isPlatformAdmin(email)
+
+	// A pending request needs someone who can approve it. On a fresh self-hosted install with
+	// no AIM_PLATFORM_ADMINS allowlist and no active administrator, the request would wait
+	// forever and nothing would say so; refuse before writing it (never write-then-refuse).
+	if !shouldAutoApprove && len(platformAdminAllowlist()) == 0 {
+		approvers, err := s.userRepo.CountByRoleAndStatus(domain.RoleAdmin, domain.UserStatusActive)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count administrators: %w", err)
+		}
+		if approvers == 0 {
+			return nil, ErrNoAdministrators
+		}
+	}
 
 	// Create new manual registration request
 	req := domain.NewUserRegistrationRequestManual(
@@ -664,14 +679,22 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 // Email comparison is case-insensitive and trims whitespace. Empty env var means
 // no platform admins exist (safe default — only approved-by-existing-admin users
 // can register).
-func isPlatformAdmin(email string) bool {
-	allowlist := os.Getenv("AIM_PLATFORM_ADMINS")
-	if allowlist == "" {
-		return false
+// platformAdminAllowlist returns the non-empty, lower-cased, trimmed entries of
+// AIM_PLATFORM_ADMINS; an unset, empty or separator-only variable yields no entries.
+func platformAdminAllowlist() []string {
+	var entries []string
+	for _, entry := range strings.Split(os.Getenv("AIM_PLATFORM_ADMINS"), ",") {
+		if e := strings.ToLower(strings.TrimSpace(entry)); e != "" {
+			entries = append(entries, e)
+		}
 	}
+	return entries
+}
+
+func isPlatformAdmin(email string) bool {
 	target := strings.ToLower(strings.TrimSpace(email))
-	for _, entry := range strings.Split(allowlist, ",") {
-		if strings.ToLower(strings.TrimSpace(entry)) == target {
+	for _, entry := range platformAdminAllowlist() {
+		if entry == target {
 			return true
 		}
 	}

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -97,17 +97,8 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 	emailDomain := extractEmailDomain(email)
 	shouldAutoApprove := isPlatformAdmin(email)
 
-	// A pending request needs someone who can approve it. On a fresh self-hosted install with
-	// no AIM_PLATFORM_ADMINS allowlist and no active administrator, the request would wait
-	// forever and nothing would say so; refuse before writing it (never write-then-refuse).
-	if !shouldAutoApprove && len(platformAdminAllowlist()) == 0 {
-		approvers, err := s.userRepo.CountByRoleAndStatus(domain.RoleAdmin, domain.UserStatusActive)
-		if err != nil {
-			return nil, fmt.Errorf("failed to count administrators: %w", err)
-		}
-		if approvers == 0 {
-			return nil, ErrNoAdministrators
-		}
+	if err := s.ensureApproverExists(shouldAutoApprove); err != nil {
+		return nil, err
 	}
 
 	// Create new manual registration request
@@ -246,6 +237,11 @@ func (s *RegistrationService) CreateAccessRequest(
 	existingRequest, err := s.registrationRepo.GetRegistrationRequestByEmail(ctx, email)
 	if err == nil && existingRequest != nil && existingRequest.IsPending() {
 		return nil, ErrRegistrationRequestExists
+	}
+
+	// An access request is never auto-approved, so it needs an approver like any other.
+	if err := s.ensureApproverExists(false); err != nil {
+		return nil, err
 	}
 
 	// Create new access request (no password)
@@ -679,6 +675,25 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 // Email comparison is case-insensitive and trims whitespace. Empty env var means
 // no platform admins exist (safe default — only approved-by-existing-admin users
 // can register).
+// ensureApproverExists refuses a request that would wait for an approval nobody in this
+// deployment can give. On a fresh self-hosted install with no AIM_PLATFORM_ADMINS allowlist
+// and no active administrator, a pending request would wait forever and nothing would say
+// so; the refusal happens before anything is written (never write-then-refuse). A request
+// that auto-approves needs no approver.
+func (s *RegistrationService) ensureApproverExists(autoApproved bool) error {
+	if autoApproved || len(platformAdminAllowlist()) > 0 {
+		return nil
+	}
+	approvers, err := s.userRepo.CountByRoleAndStatus(domain.RoleAdmin, domain.UserStatusActive)
+	if err != nil {
+		return fmt.Errorf("failed to count administrators: %w", err)
+	}
+	if approvers == 0 {
+		return ErrNoAdministrators
+	}
+	return nil
+}
+
 // platformAdminAllowlist returns the non-empty, lower-cased, trimmed entries of
 // AIM_PLATFORM_ADMINS; an unset, empty or separator-only variable yields no entries.
 func platformAdminAllowlist() []string {

--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -97,7 +98,7 @@ func (s *RegistrationService) CreateManualRegistrationRequest(
 	emailDomain := extractEmailDomain(email)
 	shouldAutoApprove := isPlatformAdmin(email)
 
-	if err := s.ensureApproverExists(shouldAutoApprove); err != nil {
+	if err := s.ensureApproverExists(email, shouldAutoApprove); err != nil {
 		return nil, err
 	}
 
@@ -240,7 +241,7 @@ func (s *RegistrationService) CreateAccessRequest(
 	}
 
 	// An access request is never auto-approved, so it needs an approver like any other.
-	if err := s.ensureApproverExists(false); err != nil {
+	if err := s.ensureApproverExists(email, false); err != nil {
 		return nil, err
 	}
 
@@ -680,30 +681,75 @@ func (s *RegistrationService) findOrCreateOrganization(ctx context.Context, doma
 // and no active administrator, a pending request would wait forever and nothing would say
 // so; the refusal happens before anything is written (never write-then-refuse). A request
 // that auto-approves needs no approver.
-func (s *RegistrationService) ensureApproverExists(autoApproved bool) error {
-	if autoApproved || len(platformAdminAllowlist()) > 0 {
+func (s *RegistrationService) ensureApproverExists(email string, autoApproved bool) error {
+	if autoApproved {
 		return nil
 	}
+	// The allowlist is intent; the users table is state. A listed address that never
+	// registered (or a mistyped entry) is not an approver, so the count runs regardless.
 	approvers, err := s.userRepo.CountByRoleAndStatus(domain.RoleAdmin, domain.UserStatusActive)
 	if err != nil {
 		return fmt.Errorf("failed to count administrators: %w", err)
 	}
 	if approvers == 0 {
+		// The client receives one message for every sub-case; the sub-case is operator-only.
+		log.Printf("registration refused for %s: 0 active administrators, %d valid AIM_PLATFORM_ADMINS entries, registrant listed=false", email, len(platformAdminAllowlist()))
 		return ErrNoAdministrators
 	}
 	return nil
 }
 
-// platformAdminAllowlist returns the non-empty, lower-cased, trimmed entries of
-// AIM_PLATFORM_ADMINS; an unset, empty or separator-only variable yields no entries.
+// platformAdminAllowlist returns the lower-cased, trimmed entries of AIM_PLATFORM_ADMINS
+// that could be an email address (something@something). An unset, empty or separator-only
+// variable yields no entries; a token that cannot be an address is ignored (reported once at
+// startup by ReportPlatformAdminAllowlist). The filter is deliberately no stricter than what
+// registration itself accepts.
 func platformAdminAllowlist() []string {
-	entries := make([]string, 0)
-	for _, entry := range strings.Split(os.Getenv("AIM_PLATFORM_ADMINS"), ",") {
-		if e := strings.ToLower(strings.TrimSpace(entry)); e != "" {
-			entries = append(entries, e)
+	entries, _ := parsePlatformAdminAllowlist(os.Getenv("AIM_PLATFORM_ADMINS"))
+	return entries
+}
+
+// parsePlatformAdminAllowlist splits the variable into accepted entries and ignored tokens.
+func parsePlatformAdminAllowlist(raw string) (entries []string, ignored []string) {
+	entries = make([]string, 0)
+	ignored = make([]string, 0)
+	for _, entry := range strings.Split(raw, ",") {
+		e := strings.ToLower(strings.TrimSpace(entry))
+		if e == "" {
+			continue
+		}
+		at := strings.Index(e, "@")
+		if at <= 0 || at == len(e)-1 {
+			ignored = append(ignored, e)
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, ignored
+}
+
+// ReportPlatformAdminAllowlist logs, once at startup, how AIM_PLATFORM_ADMINS was read: the
+// number of accepted addresses and every ignored token by position, so a mistyped variable is
+// visible to the operator without refusing to boot.
+func ReportPlatformAdminAllowlist() {
+	raw := os.Getenv("AIM_PLATFORM_ADMINS")
+	if strings.TrimSpace(raw) == "" {
+		return
+	}
+	entries, ignored := parsePlatformAdminAllowlist(raw)
+	for i, tok := range strings.Split(raw, ",") {
+		t := strings.ToLower(strings.TrimSpace(tok))
+		for _, ig := range ignored {
+			if t == ig {
+				log.Printf("AIM_PLATFORM_ADMINS entry %d (%q) is not an email address and is ignored", i+1, t)
+			}
 		}
 	}
-	return entries
+	if len(entries) == 0 {
+		log.Printf("AIM_PLATFORM_ADMINS is set but contains no email address; no account will be approved automatically")
+		return
+	}
+	log.Printf("AIM_PLATFORM_ADMINS: %d address(es) accepted", len(entries))
 }
 
 func isPlatformAdmin(email string) bool {

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -967,10 +967,12 @@ func TestRegistrationService_CreateManualRegistrationRequest_NoProfileLeavesMeta
 }
 
 func TestRegistrationService_CreateAccessRequest_Success(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
 	ctx := context.Background()
 
 	mockUserRepo := new(MockUserRepoForRegistration)
 	mockUserRepo.On("GetByEmail", "newuser@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
 
 	mockRegRepo := new(MockRegistrationRepoForService)
 	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "newuser@example.com").Return(nil, errors.New("not found"))
@@ -1010,10 +1012,12 @@ func TestRegistrationService_CreateAccessRequest_UserExists(t *testing.T) {
 }
 
 func TestRegistrationService_CreateAccessRequest_WithOrganizationName(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
 	ctx := context.Background()
 
 	mockUserRepo := new(MockUserRepoForRegistration)
 	mockUserRepo.On("GetByEmail", "user@company.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
 
 	mockRegRepo := new(MockRegistrationRepoForService)
 	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "user@company.com").Return(nil, errors.New("not found"))
@@ -1445,4 +1449,49 @@ func TestPlatformAdminAllowlist_ParsesEntries(t *testing.T) {
 	assert.Empty(t, platformAdminAllowlist())
 	t.Setenv("AIM_PLATFORM_ADMINS", " A@Example.com, b@example.com ,")
 	assert.Equal(t, []string{"a@example.com", "b@example.com"}, platformAdminAllowlist())
+}
+
+// The public access-request path writes the same pending row and needs the same approver.
+func TestRegistrationService_AccessRequest_NoAllowlistNoAdmin_RefusesBeforeWriting(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "access@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(0, nil)
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "access@example.com").Return(nil, errors.New("not found"))
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateAccessRequest(ctx, "access@example.com", "Access", "User", "needs a dashboard account", nil)
+
+	assert.Nil(t, req)
+	assert.Equal(t, ErrNoAdministrators, err)
+	mockRegRepo.AssertNotCalled(t, "CreateRegistrationRequest", mock.Anything, mock.Anything)
+	mockUserRepo.AssertExpectations(t)
+}
+
+// A failing administrator count is a failure, not a refusal and not a write.
+func TestRegistrationService_AdminCountFails_ErrorsWithoutWriting(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "db@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(0, errors.New("db down"))
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "db@example.com").Return(nil, errors.New("not found"))
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateManualRegistrationRequest(ctx, "db@example.com", "Db", "User", "Str0ng!Passw0rd", nil)
+
+	assert.Nil(t, req)
+	assert.Error(t, err)
+	assert.NotEqual(t, ErrNoAdministrators, err)
+	assert.Contains(t, err.Error(), "failed to count administrators")
+	mockRegRepo.AssertNotCalled(t, "CreateRegistrationRequest", mock.Anything, mock.Anything)
 }

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -1495,3 +1495,77 @@ func TestRegistrationService_AdminCountFails_ErrorsWithoutWriting(t *testing.T) 
 	assert.Contains(t, err.Error(), "failed to count administrators")
 	mockRegRepo.AssertNotCalled(t, "CreateRegistrationRequest", mock.Anything, mock.Anything)
 }
+
+// The allowlist is intent, not an approver. With the variable set to an address that never
+// registered (a typo, or the operator not yet signed up), a non-listed registrant must be
+// refused before anything is written, on both public creators; the count is consulted.
+func TestRegistrationService_AllowlistSetNonListedNoAdmin_Refuses(t *testing.T) {
+	for _, allowlist := range []string{"ops@exmaple.com", "true"} {
+		t.Run(allowlist, func(t *testing.T) {
+			t.Setenv("AIM_PLATFORM_ADMINS", allowlist)
+			ctx := context.Background()
+
+			mockUserRepo := new(MockUserRepoForRegistration)
+			mockUserRepo.On("GetByEmail", "first@example.com").Return(nil, errors.New("not found"))
+			mockUserRepo.On("GetByEmail", "access@example.com").Return(nil, errors.New("not found"))
+			mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(0, nil).Twice()
+
+			mockRegRepo := new(MockRegistrationRepoForService)
+			mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "first@example.com").Return(nil, errors.New("not found"))
+			mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "access@example.com").Return(nil, errors.New("not found"))
+
+			service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+			req, err := service.CreateManualRegistrationRequest(ctx, "first@example.com", "First", "User", "Str0ng!Passw0rd", nil)
+			assert.Nil(t, req)
+			assert.Equal(t, ErrNoAdministrators, err)
+
+			access, err := service.CreateAccessRequest(ctx, "access@example.com", "Access", "User", "needs a dashboard account", nil)
+			assert.Nil(t, access)
+			assert.Equal(t, ErrNoAdministrators, err)
+
+			mockRegRepo.AssertNotCalled(t, "CreateRegistrationRequest", mock.Anything, mock.Anything)
+			mockUserRepo.AssertNotCalled(t, "Create", mock.Anything)
+			mockUserRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// Once an administrator exists, a set allowlist changes nothing for a non-listed registrant.
+func TestRegistrationService_AllowlistSetNonListedWithAdmin_PendingAsToday(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "ops@example.com")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "second@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "second@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("CreateRegistrationRequest", ctx, mock.MatchedBy(func(r *domain.UserRegistrationRequest) bool {
+		return r.Status == domain.RegistrationStatusPending
+	})).Return(nil)
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateManualRegistrationRequest(ctx, "second@example.com", "Second", "User", "Str0ng!Passw0rd", nil)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, req) {
+		assert.Equal(t, domain.RegistrationStatusPending, req.Status)
+	}
+	mockRegRepo.AssertExpectations(t)
+	mockUserRepo.AssertExpectations(t)
+}
+
+// Tokens that cannot be an address are ignored, so a mistyped variable neither approves
+// anyone nor counts as an approver; the filter is no stricter than registration itself.
+func TestPlatformAdminAllowlist_IgnoresTokensThatCannotBeAnAddress(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "true, @example.com, ops@ , ,")
+	assert.Empty(t, platformAdminAllowlist())
+	assert.False(t, isPlatformAdmin("true"))
+
+	entries, ignored := parsePlatformAdminAllowlist("true, A@Example.com, x@, ops@exmaple.com")
+	assert.Equal(t, []string{"a@example.com", "ops@exmaple.com"}, entries)
+	assert.Equal(t, []string{"true", "x@"}, ignored)
+}

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -775,6 +775,11 @@ func (m *MockUserRepoForRegistration) CountActiveUsers(orgID uuid.UUID, withinMi
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockUserRepoForRegistration) CountByRoleAndStatus(role domain.UserRole, status domain.UserStatus) (int, error) {
+	args := m.Called(role, status)
+	return args.Int(0), args.Error(1)
+}
+
 // MockOrgRepoForRegistration implements domain.OrganizationRepository
 type MockOrgRepoForRegistration struct {
 	mock.Mock
@@ -913,10 +918,12 @@ func TestRegistrationService_CreateManualRegistrationRequest_WeakPassword(t *tes
 }
 
 func TestRegistrationService_CreateManualRegistrationRequest_StoresSignupProfile(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
 	ctx := context.Background()
 
 	mockUserRepo := new(MockUserRepoForRegistration)
 	mockUserRepo.On("GetByEmail", "survey@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
 
 	mockRegRepo := new(MockRegistrationRepoForService)
 	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "survey@example.com").Return(nil, errors.New("not found"))
@@ -938,10 +945,12 @@ func TestRegistrationService_CreateManualRegistrationRequest_StoresSignupProfile
 }
 
 func TestRegistrationService_CreateManualRegistrationRequest_NoProfileLeavesMetadataNil(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
 	ctx := context.Background()
 
 	mockUserRepo := new(MockUserRepoForRegistration)
 	mockUserRepo.On("GetByEmail", "plain@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
 
 	mockRegRepo := new(MockRegistrationRepoForService)
 	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "plain@example.com").Return(nil, errors.New("not found"))
@@ -1345,4 +1354,95 @@ func TestRegistrationService_ApproveRegistrationRequest_NotPending(t *testing.T)
 	assert.Nil(t, user)
 	assert.Equal(t, ErrRegistrationNotPending, err)
 	mockRegRepo.AssertExpectations(t)
+}
+
+// A fresh self-hosted install with no AIM_PLATFORM_ADMINS and no active administrator cannot
+// serve a pending request; the service must refuse before writing anything.
+func TestRegistrationService_NoAllowlistNoAdmin_RefusesBeforeWriting(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "first@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(0, nil)
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "first@example.com").Return(nil, errors.New("not found"))
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateManualRegistrationRequest(ctx, "first@example.com", "First", "User", "Str0ng!Passw0rd", nil)
+
+	assert.Nil(t, req)
+	assert.Equal(t, ErrNoAdministrators, err)
+	mockRegRepo.AssertNotCalled(t, "CreateRegistrationRequest", mock.Anything, mock.Anything)
+	mockUserRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockUserRepo.AssertExpectations(t)
+}
+
+// An allowlisted address is auto-approved exactly as before; the administrator count is not
+// even consulted.
+func TestRegistrationService_AllowlistSet_AutoApproveUnchanged(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", " Ops@Example.com ,")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "ops@example.com").Return(nil, errors.New("not found"))
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "ops@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("CreateRegistrationRequest", ctx, mock.MatchedBy(func(r *domain.UserRegistrationRequest) bool {
+		return r.Status == domain.RegistrationStatusApproved
+	})).Return(nil)
+
+	// The organization step fails on purpose: it proves the request was written as approved
+	// (the allowlist path) without exercising organization creation here.
+	mockOrgRepo := new(MockOrgRepoForRegistration)
+	mockOrgRepo.On("GetByDomain", "example.com").Return(nil, errors.New("stop here"))
+	mockOrgRepo.On("Create", mock.Anything).Return(errors.New("stop here"))
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, mockOrgRepo, nil, nil)
+
+	_, err := service.CreateManualRegistrationRequest(ctx, "ops@example.com", "Ops", "User", "Str0ng!Passw0rd", nil)
+
+	assert.Error(t, err)
+	assert.NotEqual(t, ErrNoAdministrators, err)
+	mockRegRepo.AssertExpectations(t)
+	mockUserRepo.AssertNotCalled(t, "CountByRoleAndStatus", mock.Anything, mock.Anything)
+}
+
+// With an active administrator, a pending request is servable and is created as today.
+func TestRegistrationService_NoAllowlistWithAdmin_PendingAsToday(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	ctx := context.Background()
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "second@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(1, nil)
+
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "second@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("CreateRegistrationRequest", ctx, mock.MatchedBy(func(r *domain.UserRegistrationRequest) bool {
+		return r.Status == domain.RegistrationStatusPending
+	})).Return(nil)
+
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	req, err := service.CreateManualRegistrationRequest(ctx, "second@example.com", "Second", "User", "Str0ng!Passw0rd", nil)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, req) {
+		assert.Equal(t, domain.RegistrationStatusPending, req.Status)
+	}
+	mockRegRepo.AssertExpectations(t)
+	mockUserRepo.AssertExpectations(t)
+}
+
+func TestPlatformAdminAllowlist_ParsesEntries(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	assert.Empty(t, platformAdminAllowlist())
+	t.Setenv("AIM_PLATFORM_ADMINS", " , ")
+	assert.Empty(t, platformAdminAllowlist())
+	t.Setenv("AIM_PLATFORM_ADMINS", " A@Example.com, b@example.com ,")
+	assert.Equal(t, []string{"a@example.com", "b@example.com"}, platformAdminAllowlist())
 }

--- a/apps/backend/internal/domain/user.go
+++ b/apps/backend/internal/domain/user.go
@@ -39,8 +39,8 @@ type User struct {
 	Status                 UserStatus `json:"status"`     // pending, active, suspended, deactivated
 	PasswordHash           *string    `json:"-"`          // Never expose in JSON
 	ForcePasswordChange    bool       `json:"forcePasswordChange"`
-	PasswordResetToken     *string    `json:"-"` // Never expose in JSON
-	PasswordResetExpiresAt *time.Time `json:"-"` // Never expose in JSON
+	PasswordResetToken     *string    `json:"-"`                    // Never expose in JSON
+	PasswordResetExpiresAt *time.Time `json:"-"`                    // Never expose in JSON
 	ApprovedBy             *uuid.UUID `json:"approvedBy,omitempty"` // Admin who approved this user
 	ApprovedAt             *time.Time `json:"approvedAt,omitempty"` // When user was approved
 	LastLoginAt            *time.Time `json:"lastLoginAt"`
@@ -61,4 +61,7 @@ type UserRepository interface {
 	UpdateRole(id uuid.UUID, role UserRole) error
 	Delete(id uuid.UUID) error
 	CountActiveUsers(orgID uuid.UUID, withinMinutes int) (int, error)
+	// CountByRoleAndStatus counts users across every organization with the given role and status
+	// (soft-deleted users excluded); the registration path uses it to learn whether anyone can approve.
+	CountByRoleAndStatus(role UserRole, status UserStatus) (int, error)
 }

--- a/apps/backend/internal/infrastructure/repository/user_repository.go
+++ b/apps/backend/internal/infrastructure/repository/user_repository.go
@@ -53,8 +53,8 @@ func (r *UserRepository) Create(user *domain.User) error {
 		user.Name,
 		user.AvatarURL,
 		user.Role,
-		user.Provider,    // Added provider
-		user.ProviderID,  // Added provider_id
+		user.Provider,   // Added provider
+		user.ProviderID, // Added provider_id
 		user.PasswordHash,
 		user.Status,
 		user.ForcePasswordChange,
@@ -342,6 +342,25 @@ func (r *UserRepository) CountActiveUsers(orgID uuid.UUID, withinMinutes int) (i
 	err := r.db.QueryRow(query, orgID, withinMinutes).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count active users: %w", err)
+	}
+
+	return count, nil
+}
+
+// CountByRoleAndStatus counts users across every organization with the given role and status,
+// excluding soft-deleted rows.
+func (r *UserRepository) CountByRoleAndStatus(role domain.UserRole, status domain.UserStatus) (int, error) {
+	query := `
+		SELECT COUNT(*)
+		FROM users
+		WHERE role = $1
+		  AND status = $2
+		  AND deleted_at IS NULL
+	`
+
+	var count int
+	if err := r.db.QueryRow(query, string(role), string(status)).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count users by role and status: %w", err)
 	}
 
 	return count, nil

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
@@ -55,3 +55,27 @@ func TestRegistrationSuccessMessage_StatesTheOutcome(t *testing.T) {
 		t.Fatalf("pending message must ask to wait for approval: %q", pending)
 	}
 }
+
+// The refusal carries a machine-readable code; unrelated errors carry none.
+func TestRegistrationErrorBody_CarriesTheCodeOnlyForTheOperatorRefusal(t *testing.T) {
+	body := registrationErrorBody(application.ErrNoAdministrators, NoAdministratorsMessage)
+	if body["success"] != false || body["error"] != NoAdministratorsMessage || body["code"] != NoAdministratorsCode {
+		t.Fatalf("unexpected refusal body: %v", body)
+	}
+	other := registrationErrorBody(errors.New("boom"), "Registration failed")
+	if _, ok := other["code"]; ok {
+		t.Fatalf("code attached to an unrelated error: %v", other)
+	}
+}
+
+// One message serves every refusal state (variable unset, set but nobody listed has registered,
+// sole administrator deactivated), so it must not claim the variable is unset.
+func TestNoAdministratorsMessage_IsTrueWhenTheAllowlistIsSet(t *testing.T) {
+	lower := strings.ToLower(NoAdministratorsMessage)
+	if strings.Contains(lower, "no administrators configured") || strings.Contains(lower, "not set") {
+		t.Fatalf("message asserts an unset variable, which is false when it is set: %q", NoAdministratorsMessage)
+	}
+	if !strings.Contains(lower, "no active administrator") {
+		t.Fatalf("message does not state the measured condition: %q", NoAdministratorsMessage)
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+)
+
+// The sign-up page shows the error string verbatim, so the message itself is the contract.
+func TestRegistrationErrorResponse_NoAdministratorsNamesTheVariable(t *testing.T) {
+	status, message := registrationErrorResponse(application.ErrNoAdministrators)
+	if status != fiber.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", status, fiber.StatusServiceUnavailable)
+	}
+	if !strings.Contains(message, "AIM_PLATFORM_ADMINS") {
+		t.Fatalf("message does not name AIM_PLATFORM_ADMINS: %q", message)
+	}
+	if message != NoAdministratorsMessage {
+		t.Fatalf("message is not the verbatim copy: %q", message)
+	}
+}
+
+func TestRegistrationErrorResponse_ExistingMappingsUnchanged(t *testing.T) {
+	cases := []struct {
+		err    error
+		status int
+	}{
+		{application.ErrUserAlreadyExists, fiber.StatusConflict},
+		{application.ErrRegistrationRequestExists, fiber.StatusConflict},
+		{errors.New("password validation failed: too short"), fiber.StatusBadRequest},
+		{errors.New("database exploded"), fiber.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		status, message := registrationErrorResponse(c.err)
+		if status != c.status {
+			t.Errorf("%v: status = %d, want %d", c.err, status, c.status)
+		}
+		if c.status == fiber.StatusInternalServerError && strings.Contains(message, "exploded") {
+			t.Errorf("internal error text leaked to the client: %q", message)
+		}
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
 )
 
 // The sign-up page shows the error string verbatim, so the message itself is the contract.
@@ -41,5 +42,16 @@ func TestRegistrationErrorResponse_ExistingMappingsUnchanged(t *testing.T) {
 		if c.status == fiber.StatusInternalServerError && strings.Contains(message, "exploded") {
 			t.Errorf("internal error text leaked to the client: %q", message)
 		}
+	}
+}
+
+func TestRegistrationSuccessMessage_StatesTheOutcome(t *testing.T) {
+	approved := registrationSuccessMessage(domain.RegistrationStatusApproved)
+	pending := registrationSuccessMessage(domain.RegistrationStatusPending)
+	if !strings.Contains(approved, "approved") || strings.Contains(approved, "wait") {
+		t.Fatalf("approved message must say approved and not ask to wait: %q", approved)
+	}
+	if !strings.Contains(pending, "wait for admin approval") {
+		t.Fatalf("pending message must ask to wait for approval: %q", pending)
 	}
 }

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
@@ -130,9 +130,14 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 		})
 	}
 
+	message := "Registration request submitted successfully. Please wait for admin approval."
+	if registrationRequest.Status == domain.RegistrationStatusApproved {
+		// An allowlisted address (AIM_PLATFORM_ADMINS) is approved on the spot.
+		message = "Registration approved. You can sign in now."
+	}
 	return c.Status(fiber.StatusCreated).JSON(&RegisterUserResponse{
 		Success:             true,
-		Message:             "Registration request submitted successfully. Please wait for admin approval.",
+		Message:             message,
 		RegistrationRequest: registrationRequest,
 		RequestID:           registrationRequest.ID,
 	})

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
@@ -119,33 +119,15 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 		signupProfile,
 	)
 	if err != nil {
-		// Handle specific error cases
-		switch err {
-		case application.ErrUserAlreadyExists:
-			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
-				"success": false,
-				"error":   "A user with this email already exists",
-			})
-		case application.ErrRegistrationRequestExists:
-			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
-				"success": false,
-				"error":   "A registration request with this email already exists and is pending approval",
-			})
-		default:
-			// Return validation errors (e.g. password too short) to the client
-			if strings.Contains(err.Error(), "password validation failed") {
-				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-					"success": false,
-					"error":   err.Error(),
-				})
-			}
+		status, message := registrationErrorResponse(err)
+		if status == fiber.StatusInternalServerError {
 			// SECURITY: Log unexpected errors server-side, return generic message to client
 			log.Printf("Registration request failed for email %s: %v", email, err)
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"success": false,
-				"error":   "An internal error occurred. Please try again later.",
-			})
 		}
+		return c.Status(status).JSON(fiber.Map{
+			"success": false,
+			"error":   message,
+		})
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(&RegisterUserResponse{
@@ -842,4 +824,27 @@ func (h *PublicRegistrationHandler) RegisterRoutes(app *fiber.App) {
 	public.Post("/login", h.Login)
 	public.Post("/change-password", h.ChangePassword)
 	public.Post("/forgot-password", h.ForgotPassword)
+}
+
+// NoAdministratorsMessage is shown verbatim on the sign-up page when nobody in the deployment
+// could approve the request (no AIM_PLATFORM_ADMINS allowlist and no active administrator).
+const NoAdministratorsMessage = "This deployment has no administrators configured. Set AIM_PLATFORM_ADMINS to a comma-separated list of emails and restart; accounts on that list are approved automatically."
+
+// registrationErrorResponse maps a registration failure to the status and message the client
+// receives. Unexpected errors map to 500 with a generic message; the caller logs them.
+func registrationErrorResponse(err error) (int, string) {
+	switch err {
+	case application.ErrUserAlreadyExists:
+		return fiber.StatusConflict, "A user with this email already exists"
+	case application.ErrRegistrationRequestExists:
+		return fiber.StatusConflict, "A registration request with this email already exists and is pending approval"
+	case application.ErrNoAdministrators:
+		// The deployment, not the request, is the problem: unavailable until an operator configures it.
+		return fiber.StatusServiceUnavailable, NoAdministratorsMessage
+	}
+	// Return validation errors (e.g. password too short) to the client
+	if strings.Contains(err.Error(), "password validation failed") {
+		return fiber.StatusBadRequest, err.Error()
+	}
+	return fiber.StatusInternalServerError, "An internal error occurred. Please try again later."
 }

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
@@ -68,6 +68,7 @@ type RegisterUserResponse struct {
 // @Failure 400 {object} map[string]interface{}
 // @Failure 409 {object} map[string]interface{}
 // @Failure 500 {object} map[string]interface{}
+// @Failure 503 {object} map[string]interface{}
 // @Router /api/v1/public/register [post]
 func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 	var req RegisterUserRequest
@@ -130,14 +131,9 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 		})
 	}
 
-	message := "Registration request submitted successfully. Please wait for admin approval."
-	if registrationRequest.Status == domain.RegistrationStatusApproved {
-		// An allowlisted address (AIM_PLATFORM_ADMINS) is approved on the spot.
-		message = "Registration approved. You can sign in now."
-	}
 	return c.Status(fiber.StatusCreated).JSON(&RegisterUserResponse{
 		Success:             true,
-		Message:             message,
+		Message:             registrationSuccessMessage(registrationRequest.Status),
 		RegistrationRequest: registrationRequest,
 		RequestID:           registrationRequest.ID,
 	})
@@ -470,6 +466,7 @@ type RequestAccessResponse struct {
 // @Failure 400 {object} map[string]interface{}
 // @Failure 409 {object} map[string]interface{}
 // @Failure 500 {object} map[string]interface{}
+// @Failure 503 {object} map[string]interface{}
 // @Router /api/v1/public/request-access [post]
 func (h *PublicRegistrationHandler) RequestAccess(c fiber.Ctx) error {
 	var req RequestAccessRequest
@@ -571,6 +568,11 @@ func (h *PublicRegistrationHandler) RequestAccess(c fiber.Ctx) error {
 			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
 				"success": false,
 				"error":   "An access request with this email is already pending approval",
+			})
+		case application.ErrNoAdministrators:
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"success": false,
+				"error":   NoAdministratorsMessage,
 			})
 		default:
 			// Return validation errors (e.g. password too short) to the client
@@ -852,4 +854,13 @@ func registrationErrorResponse(err error) (int, string) {
 		return fiber.StatusBadRequest, err.Error()
 	}
 	return fiber.StatusInternalServerError, "An internal error occurred. Please try again later."
+}
+
+// registrationSuccessMessage states the outcome of a successful sign-up: an allowlisted
+// address (AIM_PLATFORM_ADMINS) is approved on the spot, everyone else waits for review.
+func registrationSuccessMessage(status domain.RegistrationRequestStatus) string {
+	if status == domain.RegistrationStatusApproved {
+		return "Registration approved. You can sign in now."
+	}
+	return "Registration request submitted successfully. Please wait for admin approval."
 }

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_handler.go
@@ -125,10 +125,7 @@ func (h *PublicRegistrationHandler) RegisterUser(c fiber.Ctx) error {
 			// SECURITY: Log unexpected errors server-side, return generic message to client
 			log.Printf("Registration request failed for email %s: %v", email, err)
 		}
-		return c.Status(status).JSON(fiber.Map{
-			"success": false,
-			"error":   message,
-		})
+		return c.Status(status).JSON(registrationErrorBody(err, message))
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(&RegisterUserResponse{
@@ -569,25 +566,12 @@ func (h *PublicRegistrationHandler) RequestAccess(c fiber.Ctx) error {
 				"success": false,
 				"error":   "An access request with this email is already pending approval",
 			})
-		case application.ErrNoAdministrators:
-			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
-				"success": false,
-				"error":   NoAdministratorsMessage,
-			})
 		default:
-			// Return validation errors (e.g. password too short) to the client
-			if strings.Contains(err.Error(), "password validation failed") {
-				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-					"success": false,
-					"error":   err.Error(),
-				})
+			status, message := registrationErrorResponse(err)
+			if status == fiber.StatusInternalServerError {
+				log.Printf("Access request failed for email %s: %v", email, err)
 			}
-			// SECURITY: Log unexpected errors server-side, return generic message to client
-			log.Printf("Access request failed for email %s: %v", email, err)
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"success": false,
-				"error":   "An internal error occurred. Please try again later.",
-			})
+			return c.Status(status).JSON(registrationErrorBody(err, message))
 		}
 	}
 
@@ -835,7 +819,10 @@ func (h *PublicRegistrationHandler) RegisterRoutes(app *fiber.App) {
 
 // NoAdministratorsMessage is shown verbatim on the sign-up page when nobody in the deployment
 // could approve the request (no AIM_PLATFORM_ADMINS allowlist and no active administrator).
-const NoAdministratorsMessage = "This deployment has no administrators configured. Set AIM_PLATFORM_ADMINS to a comma-separated list of emails and restart; accounts on that list are approved automatically."
+const NoAdministratorsMessage = "This deployment has no active administrator, so new accounts cannot be approved yet. If you operate it: set AIM_PLATFORM_ADMINS to a comma-separated list of email addresses, restart, and register with one of those addresses; that account is approved automatically and can approve everyone else."
+
+// NoAdministratorsCode is the machine-readable form of that refusal.
+const NoAdministratorsCode = "noAdministrators"
 
 // registrationErrorResponse maps a registration failure to the status and message the client
 // receives. Unexpected errors map to 500 with a generic message; the caller logs them.
@@ -863,4 +850,14 @@ func registrationSuccessMessage(status domain.RegistrationRequestStatus) string 
 		return "Registration approved. You can sign in now."
 	}
 	return "Registration request submitted successfully. Please wait for admin approval."
+}
+
+// registrationErrorBody is the JSON body for a refused registration or access request; the
+// operator-actionable refusal carries a machine-readable code as well as its message.
+func registrationErrorBody(err error, message string) fiber.Map {
+	body := fiber.Map{"success": false, "error": message}
+	if err == application.ErrNoAdministrators {
+		body["code"] = NoAdministratorsCode
+	}
+	return body
 }

--- a/apps/backend/internal/interfaces/http/middleware/admin_test.go
+++ b/apps/backend/internal/interfaces/http/middleware/admin_test.go
@@ -352,3 +352,23 @@ func TestMemberMiddleware_StillBlocksAPIKey(t *testing.T) {
 	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode,
 		"API keys must NOT pass plain MemberMiddleware — key-material routes stay JWT-only")
 }
+
+// The registration guard counts users with domain.RoleAdmin as the approvers; the approval
+// routes sit behind this middleware. The two must admit the same role set, or a deployment
+// with a working approver is refused (or one without is not). Every other role is rejected.
+func TestAdminMiddleware_AdmitsExactlyTheRoleTheRegistrationGuardCounts(t *testing.T) {
+	admitted := map[domain.UserRole]bool{}
+	for _, role := range []domain.UserRole{domain.RoleAdmin, domain.RoleManager, domain.RoleMember, domain.RoleViewer} {
+		app := fiber.New()
+		app.Use(func(c fiber.Ctx) error {
+			c.Locals("role", string(role))
+			return c.Next()
+		})
+		app.Use(AdminMiddleware())
+		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+		resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+		assert.NoError(t, err)
+		admitted[role] = resp.StatusCode == fiber.StatusOK
+	}
+	assert.Equal(t, map[domain.UserRole]bool{domain.RoleAdmin: true, domain.RoleManager: false, domain.RoleMember: false, domain.RoleViewer: false}, admitted)
+}

--- a/apps/web/app/auth/register/page.tsx
+++ b/apps/web/app/auth/register/page.tsx
@@ -137,7 +137,10 @@ export default function RegisterPage() {
         error.message || "Registration failed. Please try again.";
       toast.error(errorMessage);
 
-      if (errorMessage.includes("email already exists")) {
+      if (error.code === "noAdministrators") {
+        // An operator instruction: keep it on the page, not only in a transient toast.
+        setErrors({ form: errorMessage });
+      } else if (errorMessage.includes("email already exists")) {
         setErrors({ email: "An account with this email already exists" });
       } else if (errorMessage.includes("password")) {
         setErrors({ password: errorMessage });
@@ -460,6 +463,16 @@ export default function RegisterPage() {
                 )}
               </div>
             </div>
+
+            {errors.form && (
+              <div
+                role="alert"
+                className="rounded-lg border border-danger/40 bg-danger/10 px-4 py-3 text-sm text-danger-text flex items-start gap-2"
+              >
+                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>{errors.form}</span>
+              </div>
+            )}
 
             <button
               type="submit"

--- a/apps/web/app/auth/register/page.tsx
+++ b/apps/web/app/auth/register/page.tsx
@@ -119,6 +119,12 @@ export default function RegisterPage() {
       });
 
       if (response.success) {
+        if (response.registrationRequest?.status === "approved") {
+          // An allowlisted address (AIM_PLATFORM_ADMINS) is approved on the spot.
+          toast.success("Account approved. Sign in to continue.");
+          router.push("/auth/login");
+          return;
+        }
         toast.success("Registration successful. Awaiting admin approval.");
         // Redirect to pending page with request ID
         router.push(

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -3,6 +3,9 @@
 import { toast } from "sonner";
 import { normalizeViolation, type SecurityViolation } from "./violations";
 
+/** An Error thrown for a non-2xx response, carrying the status and the backend's code when it sent one. */
+export type ApiRequestError = Error & { status?: number; code?: string };
+
 const SESSION_EXPIRED_TOAST_ID = "session-expired";
 
 // Runtime API URL configuration
@@ -686,7 +689,12 @@ class APIClient {
       // Backend can return either 'error' or 'message' field
       const errorMessage =
         error?.error || error?.message || `HTTP ${response.status}`;
-      throw new Error(errorMessage);
+      const requestError = new Error(errorMessage) as ApiRequestError;
+      requestError.status = response.status;
+      if (typeof error?.code === "string") {
+        requestError.code = error.code;
+      }
+      throw requestError;
     }
 
     // Handle 204 No Content responses (e.g., DELETE operations)

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -791,11 +791,13 @@ class APIClient {
     success: boolean;
     message: string;
     requestId: string;
+    registrationRequest?: { id: string; status: string };
   }> {
     const response = await this.request<{
       success: boolean;
       message: string;
       requestId: string;
+    registrationRequest?: { id: string; status: string };
     }>("/api/v1/public/register", {
       method: "POST",
       body: JSON.stringify(data),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,8 @@ services:
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
       # Admin user configuration (optional - override default admin password)
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@opena2a.org}
+      # Comma-separated emails approved automatically at sign-up; they become the first administrators.
+      - AIM_PLATFORM_ADMINS=${AIM_PLATFORM_ADMINS:-}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
       # DEFAULT_ADMIN_PASSWORD is read by `aim-bootstrap --default` inside the
       # container so operators can pre-set the canonical admin password via


### PR DESCRIPTION
## Summary

On a fresh self-hosted install with no `AIM_PLATFORM_ADMINS` allowlist and no active administrator, a sign-up created a pending registration request that nothing could ever approve, and nothing said so: the account waited forever. (The default administrator is seeded only by `cmd/bootstrap --default`, which an install need not run.)

The registration service now counts active administrators before writing anything, for every registrant that is not auto-approved. When there are none it refuses with `503` (body `code: noAdministrators`) and a message the sign-up page keeps on the form:

> This deployment has no active administrator, so new accounts cannot be approved yet. If you operate it: set AIM_PLATFORM_ADMINS to a comma-separated list of email addresses, restart, and register with one of those addresses; that account is approved automatically and can approve everyone else.

A set allowlist is not taken as proof that an approver exists: a mistyped entry, or a listed address that has not registered yet, used to leave a non-listed sign-up in the same unapproachable queue. The listed address itself is approved exactly as before and the count is never consulted for it. Entries that cannot be an address are ignored and reported once at startup, so a mistyped variable is visible without refusing to boot. A deployment with an administrator behaves exactly as before. The hosted product auto-approves every registration and is not affected (its backend is not part of the sync and still reads `shouldAutoApprove := true`).

The handler's error mapping moves into `registrationErrorResponse` so the status and the copy are tested. An allowlisted registrant now gets "Registration approved. You can sign in now." and the sign-up page sends them to sign-in instead of the pending screen.

## Changes

- `domain.UserRepository.CountByRoleAndStatus` (+ repository query, mocks).
- `RegistrationService`: `ensureApproverExists` refuses before writing on both public creators (register, access request) when no active administrator exists and the registrant is not auto-approved; `platformAdminAllowlist()` keeps only entries shaped like an address; `ReportPlatformAdminAllowlist()` logs accepted/ignored entries at startup.
- `PublicRegistrationHandler`: `503` + one message for every refusal state, `code: noAdministrators`; the access-request route shares the mapping; status-aware success message.
- Sign-up page: approved registrations go to sign-in; the refusal stays on the form as an alert. `lib/api.ts` errors carry `status` and the backend's `code`.
- README: the consequence of an unclaimed allowlist.

## Verification

- Unit tests: refuse-before-write on both creators with no allowlist and with a set-but-unclaimed allowlist (`ops@exmaple.com`, `true`), allowlist auto-approve unchanged (the count is not consulted), pending with an existing admin with and without an allowlist, parser filter, the handler mapping (message names `AIM_PLATFORM_ADMINS`, is true when the variable is set, body carries the code), and the admin middleware admitting exactly the role the guard counts. Red-proof: restoring the old allowlist short-circuit fails the set-but-unclaimed test; removing the refusal fails the refuse-before-write tests.
- Against a throwaway PostgreSQL with the server run from this branch: no allowlist and no admin → `POST /api/v1/public/register` returns 503 with the message and `user_registration_requests` / `users` stay at 0; allowlist set to the address → 201, request `approved`, one admin user; allowlist empty with that admin present → 201, request `pending`; fresh database with the allowlist set to a mistyped address → 503 and 0 rows; that address registers → approved admin, then a non-listed address → 201 `pending`; allowlist of non-address tokens → each reported at startup and treated as unset.
- `go vet ./...` clean, `go test ./...` 27 packages ok; `apps/web` tsc, lint, vitest (101) and `next build` green.
