### PR TITLE
Python SDK: TS-parity fixtures and drift guard for the ARP telemetry seam

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -269,7 +269,7 @@ and the modules that decide allow/deny (`aim_sdk.enforcement`,
 `aim_sdk.decision`) do not import the seam.
 
 **Port stage.** `aim_sdk.telemetry` is stage 1 of 3 of the ARP runtime-protection
-port (roadmap `arp-python-sdk-parity`), ported schema-identical to the TypeScript
+port (tracked in issue #441), ported schema-identical to the TypeScript
 reference in `sdk/typescript/src/telemetry` so both SDKs write the same
 `correlated-events.jsonl`. Stage 2 (the guard-socket client) and stage 3 (the
 engine port: event engine, runtime twin, coordinator, monitors, interceptors)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -263,6 +263,18 @@ egress-validates technique fields before transmission. Only
 `denied_injection_attempt` indicators are uploaded, to the Registry's public,
 count-only endpoint.
 
+**Producer only, never on the deny path.** Detection output is an inference the
+seam records; it never enters `verify_action` or any policy-decision deny path,
+and the modules that decide allow/deny (`aim_sdk.enforcement`,
+`aim_sdk.decision`) do not import the seam.
+
+**Port stage.** `aim_sdk.telemetry` is stage 1 of 3 of the ARP runtime-protection
+port (roadmap `arp-python-sdk-parity`), ported schema-identical to the TypeScript
+reference in `sdk/typescript/src/telemetry` so both SDKs write the same
+`correlated-events.jsonl`. Stage 2 (the guard-socket client) and stage 3 (the
+engine port: event engine, runtime twin, coordinator, monitors, interceptors)
+are not part of this package -- see the module docstring for the boundary.
+
 ## Manual mode (no OAuth)
 
 For CI environments or pre-configured credentials, skip `aim-sdk login` and pass an API key:

--- a/sdk/python/aim_sdk/telemetry/__init__.py
+++ b/sdk/python/aim_sdk/telemetry/__init__.py
@@ -7,6 +7,32 @@ Captures why a blocked agent action happened by joining the injection cause
 and stays local; only an anonymized indicator may be shared.
 
 Everything here is off the enforcement critical path and best-effort.
+
+Port stage boundary
+-------------------
+This package is the ARP telemetry seam: **stage 1 of 3** in the recorded build
+order of the ``arp-python-sdk-parity`` roadmap card. It is the correlation
+envelope, the local correlated record, the joiner, and the ``telemetry.detection``
+input, ported schema-identical to the TypeScript reference
+(``sdk/typescript/src/telemetry``) so both SDKs feed one local log format
+(``~/.opena2a/correlated-events.jsonl``).
+
+The two later stages are deliberately NOT begun here, and neither exists in this
+SDK -- each stage gates the next:
+
+* **Stage 2 -- the guard-socket client.** JSON-lines over AF_UNIX to the
+  NanoMind-Guard daemon: null on socket-absent (graceful unavailability, never a
+  benign verdict), signed-fields-or-null, never a direct-HF fallback.
+* **Stage 3 -- the engine port.** Event engine (L0), runtime twin (L1),
+  coordinator (L2), monitors, and the interceptors that patch Python primitives
+  (``builtins.open``, ``subprocess``, ``socket``) -- shipped WITH the behavioral
+  suite that guards against drift from the TS reference.
+
+ARP's contract holds at every stage, and this seam is a telemetry PRODUCER only:
+detection output never enters ``verify_action`` or any PDP deny path
+(2026-06-07 CA decision). ``aim_sdk.enforcement`` and ``aim_sdk.decision`` -- the
+modules that decide allow/deny -- do not import this package, and the only
+consumer of a detection part is the client's telemetry recorder.
 """
 from .correlation import (
     CORRELATION_ID_PREFIX,

--- a/sdk/python/aim_sdk/telemetry/__init__.py
+++ b/sdk/python/aim_sdk/telemetry/__init__.py
@@ -11,7 +11,7 @@ Everything here is off the enforcement critical path and best-effort.
 Port stage boundary
 -------------------
 This package is the ARP telemetry seam: **stage 1 of 3** in the recorded build
-order of the ``arp-python-sdk-parity`` roadmap card. It is the correlation
+order of the runtime-protection port (tracked in issue #441). It is the correlation
 envelope, the local correlated record, the joiner, and the ``telemetry.detection``
 input, ported schema-identical to the TypeScript reference
 (``sdk/typescript/src/telemetry``) so both SDKs feed one local log format

--- a/sdk/python/tests/fixtures/ts_telemetry/README.md
+++ b/sdk/python/tests/fixtures/ts_telemetry/README.md
@@ -1,0 +1,46 @@
+# TS-reference telemetry fixtures (AIM-01.AC1)
+
+Cross-SDK schema fixtures for the ARP telemetry seam. Each file pins one
+representative input shape and the JSONL record the **TypeScript reference**
+emits for it, so the Python seam (`aim_sdk.telemetry`) can be asserted
+field-for-field against the same local log format.
+
+Reference implementation (same repo, no external fetch):
+
+- `sdk/typescript/src/telemetry/correlated-record.ts`
+  — `buildCorrelatedRecord()` (record shape, builder-owned `observed` /
+  `attribution` flags) and `toSharedIndicator()` (the shared-indicator
+  reduction).
+- `sdk/typescript/src/telemetry/local-writer.ts`
+  — `writeCorrelatedRecord()` (`correlated-events.jsonl`, one compact
+  `JSON.stringify` line per record).
+
+## How each fixture was derived
+
+The `expectedRecord` / `expectedIndicator` blocks are the emitted shapes of the
+TS functions above for the given `input`: every field the TS interface declares,
+with TS-optional fields **omitted** exactly where `JSON.stringify` drops an
+`undefined` (that omission is itself part of the schema and is asserted).
+
+Fields whose value is generated per-call cannot be pinned in a fixture and are
+listed in `volatileFields`; the test asserts their *format* instead
+(`recordId`, `createdAt`, and the indicator's `triggeredAt`).
+
+## Key order
+
+JSON object key order is not part of the schema: the TS builder emits nested
+enforcement/intent/detection keys in *caller* order (object spread), so no fixed
+byte order exists to match. `test_arp_telemetry_seam_parity.py` therefore
+compares **canonicalized** JSON (`sort_keys=True`, compact separators) — the
+field names, the field values, and the set of present/omitted keys all have to
+match byte-for-byte — and separately asserts the emitted line is compact, as
+`JSON.stringify` produces.
+
+## Cases
+
+| File | Shape | `assembly.completeness` |
+| --- | --- | --- |
+| `full-join.json` | enforcement + intent + detection, every optional populated | `full` |
+| `deny-detection-only.json` | enforcement + detection, optionals omitted | `partial-missing-intent` |
+| `allow-intent-only.json` | enforcement + intent, allow verdict | `partial-missing-detection` |
+| `enforcement-only.json` | enforcement alone (the anchor fact) | `partial-missing-both` |

--- a/sdk/python/tests/fixtures/ts_telemetry/allow-intent-only.json
+++ b/sdk/python/tests/fixtures/ts_telemetry/allow-intent-only.json
@@ -1,0 +1,67 @@
+{
+  "case": "allow-intent-only",
+  "description": "Allowed action with an intent inference and no detection: the seam records allows too, and the indicator reduces to allow_action.",
+  "derivedFrom": "sdk/typescript/src/telemetry/correlated-record.ts",
+  "volatileFields": ["recordId", "createdAt", "triggeredAt"],
+  "input": {
+    "correlationId": "cde_000000002_99aabbccddee",
+    "agentId": "agent-3",
+    "joinedBy": "fallback:window",
+    "joinerVersion": "1.0",
+    "enforcement": {
+      "decision": "allow",
+      "outcome": "ALLOW",
+      "capability": "db:read",
+      "resource": "users",
+      "occurredAt": "2026-06-07T12:10:00.000Z",
+      "source": "aim-pdp"
+    },
+    "intent": {
+      "intentClass": "read",
+      "confidence": 0.9,
+      "blocked": false,
+      "source": "nanomind-intent"
+    }
+  },
+  "expectedRecord": {
+    "schemaVersion": "1.0",
+    "correlationId": "cde_000000002_99aabbccddee",
+    "agentId": "agent-3",
+    "enforcement": {
+      "observed": true,
+      "decision": "allow",
+      "outcome": "ALLOW",
+      "capability": "db:read",
+      "resource": "users",
+      "occurredAt": "2026-06-07T12:10:00.000Z",
+      "source": "aim-pdp"
+    },
+    "intent": {
+      "observed": false,
+      "intentClass": "read",
+      "confidence": 0.9,
+      "blocked": false,
+      "source": "nanomind-intent"
+    },
+    "assembly": {
+      "joinedBy": "fallback:window",
+      "completeness": "partial-missing-detection",
+      "joinerVersion": "1.0"
+    }
+  },
+  "sharedIndicatorContext": {
+    "sensorToken": "sensor-abc",
+    "agentCategory": "backend",
+    "daySinceInstall": 12,
+    "runtimeEnv": "python"
+  },
+  "expectedIndicator": {
+    "schemaVersion": "1.0",
+    "sensorToken": "sensor-abc",
+    "eventType": "allow_action",
+    "enforcementOutcome": "allow",
+    "agentCategory": "backend",
+    "daySinceInstall": 12,
+    "runtimeEnv": "python"
+  }
+}

--- a/sdk/python/tests/fixtures/ts_telemetry/deny-detection-only.json
+++ b/sdk/python/tests/fixtures/ts_telemetry/deny-detection-only.json
@@ -1,0 +1,72 @@
+{
+  "case": "deny-detection-only",
+  "description": "Detection inference present, intent missing; every TS-optional field omitted so the omission itself is asserted. Joined by the window fallback.",
+  "derivedFrom": "sdk/typescript/src/telemetry/correlated-record.ts",
+  "volatileFields": ["recordId", "createdAt", "triggeredAt"],
+  "input": {
+    "correlationId": "cde_000000001_00112233ffee",
+    "agentId": "agent-2",
+    "joinedBy": "fallback:window",
+    "joinerVersion": "1.0",
+    "enforcement": {
+      "decision": "deny",
+      "outcome": "DENY",
+      "capability": "net:connect",
+      "resource": "https://evil.example/x",
+      "occurredAt": "2026-06-07T12:05:00.000Z",
+      "source": "aim-pdp"
+    },
+    "detection": {
+      "injectionDetected": true,
+      "techniqueSource": "apia",
+      "confidence": 0.91,
+      "detector": "nanomind-guard",
+      "detectedAt": "2026-06-07T12:04:59.000Z"
+    }
+  },
+  "expectedRecord": {
+    "schemaVersion": "1.0",
+    "correlationId": "cde_000000001_00112233ffee",
+    "agentId": "agent-2",
+    "enforcement": {
+      "observed": true,
+      "decision": "deny",
+      "outcome": "DENY",
+      "capability": "net:connect",
+      "resource": "https://evil.example/x",
+      "occurredAt": "2026-06-07T12:05:00.000Z",
+      "source": "aim-pdp"
+    },
+    "detection": {
+      "observed": false,
+      "attribution": "inferred",
+      "injectionDetected": true,
+      "techniqueSource": "apia",
+      "confidence": 0.91,
+      "detector": "nanomind-guard",
+      "detectedAt": "2026-06-07T12:04:59.000Z"
+    },
+    "assembly": {
+      "joinedBy": "fallback:window",
+      "completeness": "partial-missing-intent",
+      "joinerVersion": "1.0"
+    }
+  },
+  "sharedIndicatorContext": {
+    "sensorToken": "sensor-abc",
+    "agentCategory": "backend",
+    "daySinceInstall": 0,
+    "runtimeEnv": "python"
+  },
+  "expectedIndicator": {
+    "schemaVersion": "1.0",
+    "sensorToken": "sensor-abc",
+    "eventType": "denied_injection_attempt",
+    "techniqueSource": "apia",
+    "detectionConfidence": 0.91,
+    "enforcementOutcome": "deny",
+    "agentCategory": "backend",
+    "daySinceInstall": 0,
+    "runtimeEnv": "python"
+  }
+}

--- a/sdk/python/tests/fixtures/ts_telemetry/enforcement-only.json
+++ b/sdk/python/tests/fixtures/ts_telemetry/enforcement-only.json
@@ -1,0 +1,56 @@
+{
+  "case": "enforcement-only",
+  "description": "The anchor fact alone: neither inference arrived before the window closed, so the intent and detection keys are absent from the emitted line entirely.",
+  "derivedFrom": "sdk/typescript/src/telemetry/correlated-record.ts",
+  "volatileFields": ["recordId", "createdAt", "triggeredAt"],
+  "input": {
+    "correlationId": "cde_000000003_5566778899aa",
+    "agentId": "agent-4",
+    "joinedBy": "fallback:window",
+    "joinerVersion": "1.0",
+    "enforcement": {
+      "decision": "deny",
+      "outcome": "DENY_CONTEXT",
+      "deniedReason": "policy X",
+      "capability": "fs:write",
+      "resource": "/tmp/x",
+      "occurredAt": "2026-06-07T12:15:00.000Z",
+      "source": "aim-pdp"
+    }
+  },
+  "expectedRecord": {
+    "schemaVersion": "1.0",
+    "correlationId": "cde_000000003_5566778899aa",
+    "agentId": "agent-4",
+    "enforcement": {
+      "observed": true,
+      "decision": "deny",
+      "outcome": "DENY_CONTEXT",
+      "deniedReason": "policy X",
+      "capability": "fs:write",
+      "resource": "/tmp/x",
+      "occurredAt": "2026-06-07T12:15:00.000Z",
+      "source": "aim-pdp"
+    },
+    "assembly": {
+      "joinedBy": "fallback:window",
+      "completeness": "partial-missing-both",
+      "joinerVersion": "1.0"
+    }
+  },
+  "sharedIndicatorContext": {
+    "sensorToken": "sensor-abc",
+    "agentCategory": "backend",
+    "daySinceInstall": 1,
+    "runtimeEnv": "python"
+  },
+  "expectedIndicator": {
+    "schemaVersion": "1.0",
+    "sensorToken": "sensor-abc",
+    "eventType": "deny_action",
+    "enforcementOutcome": "deny",
+    "agentCategory": "backend",
+    "daySinceInstall": 1,
+    "runtimeEnv": "python"
+  }
+}

--- a/sdk/python/tests/fixtures/ts_telemetry/full-join.json
+++ b/sdk/python/tests/fixtures/ts_telemetry/full-join.json
@@ -1,0 +1,108 @@
+{
+  "case": "full-join",
+  "description": "All three parts joined on the correlation ID, every TS-optional field populated.",
+  "derivedFrom": "sdk/typescript/src/telemetry/correlated-record.ts",
+  "volatileFields": ["recordId", "createdAt", "triggeredAt"],
+  "input": {
+    "correlationId": "cde_000000000_aabbccddeeff",
+    "agentId": "agent-1",
+    "joinedBy": "correlationId",
+    "joinerVersion": "1.0",
+    "enforcement": {
+      "decision": "deny",
+      "outcome": "DENY_INTENT",
+      "deniedBy": "aim-pdp",
+      "deniedReason": "blocked injected exfil",
+      "capability": "fs:write",
+      "resource": "/etc/secret",
+      "scope": "prod",
+      "credentialRef": "ref:db-prod",
+      "policyId": "pol-7",
+      "occurredAt": "2026-06-07T12:00:00.000Z",
+      "traceId": "trace-9",
+      "source": "aim-pdp"
+    },
+    "intent": {
+      "intentClass": "exfil",
+      "confidence": 0.7,
+      "blocked": true,
+      "source": "nanomind-intent",
+      "modelVersion": "nm-1.2.0"
+    },
+    "detection": {
+      "injectionDetected": true,
+      "attackClass": "indirect",
+      "techniqueId": "T-2002",
+      "techniqueSource": "interim-mapping",
+      "confidence": 0.84,
+      "detector": "nanomind-guard",
+      "detectorVersion": "guard-0.9",
+      "inputRef": "sha256:abcd",
+      "detectedAt": "2026-06-07T11:59:59.000Z"
+    }
+  },
+  "expectedRecord": {
+    "schemaVersion": "1.0",
+    "correlationId": "cde_000000000_aabbccddeeff",
+    "agentId": "agent-1",
+    "enforcement": {
+      "observed": true,
+      "decision": "deny",
+      "outcome": "DENY_INTENT",
+      "deniedBy": "aim-pdp",
+      "deniedReason": "blocked injected exfil",
+      "capability": "fs:write",
+      "resource": "/etc/secret",
+      "scope": "prod",
+      "credentialRef": "ref:db-prod",
+      "policyId": "pol-7",
+      "occurredAt": "2026-06-07T12:00:00.000Z",
+      "traceId": "trace-9",
+      "source": "aim-pdp"
+    },
+    "intent": {
+      "observed": false,
+      "intentClass": "exfil",
+      "confidence": 0.7,
+      "blocked": true,
+      "source": "nanomind-intent",
+      "modelVersion": "nm-1.2.0"
+    },
+    "detection": {
+      "observed": false,
+      "attribution": "inferred",
+      "injectionDetected": true,
+      "attackClass": "indirect",
+      "techniqueId": "T-2002",
+      "techniqueSource": "interim-mapping",
+      "confidence": 0.84,
+      "detector": "nanomind-guard",
+      "detectorVersion": "guard-0.9",
+      "inputRef": "sha256:abcd",
+      "detectedAt": "2026-06-07T11:59:59.000Z"
+    },
+    "assembly": {
+      "joinedBy": "correlationId",
+      "completeness": "full",
+      "joinerVersion": "1.0"
+    }
+  },
+  "sharedIndicatorContext": {
+    "sensorToken": "sensor-abc",
+    "agentCategory": "backend",
+    "daySinceInstall": 3,
+    "runtimeEnv": "python"
+  },
+  "expectedIndicator": {
+    "schemaVersion": "1.0",
+    "sensorToken": "sensor-abc",
+    "eventType": "denied_injection_attempt",
+    "techniqueId": "T-2002",
+    "techniqueSource": "interim-mapping",
+    "detectionConfidence": 0.84,
+    "enforcementOutcome": "deny",
+    "agentCategory": "backend",
+    "daySinceInstall": 3,
+    "runtimeEnv": "python"
+  }
+}

--- a/sdk/python/tests/test_arp_telemetry_seam_isolation.py
+++ b/sdk/python/tests/test_arp_telemetry_seam_isolation.py
@@ -242,7 +242,10 @@ def test_AIM_01_AC3_stage_boundary_is_documented():
     assert "stage 1 of 3" in doc
     assert "guard-socket client" in doc          # stage 2, named
     assert "engine port" in doc                  # stage 3, named
-    assert "arp-python-sdk-parity" in doc        # the recorded build order
+    assert "issue #441" in doc                   # the public tracker for stages 2-3
+    # The internal planning slug must NOT ship in a public docstring — the
+    # public issue is the reference external readers can actually follow.
+    assert "arp-python-sdk-parity" not in doc
 
 
 def test_AIM_01_AC3_no_guard_socket_client_in_the_seam():

--- a/sdk/python/tests/test_arp_telemetry_seam_isolation.py
+++ b/sdk/python/tests/test_arp_telemetry_seam_isolation.py
@@ -1,0 +1,321 @@
+"""
+AIM-01.AC2 / AC3 / AC4 -- the hard constraints on the ARP telemetry seam.
+
+AC2 (2026-06-07 CA decision): detection output is a telemetry PRODUCER only. It
+never enters ``verify_action`` or any PDP deny path, and the verification
+modules do not import the seam.
+
+AC3: the port stops at stage 1. No guard-socket client (stage 2) and no
+interceptor patching of ``builtins`` / ``subprocess`` / ``socket`` (stage 3),
+and the stage boundary is stated in the package's own docstring.
+
+AC4: the seam is stdlib-only, matching the TS module's zero-runtime-dep posture.
+"""
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+import aim_sdk.telemetry as seam
+from aim_sdk import AIMClient
+from aim_sdk.exceptions import ActionDeniedError
+from aim_sdk.telemetry import CorrelationJoiner, DetectionInput, IntentInput
+
+AIM_SDK_DIR = Path(seam.__file__).resolve().parent.parent   # .../aim_sdk
+SEAM_DIR = AIM_SDK_DIR / "telemetry"
+
+#: The modules that decide allow/deny. Nothing here may know the seam exists.
+VERIFICATION_MODULES = ["enforcement.py", "decision.py"]
+
+#: Stage-1 seam modules. ``relay.py`` is the (already-shipped) sharing pipeline,
+#: not part of the stage-1 seam, and uses ``requests`` -- an existing SDK
+#: dependency -- so it is excluded from the stdlib-only assertion.
+SEAM_MODULES = [
+    "correlation.py",
+    "correlated_record.py",
+    "joiner.py",
+    "local_writer.py",
+    "technique_mapping.py",
+]
+
+
+def _parse(path):
+    return ast.parse(Path(path).read_text(encoding="utf-8"), filename=str(path))
+
+
+def _python_files(root):
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in sorted(filenames):
+            if name.endswith(".py"):
+                yield Path(dirpath) / name
+
+
+def _imported_roots(tree):
+    """Top-level module names imported by a tree; relative imports are skipped."""
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+# --------------------------------------------------------------------------- #
+# AC2 -- detection output never reaches a verify/deny path.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "module", VERIFICATION_MODULES, ids=[f"AIM-01.AC2-{m}" for m in VERIFICATION_MODULES]
+)
+def test_AIM_01_AC2_verification_modules_do_not_import_the_seam(module):
+    path = AIM_SDK_DIR / module
+
+    # Every form: `import aim_sdk.telemetry`, `from aim_sdk.telemetry import x`,
+    # `from .telemetry import x`, `from . import telemetry`.
+    for node in ast.walk(_parse(path)):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "telemetry" not in alias.name.split("."), f"{module}: {alias.name}"
+        elif isinstance(node, ast.ImportFrom):
+            assert "telemetry" not in (node.module or "").split("."), f"{module}: {node.module}"
+            for alias in node.names:
+                assert alias.name != "telemetry", f"{module}: from . import {alias.name}"
+
+
+def test_AIM_01_AC2_only_the_telemetry_recorder_consumes_detection():
+    """Call-graph: exactly one function in the client touches the detection part."""
+    tree = _parse(AIM_SDK_DIR / "client.py")
+
+    consumers = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            func = inner.func
+            if isinstance(func, ast.Attribute) and func.attr == "ingest_detection":
+                consumers.add(node.name)
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and inner.args
+                and isinstance(inner.args[0], ast.Constant)
+                and inner.args[0].value == "detection"
+            ):
+                consumers.add(node.name)
+
+    assert consumers == {"_record_verification_telemetry"}
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class _SessionSpy:
+    def __init__(self, payload):
+        self.payload = payload
+        self.last_headers = None
+        self.headers = {}
+
+    def request(self, method, url, json=None, headers=None, data=None, timeout=None):
+        self.last_headers = headers or {}
+        return _FakeResponse(200, self.payload)
+
+    def close(self):
+        pass
+
+
+class _ExplodingDetection:
+    """A detection part that records every attribute read of it.
+
+    Nothing on the verify/deny path may inspect a detection inference. Reads are
+    recorded rather than raised because the telemetry recorder swallows
+    exceptions -- a raise would be silently absorbed and the test would pass
+    vacuously.
+    """
+
+    def __init__(self, touched):
+        object.__setattr__(self, "_touched", touched)
+
+    def __getattribute__(self, name):
+        object.__getattribute__(self, "_touched").append(name)
+        return object.__getattribute__(self, name)
+
+
+class _SentinelJoiner(CorrelationJoiner):
+    """Captures the detection part instead of assembling it into a record."""
+
+    def __init__(self, seen, **kwargs):
+        super().__init__(**kwargs)
+        self.seen = seen
+
+    def ingest_detection(self, correlation_id, detection):
+        self.seen.append(detection)
+
+
+def _client(payload, joiner):
+    client = AIMClient(
+        agent_id="agent-1", api_key="k", aim_url="http://localhost:9",
+        telemetry={"enabled": True, "joiner": joiner},
+    )
+    client.session = _SessionSpy(payload)
+    return client
+
+
+def test_AIM_01_AC2_no_verify_or_deny_path_reads_the_detection_output():
+    touched = []
+    seen = []
+    joiner = _SentinelJoiner(seen, now=lambda: 0, on_record=lambda r: None)
+    client = _client({"id": "v1", "status": "approved"}, joiner)
+    sentinel = _ExplodingDetection(touched)
+
+    result = client.verify_capability(
+        "db:read", resource="users", telemetry={"detection": sentinel}
+    )
+
+    assert result["verified"] is True
+    # The seam received it (the test is not vacuous) ...
+    assert len(seen) == 1 and seen[0] is sentinel
+    # ... and no verify/deny code path read a single field off it.
+    assert touched == []
+    client.close()
+
+
+def test_AIM_01_AC2_detection_output_cannot_change_a_verdict():
+    """A maximal-confidence injection cannot deny, and no detection cannot allow."""
+    records = []
+    allow_joiner = CorrelationJoiner(now=lambda: 0, on_record=records.append)
+    allowed = _client({"id": "v1", "status": "approved"}, allow_joiner)
+    flagged = DetectionInput(
+        injection_detected=True, confidence=1.0, detector="nanomind-guard",
+        technique_source="apia", technique_id="T-2002",
+    )
+    intent = IntentInput(
+        intent_class="exfil", confidence=1.0, blocked=True, source="nanomind-intent"
+    )
+    result = allowed.verify_capability(
+        "db:read", resource="users",
+        telemetry={"intent": intent, "detection": flagged},
+    )
+    # Detection said "injection, confidence 1.0"; the PDP said allow. Allow wins.
+    assert result["verified"] is True
+    # It was still captured as telemetry.
+    assert len(records) == 1
+    assert records[0].detection.injection_detected is True
+    assert records[0].enforcement.decision == "allow"
+    allowed.close()
+
+    clean = DetectionInput(
+        injection_detected=False, confidence=0.0, detector="nanomind-guard",
+        technique_source="apia",
+    )
+    denied = _client(
+        {"id": "v1", "status": "denied", "denialReason": "policy X"},
+        CorrelationJoiner(now=lambda: 0, on_record=lambda r: None),
+    )
+    # A clean detection cannot rescue a denial either.
+    with pytest.raises(ActionDeniedError):
+        denied.verify_capability(
+            "db:write", resource="secrets", telemetry={"detection": clean}
+        )
+    denied.close()
+
+
+# --------------------------------------------------------------------------- #
+# AC3 -- stages 2 and 3 are not begun.
+# --------------------------------------------------------------------------- #
+def test_AIM_01_AC3_stage_boundary_is_documented():
+    doc = (seam.__doc__ or "").lower()
+    assert "stage 1 of 3" in doc
+    assert "guard-socket client" in doc          # stage 2, named
+    assert "engine port" in doc                  # stage 3, named
+    assert "arp-python-sdk-parity" in doc        # the recorded build order
+
+
+def test_AIM_01_AC3_no_guard_socket_client_in_the_seam():
+    # No AF_UNIX client anywhere in the telemetry package (the guard socket is
+    # stage 2). Checked on the AST, so the docstring naming it does not count.
+    for path in _python_files(SEAM_DIR):
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "AF_UNIX":
+                pytest.fail(f"{path.name}: AF_UNIX socket client is stage 2")
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "socket"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "socket"
+            ):
+                pytest.fail(f"{path.name}: socket client is stage 2")
+
+    # And no stage-2/stage-3 module has appeared in the SDK.
+    assert not (AIM_SDK_DIR / "arp").exists()
+    for path in _python_files(AIM_SDK_DIR):
+        assert "guard" not in path.name.lower()
+        assert "interceptor" not in path.name.lower()
+
+
+def test_AIM_01_AC3_no_interceptor_patching_of_builtins_subprocess_or_socket():
+    patched_modules = {"builtins", "subprocess", "socket", "os"}
+
+    for path in _python_files(AIM_SDK_DIR):
+        for node in ast.walk(_parse(path)):
+            # `builtins.open = ...` / `subprocess.Popen = ...`
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Attribute)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id in patched_modules
+                    ):
+                        pytest.fail(
+                            f"{path.name}: patches {target.value.id}.{target.attr} "
+                            "-- interceptors are stage 3"
+                        )
+            # `setattr(builtins, "open", ...)`
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "setattr"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in patched_modules
+            ):
+                pytest.fail(
+                    f"{path.name}: setattr on {node.args[0].id} "
+                    "-- interceptors are stage 3"
+                )
+
+
+# --------------------------------------------------------------------------- #
+# AC4 -- no dependency added: the seam is stdlib-only.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "module", SEAM_MODULES, ids=[f"AIM-01.AC4-{m}" for m in SEAM_MODULES]
+)
+def test_AIM_01_AC4_seam_modules_are_stdlib_only(module):
+    import sys
+
+    stdlib = getattr(sys, "stdlib_module_names", None)
+    if stdlib is None:  # Python < 3.10
+        pytest.skip("sys.stdlib_module_names requires Python 3.10+")
+
+    for root in _imported_roots(_parse(SEAM_DIR / module)):
+        assert root in stdlib or root == "aim_sdk", (
+            f"{module} imports non-stdlib {root!r}: the seam matches the TS "
+            "module's zero-runtime-dep posture"
+        )

--- a/sdk/python/tests/test_arp_telemetry_seam_parity.py
+++ b/sdk/python/tests/test_arp_telemetry_seam_parity.py
@@ -1,0 +1,229 @@
+"""
+AIM-01.AC1 -- ARP telemetry seam: cross-SDK schema parity with the TypeScript
+reference.
+
+The Python seam (``aim_sdk.telemetry``) and the TS seam
+(``sdk/typescript/src/telemetry``) must feed ONE local log format: the same
+``correlated-events.jsonl`` record shape and the same shared-indicator
+reduction. These tests write a record from each representative input shape and
+assert the emitted JSONL fields match the TS-derived fixtures in
+``tests/fixtures/ts_telemetry/`` (see that directory's README for how the
+fixtures were derived and why the comparison is canonicalized rather than raw
+byte-ordered).
+"""
+import dataclasses
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from aim_sdk.telemetry import (
+    CORRELATED_FILE,
+    DetectionInput,
+    EnforcementInput,
+    IntentInput,
+    SharedIndicatorContext,
+    build_correlated_record,
+    read_correlated_records,
+    to_shared_indicator,
+    write_correlated_record,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "ts_telemetry"
+
+CASES = [
+    "full-join",
+    "deny-detection-only",
+    "allow-intent-only",
+    "enforcement-only",
+]
+
+# TS ``Date.prototype.toISOString`` -- millisecond precision, trailing Z.
+ISO_MS_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+# The TS reference lives in the same repo. Absent from a packaged sdist, so the
+# interface-drift guard skips rather than fails when it is not there.
+#   .../sdk/python/tests/<this file>  ->  parents[2] == .../sdk
+TS_REFERENCE = (
+    Path(__file__).resolve().parents[2]
+    / "typescript" / "src" / "telemetry" / "correlated-record.ts"
+)
+
+
+def _load(case):
+    with open(FIXTURE_DIR / f"{case}.json", "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _snake(name):
+    """camelCase (the wire/TS name) -> snake_case (the Python field name)."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _camel(name):
+    """snake_case (the Python field name) -> camelCase (the wire/TS name)."""
+    head, *rest = name.split("_")
+    return head + "".join(part[:1].upper() + part[1:] for part in rest)
+
+
+def _canonical(obj):
+    """Canonical JSON bytes: key order removed, compact separators."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _build_from_fixture(fixture):
+    """Build the Python record from the fixture's TS-named input.
+
+    The camelCase -> snake_case conversion is itself part of the assertion: a
+    field the Python dataclasses do not declare under the TS name raises
+    TypeError here.
+    """
+    data = fixture["input"]
+    enforcement = EnforcementInput(**{_snake(k): v for k, v in data["enforcement"].items()})
+    intent = None
+    if "intent" in data:
+        intent = IntentInput(**{_snake(k): v for k, v in data["intent"].items()})
+    detection = None
+    if "detection" in data:
+        detection = DetectionInput(**{_snake(k): v for k, v in data["detection"].items()})
+
+    return build_correlated_record(
+        correlation_id=data["correlationId"],
+        agent_id=data["agentId"],
+        enforcement=enforcement,
+        intent=intent,
+        detection=detection,
+        joined_by=data["joinedBy"],
+        joiner_version=data["joinerVersion"],
+    )
+
+
+def _indicator_wire(indicator):
+    """The indicator as it is emitted: camelCase, undefined optionals omitted."""
+    return {
+        _camel(k): v
+        for k, v in dataclasses.asdict(indicator).items()
+        if v is not None
+    }
+
+
+def _strip_volatile(emitted, fixture):
+    """Drop the per-call generated fields a fixture cannot pin."""
+    return {k: v for k, v in emitted.items() if k not in fixture["volatileFields"]}
+
+
+@pytest.mark.parametrize("case", CASES, ids=[f"AIM-01.AC1-{c}" for c in CASES])
+def test_AIM_01_AC1_record_fields_match_the_ts_schema(case):
+    fixture = _load(case)
+    emitted = _build_from_fixture(fixture).to_dict()
+
+    assert _canonical(_strip_volatile(emitted, fixture)) == _canonical(fixture["expectedRecord"])
+
+
+@pytest.mark.parametrize("case", CASES, ids=[f"AIM-01.AC1-{c}" for c in CASES])
+def test_AIM_01_AC1_written_jsonl_line_matches_the_ts_schema(case, tmp_path):
+    """The record as it actually lands in the shared local log."""
+    fixture = _load(case)
+    record = _build_from_fixture(fixture)
+
+    data_dir = str(tmp_path)
+    assert write_correlated_record(record, data_dir) is True
+
+    log_path = os.path.join(data_dir, CORRELATED_FILE)
+    # Same log file name as the TS writer -- one local format for both SDKs.
+    assert CORRELATED_FILE == "correlated-events.jsonl"
+
+    with open(log_path, "r", encoding="utf-8") as fh:
+        raw = fh.read()
+    assert raw.endswith("\n")
+    lines = [ln for ln in raw.split("\n") if ln]
+    assert len(lines) == 1
+
+    line = lines[0]
+    parsed = json.loads(line)
+    # Compact, one record per line -- as JSON.stringify emits.
+    assert json.dumps(parsed, separators=(",", ":")) == line
+
+    assert _canonical(_strip_volatile(parsed, fixture)) == _canonical(fixture["expectedRecord"])
+
+    # The generated fields cannot be pinned in a fixture; assert their format.
+    assert parsed["recordId"]
+    assert ISO_MS_Z.match(parsed["createdAt"])
+
+    # And the seam reads its own line back.
+    back = read_correlated_records(data_dir)
+    assert len(back) == 1
+    assert back[0].correlation_id == fixture["input"]["correlationId"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[f"AIM-01.AC1-{c}" for c in CASES])
+def test_AIM_01_AC1_shared_indicator_reduction_matches_the_ts_schema(case):
+    fixture = _load(case)
+    record = _build_from_fixture(fixture)
+    ctx = SharedIndicatorContext(
+        **{_snake(k): v for k, v in fixture["sharedIndicatorContext"].items()}
+    )
+
+    wire = _indicator_wire(to_shared_indicator(record, ctx))
+    assert ISO_MS_Z.match(wire["triggeredAt"])
+
+    assert _canonical(_strip_volatile(wire, fixture)) == _canonical(fixture["expectedIndicator"])
+
+
+@pytest.mark.parametrize(
+    "interface,accessor",
+    [
+        ("CorrelatedRecord", lambda rec, ind: rec),
+        ("EnforcementFact", lambda rec, ind: rec["enforcement"]),
+        ("IntentInference", lambda rec, ind: rec["intent"]),
+        ("DetectionInference", lambda rec, ind: rec["detection"]),
+        ("AssemblyMeta", lambda rec, ind: rec["assembly"]),
+        ("SharedIndicator", lambda rec, ind: ind),
+    ],
+    ids=[
+        "AIM-01.AC1-CorrelatedRecord",
+        "AIM-01.AC1-EnforcementFact",
+        "AIM-01.AC1-IntentInference",
+        "AIM-01.AC1-DetectionInference",
+        "AIM-01.AC1-AssemblyMeta",
+        "AIM-01.AC1-SharedIndicator",
+    ],
+)
+def test_AIM_01_AC1_emitted_field_names_match_the_ts_interfaces(interface, accessor):
+    """Drift guard read straight off the TS reference in this repo.
+
+    The fixtures pin the shapes; this pins them to the source they were derived
+    from, so a field added to (or renamed in) the TS interface fails here rather
+    than silently forking the two SDKs' log format.
+    """
+    if not TS_REFERENCE.exists():  # packaged sdist: reference not shipped
+        pytest.skip(f"TS reference not present at {TS_REFERENCE}")
+
+    ts_fields = _ts_interface_fields(TS_REFERENCE.read_text(encoding="utf-8"), interface)
+    assert ts_fields, f"could not parse TS interface {interface}"
+
+    fixture = _load("full-join")  # every optional populated
+    record = _build_from_fixture(fixture)
+    ctx = SharedIndicatorContext(
+        **{_snake(k): v for k, v in fixture["sharedIndicatorContext"].items()}
+    )
+    emitted = accessor(record.to_dict(), _indicator_wire(to_shared_indicator(record, ctx)))
+
+    assert set(emitted.keys()) == ts_fields
+
+
+def _ts_interface_fields(source, name):
+    """Field names declared by ``export interface <name> { ... }``."""
+    match = re.search(
+        r"export interface " + re.escape(name) + r"\s*\{(.*?)\n\}", source, re.DOTALL
+    )
+    if not match:
+        return set()
+    fields = set()
+    for line in match.group(1).split("\n"):
+        found = re.match(r"\s*(?:readonly\s+)?([A-Za-z_][A-Za-z0-9_]*)\??\s*:", line)
+        if found:
+            fields.add(found.group(1))
+    return fields


### PR DESCRIPTION
The telemetry seam itself (correlation envelope, correlated record, joiner, telemetry.detection input) pre-existed in this SDK (PR #281). What this adds on top:

- **TS-derived parity fixtures** (tests/fixtures/ts_telemetry/): four join scenarios exported from the TypeScript reference implementation, so the two SDKs are compared against the same bytes rather than against each description of the other.
- **Drift-guard suite** (test_arp_telemetry_seam_parity.py, 229 lines): asserts the Python join output is schema-identical to the TS fixtures field-by-field; a schema change on either side fails by name.
- **Isolation suite** (test_arp_telemetry_seam_isolation.py): AST-level proof the seam stays a telemetry producer — no AF_UNIX client, no enforcement import, detection output reaches only the telemetry recorder.
- **Stage-boundary docs** (module docstring + README): stage 1 of 3 of the runtime-protection port; stages 2-3 tracked in #441.

Producer-only contract: detection output never enters verify_action or any policy-decision deny path; aim_sdk.enforcement and aim_sdk.decision do not import this package (asserted by the isolation suite).

Test evidence: sdk/python suite 940 passed / 34 skipped.