### PR TITLE
Add the gate-file approval check

### DIFF
--- a/.github/workflows/gate-file-approval.yml
+++ b/.github/workflows/gate-file-approval.yml
@@ -1,0 +1,149 @@
+# Gate file approval — a path-scoped merge gate for this repository's own CI,
+# review, and release configuration.
+#
+# Any pull request that changes a file under .github/ must carry an approving
+# review from a listed approver, given on the pull request's current head
+# commit. Pull requests that touch nothing under .github/ pass immediately, so
+# ordinary changes stay gated by status checks alone.
+#
+# Why pull_request_target: the workflow definition is read from the BASE
+# branch, so a pull request that modifies this file is judged by the unmodified
+# copy — the gate cannot be weakened by the change it is judging. This job
+# reads only API data (the changed-file list and the review list). It must
+# never check out or execute pull request head content, must never reference a
+# repository secret, and must keep its token read-only apart from checks:write.
+# A tripwire below fails the check if a pull request tries to change that.
+#
+# The verdict is carried twice on purpose: as an explicit check run named
+# "Gate file approval" posted against the head commit (the context branch
+# protection must require), and as the job's own exit status, so that even a
+# misconfigured protection rule that requires the job context instead of the
+# check run still carries the real verdict rather than an always-green job.
+name: Gate file approval
+
+on:
+  pull_request_target:
+    # edited is required: retargeting the base branch recomputes the diff
+    # without changing the head commit, so the verdict must be re-evaluated.
+    types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+concurrency:
+  group: gate-file-approval-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate gate-file approval
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Evaluate and post the check run
+        run: |
+          set -euo pipefail
+          # The approver set. Changing it is itself a gate-file change, so the
+          # change is judged by the current set.
+          approvers="thebenignhacker"
+
+          # The files listing endpoint is capped at 3000 entries; a gate file
+          # hidden past the cap would otherwise pass unseen. Refuse to evaluate
+          # oversized pull requests instead of failing open.
+          changed_count=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .changed_files)
+          if [ "$changed_count" -ge 3000 ]; then
+            conclusion="failure"
+            title="Too many changed files to evaluate"
+            summary="This pull request changes $changed_count files, at or beyond the 3000-entry listing cap, so the gate cannot see every path. Split the pull request."
+          else
+            conclusion=""
+            title=""
+            summary=""
+          fi
+
+          # Both sides of a rename count: a pull request that renames a file OUT
+          # of .github/ reports the old path only in previous_filename, and a
+          # rename is as much a gate-file change as an edit.
+          files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+            --jq '.[] | .filename, (.previous_filename // empty)')
+
+          # grep exit 1 means no match; anything above 1 is an execution error
+          # and must abort rather than read as "no gate files" (fail closed).
+          set +e
+          printf '%s\n' "$files" | grep -q '^\.github/'
+          gate_rc=$?
+          set -e
+          [ "$gate_rc" -le 1 ]
+
+          if [ -z "$conclusion" ] && [ "$gate_rc" -eq 1 ]; then
+            conclusion="success"
+            title="No gate files touched"
+            summary="This pull request changes nothing under .github/, so no gate-file approval is required."
+          fi
+
+          if [ -z "$conclusion" ]; then
+            # Tripwire: if this pull request modifies this workflow, inspect the
+            # proposed copy AS DATA (never executed) and refuse patterns that
+            # would re-arm the pull_request_target attack surface. The patterns
+            # are split so this file cannot match itself. An unreadable proposed
+            # copy is refused too, never waved through.
+            if printf '%s\n' "$files" | grep -qx '\.github/workflows/gate-file-approval\.yml'; then
+              p_checkout='actions/''checkout'
+              p_secret='secrets''[.]'
+              p_write='contents:''[[:space:]]*write'
+              p_writeall='write-''all'
+              head_copy=$(gh api "repos/$REPO/contents/.github/workflows/gate-file-approval.yml?ref=$HEAD_SHA" --jq .content | base64 -d)
+              if [ -z "$head_copy" ]; then
+                conclusion="failure"
+                title="Gate workflow copy unreadable"
+                summary="The proposed gate-file-approval.yml could not be read for inspection (empty contents response). Refused rather than waved through."
+              elif printf '%s\n' "$head_copy" | grep -Eq "$p_checkout|$p_secret|$p_write|$p_writeall"; then
+                conclusion="failure"
+                title="Gate workflow hardening violated"
+                summary="The proposed gate-file-approval.yml checks out head content, references a secret, or widens write permissions. Those are refused regardless of approval."
+              fi
+            fi
+          fi
+
+          if [ -z "$conclusion" ]; then
+            # Latest state-changing review from an approver. A stale approval
+            # (older head commit) does not count: approval must be on the
+            # current head, so it cannot survive a later push.
+            latest=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+              | jq -s -c --arg u "$approvers" 'add
+                  | [.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+                         | select(.user.login == $u)]
+                  | last // empty')
+            state=$(printf '%s' "$latest" | jq -r '.state // empty')
+            commit=$(printf '%s' "$latest" | jq -r '.commit_id // empty')
+            if [ "$state" = "APPROVED" ] && [ "$commit" = "$HEAD_SHA" ]; then
+              conclusion="success"
+              title="Gate-file change approved"
+              summary="This pull request changes files under .github/ and carries an approving review from $approvers on the current head commit."
+            else
+              conclusion="failure"
+              title="Gate-file change needs approval"
+              summary="This pull request changes files under .github/. It requires an approving review from $approvers on the current head commit ($HEAD_SHA). Automation can author gate-file changes; it cannot approve them."
+            fi
+          fi
+
+          gh api -X POST "repos/$REPO/check-runs" \
+            -f name='Gate file approval' \
+            -f head_sha="$HEAD_SHA" \
+            -f status=completed \
+            -f conclusion="$conclusion" \
+            -f 'output[title]'="$title" \
+            -f 'output[summary]'="$summary" \
+            --jq '"check_run id=" + (.id|tostring) + " conclusion=" + .conclusion'
+
+          # Mirror the verdict in the job status so an accidentally required
+          # job context is never an always-green bypass.
+          [ "$conclusion" = "success" ]


### PR DESCRIPTION
## What this adds

A required-check workflow, `Gate file approval`, that path-scopes the merge gate for this repository's own CI, review, and release configuration: any pull request changing a file under `.github/` (edits, renames in either direction, deletions) fails the check unless it carries an approving review from a listed approver on the pull request's current head commit. Pull requests touching nothing under `.github/` pass immediately, so ordinary changes stay gated by status checks alone.

## Design

- Runs on `pull_request_target` (plus `pull_request_review`), so the workflow definition is read from the base branch: a pull request that modifies this file is judged by the unmodified copy.
- Reads only API data — the changed-file list and review list. It never checks out or executes pull request head content, references no repository secret, and its token is read-only apart from `checks:write`.
- Fails closed: API errors, oversized pull requests at the 3000-entry file-listing cap, and an unreadable proposed copy of the workflow all refuse rather than pass.
- A stale approval does not survive a content-changing push: the approving review must be on the current head commit.
- The verdict is carried both as an explicit check run against the head commit and as the job's own exit status, so a protection rule requiring either context carries the real verdict.

Identical to the workflow already proven on secretless-ai, where enforcement was verified live: a gate-file pull request stayed blocked with every other check green, an automation approval was refused and its merge attempt rejected by GitHub naming this failing check, an approver's review unblocked it, and a non-gate pull request was unaffected.

## Follow-up (separate admin step)

After this merges, `Gate file approval` is added to the branch's required status checks, and the inert review-requirement settings this check replaces are removed. Enforcement is then verified live per repository.