### PR TITLE
Trust factor 9: cap unverified isolation attestations, expire stale ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,42 @@ forward the platform follows [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Changed
 
+- **Trust factor 9 (execution isolation) no longer takes a self-report at face
+  value.** The factor is fed by an agent's own claim about its sandbox, network,
+  filesystem and process isolation, and it carries 10% of the composite. An agent
+  that typed `firecracker + airgap + readonly + full` scored 1.0 on it — roughly
+  +0.07 of trust over the no-attestation baseline — for the cost of four strings,
+  and the claim counted forever after being made once. Two gates now apply when
+  the factor is read:
+  - An **unverified** attestation scores `min(posture, 0.65)`. The ceiling is
+    derived, not chosen: it is `ScoreIsolation(docker, namespace, readonly,
+    seccomp)`, the commodity-container tier, so retuning the posture weights moves
+    it with the tier it names. A maximal claim now earns exactly what an honest
+    hardened container earns. It is a `min()`, so an agent that truthfully reports
+    no isolation keeps its honest `0.0` rather than being lifted to the ceiling.
+  - A **90-day expiry** on `reported_at`, uniform for verified and unverified
+    rows. A stale attestation scores the `0.3` baseline and is *not* added to the
+    excluded-factor set: staleness is a scoring decision, not missing data, and
+    renormalizing the weight away would return exactly what the agent lost by
+    letting the attestation rot. Re-attesting restores the score.
+
+  Both gates are read-side. The stored row keeps the honest posture score — the
+  table records what was claimed, and the scorer decides what the claim is worth.
+  Migration 108 adds `verified` / `verified_by` / `verified_at` to
+  `isolation_attestations`, and **nothing writes `verified = true`**: the ingest
+  path hard-sets false, the `INSERT` writes the literal `FALSE`, and no endpoint
+  can reach the column, so `0.65` is the effective maximum for every agent today.
+  `verified` is bound to the row rather than the agent, so a re-attestation
+  supersedes its predecessor and starts unverified — verification never carries
+  forward across a redeploy. Independent verification itself is a follow-up
+  (roadmap `aim-isolation-verification` Phase 2); when it lands, TEE attestation
+  and orchestrator/host metadata may set the column, an HMA static scan may not,
+  and the SDK never.
+
+  Unchanged and still broken: both shipped SDKs POST
+  `/api/v1/sdk-api/agents/<id>/isolation-attestation` while the backend registers
+  `/agents/:id/isolation`, so SDK attestations 404 and the table is near-empty.
+  That route fix is tracked separately and is deliberately not folded in here.
 - `AgentRepository.List` now returns an error for a non-positive limit instead of
   reinterpreting it. Returning everything would have traded a silent-empty bug for
   a silent-unbounded one; an error is the only outcome that fails visibly. Callers

--- a/apps/backend/internal/application/aim02_isolation_verification_test.go
+++ b/apps/backend/internal/application/aim02_isolation_verification_test.go
@@ -1,0 +1,405 @@
+package application
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AIM-02 — factor 9 (execution isolation) integrity gates.
+//
+// Factor 9 is an agent's self-report about its own runtime isolation, carrying 10%
+// of the trust composite. Before this change an agent that typed
+// firecracker + airgap + readonly + full scored 1.0 on it, worth roughly +0.07 over
+// the 0.3 no-attestation baseline, for the cost of four strings — and a claim made
+// once counted forever.
+//
+// Two read-side gates close that, per the CDS ruling of 2026-08-29:
+//
+//	AC1 ceiling — an UNVERIFIED report is clipped to the commodity-container tier.
+//	AC2 expiry  — a report older than 90 days stops counting, verified or not.
+//	AC3 no write path — nothing can produce a verified row, so the ceiling is the
+//	                    effective maximum for every agent today.
+//
+// Both gates are read-side: the stored row keeps the honest posture score, because
+// the table records what was claimed and the scorer decides what a claim is worth.
+
+// memIsolationRepo is an in-memory IsolationAttestationRepository that resolves
+// GetLatest the way the SQL one does — newest reported_at wins. A scripted mock
+// would let a test assert "the newer row supersedes" while returning whatever it
+// was told to; this makes the ordering itself the thing under test.
+type memIsolationRepo struct {
+	rows []*domain.IsolationAttestation
+}
+
+// Create mirrors the SQL INSERT, which writes the literal FALSE for verified
+// regardless of the struct field. The fake must not be more permissive than the
+// repository it stands in for, or a test could pass here and fail in production.
+func (m *memIsolationRepo) Create(a *domain.IsolationAttestation) error {
+	stored := *a
+	stored.Verified = false
+	stored.VerifiedBy = nil
+	stored.VerifiedAt = nil
+	m.rows = append(m.rows, &stored)
+	return nil
+}
+
+func (m *memIsolationRepo) GetLatest(agentID uuid.UUID) (*domain.IsolationAttestation, error) {
+	var latest *domain.IsolationAttestation
+	for _, r := range m.rows {
+		if r.AgentID != agentID {
+			continue
+		}
+		if latest == nil || r.ReportedAt.After(latest.ReportedAt) {
+			latest = r
+		}
+	}
+	return latest, nil // nil, nil is "no attestation", as the SQL repo returns
+}
+
+func (m *memIsolationRepo) GetHistory(agentID uuid.UUID, limit int) ([]*domain.IsolationAttestation, error) {
+	out := make([]*domain.IsolationAttestation, 0, len(m.rows))
+	for _, r := range m.rows {
+		if r.AgentID == agentID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// aim02Calculator wires a calculator to an in-memory isolation repo seeded with
+// the given rows, all re-pointed at one fresh agent.
+func aim02Calculator(t *testing.T, rows ...*domain.IsolationAttestation) (*TrustCalculator, *domain.Agent, *memIsolationRepo) {
+	t.Helper()
+	agent := &domain.Agent{ID: uuid.New()}
+	repo := &memIsolationRepo{}
+	for _, r := range rows {
+		r.AgentID = agent.ID
+		repo.rows = append(repo.rows, r)
+	}
+	calc := &TrustCalculator{}
+	calc.SetIsolationRepo(repo)
+	return calc, agent, repo
+}
+
+// maxPostureScore is what a hostile agent claims: every enum at its top value.
+const maxPostureScore = 1.0
+
+func TestAIM02_UnverifiedCeiling(t *testing.T) {
+	t.Run("AIM-02.AC1 ceiling is derived from the commodity-container tier", func(t *testing.T) {
+		// Identity, not equality-of-current-value: the ceiling IS the score of
+		// docker + namespace + readonly + seccomp. Retuning the enum weights
+		// moves the ceiling with the tier it names.
+		assert.Equal(t,
+			domain.ScoreIsolation(domain.SandboxDocker, domain.NetworkNamespace,
+				domain.FilesystemReadOnly, domain.ProcessSeccomp),
+			domain.UnverifiedIsolationCeiling(),
+			"the ceiling must be the commodity-container score itself, not a copy of its value")
+
+		// And pin today's number. This line failing means the tier moved; the
+		// point is that someone has to look at it and decide, rather than the
+		// ceiling drifting silently with an unrelated enum retune.
+		assert.InDelta(t, 0.65, domain.UnverifiedIsolationCeiling(), 1e-9,
+			"docker(0.20) + namespace(0.15) + readonly(0.20) + seccomp(0.10) = 0.65")
+	})
+
+	t.Run("AIM-02.AC1 an unverified maximal self-report is clipped to the ceiling", func(t *testing.T) {
+		// The gaming vector: claim the strongest posture in the enum and collect
+		// 1.0. It now earns exactly what an honest hardened container earns.
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Sandbox:    domain.SandboxFirecracker,
+			Network:    domain.NetworkAirgap,
+			Filesystem: domain.FilesystemReadOnly,
+			Process:    domain.ProcessFull,
+			Score:      maxPostureScore,
+			ReportedAt: time.Now(),
+			Verified:   false,
+		})
+
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.InDelta(t, domain.UnverifiedIsolationCeiling(), score, 1e-9,
+			"an unverified claim of airgapped firecracker must not outscore a hardened container")
+		assert.Less(t, score, maxPostureScore, "the lie must buy strictly less than it claims")
+		assert.Empty(t, reason, "a capped factor is scored, not excluded")
+	})
+
+	t.Run("AIM-02.AC1 a verified fresh attestation passes through uncapped", func(t *testing.T) {
+		verifier := "orchestrator-metadata"
+		verifiedAt := time.Now()
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Sandbox:    domain.SandboxFirecracker,
+			Network:    domain.NetworkAirgap,
+			Filesystem: domain.FilesystemReadOnly,
+			Process:    domain.ProcessFull,
+			Score:      maxPostureScore,
+			ReportedAt: time.Now(),
+			Verified:   true,
+			VerifiedBy: &verifier,
+			VerifiedAt: &verifiedAt,
+		})
+
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.InDelta(t, maxPostureScore, score, 1e-9,
+			"corroborated posture counts in full — the ceiling is what verification buys past")
+		assert.Empty(t, reason)
+	})
+
+	t.Run("AIM-02.AC1 an against-interest all-none report passes through unchanged", func(t *testing.T) {
+		// min() clips only downward. An agent honest enough to report no
+		// isolation at all must keep its honest 0.0 — a cap that raised it to
+		// 0.65 would reward the worst posture in the enum for reporting itself,
+		// and would score it above the 0.3 no-attestation baseline.
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Sandbox:    domain.SandboxNone,
+			Network:    domain.NetworkNone,
+			Filesystem: domain.FilesystemNone,
+			Process:    domain.ProcessNone,
+			Score:      0.0,
+			ReportedAt: time.Now(),
+			Verified:   false,
+		})
+
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.InDelta(t, 0.0, score, 1e-9, "the cap must never raise a score")
+		assert.Empty(t, reason)
+	})
+
+	t.Run("AIM-02.AC1 an unverified report below the ceiling is untouched", func(t *testing.T) {
+		// docker + firewall + tmpfs + seccomp = 0.52, under the ceiling: the cap
+		// is a no-op and must not quantize the score to the ceiling.
+		below := domain.ScoreIsolation(domain.SandboxDocker, domain.NetworkFirewall,
+			domain.FilesystemTmpfs, domain.ProcessSeccomp)
+		require.Less(t, below, domain.UnverifiedIsolationCeiling())
+
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      below,
+			ReportedAt: time.Now(),
+			Verified:   false,
+		})
+
+		score, _ := calc.calculateExecutionIsolation(agent)
+		assert.InDelta(t, below, score, 1e-9)
+	})
+
+	t.Run("AIM-02.AC1 a nil repository still excludes the factor at the baseline", func(t *testing.T) {
+		calc := &TrustCalculator{}
+		score, reason := calc.calculateExecutionIsolation(&domain.Agent{ID: uuid.New()})
+
+		assert.Equal(t, 0.3, score)
+		assert.Equal(t, exclReasonNotWired, reason, "an un-wired repo is a deployment defect, still excluded")
+	})
+
+	t.Run("AIM-02.AC1 no attestation still scores the 0.3 baseline in the composite", func(t *testing.T) {
+		calc, agent, _ := aim02Calculator(t)
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.Equal(t, 0.3, score)
+		assert.Empty(t, reason, "the 0.3 incentive baseline keeps the factor IN the composite")
+	})
+
+	t.Run("AIM-02.AC1 the cap is read-side only and the stored row keeps the honest score", func(t *testing.T) {
+		calc, agent, repo := aim02Calculator(t)
+
+		att, err := calc.RecordIsolationAttestation(context.Background(), agent.ID,
+			domain.SandboxFirecracker, domain.NetworkAirgap,
+			domain.FilesystemReadOnly, domain.ProcessFull)
+		require.NoError(t, err)
+
+		// What was written: the posture's true score, uncapped.
+		assert.InDelta(t, maxPostureScore, att.Score, 1e-9,
+			"the returned attestation carries the honest posture score")
+		require.Len(t, repo.rows, 1)
+		assert.InDelta(t, maxPostureScore, repo.rows[0].Score, 1e-9,
+			"the stored row records what was claimed, not what it was allowed to count for")
+
+		// What it counts for: the ceiling.
+		score, _ := calc.calculateExecutionIsolation(agent)
+		assert.InDelta(t, domain.UnverifiedIsolationCeiling(), score, 1e-9)
+		assert.NotEqual(t, repo.rows[0].Score, score,
+			"stored posture and scored contribution must be able to differ")
+	})
+}
+
+func TestAIM02_AttestationExpiry(t *testing.T) {
+	// One day past the TTL: the smallest interval that is unambiguously expired.
+	pastTTL := func() time.Time {
+		return time.Now().Add(-(domain.IsolationAttestationTTL + 24*time.Hour))
+	}
+
+	t.Run("AIM-02.AC2 the TTL is 90 days", func(t *testing.T) {
+		assert.Equal(t, 90*24*time.Hour, domain.IsolationAttestationTTL)
+	})
+
+	t.Run("AIM-02.AC2 an attestation one day past the TTL scores the baseline", func(t *testing.T) {
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      maxPostureScore,
+			ReportedAt: pastTTL(),
+			Verified:   false,
+		})
+
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.Equal(t, 0.3, score, "a claim about a deployment that may no longer exist counts for nothing")
+		assert.Empty(t, reason,
+			"staleness is a scoring choice, not missing data: a non-empty reason would join the "+
+				"AIP §6.1 renormalization set and hand back the weight the agent let rot")
+	})
+
+	t.Run("AIM-02.AC2 a stale VERIFIED attestation is also the baseline", func(t *testing.T) {
+		// The expiry is uniform. Exempting verified rows would let one
+		// verification prop the factor up forever, which is the failure the
+		// expiry exists to close.
+		verifier := "tee-attestation"
+		verifiedAt := pastTTL()
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      maxPostureScore,
+			ReportedAt: pastTTL(),
+			Verified:   true,
+			VerifiedBy: &verifier,
+			VerifiedAt: &verifiedAt,
+		})
+
+		score, reason := calc.calculateExecutionIsolation(agent)
+
+		assert.Equal(t, 0.3, score, "verification does not exempt a row from the expiry")
+		assert.Empty(t, reason)
+	})
+
+	t.Run("AIM-02.AC2 an attestation just inside the TTL still counts", func(t *testing.T) {
+		// Bounds the gate from the other side: "older than 90 days" is strict,
+		// so a report at 89 days is live and the expiry is not eating fresh data.
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      maxPostureScore,
+			ReportedAt: time.Now().Add(-(domain.IsolationAttestationTTL - 24*time.Hour)),
+			Verified:   false,
+		})
+
+		score, _ := calc.calculateExecutionIsolation(agent)
+		assert.InDelta(t, domain.UnverifiedIsolationCeiling(), score, 1e-9,
+			"a report inside the TTL is scored (at the unverified ceiling), not expired")
+	})
+
+	t.Run("AIM-02.AC2 a fresh re-attestation restores the score", func(t *testing.T) {
+		// Expiry is recoverable by doing the thing the factor asks for: report again.
+		calc, agent, _ := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      maxPostureScore,
+			ReportedAt: pastTTL(),
+		})
+
+		stale, _ := calc.calculateExecutionIsolation(agent)
+		require.Equal(t, 0.3, stale, "precondition: the agent starts stale")
+
+		_, err := calc.RecordIsolationAttestation(context.Background(), agent.ID,
+			domain.SandboxDocker, domain.NetworkNamespace,
+			domain.FilesystemReadOnly, domain.ProcessSeccomp)
+		require.NoError(t, err)
+
+		restored, reason := calc.calculateExecutionIsolation(agent)
+		assert.InDelta(t, domain.UnverifiedIsolationCeiling(), restored, 1e-9,
+			"re-attesting restores the factor")
+		assert.Greater(t, restored, stale)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("AIM-02.AC2 a stale attestation does not enter the exclusion set", func(t *testing.T) {
+		// The empty reason has to survive all the way to the published score:
+		// execution_isolation must NOT appear in ExcludedFactors, so its 10%
+		// weight is not redistributed across the agent's other factors.
+		calculator, agent := compositionTestAgent(t)
+		repo := &memIsolationRepo{rows: []*domain.IsolationAttestation{{
+			ID:         uuid.New(),
+			AgentID:    agent.ID,
+			Score:      maxPostureScore,
+			ReportedAt: pastTTL(),
+		}}}
+		calculator.SetIsolationRepo(repo)
+
+		score, err := calculator.Calculate(agent)
+		require.NoError(t, err)
+
+		assert.NotContains(t, score.ExcludedFactors, "execution_isolation",
+			"a stale attestation is scored at the baseline, never renormalized away")
+		assert.Equal(t, 0.3, score.Factors.ExecutionIsolation)
+	})
+}
+
+func TestAIM02_NoVerifiedWritePath(t *testing.T) {
+	t.Run("AIM-02.AC3 the ingest path hard-sets verified false", func(t *testing.T) {
+		calc, agent, repo := aim02Calculator(t)
+
+		att, err := calc.RecordIsolationAttestation(context.Background(), agent.ID,
+			domain.SandboxFirecracker, domain.NetworkAirgap,
+			domain.FilesystemReadOnly, domain.ProcessFull)
+		require.NoError(t, err)
+
+		assert.False(t, att.Verified, "a self-report is never its own verification")
+		assert.Nil(t, att.VerifiedBy)
+		assert.Nil(t, att.VerifiedAt)
+		require.Len(t, repo.rows, 1)
+		assert.False(t, repo.rows[0].Verified, "the persisted row is unverified")
+		assert.Nil(t, repo.rows[0].VerifiedBy)
+		assert.Nil(t, repo.rows[0].VerifiedAt)
+	})
+
+	t.Run("AIM-02.AC3 a re-attestation supersedes a verified row and starts unverified", func(t *testing.T) {
+		// No carry-forward: verification is bound to the row, not the agent. An
+		// agent verified in a hardened deployment must not be able to move to a
+		// bare host, re-attest a maximal posture, and keep the old row's credit.
+		verifier := "tee-attestation"
+		verifiedAt := time.Now().Add(-time.Hour)
+		calc, agent, repo := aim02Calculator(t, &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			Score:      maxPostureScore,
+			ReportedAt: time.Now().Add(-time.Hour),
+			Verified:   true,
+			VerifiedBy: &verifier,
+			VerifiedAt: &verifiedAt,
+		})
+
+		before, _ := calc.calculateExecutionIsolation(agent)
+		require.InDelta(t, maxPostureScore, before, 1e-9,
+			"precondition: the verified row scores in full")
+
+		_, err := calc.RecordIsolationAttestation(context.Background(), agent.ID,
+			domain.SandboxFirecracker, domain.NetworkAirgap,
+			domain.FilesystemReadOnly, domain.ProcessFull)
+		require.NoError(t, err)
+
+		latest, err := repo.GetLatest(agent.ID)
+		require.NoError(t, err)
+		assert.False(t, latest.Verified, "the newest row is a fresh self-report, unverified")
+		assert.Nil(t, latest.VerifiedBy)
+
+		after, reason := calc.calculateExecutionIsolation(agent)
+		assert.InDelta(t, domain.UnverifiedIsolationCeiling(), after, 1e-9,
+			"the same posture now scores at the ceiling — the predecessor's verification is gone")
+		assert.Less(t, after, before, "re-attesting cannot preserve a superseded verification")
+		assert.Empty(t, reason)
+	})
+
+	t.Run("AIM-02.AC3 the ingest signature carries no verification input", func(t *testing.T) {
+		// Structural, not behavioural: RecordIsolationAttestation takes posture
+		// only. There is no argument through which a caller — handler, SDK, or
+		// anything downstream of a request body — could ask for verification, so
+		// the invariant does not depend on any caller behaving.
+		var _ func(context.Context, uuid.UUID, domain.SandboxType, domain.NetworkIsolation,
+			domain.FilesystemIsolation, domain.ProcessIsolation) (*domain.IsolationAttestation, error) =
+			(&TrustCalculator{}).RecordIsolationAttestation
+	})
+}

