### PR TITLE
SDK README: credential requirement beside the Express and Fastify examples; 1.3.1 known issues

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -28,6 +28,19 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
   the non-root shape where ss cannot name the owning process and the data
   lines end at the peer column.
 
+### Known issues
+
+Both reproduce on 1.3.0 and are unchanged by this release; scheduled for 1.3.2.
+
+- The README's Express and Fastify examples answer 401 and never contact AIM unless
+  `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY` and `AIM_ORGANIZATION_ID` are all set;
+  the middleware options carry no way to pass credentials
+  ([#449](https://github.com/opena2a-org/agent-identity-management/issues/449)).
+- `aimErrorHandler` passes an upstream 5xx to Express's default handler, which renders a
+  stack trace with local paths outside `NODE_ENV=production`; the Fastify plugin answers the
+  same case as JSON ([#450](https://github.com/opena2a-org/agent-identity-management/issues/450)).
+
+
 ## [1.3.0] - 2026-08-24
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -89,6 +89,8 @@ app.get('/api/profile', (req, res) => {
 app.use(aimErrorHandler);
 ```
 
+The middleware authenticates to AIM as a registered agent. `apiKey` alone does not give it an identity: set `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY` and `AIM_ORGANIZATION_ID` in the environment (all four; `loadCredentialsFromEnv()` returns `null` when any is missing). Without them every verified route answers 401 and AIM is never contacted ([#449](https://github.com/opena2a-org/agent-identity-management/issues/449)). `aimErrorHandler` answers denial and authentication errors as JSON; other SDK errors, including an upstream 5xx, are passed to Express's default handler, which renders a stack trace outside `NODE_ENV=production` ([#450](https://github.com/opena2a-org/agent-identity-management/issues/450)).
+
 ## Fastify Integration
 
 ```typescript
@@ -110,6 +112,8 @@ fastify.post('/api/data', {
   return { success: true };
 });
 ```
+
+The plugin needs the same registered-agent credentials as the Express middleware: `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY` and `AIM_ORGANIZATION_ID`, all four; with `{ baseUrl, apiKey }` alone every verified route answers 401 ([#449](https://github.com/opena2a-org/agent-identity-management/issues/449)).
 
 ## Local Credential Verification (offline)
 


### PR DESCRIPTION
## What

Two sentences beside the README's Express and Fastify examples, and a Known-issues block under the 1.3.1 CHANGELOG entry.

Followed literally, both examples answer 401 and never contact AIM: the middleware authenticates as a registered agent and `apiKey` alone gives it no identity; all four `AIM_*` credential variables are required (`loadCredentialsFromEnv()` returns `null` when any is missing). The Express error handler passes an upstream 5xx to Express's default handler, which renders a stack trace outside `NODE_ENV=production`.

Both reproduce on the published 1.3.0 and are unchanged by 1.3.1; tracked as #449 and #450, scheduled for 1.3.2. Docs only; no code changes.
