### PR TITLE
Release @opena2a/aim-sdk 1.3.1

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-09-02
+
+### Added
+
+- `AgentType.DEMO`, the agent type the one-command demo registers (#431).
+
 ### Fixed
 
 - **NetworkMonitor ss parser read the columns of `ss -tpn` while running

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.1.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opena2a/aim-sdk",
-      "version": "1.1.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opena2a/aim-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Agent Identity Management SDK for TypeScript/Node.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -12,4 +12,4 @@
  * have published reporting a version it was not. The test fails the build
  * instead.
  */
-export const SDK_VERSION = '1.3.0';
+export const SDK_VERSION = '1.3.1';


### PR DESCRIPTION
## Release @opena2a/aim-sdk 1.3.1

Version bump for the SDK (`package.json`, `package-lock.json`, `src/version.ts`) and the 1.3.1 CHANGELOG section, on top of the release workflow that now runs the SDK suite and typecheck before publishing.

### Ships

- `AgentType.DEMO`, the agent type the one-command demo registers (#431).
- NetworkMonitor ss parser: picks the address columns from the header line whether or not ss prints a `State` column, so `ss -tpn state established` no longer shifts every field left by one; the non-root shape without a process column is kept (#446).

### Verified on this commit

- `vitest run` under CI=true: 1158 passed, 36 environment-gated integration cases skipped; `tsc --noEmit` and `tsup` green; eslint 0 errors.
- The packed tarball installs in a clean directory and imports as CommonJS and ESM; `VERSION` reads `1.3.1`; `AgentType.DEMO` is present; `NetworkMonitor` exports from `@opena2a/aim-sdk/arp`.
- The tag `sdk-ts-v1.3.1` will be pushed on the squash-merge commit; the publish job runs from that tag.