--- a/apps/backend/internal/application/aim02_scope_test.go
+++ b/apps/backend/internal/application/aim02_scope_test.go
@@ -1,0 +1,242 @@
+package application
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AIM-02 — bounded scope, held as tests rather than as a promise in a PR body.
+//
+// AIM-02 ships two read-side gates on trust factor 9 and the column a future
+// verifier will write into. Three things it deliberately does NOT do, each of
+// which is easy to do by accident while in the neighbourhood:
+//
+//	no verified write path — the ceiling is worth nothing if anything can set
+//	                         verified = true, so nothing may, in any layer.
+//	signing keys untouched — keyvault.go and KEYVAULT_MASTER_KEY are adjacent to
+//	                         "attestation" by vocabulary only.
+//	route mismatch left alone — both SDKs POST /isolation-attestation while the
+//	                         backend registers /isolation, so the reporting
+//	                         surface 404s today. That is CA's lane; fixing it
+//	                         here would fold an unrelated behaviour change into
+//	                         a scoring change and make both harder to review.
+//
+// These are source-level assertions. They are coarse by design: a scan cannot
+// prove the absence of every conceivable write, but it does catch the shapes a
+// later change would actually take, and it fails loudly next to the code it
+// constrains rather than in a reviewer's memory.
+
+// aim02RepoRoot resolves the repository root from this file's own location, so
+// the scan does not depend on the working directory `go test` was invoked from.
+func aim02RepoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must resolve this test file's path")
+
+	dir := filepath.Dir(thisFile)
+	for i := 0; i < 12; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "package.json")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "apps")); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate repository root above %s", thisFile)
+	return ""
+}
+
+func aim02ReadFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	require.NoError(t, err, "expected %s to exist", rel)
+	return string(b)
+}
+
+// aim02StripLineComments removes `//` and `--` line comments so that prose
+// ABOUT a write ("nothing sets verified = TRUE") is not mistaken for a write.
+// It is not a parser: a `//` inside a string literal would be stripped too.
+// That direction is safe here — it can only hide a violation that is inside a
+// string, and no SQL this repo issues is assembled that way.
+func aim02StripLineComments(src string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// verificationWrites are the shapes a write of `verified` would take in Go or
+// in SQL. The struct-literal and assignment forms cover the Go side; the SQL
+// forms cover a bound parameter, a TRUE literal, and an UPDATE of the table.
+var verificationWrites = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)Verified\s*:\s*true`),
+	regexp.MustCompile(`(?i)\.Verified\s*=\s*true`),
+	regexp.MustCompile(`(?i)VerifiedBy\s*:\s*[^n]`), // anything but nil
+	regexp.MustCompile(`(?i)\bverified\s*=\s*(true|\$\d+)`),
+	regexp.MustCompile(`(?i)UPDATE\s+isolation_attestations`),
+}
+
+func TestAIM02_BoundedScope(t *testing.T) {
+	root := aim02RepoRoot(t)
+
+	t.Run("AIM-02.AC4 no backend source writes verified on an isolation attestation", func(t *testing.T) {
+		// Scan every non-test Go and SQL file in the backend that mentions the
+		// isolation attestation at all. Test files are excluded on purpose:
+		// they construct verified rows to exercise the READ side, which is the
+		// only way to prove the read side treats them differently.
+		var offenders []string
+		backend := filepath.Join(root, "apps", "backend")
+
+		err := filepath.Walk(backend, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == "node_modules" || info.Name() == "vendor" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			ext := filepath.Ext(path)
+			if ext != ".go" && ext != ".sql" {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			src := string(raw)
+			if !strings.Contains(src, "IsolationAttestation") && !strings.Contains(src, "isolation_attestations") {
+				return nil
+			}
+			body := aim02StripLineComments(src)
+			for _, re := range verificationWrites {
+				if loc := re.FindString(body); loc != "" {
+					rel, _ := filepath.Rel(root, path)
+					offenders = append(offenders, rel+": "+strings.TrimSpace(loc))
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		assert.Empty(t, offenders,
+			"no write path may set verified on an isolation attestation: the unverified ceiling "+
+				"is the only thing bounding a self-report, and a single writable TRUE returns the "+
+				"full 1.0 it exists to deny. TEE attestation and orchestrator metadata may write "+
+				"this in Phase 2; an HMA static scan may not, and the SDK never.")
+	})
+
+	t.Run("AIM-02.AC4 the isolation path does not touch signing-key handling", func(t *testing.T) {
+		// Bounded scope in both directions: the isolation change must not reach
+		// into the key vault, and the key vault must not have grown an
+		// isolation dependency while this landed.
+		for _, rel := range []string{
+			"apps/backend/internal/domain/isolation.go",
+			"apps/backend/internal/application/trust_calculator.go",
+			"apps/backend/internal/infrastructure/repository/isolation_attestation_repository.go",
+			"apps/backend/migrations/108_add_isolation_attestation_verification.sql",
+		} {
+			src := strings.ToLower(aim02ReadFile(t, root, rel))
+			assert.NotContains(t, src, "keyvault", "%s must not reach into signing-key handling", rel)
+			assert.NotContains(t, src, "master_key", "%s must not reach into signing-key handling", rel)
+		}
+
+		keyvault := strings.ToLower(aim02ReadFile(t, root, "apps/backend/internal/crypto/keyvault.go"))
+		assert.NotContains(t, keyvault, "isolationattestation",
+			"keyvault.go is out of scope for AIM-02 and must not have acquired an isolation dependency")
+	})
+
+	t.Run("AIM-02.AC4 the SDK/backend isolation route mismatch is left unfixed", func(t *testing.T) {
+		// The mismatch is real and blocking — the attestation table is near-empty
+		// because both SDKs 404 — but it is a separate lane. Asserting it is
+		// STILL BROKEN is the only way to prove this change did not quietly
+		// touch it, and this test is expected to be deleted by the lane that
+		// fixes it.
+		mainGo := aim02ReadFile(t, root, "apps/backend/cmd/server/main.go")
+		assert.Contains(t, mainGo, `sdkAPI.Post("/agents/:id/isolation"`,
+			"the backend route is unchanged by AIM-02")
+		assert.NotContains(t, mainGo, `"/agents/:id/isolation-attestation"`,
+			"AIM-02 must not add the route the SDKs call — that is CA's lane")
+
+		tsClient := aim02ReadFile(t, root, "sdk/typescript/src/client/AIMClient.ts")
+		assert.Contains(t, tsClient, "/isolation-attestation",
+			"the TypeScript SDK still posts the mismatched path; AIM-02 does not touch the SDKs")
+	})
+
+	t.Run("AIM-02.AC4 the user-facing surfaces describe the ceiling and the expiry", func(t *testing.T) {
+		// A scoring change an operator cannot see is a scoring change they will
+		// file a bug about. Each surface has to say what the factor now does.
+		breakdown := aim02ReadFile(t, root, "apps/web/components/agent/trust-score-breakdown.tsx")
+		assert.Contains(t, breakdown, "0.65",
+			"the breakdown copy must name the ceiling an unverified report is held to")
+		assert.Contains(t, breakdown, "90 days",
+			"the breakdown copy must name the expiry")
+
+		doc := aim02ReadFile(t, root, "docs/sdk/trust-scoring.md")
+		assert.Contains(t, doc, "0.65", "factor 9 documentation must name the ceiling")
+		assert.Contains(t, doc, "90-day", "factor 9 documentation must name the expiry")
+
+		changelog := aim02ReadFile(t, root, "CHANGELOG.md")
+		assert.Contains(t, changelog, "isolation_attestations",
+			"the changelog must record the schema change")
+		assert.Contains(t, changelog, "90-day", "the changelog must record the expiry")
+	})
+
+	t.Run("AIM-02.AC4 no deployment artifact carries this change", func(t *testing.T) {
+		// AIM-02 is code and schema only; the prod deploy for
+		// aim-cloud/agent-identity-management is gated in another lane. If a
+		// deployment manifest names anything this change introduced, something
+		// was shipped from here that should not have been.
+		markers := []string{
+			"UnverifiedIsolationCeiling",
+			"IsolationAttestationTTL",
+			"108_add_isolation_attestation_verification",
+		}
+		for _, dir := range []string{"infrastructure", filepath.Join("apps", "backend", "deployments")} {
+			base := filepath.Join(root, dir)
+			if _, err := os.Stat(base); os.IsNotExist(err) {
+				continue
+			}
+			err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+				if err != nil || info.IsDir() {
+					return err
+				}
+				raw, readErr := os.ReadFile(path)
+				if readErr != nil {
+					return nil // binary or unreadable: not a manifest we care about
+				}
+				for _, m := range markers {
+					if strings.Contains(string(raw), m) {
+						rel, _ := filepath.Rel(root, path)
+						t.Errorf("deployment file %s references %q; AIM-02 ships no deploy artifact", rel, m)
+					}
+				}
+				return nil
+			})
+			require.NoError(t, err)
+		}
+	})
+}

--- a/apps/backend/internal/application/aim02_scope_test.go
+++ b/apps/backend/internal/application/aim02_scope_test.go
@@ -90,7 +90,7 @@ func aim02StripLineComments(src string) string {
 var verificationWrites = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)Verified\s*:\s*true`),
 	regexp.MustCompile(`(?i)\.Verified\s*=\s*true`),
