### PR TITLE
Refresh mints role and email from the user record, never from the token

### DIFF
--- a/apps/backend/cmd/server/main.go
+++ b/apps/backend/cmd/server/main.go
@@ -1279,10 +1279,12 @@ func initHandlers(services *Services, repos *Repositories, jwtService *auth.JWTS
 		AuthRefresh: handlers.NewAuthRefreshHandler(
 			jwtService,
 			services.SDKToken,
+			repos.User, // role/email re-read at refresh; never from the token
 		),
 		SDKTokenRecovery: handlers.NewSDKTokenRecoveryHandler(
 			services.SDKToken,
 			jwtService,
+			repos.User,
 		),
 		Capability: handlers.NewCapabilityHandler(
 			services.Capability,

--- a/apps/backend/internal/domain/user.go
+++ b/apps/backend/internal/domain/user.go
@@ -19,6 +19,18 @@ const (
 // UserStatus represents user account status
 type UserStatus string
 
+// CanHoldSession reports whether the account may keep or mint a session. It is
+// an allow-list — users.status has no CHECK constraint, so an unrecognised
+// value must fail closed — and a soft-deleted user never qualifies. Used by
+// token refresh and SDK token recovery; pending is admitted because login
+// admits it.
+func (u *User) CanHoldSession() bool {
+	if u == nil || u.DeletedAt != nil {
+		return false
+	}
+	return u.Status == UserStatusActive || u.Status == UserStatusPending
+}
+
 const (
 	UserStatusPending     UserStatus = "pending"     // Awaiting admin approval
 	UserStatusActive      UserStatus = "active"      // Can use system

--- a/apps/backend/internal/infrastructure/auth/jwt.go
+++ b/apps/backend/internal/infrastructure/auth/jwt.go
@@ -289,29 +289,18 @@ func (s *JWTService) ValidateToken(tokenString string) (*JWTClaims, error) {
 	return nil, fmt.Errorf("invalid token")
 }
 
-// RefreshAccessToken generates a new access token from a refresh token
-func (s *JWTService) RefreshAccessToken(refreshToken string) (string, error) {
-	claims, err := s.ValidateToken(refreshToken)
-	if err != nil {
-		return "", err
-	}
-
-	// An access token must not be usable to mint another access token. (Empty
-	// TokenType = legacy token issued before this claim; allowed during grace.)
-	if claims.TokenType == TokenTypeAccess {
-		return "", fmt.Errorf("access token cannot be used to refresh")
-	}
-
-	// Generate new access token
-	return s.GenerateAccessToken(claims.UserID, claims.OrganizationID, claims.Email, claims.Role)
-}
-
 // RefreshTokenPair generates new access AND refresh tokens (token rotation)
 // This implements token rotation for enhanced security:
 // - Old refresh token is invalidated after use
 // - New refresh token issued with 90-day expiry
 // Returns: newAccessToken, newRefreshToken, error
-func (s *JWTService) RefreshTokenPair(refreshToken string) (string, string, error) {
+//
+// A refresh token is an identity handle, not an authorization grant: the
+// caller supplies the principal's CURRENT email and role (read from the user
+// record), and nothing here reads the refresh token's own Email or Role
+// claims. Login-issued refresh tokens carry none; an embedded role would
+// outlive a demotion for the refresh lifetime.
+func (s *JWTService) RefreshTokenPair(refreshToken, email, role string) (string, string, error) {
 	claims, err := s.ValidateToken(refreshToken)
 	if err != nil {
 		return "", "", err
@@ -328,15 +317,15 @@ func (s *JWTService) RefreshTokenPair(refreshToken string) (string, string, erro
 
 	var newAccessToken, newRefreshToken string
 
-	// Generate new access token
-	newAccessToken, err = s.GenerateAccessToken(claims.UserID, claims.OrganizationID, claims.Email, claims.Role)
+	// Generate new access token from the supplied principal
+	newAccessToken, err = s.GenerateAccessToken(claims.UserID, claims.OrganizationID, email, role)
 	if err != nil {
 		return "", "", err
 	}
 
 	// Generate new refresh token (with same type as original)
 	if isSDKToken {
-		newRefreshToken, err = s.GenerateSDKRefreshToken(claims.UserID, claims.OrganizationID, claims.Email, claims.Role)
+		newRefreshToken, err = s.GenerateSDKRefreshToken(claims.UserID, claims.OrganizationID, email, role)
 	} else {
 		newRefreshToken, err = s.GenerateRefreshToken(claims.UserID, claims.OrganizationID)
 	}

--- a/apps/backend/internal/infrastructure/auth/jwt_refresh_role_test.go
+++ b/apps/backend/internal/infrastructure/auth/jwt_refresh_role_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import (
+	"testing"
+)
+
+// A refresh token is an identity handle, not an authorization grant. Before
+// these tests existed, RefreshTokenPair re-minted the access token from the
+// refresh token's own claims, and login-issued refresh tokens embed no role —
+// so every refreshed browser login (Google or password) came back with role ""
+// and hit the fail-closed member gate: the SDK's OAuth registration 403ed for
+// every user after its first refresh (reproduced on production 2026-08-27).
+
+// The principal supplied by the caller (read from the user record) is what the
+// new access token AND the rotated refresh token carry — even when the old SDK
+// refresh token embeds something else.
+func TestRefreshTokenPair_MintsFromSuppliedPrincipal(t *testing.T) {
+	cleanup := setupJWTTest(t)
+	defer cleanup()
+	svc := NewJWTService()
+
+	sdkRefresh, err := svc.GenerateSDKRefreshToken("user-1", "org-1", "sdk@example.com", "admin")
+	if err != nil {
+		t.Fatalf("GenerateSDKRefreshToken: %v", err)
+	}
+
+	newAccess, newRefresh, err := svc.RefreshTokenPair(sdkRefresh, "db@example.com", "viewer")
+	if err != nil {
+		t.Fatalf("RefreshTokenPair: %v", err)
+	}
+	for name, tok := range map[string]string{"access": newAccess, "rotated refresh": newRefresh} {
+		claims, err := svc.ValidateToken(tok)
+		if err != nil {
+			t.Fatalf("ValidateToken(%s): %v", name, err)
+		}
+		if claims.Role != "viewer" || claims.Email != "db@example.com" {
+			t.Fatalf("%s token carries %q/%q, want the supplied principal viewer/db@example.com", name, claims.Role, claims.Email)
+		}
+	}
+}
+
+// The login-issuer variant: the role survives a refresh because the caller
+// re-supplies it, not because the refresh token carried it.
+func TestRefreshTokenPairPreservesUserRoleAndEmail(t *testing.T) {
+	cleanup := setupJWTTest(t)
+	defer cleanup()
+	svc := NewJWTService()
+
+	_, refresh, err := svc.GenerateTokenPair("user-1", "org-1", "person@example.com", "admin")
+	if err != nil {
+		t.Fatalf("GenerateTokenPair: %v", err)
+	}
+	newAccess, _, err := svc.RefreshTokenPair(refresh, "person@example.com", "admin")
+	if err != nil {
+		t.Fatalf("RefreshTokenPair: %v", err)
+	}
+	claims, err := svc.ValidateToken(newAccess)
+	if err != nil {
+		t.Fatalf("ValidateToken(new access): %v", err)
+	}
+	if claims.Role != "admin" {
+		t.Fatalf("refreshed access token lost the role: got %q, want %q", claims.Role, "admin")
+	}
+	if claims.Email != "person@example.com" {
+		t.Fatalf("refreshed access token lost the email: got %q", claims.Email)
+	}
+}
+
+// Pins the contract: a login-issued refresh token carries no authorization.
+// Embedding a role here would move authorization into a 7-day credential that
+// nothing revokes on demotion.
+func TestGenerateTokenPair_RefreshTokenCarriesNoAuthorization(t *testing.T) {
+	cleanup := setupJWTTest(t)
+	defer cleanup()
+	svc := NewJWTService()
+
+	_, refresh, err := svc.GenerateTokenPair("user-1", "org-1", "person@example.com", "admin")
+	if err != nil {
+		t.Fatalf("GenerateTokenPair: %v", err)
+	}
+	claims, err := svc.ValidateToken(refresh)
+	if err != nil {
+		t.Fatalf("ValidateToken(refresh): %v", err)
+	}
+	if claims.Role != "" || claims.Email != "" {
+		t.Fatalf("refresh token must carry no role/email, got %q/%q", claims.Role, claims.Email)
+	}
+	if claims.UserID != "user-1" || claims.OrganizationID != "org-1" {
+		t.Fatalf("refresh token must still identify the principal, got %q/%q", claims.UserID, claims.OrganizationID)
+	}
+}

--- a/apps/backend/internal/infrastructure/auth/jwt_test.go
+++ b/apps/backend/internal/infrastructure/auth/jwt_test.go
@@ -227,40 +227,6 @@ func TestJWTService_ValidateToken_Expired(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestJWTService_RefreshAccessToken(t *testing.T) {
-	cleanup := setupJWTTest(t)
-	defer cleanup()
-
-	service := NewJWTService()
-	userID := uuid.New().String()
-	orgID := uuid.New().String()
-
-	// Generate a refresh token
-	refreshToken, err := service.GenerateRefreshToken(userID, orgID)
-	require.NoError(t, err)
-
-	// Use it to get a new access token
-	newAccessToken, err := service.RefreshAccessToken(refreshToken)
-	require.NoError(t, err)
-	assert.NotEmpty(t, newAccessToken)
-
-	// Validate the new access token
-	claims, err := service.ValidateToken(newAccessToken)
-	require.NoError(t, err)
-	assert.Equal(t, userID, claims.UserID)
-	assert.Equal(t, orgID, claims.OrganizationID)
-}
-
-func TestJWTService_RefreshAccessToken_InvalidToken(t *testing.T) {
-	cleanup := setupJWTTest(t)
-	defer cleanup()
-
-	service := NewJWTService()
-
-	_, err := service.RefreshAccessToken("invalid-token")
-	assert.Error(t, err)
-}
-
 func TestJWTService_RefreshTokenPair(t *testing.T) {
 	cleanup := setupJWTTest(t)
 	defer cleanup()
@@ -274,7 +240,7 @@ func TestJWTService_RefreshTokenPair(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rotate tokens
-	newAccessToken, newRefreshToken, err := service.RefreshTokenPair(refreshToken)
+	newAccessToken, newRefreshToken, err := service.RefreshTokenPair(refreshToken, "test@example.com", "admin")
 	require.NoError(t, err)
 	assert.NotEmpty(t, newAccessToken)
 	assert.NotEmpty(t, newRefreshToken)
@@ -302,7 +268,7 @@ func TestJWTService_RefreshTokenPair_RejectsAccessToken(t *testing.T) {
 	accessToken, err := service.GenerateAccessToken(userID, orgID, "test@example.com", "admin")
 	require.NoError(t, err)
 
-	_, _, err = service.RefreshTokenPair(accessToken)
+	_, _, err = service.RefreshTokenPair(accessToken, "test@example.com", "admin")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "access token cannot be used to refresh")
 }
@@ -346,7 +312,7 @@ func TestJWTService_RefreshTokenPair_SDKToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rotate tokens - should generate new SDK refresh token
-	newAccessToken, newRefreshToken, err := service.RefreshTokenPair(sdkRefreshToken)
+	newAccessToken, newRefreshToken, err := service.RefreshTokenPair(sdkRefreshToken, "sdk@example.com", "admin")
 	require.NoError(t, err)
 	assert.NotEmpty(t, newAccessToken)
 	assert.NotEmpty(t, newRefreshToken)

--- a/apps/backend/internal/infrastructure/repository/user_repository.go
+++ b/apps/backend/internal/infrastructure/repository/user_repository.go
@@ -69,10 +69,14 @@ func (r *UserRepository) Create(user *domain.User) error {
 
 // GetByID retrieves a user by ID
 func (r *UserRepository) GetByID(id uuid.UUID) (*domain.User, error) {
+	// deleted_at is load-bearing: User.CanHoldSession refuses soft-deleted
+	// accounts at token refresh and recovery, and a predicate whose data path
+	// never feeds the field it checks is a decoy control.
 	query := `
 		SELECT id, organization_id, email, name, avatar_url, role,
 		       password_hash, force_password_change, last_login_at,
-		       status, created_at, updated_at, approved_by, approved_at
+		       status, created_at, updated_at, approved_by, approved_at,
+		       deleted_at
 		FROM users
 		WHERE id = $1
 	`
@@ -95,6 +99,7 @@ func (r *UserRepository) GetByID(id uuid.UUID) (*domain.User, error) {
 		&user.UpdatedAt,
 		&user.ApprovedBy,
 		&user.ApprovedAt,
+		&user.DeletedAt,
 	)
 
 	if err == sql.ErrNoRows {

--- a/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler.go
@@ -16,14 +16,48 @@ import (
 type AuthRefreshHandler struct {
 	jwtService      *auth.JWTService
 	sdkTokenService *application.SDKTokenService
+	users           domain.UserRepository
 }
 
-// NewAuthRefreshHandler creates a new auth refresh handler
-func NewAuthRefreshHandler(jwtService *auth.JWTService, sdkTokenService *application.SDKTokenService) *AuthRefreshHandler {
+// NewAuthRefreshHandler creates a new auth refresh handler. A refresh token is
+// an identity handle, not an authorization grant: the new access token's role
+// and email are read from the user record at refresh time, so the user
+// repository is mandatory — a nil one is a boot-time refusal, never a fallback
+// to the token's own claims.
+func NewAuthRefreshHandler(jwtService *auth.JWTService, sdkTokenService *application.SDKTokenService, users domain.UserRepository) *AuthRefreshHandler {
+	if users == nil {
+		panic("NewAuthRefreshHandler: user repository is required")
+	}
 	return &AuthRefreshHandler{
 		jwtService:      jwtService,
 		sdkTokenService: sdkTokenService,
+		users:           users,
 	}
+}
+
+// refreshPrincipal resolves the account behind a refresh token from the
+// database and decides whether it may still hold a session. It returns the
+// user to mint from, or the 401 reason. No path falls back to the token's
+// embedded role or email.
+func (h *AuthRefreshHandler) refreshPrincipal(claims *auth.JWTClaims) (*domain.User, string) {
+	if claims.TokenType == auth.TokenTypeAccess || claims.Issuer == auth.IssuerService {
+		return nil, "Invalid or expired refresh token"
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		return nil, "Invalid or expired refresh token"
+	}
+	user, err := h.users.GetByID(userID)
+	if err != nil || user == nil {
+		return nil, "Invalid or expired refresh token"
+	}
+	if user.OrganizationID.String() != claims.OrganizationID {
+		return nil, "Invalid or expired refresh token"
+	}
+	if !user.CanHoldSession() {
+		return nil, "Account is not active"
+	}
+	return user, ""
 }
 
 // RefreshToken godoc
@@ -94,8 +128,24 @@ func (h *AuthRefreshHandler) RefreshToken(c fiber.Ctx) error {
 		}
 	}
 
+	// Resolve the principal from the database: role and email come from the
+	// user record, never from the refresh token's claims (login-issued refresh
+	// tokens carry none, and an embedded role would outlive a demotion).
+	claims, err := h.jwtService.ValidateToken(req.RefreshToken)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Invalid or expired refresh token",
+		})
+	}
+	user, refusal := h.refreshPrincipal(claims)
+	if refusal != "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": refusal,
+		})
+	}
+
 	// Validate refresh token and generate new tokens (with rotation)
-	newAccessToken, newRefreshToken, err := h.jwtService.RefreshTokenPair(req.RefreshToken)
+	newAccessToken, newRefreshToken, err := h.jwtService.RefreshTokenPair(req.RefreshToken, user.Email, string(user.Role))
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "Invalid or expired refresh token",

--- a/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_refresh_handler_test.go
@@ -14,9 +14,13 @@ import (
 // NewAuthRefreshHandler Tests
 // ===========================
 
-func TestNewAuthRefreshHandler_NilDeps(t *testing.T) {
-	handler := NewAuthRefreshHandler(nil, nil)
-	assert.NotNil(t, handler)
+func TestNewAuthRefreshHandler_NilUserRepoPanics(t *testing.T) {
+	// A nil user repository must be a boot-time refusal: the alternative is a
+	// silent fallback to the refresh token's own (empty) role claims.
+	assert.Panics(t, func() {
+		NewAuthRefreshHandler(nil, nil, nil)
+	})
+	assert.NotNil(t, NewAuthRefreshHandler(nil, nil, &refreshTestUserRepo{}))
 }
 
 // ===========================
@@ -24,7 +28,7 @@ func TestNewAuthRefreshHandler_NilDeps(t *testing.T) {
 // ===========================
 
 func TestAuthRefreshHandler_RefreshToken_InvalidJSON(t *testing.T) {
-	handler := &AuthRefreshHandler{}
+	handler := &AuthRefreshHandler{users: &refreshTestUserRepo{}}
 	app := fiber.New()
 	app.Post("/auth/refresh", handler.RefreshToken)
 
@@ -39,7 +43,7 @@ func TestAuthRefreshHandler_RefreshToken_InvalidJSON(t *testing.T) {
 }
 
 func TestAuthRefreshHandler_RefreshToken_MissingToken(t *testing.T) {
-	handler := &AuthRefreshHandler{}
+	handler := &AuthRefreshHandler{users: &refreshTestUserRepo{}}
 	app := fiber.New()
 	app.Post("/auth/refresh", handler.RefreshToken)
 
@@ -55,7 +59,7 @@ func TestAuthRefreshHandler_RefreshToken_MissingToken(t *testing.T) {
 }
 
 func TestAuthRefreshHandler_RefreshToken_EmptyToken(t *testing.T) {
-	handler := &AuthRefreshHandler{}
+	handler := &AuthRefreshHandler{users: &refreshTestUserRepo{}}
 	app := fiber.New()
 	app.Post("/auth/refresh", handler.RefreshToken)
 

--- a/apps/backend/internal/interfaces/http/handlers/auth_refresh_principal_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/auth_refresh_principal_test.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
+)
+
+// A refresh token is an identity handle: the minted pair's role and email come
+// from the user record at refresh time, and an account that may not hold a
+// session cannot refresh one. Before these tests, RefreshTokenPair copied the
+// refresh token's own claims — login-issued tokens carry none, so every
+// refreshed browser session became role-less and 403ed at the member gates
+// (reproduced on production 2026-08-27).
+
+// refreshTestUserRepo stubs domain.UserRepository; only GetByID is real.
+type refreshTestUserRepo struct {
+	domain.UserRepository
+	getByID func(id uuid.UUID) (*domain.User, error)
+}
+
+func (r *refreshTestUserRepo) GetByID(id uuid.UUID) (*domain.User, error) {
+	if r.getByID == nil {
+		return nil, fmt.Errorf("unexpected GetByID")
+	}
+	return r.getByID(id)
+}
+
+// refreshTestSDKRepo stubs domain.SDKTokenRepository for the rotation path.
+type refreshTestSDKRepo struct {
+	domain.SDKTokenRepository
+	getByTokenHash func(hash string) (*domain.SDKToken, error)
+	created        []*domain.SDKToken
+}
+
+func (r *refreshTestSDKRepo) GetByTokenHash(hash string) (*domain.SDKToken, error) {
+	if r.getByTokenHash == nil {
+		return nil, fmt.Errorf("not tracked")
+	}
+	return r.getByTokenHash(hash)
+}
+func (r *refreshTestSDKRepo) RecordUsage(tokenID string, ipAddress string) error { return nil }
+func (r *refreshTestSDKRepo) RevokeByTokenHash(tokenHash string, reason string) error {
+	return nil
+}
+func (r *refreshTestSDKRepo) Create(token *domain.SDKToken) error {
+	r.created = append(r.created, token)
+	return nil
+}
+
+func decodeRoleEmail(t *testing.T, token string) (string, string) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims struct {
+		Role  string `json:"role"`
+		Email string `json:"email"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	return claims.Role, claims.Email
+}
+
+func newRefreshTestApp(t *testing.T, users domain.UserRepository, sdkRepo domain.SDKTokenRepository) (*fiber.App, *auth.JWTService) {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-secret-key-for-unit-tests-32")
+	jwtSvc := auth.NewJWTService()
+	if sdkRepo == nil {
+		sdkRepo = &refreshTestSDKRepo{}
+	}
+	h := NewAuthRefreshHandler(jwtSvc, application.NewSDKTokenService(sdkRepo), users)
+	app := fiber.New()
+	app.Post("/auth/refresh", h.RefreshToken)
+	return app, jwtSvc
+}
+
+func postRefresh(t *testing.T, app *fiber.App, refreshToken string) (*RefreshTokenResponse, int) {
+	t.Helper()
+	body := fmt.Sprintf(`{"refreshToken":%q}`, refreshToken)
+	req := httptest.NewRequest("POST", "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var out RefreshTokenResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return &out, resp.StatusCode
+}
+
+func activeUser(id, orgID uuid.UUID, role domain.UserRole, email string) *domain.User {
+	return &domain.User{
+		ID:             id,
+		OrganizationID: orgID,
+		Email:          email,
+		Role:           role,
+		Status:         domain.UserStatusActive,
+	}
+}
+
+// H1: the login-issuer P0 regression — the refreshed pair carries the user's
+// CURRENT role and email from the database (here: demoted admin -> member).
+func TestRefreshToken_MintsRoleAndEmailFromUserRecord(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(id uuid.UUID) (*domain.User, error) {
+		require.Equal(t, userID, id)
+		return activeUser(userID, orgID, domain.RoleMember, "current@example.com"), nil
+	}}
+	app, jwtSvc := newRefreshTestApp(t, users, nil)
+	_, refresh, err := jwtSvc.GenerateTokenPair(userID.String(), orgID.String(), "old@example.com", "admin")
+	require.NoError(t, err)
+
+	out, status := postRefresh(t, app, refresh)
+	require.Equal(t, fiber.StatusOK, status)
+	role, email := decodeRoleEmail(t, out.AccessToken)
+	assert.Equal(t, "member", role, "role must come from the user record, not the old token")
+	assert.Equal(t, "current@example.com", email)
+}
+
+// H2: SDK-issuer tokens embed a role, but the DB still wins.
+func TestRefreshToken_SDKTokenRoleComesFromDB(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) {
+		return activeUser(userID, orgID, domain.RoleViewer, "db@example.com"), nil
+	}}
+	sdkRepo := &refreshTestSDKRepo{getByTokenHash: func(string) (*domain.SDKToken, error) {
+		return &domain.SDKToken{
+			ID:             uuid.New(),
+			UserID:         userID,
+			OrganizationID: orgID,
+			ExpiresAt:      time.Now().Add(24 * time.Hour),
+		}, nil
+	}}
+	app, jwtSvc := newRefreshTestApp(t, users, sdkRepo)
+	refresh, err := jwtSvc.GenerateSDKRefreshToken(userID.String(), orgID.String(), "sdk@example.com", "admin")
+	require.NoError(t, err)
+
+	out, status := postRefresh(t, app, refresh)
+	require.Equal(t, fiber.StatusOK, status)
+	role, _ := decodeRoleEmail(t, out.AccessToken)
+	assert.Equal(t, "viewer", role, "an embedded admin role must not survive when the DB says viewer")
+}
+
+// H3: accounts that may not hold a session cannot refresh one. The status set
+// is an allow-list: an unrecognised value fails closed.
+func TestRefreshToken_RefusedForAccountsThatCannotHoldASession(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	deleted := time.Now()
+	cases := map[string]*domain.User{
+		"suspended":      {ID: userID, OrganizationID: orgID, Role: domain.RoleAdmin, Status: domain.UserStatusSuspended},
+		"deactivated":    {ID: userID, OrganizationID: orgID, Role: domain.RoleAdmin, Status: domain.UserStatusDeactivated},
+		"soft-deleted":   {ID: userID, OrganizationID: orgID, Role: domain.RoleAdmin, Status: domain.UserStatusActive, DeletedAt: &deleted},
+		"unknown-status": {ID: userID, OrganizationID: orgID, Role: domain.RoleAdmin, Status: domain.UserStatus("zombie")},
+	}
+	for name, user := range cases {
+		t.Run(name, func(t *testing.T) {
+			users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) { return user, nil }}
+			app, jwtSvc := newRefreshTestApp(t, users, nil)
+			_, refresh, err := jwtSvc.GenerateTokenPair(userID.String(), orgID.String(), "x@example.com", "admin")
+			require.NoError(t, err)
+
+			out, status := postRefresh(t, app, refresh)
+			assert.Equal(t, fiber.StatusUnauthorized, status)
+			assert.Empty(t, out.AccessToken, "a refused refresh must not return a token")
+		})
+	}
+}
+
+// H4: a lookup error is a refusal, never a fallback to the token's claims.
+func TestRefreshToken_LookupErrorFailsClosed(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) {
+		return nil, fmt.Errorf("db unavailable")
+	}}
+	app, jwtSvc := newRefreshTestApp(t, users, nil)
+	_, refresh, err := jwtSvc.GenerateTokenPair(userID.String(), orgID.String(), "x@example.com", "admin")
+	require.NoError(t, err)
+
+	out, status := postRefresh(t, app, refresh)
+	assert.Equal(t, fiber.StatusUnauthorized, status)
+	assert.Empty(t, out.AccessToken)
+}
+
+// H5: an unknown user is a refusal.
+func TestRefreshToken_UnknownUserRefused(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) { return nil, nil }}
+	app, jwtSvc := newRefreshTestApp(t, users, nil)
+	_, refresh, err := jwtSvc.GenerateTokenPair(userID.String(), orgID.String(), "x@example.com", "admin")
+	require.NoError(t, err)
+
+	_, status := postRefresh(t, app, refresh)
+	assert.Equal(t, fiber.StatusUnauthorized, status)
+}
+
+// H6: the token's organization must match the user record's.
+func TestRefreshToken_OrgMismatchRefused(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) {
+		return activeUser(userID, uuid.New(), domain.RoleAdmin, "x@example.com"), nil
+	}}
+	app, jwtSvc := newRefreshTestApp(t, users, nil)
+	_, refresh, err := jwtSvc.GenerateTokenPair(userID.String(), orgID.String(), "x@example.com", "admin")
+	require.NoError(t, err)
+
+	_, status := postRefresh(t, app, refresh)
+	assert.Equal(t, fiber.StatusUnauthorized, status)
+}
+
+// H7: a service-principal token can never traverse the human refresh path.
+func TestRefreshToken_ServiceTokenRefused(t *testing.T) {
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) {
+		t.Fatal("a service token must be refused before any user lookup")
+		return nil, nil
+	}}
+	app, jwtSvc := newRefreshTestApp(t, users, nil)
+	svcToken, err := jwtSvc.GenerateServiceToken(uuid.New().String(), uuid.New().String())
+	require.NoError(t, err)
+
+	_, status := postRefresh(t, app, svcToken)
+	assert.Equal(t, fiber.StatusUnauthorized, status)
+}

--- a/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_handler.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_handler.go
@@ -16,15 +16,24 @@ import (
 type SDKTokenRecoveryHandler struct {
 	sdkTokenService *application.SDKTokenService
 	jwtService      *auth.JWTService
+	users           domain.UserRepository
 }
 
+// NewSDKTokenRecoveryHandler builds the recovery handler. The recovered pair's
+// role and email are read from the user record, so the user repository is
+// mandatory (boot-time refusal on nil, no fallback).
 func NewSDKTokenRecoveryHandler(
 	sdkTokenService *application.SDKTokenService,
 	jwtService *auth.JWTService,
+	users domain.UserRepository,
 ) *SDKTokenRecoveryHandler {
+	if users == nil {
+		panic("NewSDKTokenRecoveryHandler: user repository is required")
+	}
 	return &SDKTokenRecoveryHandler{
 		sdkTokenService: sdkTokenService,
 		jwtService:      jwtService,
+		users:           users,
 	}
 }
 
@@ -78,12 +87,27 @@ func (h *SDKTokenRecoveryHandler) RecoverRevokedToken(c fiber.Ctx) error {
 		})
 	}
 
+	// The recovered pair carries the account's CURRENT role and email, read
+	// from the database; an account that may no longer hold a session cannot
+	// recover one.
+	user, err := h.users.GetByID(oldToken.UserID)
+	if err != nil || user == nil || user.OrganizationID != oldToken.OrganizationID {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Invalid or expired refresh token",
+		})
+	}
+	if !user.CanHoldSession() {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Account is not active",
+		})
+	}
+
 	// Generate new SDK token pair for the same user
 	newAccessToken, newRefreshToken, err := h.jwtService.GenerateTokenPair(
 		oldToken.UserID.String(),
 		oldToken.OrganizationID.String(),
-		"", // email will be populated from DB
-		"", // role will be populated from DB
+		user.Email,
+		string(user.Role),
 	)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_handler_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_handler_test.go
@@ -15,7 +15,7 @@ import (
 // ===========================
 
 func TestNewSDKTokenRecoveryHandler_NilDeps(t *testing.T) {
-	handler := NewSDKTokenRecoveryHandler(nil, nil)
+	handler := NewSDKTokenRecoveryHandler(nil, nil, &refreshTestUserRepo{})
 	assert.NotNil(t, handler)
 }
 
@@ -24,7 +24,7 @@ func TestNewSDKTokenRecoveryHandler_NilDeps(t *testing.T) {
 // ===========================
 
 func TestSDKTokenRecoveryHandler_RecoverRevokedToken_InvalidJSON(t *testing.T) {
-	handler := &SDKTokenRecoveryHandler{}
+	handler := &SDKTokenRecoveryHandler{users: &refreshTestUserRepo{}}
 	app := fiber.New()
 	app.Post("/sdk/recover", handler.RecoverRevokedToken)
 
@@ -39,7 +39,7 @@ func TestSDKTokenRecoveryHandler_RecoverRevokedToken_InvalidJSON(t *testing.T) {
 }
 
 func TestSDKTokenRecoveryHandler_RecoverRevokedToken_EmptyOldRefreshToken(t *testing.T) {
-	handler := &SDKTokenRecoveryHandler{}
+	handler := &SDKTokenRecoveryHandler{users: &refreshTestUserRepo{}}
 	app := fiber.New()
 	app.Post("/sdk/recover", handler.RecoverRevokedToken)
 

--- a/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_principal_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/sdk_token_recovery_principal_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/infrastructure/auth"
+)
+
+// The recovery path previously minted the new pair with role "" and email ""
+// (a comment claimed "will be populated from DB"; nothing did). The recovered
+// pair now carries the account's CURRENT role and email, and an account that
+// may not hold a session cannot recover one.
+
+func newRecoveryTestApp(t *testing.T, users domain.UserRepository, sdkRepo domain.SDKTokenRepository) (*fiber.App, *auth.JWTService) {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-secret-key-for-unit-tests-32")
+	jwtSvc := auth.NewJWTService()
+	h := NewSDKTokenRecoveryHandler(application.NewSDKTokenService(sdkRepo), jwtSvc, users)
+	app := fiber.New()
+	app.Post("/auth/sdk/recover", h.RecoverRevokedToken)
+	return app, jwtSvc
+}
+
+func postRecover(t *testing.T, app *fiber.App, oldRefreshToken string) (*RecoverTokenResponse, int) {
+	t.Helper()
+	body := fmt.Sprintf(`{"oldRefreshToken":%q}`, oldRefreshToken)
+	req := httptest.NewRequest("POST", "/auth/sdk/recover", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var out RecoverTokenResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return &out, resp.StatusCode
+}
+
+func revokedSDKToken(userID, orgID uuid.UUID) *domain.SDKToken {
+	revoked := time.Now().Add(-time.Hour)
+	return &domain.SDKToken{
+		ID:             uuid.New(),
+		UserID:         userID,
+		OrganizationID: orgID,
+		RevokedAt:      &revoked,
+		ExpiresAt:      time.Now().Add(24 * time.Hour),
+	}
+}
+
+// R1: the recovered pair carries the DB role and email (pre-fix: "" and "").
+func TestRecoverRevokedToken_MintsRoleAndEmailFromUserRecord(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(id uuid.UUID) (*domain.User, error) {
+		require.Equal(t, userID, id)
+		return activeUser(userID, orgID, domain.RoleManager, "current@example.com"), nil
+	}}
+	sdkRepo := &refreshTestSDKRepo{getByTokenHash: func(string) (*domain.SDKToken, error) {
+		return revokedSDKToken(userID, orgID), nil
+	}}
+	app, jwtSvc := newRecoveryTestApp(t, users, sdkRepo)
+	oldRefresh, err := jwtSvc.GenerateSDKRefreshToken(userID.String(), orgID.String(), "old@example.com", "admin")
+	require.NoError(t, err)
+
+	out, status := postRecover(t, app, oldRefresh)
+	require.Equal(t, fiber.StatusOK, status)
+	role, email := decodeRoleEmail(t, out.AccessToken)
+	assert.Equal(t, "manager", role, "recovered pair must carry the DB role, not an empty one")
+	assert.Equal(t, "current@example.com", email)
+}
+
+// R2: an account that may not hold a session cannot recover one.
+func TestRecoverRevokedToken_RefusedForInactiveAccount(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	users := &refreshTestUserRepo{getByID: func(uuid.UUID) (*domain.User, error) {
+		return &domain.User{ID: userID, OrganizationID: orgID, Role: domain.RoleAdmin, Status: domain.UserStatusSuspended}, nil
+	}}
+	sdkRepo := &refreshTestSDKRepo{getByTokenHash: func(string) (*domain.SDKToken, error) {
+		return revokedSDKToken(userID, orgID), nil
+	}}
+	app, jwtSvc := newRecoveryTestApp(t, users, sdkRepo)
+	oldRefresh, err := jwtSvc.GenerateSDKRefreshToken(userID.String(), orgID.String(), "old@example.com", "admin")
+	require.NoError(t, err)
+
+	out, status := postRecover(t, app, oldRefresh)
+	assert.Equal(t, fiber.StatusUnauthorized, status)
+	assert.Empty(t, out.AccessToken)
+}
+
+// The nil-users boot refusal mirrors the refresh handler's.
+func TestNewSDKTokenRecoveryHandler_NilUserRepoPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewSDKTokenRecoveryHandler(nil, nil, nil)
+	})
+}


### PR DESCRIPTION
## What

`POST /api/v1/auth/refresh` re-minted access tokens from the refresh token's own claims. Login-issued refresh tokens embed no role or email, so after one refresh every browser-originated session (Google or password) carried an empty role and the fail-closed member gates returned 403 — the SDK's OAuth registration failed for every such user (reproduced live today while testing `aim-sdk demo`), and browser sessions past the access TTL lost their role the same way. The SDK token recovery path minted empty role and email outright.

A refresh token is an identity handle, not an authorization grant:

- `RefreshTokenPair` now takes the principal's current email and role; nothing reads the refresh token's embedded ones (SDK-issuer tokens' embedded values become informational).
- The refresh handler resolves the principal from the user repository — a mandatory dependency (boot-time refusal on nil; a fallback to claims would silently reintroduce the stale-role behaviour) — and refuses refresh when the user is missing, the lookup errors, the organization doesn't match the token, or the account cannot hold a session (allow-list of `active` and `pending`; `users.status` has no CHECK constraint, so unknown values fail closed; the predicate lives once on `domain.User`). Service-principal tokens are refused before any lookup.
- The recovery path applies the same rule and mints from the record.
- The dead `RefreshAccessToken` helper is removed.

Because role is re-read at mint time, refresh tokens issued before this fix — which would otherwise stay role-less forever — heal on their first refresh after deployment.

## Verification

- Contract tests: a login refresh token carries no role/email (pins the shape); the minted pair carries the supplied principal even when the old SDK token embeds something else.
- Handler tests: role/email come from the DB for both issuers (demoted admin → member; embedded admin → viewer); suspended/deactivated/soft-deleted/unknown-status accounts, lookup errors, unknown users, org mismatches, and service tokens all get 401 with no token in the body; nil user repository panics at construction.
- Mutation checks, each failing a named test: re-minting from claims; removing the session predicate; fabricating a matching-org principal on lookup failure (a first fabricated-principal mutant was refused by the org-match check — defense in depth — so the sharper matching-org mutant proves the lookup tests have their own teeth).
- `go vet ./...` clean; full runs of the auth, handlers, application, and cmd/server packages green. HMA exit 0.