### PR TITLE
Report the allowlist truthfully in the refusal log and pin the 503 mapping at the routes

### DIFF
--- a/apps/backend/internal/application/registration_service.go
+++ b/apps/backend/internal/application/registration_service.go
@@ -693,7 +693,7 @@ func (s *RegistrationService) ensureApproverExists(email string, autoApproved bo
 	}
 	if approvers == 0 {
 		// The client receives one message for every sub-case; the sub-case is operator-only.
-		log.Printf("registration refused for %s: 0 active administrators, %d valid AIM_PLATFORM_ADMINS entries, registrant listed=false", email, len(platformAdminAllowlist()))
+		log.Printf("registration refused for %s: 0 active administrators, %d valid AIM_PLATFORM_ADMINS entries, registrant listed=%t", email, len(platformAdminAllowlist()), isPlatformAdmin(email))
 		return ErrNoAdministrators
 	}
 	return nil
@@ -736,13 +736,15 @@ func ReportPlatformAdminAllowlist() {
 	if strings.TrimSpace(raw) == "" {
 		return
 	}
-	entries, ignored := parsePlatformAdminAllowlist(raw)
+	entries, _ := parsePlatformAdminAllowlist(raw)
 	for i, tok := range strings.Split(raw, ",") {
 		t := strings.ToLower(strings.TrimSpace(tok))
-		for _, ig := range ignored {
-			if t == ig {
-				log.Printf("AIM_PLATFORM_ADMINS entry %d (%q) is not an email address and is ignored", i+1, t)
-			}
+		if t == "" {
+			continue
+		}
+		// One line per position, so a token that appears twice is reported where it appears.
+		if accepted, _ := parsePlatformAdminAllowlist(t); len(accepted) == 0 {
+			log.Printf("AIM_PLATFORM_ADMINS entry %d (%q) is not an email address and is ignored", i+1, t)
 		}
 	}
 	if len(entries) == 0 {

--- a/apps/backend/internal/application/registration_service_test.go
+++ b/apps/backend/internal/application/registration_service_test.go
@@ -1,8 +1,11 @@
 package application
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1568,4 +1571,61 @@ func TestPlatformAdminAllowlist_IgnoresTokensThatCannotBeAnAddress(t *testing.T)
 	entries, ignored := parsePlatformAdminAllowlist("true, A@Example.com, x@, ops@exmaple.com")
 	assert.Equal(t, []string{"a@example.com", "ops@exmaple.com"}, entries)
 	assert.Equal(t, []string{"true", "x@"}, ignored)
+}
+
+// The refusal log line reports whether the registrant is on the allowlist; on the
+// access-request route a listed address is still not auto-approved, so the value must be
+// computed, not assumed.
+func TestRegistrationService_RefusalLogLine_ReportsWhetherTheRegistrantIsListed(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "ops@example.com")
+	ctx := context.Background()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	mockUserRepo := new(MockUserRepoForRegistration)
+	mockUserRepo.On("GetByEmail", "ops@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("GetByEmail", "other@example.com").Return(nil, errors.New("not found"))
+	mockUserRepo.On("CountByRoleAndStatus", domain.RoleAdmin, domain.UserStatusActive).Return(0, nil).Twice()
+	mockRegRepo := new(MockRegistrationRepoForService)
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "ops@example.com").Return(nil, errors.New("not found"))
+	mockRegRepo.On("GetRegistrationRequestByEmail", ctx, "other@example.com").Return(nil, errors.New("not found"))
+	service := NewRegistrationService(mockRegRepo, mockUserRepo, nil, nil, nil)
+
+	_, err := service.CreateAccessRequest(ctx, "ops@example.com", "Ops", "User", "needs a dashboard account", nil)
+	assert.Equal(t, ErrNoAdministrators, err)
+	assert.Contains(t, buf.String(), "registration refused for ops@example.com: 0 active administrators, 1 valid AIM_PLATFORM_ADMINS entries, registrant listed=true")
+
+	buf.Reset()
+	_, err = service.CreateAccessRequest(ctx, "other@example.com", "Other", "User", "needs a dashboard account", nil)
+	assert.Equal(t, ErrNoAdministrators, err)
+	assert.Contains(t, buf.String(), "registrant listed=false")
+	assert.NotContains(t, buf.String(), "ops@example.com", "allowlist entries must not be logged")
+}
+
+// The startup report names every ignored token by position, once, and says when the variable
+// yields no address at all.
+func TestReportPlatformAdminAllowlist_ReportsIgnoredTokensOncePerPosition(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	t.Setenv("AIM_PLATFORM_ADMINS", "true, A@Example.com, true, x@")
+	ReportPlatformAdminAllowlist()
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, `entry 1 ("true")`), out)
+	assert.Equal(t, 1, strings.Count(out, `entry 3 ("true")`), out)
+	assert.Equal(t, 1, strings.Count(out, `entry 4 ("x@")`), out)
+	assert.Equal(t, 3, strings.Count(out, "is not an email address and is ignored"), out)
+	assert.Contains(t, out, "1 address(es) accepted")
+
+	buf.Reset()
+	t.Setenv("AIM_PLATFORM_ADMINS", "true")
+	ReportPlatformAdminAllowlist()
+	assert.Contains(t, buf.String(), "contains no email address")
+
+	buf.Reset()
+	t.Setenv("AIM_PLATFORM_ADMINS", "")
+	ReportPlatformAdminAllowlist()
+	assert.Empty(t, buf.String(), "an unset variable is not reported")
 }

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_routes_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_routes_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+)
+
+// Minimal repositories for the refusal path: the routes read the user and the request by
+// email (the access route also checks any status), then the service counts approvers. Nothing else is reachable before the refusal, so
+// every other method is left to the embedded nil interface (a call would panic the test).
+type refusalUserRepo struct{ domain.UserRepository }
+
+func (refusalUserRepo) GetByEmail(string) (*domain.User, error) { return nil, errors.New("not found") }
+func (refusalUserRepo) CountByRoleAndStatus(domain.UserRole, domain.UserStatus) (int, error) {
+	return 0, nil
+}
+
+type refusalRegistrationRepo struct {
+	application.RegistrationRepository
+}
+
+func (refusalRegistrationRepo) GetRegistrationRequestByEmail(context.Context, string) (*domain.UserRegistrationRequest, error) {
+	return nil, errors.New("not found")
+}
+func (refusalRegistrationRepo) GetRegistrationRequestByEmailAnyStatus(context.Context, string) (*domain.UserRegistrationRequest, error) {
+	return nil, errors.New("not found")
+}
+
+// Both public creators must map the bare sentinel to 503 with the code and the message that
+// names the variable. A helper-level test cannot see a route that stops calling the helper.
+func TestPublicRegistrationRoutes_RefuseWith503AndCodeWhenNoAdministratorExists(t *testing.T) {
+	t.Setenv("AIM_PLATFORM_ADMINS", "ops@example.com") // set but unclaimed: predicate B, not A
+	service := application.NewRegistrationService(refusalRegistrationRepo{}, refusalUserRepo{}, nil, nil, nil)
+	// The access-request route asks the auth service for the user first; it only forwards to the repo.
+	authService := application.NewAuthService(refusalUserRepo{}, nil, nil, nil, nil, nil)
+	handler := NewPublicRegistrationHandler(service, authService, nil)
+
+	app := fiber.New()
+	app.Post("/register", handler.RegisterUser)
+	app.Post("/request-access", handler.RequestAccess)
+
+	cases := []struct {
+		route string
+		body  map[string]any
+	}{
+		{"/register", map[string]any{"email": "first@example.com", "firstName": "First", "lastName": "User", "password": "Str0ng!Passw0rd"}},
+		{"/request-access", map[string]any{"email": "access@example.com", "fullName": "Access User", "reason": "needs a dashboard account"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.route, func(t *testing.T) {
+			payload, _ := json.Marshal(tc.body)
+			req := httptest.NewRequest("POST", tc.route, bytes.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if resp.StatusCode != fiber.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", resp.StatusCode)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body["code"] != NoAdministratorsCode {
+				t.Fatalf("code = %v, want %q", body["code"], NoAdministratorsCode)
+			}
+			msg, _ := body["error"].(string)
+			if !strings.Contains(msg, "AIM_PLATFORM_ADMINS") {
+				t.Fatalf("message does not name the variable: %q", msg)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/interfaces/http/handlers/public_registration_routes_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/public_registration_routes_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
@@ -60,7 +61,8 @@ func TestPublicRegistrationRoutes_RefuseWith503AndCodeWhenNoAdministratorExists(
 			payload, _ := json.Marshal(tc.body)
 			req := httptest.NewRequest("POST", tc.route, bytes.NewReader(payload))
 			req.Header.Set("Content-Type", "application/json")
-			resp, err := app.Test(req)
+			// Fiber's default test timeout is one second; a loaded CI runner needs more.
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: 30 * time.Second, FailOnTimeout: true})
 			if err != nil {
 				t.Fatalf("request failed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Follow-up to #425, from an adversarial review of the merged commit.

- The refusal log line said `registrant listed=false` for every refusal. On the access-request route a listed address is not auto-approved either, so the line was wrong exactly when an operator would read it. The value is now computed.
- The startup report cross-joined tokens with ignored entries, so a token that appeared twice was reported four times. It now reports once per position.

## Verification

- New tests: the log line's `listed` value on both cases, with allowlist entries never written to the log; the startup report once per position, the no-address case, and the unset case; and both public routes exercised through a real handler and a real service over stub repositories, mapped to `503` with `code: noAdministrators` and the message naming `AIM_PLATFORM_ADMINS` — so a route that stops using the shared mapping fails a test (the previous pins were helper-level only).
- `go vet ./...` clean; `go test ./...` 27 packages ok.