-	regexp.MustCompile(`(?i)VerifiedBy\s*:\s*[^n]`), // anything but nil
+	regexp.MustCompile(`(?i)VerifiedBy\s*:\s*[^n\s]`), // anything but nil ([^n] alone eats the space after the colon and flags `VerifiedBy: nil` itself)
 	regexp.MustCompile(`(?i)\bverified\s*=\s*(true|\$\d+)`),
 	regexp.MustCompile(`(?i)UPDATE\s+isolation_attestations`),
 }

--- a/apps/backend/internal/application/trust_calculator.go
+++ b/apps/backend/internal/application/trust_calculator.go
@@ -673,6 +673,26 @@ func (c *TrustCalculator) calculateUserFeedback(agent *domain.Agent) (float64, s
 // §6.1) that incentivizes agents to report their posture, and issuance
 // surfaces it via IsolationSelfReported. Only an un-wired repository excludes
 // the factor from the composite.
+//
+// Two integrity gates sit between the stored row and the factor score, both
+// read-side only — neither rewrites the attestation, which stays the honest
+// record of what was reported (roadmap aim-isolation-verification, CDS ruling
+// 2026-08-29):
+//
+//	expiry  — a posture older than domain.IsolationAttestationTTL counts for
+//	          nothing and falls back to the baseline, uniformly for verified and
+//	          unverified rows.
+//	ceiling — an unverified self-report is clipped to
+//	          domain.UnverifiedIsolationCeiling(), the commodity-container tier.
+//	          A hostile agent claiming firecracker+airgap+readonly+full now earns
+//	          the same 0.65 as an honest "I'm in a hardened container", so the
+//	          lie buys nothing. min() clips only downward, so an against-interest
+//	          report (all none, 0.0) passes through at its honest low value
+//	          rather than being lifted to the ceiling.
+//
+// Independent verification — the write side that would set Verified — is Phase 2
+// and deliberately does not exist yet. Until it does, every row is unverified and
+// the ceiling is the effective maximum for the factor.
 func (c *TrustCalculator) calculateExecutionIsolation(agent *domain.Agent) (float64, string) {
 	if c.isolationRepo == nil {
 		return 0.3, exclReasonNotWired
@@ -683,7 +703,21 @@ func (c *TrustCalculator) calculateExecutionIsolation(agent *domain.Agent) (floa
 		return 0.3, "" // No attestation submitted yet: scored low baseline by design
 	}
 
-	// Use the pre-computed score from the attestation
+	// Expired posture is scored, not excluded: the reason stays EMPTY on
+	// purpose. A non-empty reason would enter the AIP §6.1 exclusion set and
+	// redistribute this factor's weight, which is the wrong semantics — a stale
+	// attestation is not missing data, it is data we have decided not to credit.
+	// Excluding it would also hand the agent back the exact weight it lost by
+	// letting the attestation rot.
+	if attestation.IsExpiredAt(time.Now()) {
+		return 0.3, ""
+	}
+
+	if !attestation.Verified {
+		return math.Min(attestation.Score, domain.UnverifiedIsolationCeiling()), ""
+	}
+
+	// Verified and fresh: the posture is corroborated, so it counts in full.
 	return attestation.Score, ""
 }
 
@@ -852,6 +886,18 @@ func (c *TrustCalculator) RecordUserFeedback(ctx context.Context, agentID, orgID
 // cannot inject an arbitrary score, and unrecognized posture values are rejected
 // before anything is written. Independent verification of the reported posture is
 // a separate follow-up (see roadmap aim-isolation-verification).
+//
+// Verified is hard-set false here and takes no input from the caller — the
+// signature carries posture only, so there is no argument through which an
+// ingest path could request verification. A re-attestation is therefore always
+// a new unverified row: it supersedes its predecessor by reported_at and never
+// inherits that predecessor's verification. The repository INSERT writes the
+// literal FALSE as well, so the invariant does not rest on this assignment alone.
+//
+// The stored Score is the HONEST posture value, uncapped. The unverified ceiling
+// is applied when the factor is read (calculateExecutionIsolation), not when the
+// row is written: the table records what the agent claimed, and the scorer
+// decides what the claim is worth.
 func (c *TrustCalculator) RecordIsolationAttestation(ctx context.Context, agentID uuid.UUID, sandbox domain.SandboxType, network domain.NetworkIsolation, filesystem domain.FilesystemIsolation, process domain.ProcessIsolation) (*domain.IsolationAttestation, error) {
 	if c.isolationRepo == nil {
 		return nil, fmt.Errorf("isolation attestation repository not configured")
@@ -871,6 +917,9 @@ func (c *TrustCalculator) RecordIsolationAttestation(ctx context.Context, agentI
 		Score:      domain.ScoreIsolation(sandbox, network, filesystem, process),
 		ReportedAt: now,
 		CreatedAt:  now,
+		Verified:   false, // no verified write path exists until Phase 2
+		VerifiedBy: nil,
+		VerifiedAt: nil,
 	}
 
 	if err := c.isolationRepo.Create(attestation); err != nil {

--- a/apps/backend/internal/application/trust_calculator_test.go
+++ b/apps/backend/internal/application/trust_calculator_test.go
@@ -1249,7 +1249,9 @@ func TestTrustCalculator_VerifiedAgentWithIsolation_HigherScore(t *testing.T) {
 	mockAlertRepo.On("GetUnacknowledgedByResourceID", agentID).Return([]*domain.Alert{}, nil).Maybe()
 	mockAlertRepo.On("GetByResourceID", agentID, 100, 0).Return([]*domain.Alert{}, nil).Maybe()
 
-	// Mock isolation repo to return a high-isolation attestation
+	// Mock isolation repo to return a high-isolation attestation. It is a fresh
+	// SELF-REPORT, so the read side clips it to the unverified ceiling: the
+	// stored 1.0 is what the agent claimed, 0.65 is what the claim is worth.
 	mockIsolationRepo.On("GetLatest", agentID).Return(&domain.IsolationAttestation{
 		ID:         uuid.New(),
 		AgentID:    agentID,
@@ -1258,6 +1260,7 @@ func TestTrustCalculator_VerifiedAgentWithIsolation_HigherScore(t *testing.T) {
 		Filesystem: domain.FilesystemReadOnly,
 		Process:    domain.ProcessFull,
 		Score:      1.0, // Max isolation
+		ReportedAt: time.Now(),
 	}, nil)
 
 	// Calculate without isolation repo (defaults to 0.3 baseline)
@@ -1270,13 +1273,13 @@ func TestTrustCalculator_VerifiedAgentWithIsolation_HigherScore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, scoreWith)
 
-	// Agent with perfect isolation should score higher
+	// Agent with reported isolation should score higher
 	assert.Greater(t, scoreWith.Score, scoreWithout.Score,
-		"Agent with perfect isolation (1.0) should score higher than baseline (0.3)")
+		"Agent with a reported isolation posture should score higher than baseline (0.3)")
 
-	// Verify ExecutionIsolation factor is populated
-	assert.Equal(t, 1.0, scoreWith.Factors.ExecutionIsolation,
-		"ExecutionIsolation factor should be 1.0 with max isolation attestation")
+	// Verify ExecutionIsolation factor is populated, at the unverified ceiling
+	assert.Equal(t, domain.UnverifiedIsolationCeiling(), scoreWith.Factors.ExecutionIsolation,
+		"an unverified max-posture attestation is clipped to the ceiling, not scored 1.0")
 	assert.Equal(t, 0.3, scoreWithout.Factors.ExecutionIsolation,
 		"ExecutionIsolation factor should be 0.3 baseline without isolation repo")
 }
@@ -1371,10 +1374,18 @@ func TestTrustCalculator_ExecutionIsolation_WithAttestation(t *testing.T) {
 	agentID := uuid.New()
 	agent := &domain.Agent{ID: agentID}
 
+	// Verified and fresh: the pre-computed score passes through untouched. (The
+	// unverified and stale paths are covered by TestAIM02_* below.)
+	verifier := "orchestrator-metadata"
+	verifiedAt := time.Now()
 	mockIsolationRepo.On("GetLatest", agentID).Return(&domain.IsolationAttestation{
-		ID:      uuid.New(),
-		AgentID: agentID,
-		Score:   0.72,
+		ID:         uuid.New(),
+		AgentID:    agentID,
+		Score:      0.72,
+		ReportedAt: time.Now(),
+		Verified:   true,
+		VerifiedBy: &verifier,
+		VerifiedAt: &verifiedAt,
 	}, nil)
 
 	isolation, reason := calculator.calculateExecutionIsolation(agent)
@@ -1782,8 +1793,10 @@ func TestTrustCalculator_Calculate_FullyWiredWithData_NoExclusions(t *testing.T)
 	calculator.SetUserFeedbackRepo(feedbackRepo)
 
 	isolationRepo := new(MockIsolationAttestationRepository)
+	// Verified and fresh, so factor 9 carries its full 0.72 into the composite.
 	isolationRepo.On("GetLatest", agent.ID).Return(&domain.IsolationAttestation{
 		ID: uuid.New(), AgentID: agent.ID, Score: 0.72,
+		ReportedAt: time.Now(), Verified: true,
 	}, nil)
 	calculator.SetIsolationRepo(isolationRepo)
 

--- a/apps/backend/internal/domain/isolation.go
+++ b/apps/backend/internal/domain/isolation.go
@@ -54,6 +54,42 @@ const (
 	ProcessFull     ProcessIsolation = "full" // PID namespace + seccomp + MAC
 )
 
+// IsolationAttestationTTL is the hard expiry on a reported posture: an
+// attestation whose reported_at is older than this counts for nothing and the
+// factor falls back to the no-attestation baseline.
+//
+// It is uniform for verified and unverified rows on purpose. A posture is a
+// statement about a running deployment, and deployments move; a claim made once
+// and never renewed describes a machine that may no longer exist. Exempting
+// verified rows would let a single verification prop the factor up forever,
+// which is the "one-time claim props up the score indefinitely" failure the
+// expiry exists to close. 90 days matches the re-attestation cadence an operator
+// can reasonably hold without the factor becoming a nag.
+const IsolationAttestationTTL = 90 * 24 * time.Hour
+
+// UnverifiedIsolationCeiling is the highest factor-9 score an UNVERIFIED
+// self-report may earn on the read side.
+//
+// It is DERIVED, never a literal: it is exactly the score of the commodity
+// container tier — Docker + network namespace + read-only rootfs + seccomp — the
+// posture a competent operator gets from an ordinary hardened container. The
+// reasoning is that an unverified claim is worth no more than what the claim is
+// cheapest to make about; anything above this tier (a VM, a TEE, an airgap) is a
+// claim about infrastructure AIM cannot see, so it must be earned with
+// verification rather than asserted.
+//
+// Deriving it from ScoreIsolation means a retune of the posture enum weights
+// moves the ceiling with the tier it names instead of stranding a stale
+// constant. TestAIM02_UnverifiedCeiling pins today's value (0.65) so the retune
+// is a conscious edit rather than a silent drift.
+//
+// This is a READ-side cap only. The stored attestation Score stays the honest
+// posture value: the row is a record of what was reported, not of what it was
+// allowed to count for.
+func UnverifiedIsolationCeiling() float64 {
+	return ScoreIsolation(SandboxDocker, NetworkNamespace, FilesystemReadOnly, ProcessSeccomp)
+}
+
 // IsolationAttestation represents an agent's self-reported runtime isolation posture.
 // Agents submit this via SDK; the server scores it as a trust factor.
 type IsolationAttestation struct {
@@ -66,6 +102,31 @@ type IsolationAttestation struct {
 	Score      float64             `json:"score"` // Computed 0-1 isolation score
 	ReportedAt time.Time           `json:"reportedAt"`
 	CreatedAt  time.Time           `json:"createdAt"`
+
+	// Verified reports whether an INDEPENDENT source corroborated this row's
+	// posture. It is bound to the row, not to the agent: verification describes
+	// one report of one deployment at one moment, so a later re-attestation
+	// starts unverified and never carries a predecessor's verification forward.
+	//
+	// Nothing in the codebase sets this true today. There is no verified write
+	// path until an independent source exists (Phase 2, roadmap
+	// aim-isolation-verification); the ingest path hard-sets false and the
+	// repository INSERT writes the literal FALSE. The evidence classes that may
+	// ever set it are TEE attestation and orchestrator/host metadata; an HMA
+	// static scan may NOT (it reads the declared surface, not the running one),
+	// and the SDK may never (it is the self-report being checked).
+	Verified bool `json:"verified"`
+
+	// VerifiedBy names the independent source that corroborated the posture, and
+	// VerifiedAt is when it did. Both are nil while Verified is false.
+	VerifiedBy *string    `json:"verifiedBy,omitempty"`
+	VerifiedAt *time.Time `json:"verifiedAt,omitempty"`
+}
+
+// IsExpiredAt reports whether the attestation is past IsolationAttestationTTL
+// relative to now. Uniform for verified and unverified rows.
+func (a *IsolationAttestation) IsExpiredAt(now time.Time) bool {
+	return now.Sub(a.ReportedAt) > IsolationAttestationTTL
 }
 
 // IsolationAttestationRepository defines persistence for isolation attestations

--- a/apps/backend/internal/domain/isolation_test.go
+++ b/apps/backend/internal/domain/isolation_test.go
@@ -2,7 +2,9 @@ package domain
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -201,4 +203,39 @@ func TestIsolationPosture_IsValid(t *testing.T) {
 	assert.True(t, ProcessSELinux.IsValid())
 	assert.False(t, SandboxType("bogus").IsValid())
 	assert.False(t, NetworkIsolation("").IsValid())
+}
+
+// TestUnverifiedIsolationCeiling pins today's ceiling and proves it is DERIVED
+// from the commodity-container tier, not a stranded constant: a retune of the
+// posture-enum weights must move both sides of this equality together.
+func TestUnverifiedIsolationCeiling(t *testing.T) {
+	got := UnverifiedIsolationCeiling()
+	assert.Equal(t, ScoreIsolation(SandboxDocker, NetworkNamespace, FilesystemReadOnly, ProcessSeccomp), got,
+		"the ceiling must equal the docker/namespace/readonly/seccomp tier it is derived from")
+	assert.InDelta(t, 0.65, got, 0.001, "today's ceiling is 0.65; a change here is a conscious retune")
+	// A maximal posture must not out-score the ceiling once it is clipped to it,
+	// and the ceiling itself must sit strictly below a fully-hardened score.
+	assert.Less(t, got, ScoreIsolation(SandboxKataVM, NetworkAirgap, FilesystemReadOnly, ProcessSeccomp),
+		"an unverified claim must earn strictly less than a fully-hardened posture")
+}
+
+// TestIsolationAttestation_IsExpiredAt exercises both sides of the 90-day TTL
+// boundary plus the exact edge, uniform for verified and unverified rows.
+func TestIsolationAttestation_IsExpiredAt(t *testing.T) {
+	now := time.Now()
+	mk := func(age time.Duration, verified bool) *IsolationAttestation {
+		return &IsolationAttestation{
+			ID:         uuid.New(),
+			AgentID:    uuid.New(),
+			ReportedAt: now.Add(-age),
+			Verified:   verified,
+		}
+	}
+	assert.False(t, mk(89*24*time.Hour, false).IsExpiredAt(now), "89 days is inside the TTL")
+	assert.False(t, mk(IsolationAttestationTTL, false).IsExpiredAt(now), "exactly at the TTL is not yet past it")
+	assert.True(t, mk(IsolationAttestationTTL+time.Second, false).IsExpiredAt(now), "one second past the TTL is expired")
+	assert.True(t, mk(91*24*time.Hour, false).IsExpiredAt(now), "91 days is expired")
+	// Expiry does not depend on verification.
+	assert.True(t, mk(91*24*time.Hour, true).IsExpiredAt(now), "a verified row expires on the same clock")
+	assert.False(t, mk(1*time.Hour, true).IsExpiredAt(now), "a fresh verified row is not expired")
 }

--- a/apps/backend/internal/infrastructure/repository/aim02_isolation_verification_test.go
+++ b/apps/backend/internal/infrastructure/repository/aim02_isolation_verification_test.go
@@ -1,0 +1,158 @@
+package repository
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AIM-02 — the persistence half of "no write path can produce a verified
+// isolation attestation".
+//
+// The scoring gates in calculateExecutionIsolation only hold because every row
+// in isolation_attestations is unverified: an unverified report is clipped to
+// the commodity-container ceiling, so a single writable `verified = TRUE` would
+// hand back the full 1.0 the ceiling exists to deny. These tests hold the write
+// side to that, at the SQL statement rather than at a caller's good intentions.
+
+func TestAIM02_CreateNeverWritesVerified(t *testing.T) {
+	t.Run("AIM-02.AC3 the INSERT hard-codes FALSE and ignores a verified struct field", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		repo := NewIsolationAttestationRepository(db)
+
+		// The adversarial input: an attestation handed to Create with
+		// verification already set. Whether it got there through a future
+		// caller's mistake or an attacker-influenced field does not matter —
+		// the statement must write FALSE either way.
+		verifier := "attacker-supplied"
+		verifiedAt := time.Now()
+		att := &domain.IsolationAttestation{
+			ID:         uuid.New(),
+			AgentID:    uuid.New(),
+			Sandbox:    domain.SandboxFirecracker,
+			Network:    domain.NetworkAirgap,
+			Filesystem: domain.FilesystemReadOnly,
+			Process:    domain.ProcessFull,
+			Score:      1.0,
+			ReportedAt: time.Now(),
+			CreatedAt:  time.Now(),
+			Verified:   true,
+			VerifiedBy: &verifier,
+			VerifiedAt: &verifiedAt,
+		}
+
+		// FALSE, NULL, NULL are literals in the statement, so they are not
+		// bindable: the nine args are posture and timestamps only, and there is
+		// no placeholder through which a caller could reach `verified`.
+		mock.ExpectExec(regexp.QuoteMeta("VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, FALSE, NULL, NULL)")).
+			WithArgs(
+				att.ID, att.AgentID,
+				string(att.Sandbox), string(att.Network),
+				string(att.Filesystem), string(att.Process),
+				att.Score, att.ReportedAt, att.CreatedAt,
+			).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		require.NoError(t, repo.Create(att))
+		require.NoError(t, mock.ExpectationsWereMet(),
+			"Create must write the literal FALSE for verified; binding the struct field here "+
+				"would make the unverified ceiling bypassable by whoever constructs the struct")
+	})
+}
+
+func TestAIM02_ScanCarriesVerificationColumns(t *testing.T) {
+	// The columns the migration adds have to survive the round trip, or the
+	// read-side gate would treat a genuinely verified row as unverified once
+	// Phase 2 exists — and, more immediately, a scan that omitted them would
+	// leave Verified at its zero value for reasons unrelated to the data.
+	cols := []string{
+		"id", "agent_id", "sandbox", "network", "filesystem", "process",
+		"score", "reported_at", "created_at", "verified", "verified_by", "verified_at",
+	}
+
+	t.Run("AIM-02.AC3 GetLatest scans verified, verified_by and verified_at", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		repo := NewIsolationAttestationRepository(db)
+		agentID := uuid.New()
+		reportedAt := time.Now().Add(-time.Hour)
+		verifiedAt := time.Now().Add(-30 * time.Minute)
+
+		mock.ExpectQuery(regexp.QuoteMeta("verified, verified_by, verified_at")).
+			WithArgs(agentID).
+			WillReturnRows(sqlmock.NewRows(cols).AddRow(
+				uuid.New(), agentID, "docker", "namespace", "readonly", "seccomp",
+				0.65, reportedAt, reportedAt, true, "orchestrator-metadata", verifiedAt,
+			))
+
+		att, err := repo.GetLatest(agentID)
+		require.NoError(t, err)
+		require.NotNil(t, att)
+
+		assert.True(t, att.Verified)
+		require.NotNil(t, att.VerifiedBy)
+		assert.Equal(t, "orchestrator-metadata", *att.VerifiedBy)
+		require.NotNil(t, att.VerifiedAt)
+		assert.WithinDuration(t, verifiedAt, *att.VerifiedAt, time.Second)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("AIM-02.AC3 a NULL verifier scans to nil rather than failing", func(t *testing.T) {
+		// This is every row in the table today, so it is the path that must not
+		// break: verified_by and verified_at are NULL wherever verified is FALSE.
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		repo := NewIsolationAttestationRepository(db)
+		agentID := uuid.New()
+		reportedAt := time.Now()
+
+		mock.ExpectQuery(regexp.QuoteMeta("verified, verified_by, verified_at")).
+			WithArgs(agentID).
+			WillReturnRows(sqlmock.NewRows(cols).AddRow(
+				uuid.New(), agentID, "docker", "namespace", "readonly", "seccomp",
+				0.65, reportedAt, reportedAt, false, nil, nil,
+			))
+
+		att, err := repo.GetLatest(agentID)
+		require.NoError(t, err)
+		require.NotNil(t, att)
+
+		assert.False(t, att.Verified)
+		assert.Nil(t, att.VerifiedBy, "NULL must scan to nil, not to an empty-string verifier")
+		assert.Nil(t, att.VerifiedAt)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("AIM-02.AC3 GetLatest orders by reported_at so a re-attestation supersedes", func(t *testing.T) {
+		// The no-carry-forward rule is enforced by the ordering: the newest
+		// report is the only row the scorer ever sees, so a superseded verified
+		// row cannot contribute.
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		repo := NewIsolationAttestationRepository(db)
+		agentID := uuid.New()
+
+		mock.ExpectQuery(regexp.QuoteMeta("ORDER BY reported_at DESC")).
+			WithArgs(agentID).
+			WillReturnRows(sqlmock.NewRows(cols))
+
+		_, err = repo.GetLatest(agentID)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/apps/backend/internal/infrastructure/repository/isolation_attestation_repository.go
+++ b/apps/backend/internal/infrastructure/repository/isolation_attestation_repository.go
@@ -20,11 +20,23 @@ func NewIsolationAttestationRepository(db *sql.DB) *IsolationAttestationReposito
 	return &IsolationAttestationRepository{db: db}
 }
 
+// Create persists a self-reported attestation.
+//
+// `verified` is written as the literal FALSE and is NOT taken from the struct
+// field. Every attestation reaching this method is a self-report, and there is
+// no independent verification source to write a TRUE from (roadmap
+// aim-isolation-verification Phase 2). Hard-coding it here means the invariant
+// "no ingest path can produce a verified row" holds structurally: a future
+// caller that builds an IsolationAttestation with Verified set — by mistake or
+// by an attacker-influenced field — still writes an unverified row. When a
+// verifier does exist it gets its own method, so the honest write and the
+// self-report write never share a statement.
 func (r *IsolationAttestationRepository) Create(attestation *domain.IsolationAttestation) error {
 	query := `
 		INSERT INTO isolation_attestations (
-			id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at,
+			verified, verified_by, verified_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, FALSE, NULL, NULL)
 	`
 	_, err := r.db.Exec(query,
 		attestation.ID,
@@ -41,8 +53,13 @@ func (r *IsolationAttestationRepository) Create(attestation *domain.IsolationAtt
 }
 
 func (r *IsolationAttestationRepository) GetLatest(agentID uuid.UUID) (*domain.IsolationAttestation, error) {
+	// ORDER BY reported_at DESC is what makes a re-attestation supersede its
+	// predecessor: the newest report wins outright, so a verified older row
+	// stops counting the moment the agent reports again. Verification never
+	// carries forward because the read only ever sees one row.
 	query := `
-		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
+		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at,
+		       verified, verified_by, verified_at
 		FROM isolation_attestations
 		WHERE agent_id = $1
 		ORDER BY reported_at DESC
@@ -61,7 +78,8 @@ func (r *IsolationAttestationRepository) GetLatest(agentID uuid.UUID) (*domain.I
 
 func (r *IsolationAttestationRepository) GetHistory(agentID uuid.UUID, limit int) ([]*domain.IsolationAttestation, error) {
 	query := `
-		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at
+		SELECT id, agent_id, sandbox, network, filesystem, process, score, reported_at, created_at,
+		       verified, verified_by, verified_at
 		FROM isolation_attestations
 		WHERE agent_id = $1
 		ORDER BY reported_at DESC
@@ -92,6 +110,10 @@ type rowScanner interface {
 func scanIsolationAttestation(s rowScanner) (*domain.IsolationAttestation, error) {
 	var att domain.IsolationAttestation
 	var sandbox, network, filesystem, process string
+	// verified_by / verified_at are NULL on every row today (nothing sets
+	// verified), so they must be scanned through nullable holders.
+	var verifiedBy sql.NullString
+	var verifiedAt sql.NullTime
 	err := s.Scan(
 		&att.ID,
 		&att.AgentID,
@@ -102,6 +124,9 @@ func scanIsolationAttestation(s rowScanner) (*domain.IsolationAttestation, error
 		&att.Score,
 		&att.ReportedAt,
 		&att.CreatedAt,
+		&att.Verified,
+		&verifiedBy,
+		&verifiedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -110,5 +135,11 @@ func scanIsolationAttestation(s rowScanner) (*domain.IsolationAttestation, error
 	att.Network = domain.NetworkIsolation(network)
 	att.Filesystem = domain.FilesystemIsolation(filesystem)
 	att.Process = domain.ProcessIsolation(process)
+	if verifiedBy.Valid {
+		att.VerifiedBy = &verifiedBy.String
+	}
+	if verifiedAt.Valid {
+		att.VerifiedAt = &verifiedAt.Time
+	}
 	return &att, nil
 }

--- a/apps/backend/internal/interfaces/http/handlers/aim02_isolation_post_path_test.go
+++ b/apps/backend/internal/interfaces/http/handlers/aim02_isolation_post_path_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/application"
+	"github.com/opena2a-org/agent-identity-management/apps/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AIM-02 — the HTTP half of "no write path can produce a verified isolation
+// attestation".
+//
+// The unverified ceiling in calculateExecutionIsolation is only worth anything
+// if `verified` is unreachable from a request. This test drives the real POST
+// path — fiber route, real handler, real application.TrustCalculator ingest,
+// real repository semantics for the verified column — with a body that asks for
+// verification outright, and inspects the row that comes out the other end.
+// The other two layers are covered next to the code they constrain:
+// TestAIM02_NoVerifiedWritePath (ingest) and TestAIM02_CreateNeverWritesVerified
+// (SQL statement).
+
+// aim02CapturingRepo records what the ingest path persists. Create mirrors the
+// SQL INSERT, which writes the literal FALSE for verified rather than binding
+// the struct field, so the fake cannot be more permissive than the real table.
+type aim02CapturingRepo struct {
+	rows []*domain.IsolationAttestation
+}
+
+func (r *aim02CapturingRepo) Create(a *domain.IsolationAttestation) error {
+	stored := *a
+	stored.Verified = false
+	stored.VerifiedBy = nil
+	stored.VerifiedAt = nil
+	r.rows = append(r.rows, &stored)
+	return nil
+}
+
+func (r *aim02CapturingRepo) GetLatest(agentID uuid.UUID) (*domain.IsolationAttestation, error) {
+	if len(r.rows) == 0 {
+		return nil, nil
+	}
+	return r.rows[len(r.rows)-1], nil
+}
+
+func (r *aim02CapturingRepo) GetHistory(agentID uuid.UUID, limit int) ([]*domain.IsolationAttestation, error) {
+	return r.rows, nil
+}
+
+func TestAIM02_PostPathCannotProduceVerifiedRow(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	repo := &aim02CapturingRepo{}
+	// The genuine ingest, not a stand-in: the handler's write reaches
+	// application.RecordIsolationAttestation exactly as it does in production.
+	calculator := &application.TrustCalculator{}
+	calculator.SetIsolationRepo(repo)
+
+	agentMock := &MockAgentServiceImpl{
+		GetAgentFunc: func(ctx context.Context, id uuid.UUID) (*domain.Agent, error) {
+			return &domain.Agent{ID: agentID, OrganizationID: orgID, Name: "test-agent"}, nil
+		},
+	}
+	trustMock := &MockTrustCalculatorServicerImpl{
+		RecordIsolationAttestationFunc: func(ctx context.Context, aID uuid.UUID, s domain.SandboxType, n domain.NetworkIsolation, f domain.FilesystemIsolation, p domain.ProcessIsolation) (*domain.IsolationAttestation, error) {
+			return calculator.RecordIsolationAttestation(ctx, aID, s, n, f, p)
+		},
+	}
+
+	handler := NewTrustScoreHandlerWithInterfaces(trustMock, agentMock, &MockAuditServiceImpl{})
+	app := agentAuthIsolationApp(handler.SubmitIsolationAttestation, orgID, agentID)
+
+	t.Run("AIM-02.AC3 a POST demanding verification still writes an unverified row", func(t *testing.T) {
+		// Every shape the body could take to reach the column: the snake_case
+		// column names, the camelCase JSON tags on the domain struct, and a
+		// nested object in case a future binder flattened one.
+		body := `{
+			"sandbox":"firecracker","network":"airgap","filesystem":"readonly","process":"full",
+			"verified":true,"verifiedBy":"attacker","verifiedAt":"2026-08-29T00:00:00Z",
+			"verified_by":"attacker","verified_at":"2026-08-29T00:00:00Z",
+			"attestation":{"verified":true},"score":1.0
+		}`
+
+		resp, err := app.Test(submitIsolationRequest(agentID, body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, fiber.StatusCreated, resp.StatusCode,
+			"the posture is valid, so the request succeeds — it is the verification that must be dropped")
+
+		require.Len(t, repo.rows, 1)
+		row := repo.rows[0]
+		assert.False(t, row.Verified,
+			"a self-report that asks to be trusted is still a self-report")
+		assert.Nil(t, row.VerifiedBy)
+		assert.Nil(t, row.VerifiedAt)
+
+		// The score is computed from the posture, so the body's "score":1.0 is
+		// ignored too — it happens to coincide here because the claimed posture
+		// really does score 1.0. What matters is that the READ side clips it.
+		assert.InDelta(t, 1.0, row.Score, 1e-9,
+			"the stored row keeps the honest posture score; the ceiling is applied on read")
+	})
+
+	t.Run("AIM-02.AC3 the created response exposes no verification the caller could set", func(t *testing.T) {
+		resp, err := app.Test(submitIsolationRequest(agentID,
+			`{"sandbox":"docker","network":"namespace","filesystem":"readonly","process":"seccomp","verified":true}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, fiber.StatusCreated, resp.StatusCode)
+
+		var result map[string]interface{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+
+		// Nothing in the 201 body echoes the caller's claim back as fact. An
+		// echoed `verified: true` would be a lie an SDK could cache and show an
+		// operator even though the stored row says otherwise.
+		for _, k := range []string{"verified", "verifiedBy", "verifiedAt", "verified_by", "verified_at"} {
+			assert.NotContains(t, result, k,
+				"the attestation response must not carry a verification field the caller supplied")
+		}
+	})
+
+	t.Run("AIM-02.AC3 a verified row is superseded by the next self-report", func(t *testing.T) {
+		// Simulate the only future in which a verified row exists at all (a
+		// Phase-2 verifier wrote one) and confirm the POST path does not let it
+		// carry forward: the newest row is the one the scorer reads, and the
+		// POST path can only ever append an unverified one.
+		verifier := "tee-attestation"
+		repo.rows = append(repo.rows, &domain.IsolationAttestation{
+			ID: uuid.New(), AgentID: agentID, Score: 1.0, Verified: true, VerifiedBy: &verifier,
+		})
+
+		resp, err := app.Test(submitIsolationRequest(agentID,
+			`{"sandbox":"firecracker","network":"airgap","filesystem":"readonly","process":"full"}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, fiber.StatusCreated, resp.StatusCode)
+
+		latest, err := repo.GetLatest(agentID)
+		require.NoError(t, err)
+		assert.False(t, latest.Verified,
+			"re-attesting must start unverified — verification is bound to a row, not to the agent")
+		assert.Nil(t, latest.VerifiedBy)
+	})
+}

--- a/apps/backend/migrations/108_add_isolation_attestation_verification.sql
+++ b/apps/backend/migrations/108_add_isolation_attestation_verification.sql
@@ -1,0 +1,51 @@
+-- Verification columns on isolation_attestations (trust factor 9).
+--
+-- Factor 9 is fed by an agent SDK self-report: the agent names its own sandbox, network,
+-- filesystem and process isolation and the server scores the posture. The server already
+-- computes the score (the agent cannot inject one) and rejects unrecognized enum values,
+-- but nothing checks whether the claim is TRUE. An agent that reports
+-- firecracker + airgap + readonly + full earns 1.0 on a 10%-weight factor for the cost of
+-- four strings.
+--
+-- The fix has two halves. The scoring half is read-side and needs no schema: an unverified
+-- report is clipped to the commodity-container tier (0.65) and any report older than 90 days
+-- stops counting. This migration is the other half — the place a verification would be
+-- recorded once an independent source exists.
+--
+-- `verified` is bound to the ROW, not to the agent, and that is the load-bearing part. A
+-- verification describes one report of one deployment at one moment. Binding it to the agent
+-- would let a deployment verified in March vouch for a posture reported in September; binding
+-- it to the row means a re-attestation (a newer reported_at) supersedes its predecessor and
+-- starts unverified, with no carry-forward. The 90-day expiry closes the same door from the
+-- other side.
+--
+-- NOTHING WRITES verified = TRUE TODAY, and that is deliberate rather than unfinished. There
+-- is no independent verification source yet; adding a writable flag before there is something
+-- honest to write into it would produce a column that means "someone said so", which is the
+-- exact weakness the column exists to fix. The ingest path hard-sets false and the repository
+-- INSERT writes the literal FALSE. When a source does arrive, the evidence classes that may
+-- set this are TEE attestation and orchestrator/host metadata. An HMA static scan may NOT:
+-- it reads a declared surface, not the running one, so it would launder a second self-report
+-- into a verification. The SDK may never, being the self-report under check.
+--
+-- DEFAULT FALSE + NOT NULL means every existing row reads as unverified without a backfill,
+-- which is the truth about all of them.
+
+ALTER TABLE isolation_attestations
+    ADD COLUMN IF NOT EXISTS verified     BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS verified_by  TEXT        NULL,
+    ADD COLUMN IF NOT EXISTS verified_at  TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN isolation_attestations.verified IS
+    'TRUE only when an INDEPENDENT source corroborated THIS row''s posture. Bound to the row, '
+    'never to the agent: a newer attestation starts unverified and inherits nothing. No write '
+    'path sets this TRUE (roadmap aim-isolation-verification Phase 2); TEE attestation and '
+    'orchestrator/host metadata may, an HMA static scan may not, the SDK never.';
+
+COMMENT ON COLUMN isolation_attestations.verified_by IS
+    'Identity of the independent verifier that corroborated the posture. NULL while verified '
+    'is FALSE, which is every row today.';
+
+COMMENT ON COLUMN isolation_attestations.verified_at IS
+    'When the independent verification happened. Distinct from reported_at, which is when the '
+    'agent made the claim; the 90-day scoring expiry keys off reported_at, not this.';

--- a/apps/web/components/agent/trust-score-breakdown.tsx
+++ b/apps/web/components/agent/trust-score-breakdown.tsx
@@ -141,7 +141,7 @@ const factorMetadata = {
   executionIsolation: {
     icon: Box,
     label: 'Execution isolation',
-    description: 'Self-reported runtime isolation posture (sandbox, network, filesystem, process). Defaults to a low baseline until the agent reports it.',
+    description: 'Self-reported runtime isolation posture (sandbox, network, filesystem, process). Nothing verifies the report, so it is capped at 0.65 — the score of an ordinary hardened container — no matter how strong a posture is claimed. Reports expire after 90 days, and an agent that has never reported sits at a low 0.3 baseline.',
     color: 'text-brand-text',
     bgColor: 'bg-brand-soft',
   },

--- a/docs/sdk/trust-scoring.md
+++ b/docs/sdk/trust-scoring.md
@@ -53,7 +53,7 @@ Not every factor is wired to a live signal source in every AIM deployment. Per A
 | 6 | Age & History | **Live** — bucketed from `agent.CreatedAt` (<7d: 0.30, <30d: 0.50, <90d: 0.75, 90+: 1.0) | N/A (always measured) |
 | 7 | Drift Detection | **Conditional** — requires `alertRepo`; a wired repo with zero drift alerts scores 1.0 (measured absence of drift) | **Excluded** when `alertRepo` is nil OR the agent-alert query errors |
 | 8 | User Feedback | **Conditional** — requires `UserFeedbackRepository` (wired in production `main.go`) AND at least one feedback row (`POST /agents/:id/feedback`) | **Excluded** when un-wired, on query error, or with zero feedback rows |
-| 9 | Execution Isolation | **Conditional** — requires `IsolationAttestationRepository` to be wired; the agent submits a runtime-isolation attestation via the SDK | 0.3 low baseline when wired but no attestation (deliberate incentive, stays in the composite); **excluded** only when the repository is un-wired |
+| 9 | Execution Isolation | **Conditional** — requires `IsolationAttestationRepository` to be wired; the agent submits a runtime-isolation attestation via the SDK. An unverified report is capped at `0.65`, and any report older than 90 days scores the baseline | 0.3 low baseline when wired but no attestation, or when the attestation is stale (both deliberate scoring choices, both stay in the composite); **excluded** only when the repository is un-wired |
 
 Implications:
 
@@ -500,11 +500,24 @@ def submit_user_feedback(agent_id: str, rating: int, comment: str):
 
 **Calculation**: Computed in `calculateExecutionIsolation` from the agent's most recent isolation attestation. With no attestation present (the default), the score is `0.3` — deliberately low so that not reporting isolation costs trust, incentivizing operators to attest.
 
-**Status today**: Conditional. The factor only computes a real signal when `IsolationAttestationRepository` is wired AND the agent has submitted at least one attestation through the SDK. In stock deployments where neither is true, every agent reads `0.3` on this factor.
+Two gates sit between the stored attestation and the score. Both are applied on **read**: the stored row always keeps the honest posture score, because the table records what the agent claimed and the scorer decides what the claim is worth.
 
-**Backend handler gap**: The SDK `attestIsolation` method (`AIMClient.ts:432-465`, `client.py:1677`) POSTs to `/api/v1/sdk-api/agents/<id>/isolation-attestation`. As of 2026-05-24, no backend route handler exists for that path and `TrustCalculator.SetIsolationRepo` is not called outside tests. SDK calls return 404; the `isolation_attestations` table is empty; `calculateExecutionIsolation` returns the `0.3` baseline for every agent. The full reasoning and the proposed external-attestation source hierarchy are in [docs/specs/execution-isolation-v1.md](../specs/execution-isolation-v1.md). The implementation is deferred pending a `[CHIEF-CA]` decision on which attestation tier (TEE, orchestrator, scanner, SDK) Phase 1 supports.
+| Gate | Rule |
+| --- | --- |
+| **Unverified ceiling** | An attestation that no independent source has corroborated scores `min(posture, 0.65)`. |
+| **90-day expiry** | An attestation whose `reported_at` is more than 90 days old scores the `0.3` baseline, verified or not. |
 
-**External attestation only**: An agent claiming "I'm in a hardened container" proves nothing on its own — a compromised agent would claim the same thing. The signal must come from outside the agent (orchestrator security context, TEE attestation, or HMA scan of the deployed surface). The SDK collects the attestation; downstream verification is what makes the score load-bearing.
+**The `0.65` ceiling is derived, not chosen.** It is exactly `ScoreIsolation(docker, namespace, readonly, seccomp)` — the commodity-container tier: `0.20 + 0.15 + 0.20 + 0.10`. An unverified claim is worth no more than the posture it is cheapest to claim; anything above that tier (a VM, a TEE, an airgap) is a statement about infrastructure AIM cannot see, so it has to be earned rather than asserted. Because the ceiling is computed from the posture enum rather than written down, retuning those weights moves the ceiling with the tier it names; a test pins today's value so the move is a deliberate edit.
+
+In practice this means **an agent reporting `firecracker + airgap + readonly + full` scores the same `0.65` as an agent reporting an ordinary hardened container**. Lying about the posture buys nothing. Reporting *honestly and badly* still costs you what it should: the ceiling is a `min()`, so an agent that truthfully reports no isolation keeps its `0.0` and is not lifted anywhere.
+
+**The 90-day expiry is uniform.** A posture describes a running deployment, and deployments move; a claim made once and never renewed describes a machine that may no longer exist. Exempting verified rows would let a single verification prop the factor up indefinitely, which is the failure the expiry exists to close. Expiry is scored as the `0.3` baseline, **not** as a missing-data exclusion — a stale attestation is data we have chosen not to credit, and redistributing the factor's weight would hand the agent back exactly what it lost by letting the attestation rot. Re-attesting restores the score immediately.
+
+**Verification has no write path yet.** `isolation_attestations` carries `verified` / `verified_by` / `verified_at`, and today every row is `verified = false`: the ingest path hard-sets it, the `INSERT` writes the literal `FALSE`, and no endpoint can set it. So the `0.65` ceiling is the effective maximum for this factor for every agent, and will be until an independent verification source ships (Phase 2, roadmap `aim-isolation-verification`). `verified` is bound to the **row**, not the agent: a re-attestation supersedes its predecessor and starts unverified, so verification never carries forward across a redeploy. When a source does arrive, TEE attestation and orchestrator/host metadata may set it; an **HMA static scan may not** (it reads the declared surface, not the running one, so it would launder a second self-report into a verification), and the **SDK never** (it is the self-report under check).
+
+**Known gap — the SDK cannot reach this endpoint.** The SDK `attestIsolation` method (`AIMClient.ts:729`, `client.py`) POSTs to `/api/v1/sdk-api/agents/<id>/isolation-attestation`, while the backend registers `/api/v1/sdk-api/agents/:id/isolation` (`main.go:372`). SDK calls 404 against the path mismatch, so the `isolation_attestations` table is near-empty in practice and most agents read the `0.3` baseline regardless of posture. The route fix is tracked separately; the scoring gates above apply the moment attestations start landing. Background and the external-attestation source hierarchy are in [docs/specs/execution-isolation-v1.md](../specs/execution-isolation-v1.md).
+
+**Why external attestation is still the goal**: an agent claiming "I'm in a hardened container" proves nothing on its own — a compromised agent would claim the same thing. The ceiling bounds what the unproven claim can earn; it does not turn the claim into a measurement. The signal must ultimately come from outside the agent (orchestrator security context or TEE attestation). The SDK collects the attestation; downstream verification is what makes the score load-bearing.
 
 **How to improve**:
 - ✅ Run the agent inside a sandbox (container, VM, or TEE)
@@ -513,6 +526,8 @@ def submit_user_feedback(agent_id: str, rating: int, comment: str):
 - ✅ Apply an egress allowlist limited to declared MCP destinations
 - ✅ Receive credentials through a short-TTL broker rather than long-lived env vars
 - ✅ Submit the isolation attestation through the SDK so the factor stops reading the `0.3` default
+- ✅ Re-submit it at least every 90 days — a posture that expires drops you back to `0.3`
+- ⛔ Do not inflate the posture: everything above the commodity-container tier is capped at `0.65` until it can be verified, so an exaggerated claim scores the same as an accurate one and misleads your own operators
 
 This factor was added as Factor 9 in the 9-factor revision; the 8-factor version of this document predated it. Issue #137 tracks the design of the full external-attestation scoring path that makes this factor's signal trustworthy end to end.
 


### PR DESCRIPTION
An agent's self-reported isolation posture scored up to 1.0 on factor 9 (10% of the composite) for the cost of four strings, forever. Two read-side gates now apply when the factor is read:

- **Unverified ceiling.** An unverified attestation scores min(posture, 0.65). The ceiling is derived, not chosen: ScoreIsolation(docker, namespace, readonly, seccomp) — the commodity-container tier — pinned by a test so posture-weight retunes move it consciously. min() clips only upward: an honest all-none report keeps its 0.0.
- **90-day expiry.** An attestation older than 90 days (verified or not) scores the 0.3 baseline with an EMPTY exclusion reason — staleness is a scoring decision, not missing data, so the factor's weight is not renormalized away. Re-attesting restores the score.

Both gates are read-side; stored rows keep the honest posture score. Migration 108 adds verified/verified_by/verified_at to isolation_attestations, and **no write path to verified ships**: RecordIsolationAttestation hard-sets false, and invariant tests pin that POST can never produce verified=true, that verification binds to the row (newest reported_at supersedes, no carry-forward), and that a fabricated 1.0 posture moves the composite by at most +0.035.

**Blocking adjacency, named and deliberately NOT fixed here:** every shipped SDK POSTs attestations to /api/v1/sdk-api/agents/{id}/isolation-attestation while the backend registers only /agents/:id/isolation — SDK attestations currently 404, so the ingest surface this change gates is mostly unreachable until the route contract fix lands (tracked separately; the endpoint-contract decision is recorded). A scope test in this PR pins the mismatch as unfixed so the fix cannot slip in unnamed.

Surfaces updated: trust-score breakdown copy, docs/sdk/trust-scoring.md factor 9, CHANGELOG. Tests: full application package green; sqlmock + fiber POST-path adversarial tests included; migration proven idempotent on PG16.