### PR TITLE
Make the mobile nav drawer and remaining menus opaque overlay surfaces

### DIFF
--- a/apps/web/app/dashboard/mcp/supply-chain/page.tsx
+++ b/apps/web/app/dashboard/mcp/supply-chain/page.tsx
@@ -860,7 +860,7 @@ function SupplyChainPage() {
                 </button>
                 <div
                   id="abom-export-dropdown"
-                  className="hidden absolute right-0 mt-2 w-48 glass-chrome overflow-hidden z-10"
+                  className="hidden absolute right-0 mt-2 w-48 overlay-surface overflow-hidden z-10"
                 >
                   <button
                     onClick={() => {
@@ -2125,7 +2125,7 @@ function SupplyChainPage() {
           {/* Agent Detail Modal */}
           {selectedAgent && (
             <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-              <div className="glass-chrome max-w-2xl w-full max-h-[90vh] overflow-hidden">
+              <div className="overlay-surface max-w-2xl w-full max-h-[90vh] overflow-hidden">
                 {/* Modal Header */}
                 <div className="px-6 py-4 border-b border-divider flex items-center justify-between">
                   <div className="flex items-center gap-3">

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -387,7 +387,7 @@ export function Sidebar({ mobileOpen: mobileOpenProp, onMobileOpenChange }: Side
       )}
       <aside
         className={cn(
-          "glass-chrome fixed bottom-3 left-3 top-3 z-50 flex w-[280px] max-w-[85vw] flex-col px-3.5 py-5 transition-transform duration-300 ease-out lg:hidden",
+          "overlay-surface fixed bottom-3 left-3 top-3 z-50 flex w-[280px] max-w-[85vw] flex-col px-3.5 py-5 transition-transform duration-300 ease-out lg:hidden",
           mobileOpen ? "translate-x-0" : "-translate-x-[120%]"
         )}
         aria-hidden={!mobileOpen}


### PR DESCRIPTION
The mobile navigation drawer (opened from the bottom tab bar) still rendered as translucent glass over arbitrary page content, as did the supply-chain page's row menu and its agent detail modal — the overlay rule (opaque surfaces for anything that floats over content) was applied to dialogs and the profile menu earlier but these three were missed. All three now use the shared `overlay-surface` primitive. The desktop sidebar, bottom tab bar, and loading veil stay glass deliberately: page chrome and a scrim, not overlays.

Verified on the dev server at 375px: drawer background is solid `rgb(255,255,255)`, tsc and both test suites green.