### PR TITLE
ARP L2 sends nothing to a vendor unless it was configured to

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -47,12 +47,22 @@ it predates the ARP module and contains none of this code.
   `'ollama'`, `'anthropic'` or `'openai'`.
 - When L2 is switched on but no adapter is named, ARP says so once on startup and
   runs without L2. L0 and L1 are unaffected and still gate.
-- Even with a remote adapter configured deliberately, matched material no longer
-  travels. `event.data` is rendered through an allowlist, and withheld values are
+- Even with a remote adapter configured deliberately, `event.data` no longer
+  travels raw. It is rendered through an allowlist, and withheld values are
   replaced by a length-and-character-class descriptor. The pattern id and the fact
   of a match still travel, so assessment still works. This closes the sharpest
   case, where check `OL-001` ("API key in output") rendered the matched credential
   into the prompt and posted it to the vendor.
+
+  **Scope of that redaction, stated exactly:** it covers `event.data`. It does
+  **not** cover `event.description`, which the prompt still carries verbatim. Most
+  descriptions are tool-authored text plus an identifier (a pattern id, a hostname,
+  a file path, a tool name), but the process monitor composes descriptions that
+  embed up to 100 characters of the child command line. So an operator who
+  deliberately configures a remote adapter still sends that much command line to
+  their chosen vendor. This is pinned by a test rather than left to be discovered
+  (`l2-egress-default.test.ts`, T6) and is tracked for a follow-up; it does not
+  affect the default configuration, under which L2 makes no outbound call at all.
 
 **If you were relying on the old behaviour**, set both fields explicitly:
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,80 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security — ARP's L2 no longer sends anything to a vendor by default
+
+ARP shipped `intelligence: { enabled: true, adapter: 'agent-proxy' }` as its
+default, and `agent-proxy` chose a destination by reading whichever model key
+happened to be exported: `ANTHROPIC_API_KEY`, else `OPENAI_API_KEY`, else a
+local Ollama. On any machine with one of those set — a developer laptop, a CI
+runner for an agent project — a default-configured ARP therefore sent
+qualifying events to that vendor, authenticated with the operator's own key and
+billed to their own account. Nothing in the README said so.
+
+Measured against a real install of published 1.3.1, with the HTTP layer stubbed
+so no socket is opened and with a synthetic key: one `critical` network event
+under the shipped default produced a single outbound attempt to
+`api.anthropic.com/v1/messages`, headers `x-api-key, anthropic-version,
+content-type, Content-Length`, body 574 bytes — **carrying the planted command
+line verbatim**. A `critical` event bypasses batching, and the network monitor
+emits `critical` and is on by default, so this is the default path rather than
+an edge case.
+
+Affected: **1.0.0 through 1.3.1**, every published version — verified by reading
+`dist/arp/index.js` out of each tarball. `arp-guard@0.3.0` is **not** affected;
+it predates the ARP module and contains none of this code.
+
+**What changes**
+
+- `intelligence.enabled` now defaults to off, and every gate that can start L2
+  requires an explicit `true`. Absent means off. Previously the gates tested
+  `!== false`, so an absent value meant ON — and because config is merged
+  shallowly, an operator who set only `intelligence.budgetUsd` replaced the whole
+  object and armed the vendor channel. **Narrowing the budget, a hardening
+  action, used to switch L2 on.**
+- `intelligence.adapter` has no default and must be named explicitly. There is no
+  automatic provider selection any more.
+- `createAdapter('agent-proxy')` and `autoDetectAdapter()` now throw. The
+  `'agent-proxy'` union member is kept so existing builds still compile; it
+  refuses at runtime rather than guessing a destination. **This is the breaking
+  change**: code that set `adapter: 'agent-proxy'` explicitly must now choose
+  `'ollama'`, `'anthropic'` or `'openai'`.
+- When L2 is switched on but no adapter is named, ARP says so once on startup and
+  runs without L2. L0 and L1 are unaffected and still gate.
+- Even with a remote adapter configured deliberately, matched material no longer
+  travels. `event.data` is rendered through an allowlist, and withheld values are
+  replaced by a length-and-character-class descriptor. The pattern id and the fact
+  of a match still travel, so assessment still works. This closes the sharpest
+  case, where check `OL-001` ("API key in output") rendered the matched credential
+  into the prompt and posted it to the vendor.
+
+**If you were relying on the old behaviour**, set both fields explicitly:
+
+```typescript
+intelligence: { enabled: true, adapter: 'ollama' }   // inference stays local
+```
+
+**Rotation.** Keys sent as `x-api-key` went to their own intended vendor and are
+not an exposure. What may be exposed is material carried in event content:
+operators who ran with the AI layer (`aiLayer.prompt.enabled`, opt-in) should
+treat credentials their agent surfaced in model output as disclosed to the
+configured vendor and rotate those.
+
+### The egress census asks what leaves the process, not what leaves for the registry
+
+`telemetry-egress-census.test.ts` claimed to pin the whole channel set and did
+not: it filtered on `api.oa2a.org`, so the L2 vendor channel was invisible
+because it addresses `api.anthropic.com` — and invisible a second time because it
+sends via `mod.request(...)` through an aliased module handle the matcher did not
+recognise. Widening the host list alone would not have found it.
+
+The census now enumerates every module that transmits off-process, matches
+aliased sends, and carries named positive controls so a matcher that stops seeing
+a known channel fails instead of reporting clean. Modules that transmit because
+the caller asked them to — the AIM client, A2A, OAuth, secrets, CRL fetch, the
+ARP proxy forwarder — are listed with the reason rather than filtered out, so
+they stay in scope if one ever grows an observational side-channel.
+
 ## [1.3.1] - 2026-09-02
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -363,8 +363,16 @@ intelligence: {
 `adapter` chooses where inference runs. `'ollama'` keeps it on the machine.
 `'anthropic'` and `'openai'` send event content to that vendor, authenticated
 with your own key and billed to your own account — choose them only if you
-intend that. Even then, matched material is withheld: the pattern id and the
-shape of a match travel, the matched text and command lines do not.
+intend that.
+
+If you do choose a remote adapter, this is what leaves and what does not.
+`event.data` is allowlisted: identifiers and structural facts (pattern id,
+category, direction, tool name, peer agent ids, protocol, port, pid) travel,
+and everything else — matched text, command lines, arguments — is replaced by a
+`<withheld: N chars, classes>` descriptor. The event's `description` is **not**
+redacted and is sent as written; it is normally tool-authored text plus an
+identifier such as a hostname or file path, but process-monitor descriptions
+embed up to 100 characters of the child command line.
 
 If `enabled` is true but no `adapter` is set, L2 does not run and ARP says so
 once on startup; L0 and L1 are unaffected and still gate.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -347,6 +347,35 @@ runtime protection lives here, inside the agent process. This module is the
 canonical home of the ARP engine; hackmyagent's `./arp` export is being
 converted to a thin re-export of it.
 
+### L2 sends nothing unless you configure it
+
+L0 (rules) and L1 (behavioral twin) run entirely in-process and make no
+outbound connections. **L2 is off by default**, and turning it on takes two
+deliberate settings, not one:
+
+```typescript
+intelligence: {
+  enabled: true,        // absent or false means L2 does not run
+  adapter: 'ollama',    // required: there is no automatic provider selection
+}
+```
+
+`adapter` chooses where inference runs. `'ollama'` keeps it on the machine.
+`'anthropic'` and `'openai'` send event content to that vendor, authenticated
+with your own key and billed to your own account — choose them only if you
+intend that. Even then, matched material is withheld: the pattern id and the
+shape of a match travel, the matched text and command lines do not.
+
+If `enabled` is true but no `adapter` is set, L2 does not run and ARP says so
+once on startup; L0 and L1 are unaffected and still gate.
+
+> **Changed in 1.4.0.** Versions 1.0.0 through 1.3.1 defaulted to
+> `enabled: true` with `adapter: 'agent-proxy'`, which picked a destination from
+> whichever model key was exported in the environment — so a default
+> installation on a machine with `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` set
+> sent event content to that vendor. `'agent-proxy'` now throws rather than
+> guessing. See the CHANGELOG for the upgrade note.
+
 ```typescript
 import { EventEngine, FilesystemMonitor, EnforcementEngine } from '@opena2a/aim-sdk/arp';
 

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -64,7 +64,14 @@ async function startGuard(): Promise<void> {
 
   console.log(`\n  ARP Guard v${VERSION}`);
   console.log(`  Agent: ${config.agentName}`);
-  console.log(`  Intelligence: ${config.intelligence?.enabled !== false ? '3-Layer (L0+L1+L2)' : 'L0+L1 only'}`);
+  // Report what is actually running, which is not the same question as
+  // `enabled !== false`. L2 needs an explicit `enabled: true` AND a named
+  // adapter, so an unconfigured install runs L0+L1 — printing "3-Layer" there
+  // would tell the operator a layer is protecting them when it is not.
+  const l2Adapter = config.intelligence?.enabled === true ? config.intelligence?.adapter : undefined;
+  console.log(
+    `  Intelligence: ${l2Adapter ? `3-Layer (L0+L1+L2 via ${l2Adapter})` : 'L0+L1 only (L2 not configured)'}`,
+  );
   console.log(`  Budget: $${config.intelligence?.budgetUsd ?? 5.00}/month`);
   console.log(`  Monitors: ${Object.entries(config.monitors ?? {}).filter(([, v]) => (v as { enabled: boolean }).enabled).map(([k]) => k).join(', ') || 'all'}`);
   console.log();

--- a/sdk/typescript/src/arp/config/loader.ts
+++ b/sdk/typescript/src/arp/config/loader.ts
@@ -86,9 +86,25 @@ export function defaultConfig(): ARPConfig {
       heartbeat: { enabled: false },
     },
     rules: [],
+    // L2 (LLM-assisted analysis) is OFF unless the operator turns it on and says
+    // WHERE inference runs. Both omissions below are load-bearing.
+    //
+    // `enabled` is ABSENT, not `false`, and the difference matters in two
+    // directions. Every gate that can start L2 tests `enabled === true`, so absent
+    // is off exactly as firmly as false is — the security property does not depend
+    // on which one is written here. But `intelligence.enabled === false` is also a
+    // documented kill switch for the local behavioral twin (see buildRuntimeTwin in
+    // index.ts), so writing an explicit false here would have switched the twin off
+    // for everyone by default, disabling L1's behavioral signal as a side effect of
+    // an egress fix. Absent keeps "the operator switched intelligence off"
+    // distinguishable from "the operator said nothing".
+    //
+    // `adapter` is ABSENT on purpose too. It used to default to 'agent-proxy',
+    // which resolved a destination from whichever model key happened to be exported
+    // (ANTHROPIC_API_KEY, else OPENAI_API_KEY, else a local Ollama). A security
+    // tool must not pick who receives its observations from ambient environment
+    // state. Choosing a destination is now an explicit act.
     intelligence: {
-      enabled: true,
-      adapter: 'agent-proxy',
       budgetUsd: 5.0,
       maxTokensPerCall: 300,
       maxCallsPerHour: 20,

--- a/sdk/typescript/src/arp/index.ts
+++ b/sdk/typescript/src/arp/index.ts
@@ -350,11 +350,18 @@ export class AgentRuntimeProtection {
       this.monitors.push(new A2AProtocolInterceptor(this.engine, al.a2a.trustedAgents));
     }
 
-    // The master opt-out (env / marker file / config) disables every channel
-    // THIS module produces, so a customer who opts out is not surprised by a
-    // second one. Resolved once here and applied to both channels below; the
-    // third (fleet gradients) applies it in RuntimeTwin itself, at construction
-    // and again before each send.
+    // The master opt-out (env / marker file / config) disables the three
+    // TELEMETRY channels this module produces — the two applied below plus fleet
+    // gradients, which RuntimeTwin applies itself at construction and again
+    // before each send. Resolved once here.
+    //
+    // It does NOT reach the L2 intelligence coordinator. That is not an
+    // oversight left standing: L2 is governed by its own switch, which is now
+    // off by default and additionally requires an explicitly chosen adapter, so
+    // there is no default-on channel for this opt-out to have to catch. Said
+    // plainly because the previous wording here claimed this opt-out disabled
+    // "every channel THIS module produces", which was false while L2 defaulted
+    // to on — and a false comment is how the next reader repeats the mistake.
     //
     // It does NOT govern src/telemetry/relay.ts, which is the AIM client's
     // causal-denial channel with its own switch, default off. That exclusion is
@@ -525,11 +532,20 @@ export class AgentRuntimeProtection {
  * and the default policy is visible in one place.
  *
  * Default policy:
- *   - When `intelligence.enabled === false`: no twin (L2 disabled implies
- *     the behavioral layer is also unwanted).
+ *   - When `intelligence.enabled === false`: no twin (L2 disabled explicitly
+ *     implies the behavioral layer is also unwanted).
  *   - When `intelligence.runtimeTwin.enabled === false`: no twin.
  *   - Otherwise: construct a twin seeded from `config.agentName`, with
  *     fleet federation opt-in from the config (default off).
+ *
+ * Note the asymmetry with the L2 gates, which require `enabled === true`. Here an
+ * ABSENT `enabled` still builds the twin, and that difference is load-bearing:
+ * `defaultConfig()` deliberately leaves `intelligence.enabled` absent rather than
+ * setting it to false, so that "the operator explicitly switched intelligence off"
+ * stays distinguishable from "the operator said nothing". L2 treats both as off.
+ * The twin, which is local and feeds L1's risk signal, only turns off for the
+ * explicit one — otherwise flipping the L2 default would have silently disabled
+ * the behavioral signal for everyone as a side effect of an egress fix.
  */
 function buildRuntimeTwin(config: ARPConfig): RuntimeTwin | null {
   const ic = config.intelligence;

--- a/sdk/typescript/src/arp/intelligence/adapters.ts
+++ b/sdk/typescript/src/arp/intelligence/adapters.ts
@@ -156,16 +156,35 @@ export function createAdapter(type: LLMAdapterType, config?: Record<string, unkn
     case 'openai': return new OpenAIAdapter(config);
     case 'ollama': return new OllamaAdapter(config);
     case 'agent-proxy':
-      // Auto-detect: try Anthropic first, then OpenAI, then Ollama
-      if (process.env.ANTHROPIC_API_KEY) return new AnthropicAdapter(config);
-      if (process.env.OPENAI_API_KEY) return new OpenAIAdapter(config);
-      return new OllamaAdapter(config);
+      // 'agent-proxy' used to read ANTHROPIC_API_KEY, then OPENAI_API_KEY, then fall
+      // back to a local Ollama — so an environment variable set for an unrelated
+      // purpose decided where a security tool sent the events it observed, including
+      // process command lines. The operator never chose that destination, so there was
+      // nothing for them to have consented to.
+      //
+      // The union member is kept rather than removed so that an existing consumer's
+      // build does not break; it now refuses at runtime instead, and the caller in
+      // coordinator.ts turns this into `adapter = null` (L2 withheld, L0/L1 intact).
+      throw new Error(
+        "adapter 'agent-proxy' no longer selects a provider from environment credentials; " +
+          "set intelligence.adapter to 'ollama' (inference stays on this machine), " +
+          "or to 'anthropic' or 'openai' to send event content to that vendor deliberately",
+      );
     default:
       throw new Error(`Unknown LLM adapter type: ${type}`);
   }
 }
 
-/** Auto-detect the best available adapter */
+/**
+ * @deprecated Always throws. There is no automatic adapter selection any more.
+ *
+ * This used to pick a destination from whichever model key was exported in the
+ * environment. Selecting who receives ARP's observations is now an explicit act:
+ * set `intelligence.adapter` to 'ollama', 'anthropic' or 'openai'.
+ *
+ * The export is kept so an existing consumer's build does not break; it refuses at
+ * runtime rather than quietly choosing a vendor.
+ */
 export function autoDetectAdapter(config?: Record<string, unknown>): LLMAdapter {
   return createAdapter('agent-proxy', config);
 }

--- a/sdk/typescript/src/arp/intelligence/coordinator.ts
+++ b/sdk/typescript/src/arp/intelligence/coordinator.ts
@@ -10,7 +10,7 @@ import type {
   EventSeverity,
 } from '../types';
 import { BudgetController } from './budget';
-import { autoDetectAdapter, createAdapter } from './adapters';
+import { createAdapter } from './adapters';
 import { AnomalyDetector } from './anomaly';
 import {
   DEFAULT_BEHAVIORAL_RISK_TIMEOUT_MS,
@@ -126,19 +126,58 @@ export class IntelligenceCoordinator {
     // Build agent context for LLM prompts
     this.agentContext = buildAgentContext(arpConfig);
 
-    // Initialize LLM adapter if intelligence is enabled
-    if (this.config.enabled !== false) {
+    // Initialize the LLM adapter only when L2 is switched on explicitly.
+    //
+    // Both halves of this condition are deliberate and fail closed:
+    //
+    //   enabled === true   an ABSENT `enabled` must mean off, not on. `loadConfig`
+    //                      merges a parsed config shallowly over the defaults, so an
+    //                      operator who sets only `intelligence.budgetUsd` replaces the
+    //                      whole intelligence object and arrives here with `enabled`
+    //                      undefined. Under the previous `!== false` test that path
+    //                      built an adapter — narrowing the budget, a hardening action,
+    //                      switched L2 on.
+    //
+    //   this.config.adapter  an ABSENT adapter must mean NO adapter. This used to fall
+    //                      back to autoDetectAdapter(), which chose an outbound
+    //                      destination from whichever model key happened to be exported
+    //                      in the environment. That made an unrelated environment
+    //                      variable decide where a security tool sends its observations,
+    //                      which is not a choice the operator ever made.
+    //
+    // When L2 is not configured it does not run at all: not remotely, and not locally.
+    // L0 and L1 are unaffected and still gate.
+    if (this.config.enabled === true && this.config.adapter) {
       try {
-        if (this.config.adapter) {
-          this.adapter = createAdapter(this.config.adapter, this.config.adapterConfig);
-        } else {
-          this.adapter = autoDetectAdapter(this.config.adapterConfig);
-        }
-      } catch {
-        // No adapter available — L2 disabled, L0+L1 still work
+        this.adapter = createAdapter(this.config.adapter, this.config.adapterConfig);
+      } catch (error) {
+        // Adapter could not be constructed — L2 withheld, L0+L1 still work. Say so
+        // once, naming the precondition and the fix, rather than degrading silently.
         this.adapter = null;
+        this.reportL2Unavailable(error instanceof Error ? error.message : String(error));
       }
+    } else if (this.config.enabled === true) {
+      this.reportL2Unavailable(
+        "no 'intelligence.adapter' is configured",
+      );
     }
+  }
+
+  /**
+   * Report, once, that L2 is not running and what would turn it on.
+   *
+   * A precondition a control needs and cannot find is reported with the missing
+   * precondition named and a runnable fix — never a softer verdict and never silence.
+   * L2 is an optional enrichment rather than a security check being skipped, so
+   * withholding it is not a failure of the run: L0 and L1 still gate.
+   */
+  private reportL2Unavailable(reason: string): void {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ARP] L2 intelligence is not running (${reason}). L0 and L1 are unaffected and still gate. ` +
+        "To enable it, set intelligence.enabled to true and choose intelligence.adapter explicitly: " +
+        "'ollama' keeps inference local; 'anthropic' or 'openai' send event content to that vendor.",
+    );
   }
 
   /**
@@ -282,8 +321,10 @@ export class IntelligenceCoordinator {
   }
 
   private shouldEscalateToL2(event: ARPEvent): boolean {
-    // L2 disabled
-    if (this.config.enabled === false) return false;
+    // L2 runs only when it was switched on explicitly. Absent means off, for the same
+    // reason as in the constructor: a shallow-merged partial config arrives here with
+    // `enabled` undefined, and `=== false` would let it through.
+    if (this.config.enabled !== true) return false;
     if (!this.adapter) return false;
 
     // Only escalate if L1 flagged it
@@ -392,6 +433,60 @@ const AI_LAYER_SOURCES = new Set(['prompt', 'mcp-protocol', 'a2a-protocol']);
  * Designed for speed and cost efficiency. No chain-of-thought.
  * Uses specialized templates for AI-layer threats.
  */
+/**
+ * Fields of `event.data` that may travel to an L2 adapter verbatim.
+ *
+ * This is an ALLOWLIST, and that direction is the point: a denylist protects only
+ * the fields someone remembered to name, so the next monitor that adds a field
+ * carrying raw material leaks it by default. Everything not named here is replaced
+ * with a non-reversible shape descriptor.
+ *
+ * What belongs here: identifiers and structural facts that let a model judge whether
+ * a detection is a true positive. What does not: the matched material itself
+ * (`matchedText`), the command line (`command`), file contents, or arguments.
+ */
+const L2_ALLOWED_DATA_FIELDS = new Set([
+  'patternId',
+  'patternCategory',
+  'direction',
+  'toolName',
+  'from',
+  'to',
+  'protocol',
+  'method',
+  'eventType',
+  'port',
+  'pid',
+]);
+
+/**
+ * Describe a value without disclosing it: length and character classes only.
+ *
+ * The model still learns that something matched and roughly what shape it had,
+ * which is what the assessment needs. It does not learn the value. A control that
+ * detects a leaked credential must not transmit the credential to a third party in
+ * order to ask about it.
+ */
+function describeWithheld(value: unknown): string {
+  const s = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
+  const classes: string[] = [];
+  if (/[a-z]/.test(s)) classes.push('lower');
+  if (/[A-Z]/.test(s)) classes.push('upper');
+  if (/[0-9]/.test(s)) classes.push('digit');
+  if (/[^A-Za-z0-9]/.test(s)) classes.push('symbol');
+  return `<withheld: ${s.length} chars${classes.length ? ', ' + classes.join('+') : ''}>`;
+}
+
+/** Render `event.data` for an L2 prompt, allowlisted and shape-described. */
+function summarizeEventDataForL2(data: Record<string, unknown> | undefined): string {
+  if (!data) return '{}';
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) {
+    out[k] = L2_ALLOWED_DATA_FIELDS.has(k) ? v : describeWithheld(v);
+  }
+  return JSON.stringify(out).slice(0, 500);
+}
+
 function buildMicroPrompt(agentContext: string, event: ARPEvent): string {
   if (AI_LAYER_SOURCES.has(event.source)) {
     return buildAILayerPrompt(agentContext, event);
@@ -403,7 +498,7 @@ ${agentContext}
 
 Event: ${event.source} monitor detected ${event.category} (${event.severity})
 Detail: ${event.description}
-Data: ${JSON.stringify(event.data).slice(0, 500)}
+Data: ${summarizeEventDataForL2(event.data as Record<string, unknown> | undefined)}
 
 Is this behavior consistent with the agent's declared purpose and capabilities?
 Respond in exactly this format:
@@ -444,7 +539,7 @@ ${agentContext}
 
 Detection: ${event.description}
 Context: ${contentContext}
-Matched text: "${String(matchedText).slice(0, 300)}"
+Matched text: ${describeWithheld(matchedText)}
 Pattern: ${patternId} — ${patternCategory}
 Severity: ${event.severity}
 

--- a/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
+++ b/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
@@ -236,4 +236,42 @@ describe('when a remote adapter IS configured, raw material still does not trave
     // The fact of the match still travels, so the model can still assess it.
     expect(body).toMatch(/withheld: \d+ chars/);
   });
+
+  it('T6: event.description is NOT redacted — this is the known residual, pinned', async () => {
+    // Honest boundary of the R6 redaction, asserted rather than described.
+    //
+    // The allowlist covers `event.data`. It does NOT cover `event.description`,
+    // which every prompt builder sends verbatim, and the process monitor composes
+    // descriptions like `New child process: PID 123 — <first 100 chars of command>`
+    // (monitors/process.ts). So on a deliberately configured remote adapter, up to
+    // 100 characters of a command line still reach the vendor through the
+    // description, even though `data.command` is withheld.
+    //
+    // This test exists so that stays a KNOWN, tested property instead of a claim
+    // someone later discovers is false. If description redaction lands, this test
+    // should flip to asserting absence — do not simply delete it.
+    const event = criticalEvent({
+      source: 'process',
+      description: `New child process: PID 4242 — ${CANARY_COMMAND}`,
+      data: { pid: 4242, command: CANARY_COMMAND },
+    });
+
+    await runAnalyze(
+      { enabled: true, adapter: 'anthropic', adapterConfig: { apiKey: SYNTHETIC_KEY } },
+      event,
+    );
+
+    expect(requests.length, 'no request captured — nothing was measured').toBeGreaterThan(0);
+    const body = requests.map(r => r.body).join('');
+
+    // data.command IS withheld by the allowlist.
+    expect(body).toMatch(/withheld: \d+ chars/);
+
+    // ...but the same value inside the description is not. Asserting the leak
+    // rather than pretending it is closed.
+    expect(
+      body,
+      'description redaction has landed — update this test and the CHANGELOG claim',
+    ).toContain(CANARY_COMMAND);
+  });
 });

--- a/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
+++ b/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * L2 must not send anything to a third party unless the operator switched it on AND
+ * chose the destination.
+ *
+ * Every published `@opena2a/aim-sdk` from 1.0.0 to 1.3.1 shipped
+ * `intelligence: { enabled: true, adapter: 'agent-proxy' }`, and `agent-proxy`
+ * resolved a destination from whichever model key happened to be exported. A
+ * default-configured ARP therefore sent event content — including truncated command
+ * lines — to a vendor, billed to the operator's own account, with nothing in the
+ * README saying so.
+ *
+ * These tests are written against the two gates that let that happen, not against
+ * the symptom:
+ *
+ *   - the constructor built an adapter on `enabled !== false`, so an ABSENT value
+ *     (which is what a shallow-merged partial config produces) meant ON;
+ *   - an absent `adapter` fell back to auto-detection from the environment.
+ *
+ * Every assertion below has a positive control in the SAME run. Without one, a
+ * broken harness — a mock that stops intercepting, a constructor that throws early —
+ * produces zero outbound requests and reads exactly like a pass.
+ *
+ * Mutation results, measured when this suite was written, stated because "which
+ * mutant survives" is the only honest description of what a suite covers:
+ *
+ *   killed  restoring `enabled: true, adapter: 'agent-proxy'` to defaultConfig()   -> T0
+ *   killed  restoring the env-scanning body of createAdapter('agent-proxy')        -> T3
+ *   killed  restoring the raw `Matched text: "..."` interpolation                  -> T5
+ *   killed  reverting BOTH L2 gates in coordinator.ts to `enabled !== false`       -> T2c
+ *   SURVIVES  reverting EITHER gate alone
+ *
+ * That last line is not a gap being papered over. The constructor gate and
+ * `shouldEscalateToL2` are deliberately redundant, so either one alone still
+ * prevents the egress — which means no test can attribute the property to one of
+ * them. The pair is what is proven, and it is proven by reverting the pair. Do not
+ * "simplify" by deleting one on the grounds that tests still pass.
+ */
+
+const requests: Array<{ hostname?: string; path?: string; body: string }> = [];
+
+function fakeRequest(options: Record<string, unknown>, cb?: (res: unknown) => void) {
+  const record = { hostname: options.hostname as string, path: options.path as string, body: '' };
+  requests.push(record);
+  const res = {
+    statusCode: 200,
+    on(event: string, handler: (chunk?: unknown) => void) {
+      if (event === 'data') handler(Buffer.from(JSON.stringify({ content: [{ text: 'CONSISTENT: YES' }] })));
+      if (event === 'end') handler();
+      return res;
+    },
+  };
+  if (cb) setImmediate(() => cb(res));
+  return {
+    on() { return this; },
+    write(chunk: string) { record.body += chunk; },
+    end() { /* no socket is ever opened */ },
+    destroy() { /* no-op */ },
+  };
+}
+
+vi.mock('https', () => ({ request: fakeRequest, default: { request: fakeRequest } }));
+vi.mock('http', () => ({ request: fakeRequest, default: { request: fakeRequest } }));
+
+import { IntelligenceCoordinator } from './coordinator';
+import { createAdapter } from './adapters';
+import { defaultConfig } from '../config/loader';
+import type { ARPConfig, ARPEvent, IntelligenceConfig } from '../types';
+
+const SYNTHETIC_KEY = 'sk-ant-' + 'test' + '-' + '0'.repeat(24);
+const CANARY_COMMAND = 'CANARY' + 'COMMANDLINE' + '7f3a91';
+const CANARY_MATCHED = 'CANARY' + 'MATCHEDSECRET' + 'b42e08';
+
+function dataDir(): string {
+  return mkdtempSync(join(tmpdir(), 'arp-l2-egress-'));
+}
+
+function criticalEvent(overrides: Partial<ARPEvent> = {}): ARPEvent {
+  return {
+    id: 'evt-1',
+    timestamp: new Date().toISOString(),
+    source: 'network',
+    category: 'suspicious',
+    severity: 'critical',
+    description: 'Outbound connection to an unexpected host',
+    data: { command: CANARY_COMMAND, remoteAddr: '203.0.113.9:443' },
+    ...overrides,
+  } as ARPEvent;
+}
+
+function cfg(intelligence: IntelligenceConfig | undefined): ARPConfig {
+  return { ...defaultConfig(), agentName: 'test-agent', intelligence } as ARPConfig;
+}
+
+async function runAnalyze(intelligence: IntelligenceConfig | undefined, event = criticalEvent()) {
+  const c = new IntelligenceCoordinator(cfg(intelligence), dataDir());
+  await c.analyze(event);
+  return c;
+}
+
+beforeEach(() => {
+  requests.length = 0;
+  process.env.ANTHROPIC_API_KEY = SYNTHETIC_KEY;
+  process.env.OPENAI_API_KEY = SYNTHETIC_KEY;
+});
+
+afterEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+});
+
+describe('the shipped default itself', () => {
+  it('T0: defaultConfig() has L2 off and names no destination', () => {
+    // This asserts the DEFAULT, not its consequence, and it exists because the
+    // behavioural tests below could not tell the two apart.
+    //
+    // Restoring `enabled: true, adapter: 'agent-proxy'` here left every other test
+    // in this file green: createAdapter('agent-proxy') now throws, so the adapter
+    // came back null and no request was made either way. That makes the two fixes a
+    // layered defence whose inner layer no test could distinguish from its absence.
+    // Both layers are wanted; this is the one that pins the outer one.
+    const intel = defaultConfig().intelligence ?? {};
+
+    // Not `toBe(false)`: `enabled` is deliberately ABSENT. Every gate that starts
+    // L2 tests `=== true`, so absent is off just as firmly — while an explicit
+    // false here would also trip the twin kill switch in buildRuntimeTwin and
+    // disable L1's behavioral signal by default. What must hold is that the
+    // default is not TRUE, whichever of the two spellings is in use.
+    expect(intel.enabled, 'L2 must not default to on').not.toBe(true);
+    expect(
+      intel.adapter,
+      'the default must name no destination — an adapter chosen by default is a destination the operator never picked',
+    ).toBeUndefined();
+  });
+});
+
+describe('L2 sends nothing unless it was configured to', () => {
+  it('T1: the shipped default makes no outbound call, even with vendor keys exported', async () => {
+    // The exact acceptance line from the roadmap unit: on a machine exporting
+    // ANTHROPIC_API_KEY, a default-config ARP run makes no outbound vendor call.
+    await runAnalyze(defaultConfig().intelligence);
+    expect(requests, `default config sent: ${JSON.stringify(requests)}`).toEqual([]);
+
+    // POSITIVE CONTROL, same run, same mock: an explicitly configured adapter DOES
+    // send. If this is empty the harness is broken and the assertion above is
+    // vacuous rather than true.
+    await runAnalyze({ enabled: true, adapter: 'anthropic', adapterConfig: { apiKey: SYNTHETIC_KEY } });
+    expect(requests.length, 'positive control produced no request — the mock is not intercepting').toBeGreaterThan(0);
+    expect(requests[0].hostname).toBe('api.anthropic.com');
+  });
+
+  it('T2: a partial config that sets only budgetUsd does not arm the vendor channel', async () => {
+    // loadConfig merges shallowly, so this replaces the whole intelligence object and
+    // arrives at the coordinator with `enabled` undefined. Under the previous
+    // `enabled !== false` test this path egressed: narrowing the budget, a hardening
+    // action, switched L2 on.
+    await runAnalyze({ budgetUsd: 1 } as IntelligenceConfig);
+    expect(requests, `partial config sent: ${JSON.stringify(requests)}`).toEqual([]);
+  });
+
+  it('T2b: enabled:true with no adapter still sends nothing — absent means no destination', async () => {
+    await runAnalyze({ enabled: true } as IntelligenceConfig);
+    expect(requests, `adapterless config sent: ${JSON.stringify(requests)}`).toEqual([]);
+  });
+
+  it('T2c: an adapter named with `enabled` ABSENT sends nothing — absent is not on', async () => {
+    // This is the fixture that actually exercises the `enabled` gate, and it exists
+    // because the first version of this suite did not.
+    //
+    // T2 above sets only budgetUsd, so it has no adapter either — which means the
+    // adapter half of the condition answers first and the `enabled` half is never
+    // consulted. Reverting `enabled === true` back to `enabled !== false` left the
+    // whole suite green. A test that cannot fail is not evidence.
+    //
+    // Here the destination IS named, so the ONLY thing standing between this config
+    // and a vendor request is how an absent `enabled` is read. Under the shipped
+    // `!== false` this egressed; under `=== true` it does not. This is also the
+    // realistic shape: an operator who sets adapter and budget while relying on the
+    // old default-true.
+    await runAnalyze({
+      adapter: 'anthropic',
+      adapterConfig: { apiKey: SYNTHETIC_KEY },
+      budgetUsd: 1,
+    } as IntelligenceConfig);
+    expect(
+      requests,
+      `a config naming a vendor with enabled absent sent: ${JSON.stringify(requests)}`,
+    ).toEqual([]);
+  });
+
+  it('T3: agent-proxy refuses instead of resolving a vendor from the environment', () => {
+    expect(() => createAdapter('agent-proxy')).toThrow(/no longer selects a provider from environment credentials/);
+
+    // POSITIVE CONTROL: the ones that should still build, still build — so the throw
+    // above is a deliberate refusal and not createAdapter being broken outright.
+    expect(createAdapter('ollama').name).toBe('ollama');
+    expect(createAdapter('anthropic', { apiKey: SYNTHETIC_KEY }).name).toBe('anthropic');
+  });
+});
+
+describe('when a remote adapter IS configured, raw material still does not travel', () => {
+  it('T5: the command line and matched secret are withheld, the pattern id is not', async () => {
+    const event = criticalEvent({
+      source: 'prompt',
+      description: 'LLM response matched output leak pattern OL-001',
+      data: {
+        patternId: 'OL-001',
+        patternCategory: 'output-leak',
+        direction: 'output',
+        matchedText: CANARY_MATCHED,
+        command: CANARY_COMMAND,
+      },
+    });
+
+    await runAnalyze(
+      { enabled: true, adapter: 'anthropic', adapterConfig: { apiKey: SYNTHETIC_KEY } },
+      event,
+    );
+
+    expect(requests.length, 'no request was captured — nothing was measured').toBeGreaterThan(0);
+    const body = requests.map(r => r.body).join('');
+
+    // The material must not be there.
+    expect(body, 'the matched secret reached the vendor').not.toContain(CANARY_MATCHED);
+    expect(body, 'the command line reached the vendor').not.toContain(CANARY_COMMAND);
+
+    // CONTROL: a value the boundary is proven NOT to remove. Without this the test
+    // would also pass if the redactor simply emptied the whole prompt, which would
+    // make L2 useless rather than safe.
+    expect(body, 'the pattern id was stripped too — the redaction is over-broad').toContain('OL-001');
+
+    // The fact of the match still travels, so the model can still assess it.
+    expect(body).toMatch(/withheld: \d+ chars/);
+  });
+});

--- a/sdk/typescript/src/arp/types.ts
+++ b/sdk/typescript/src/arp/types.ts
@@ -149,7 +149,17 @@ export interface AlertCondition {
 // --- Intelligence Layer (the innovation) ---
 
 export interface IntelligenceConfig {
-  /** Enable LLM-assisted analysis (default: true) */
+  /**
+   * Enable LLM-assisted analysis (default: **off**).
+   *
+   * Absent means off: L2 starts only on an explicit `true`. It additionally
+   * requires `adapter` to be set explicitly — there is no automatic provider
+   * selection, so nothing is sent anywhere until you say where. See
+   * `LLMAdapterType`.
+   *
+   * Setting this to `false` explicitly also disables the local behavioral twin
+   * (L1's risk source). Leaving it absent does not.
+   */
   enabled?: boolean;
   /**
    * Trusted NanoMind-Guard hybrid public key (Ed25519+ML-DSA-44), JSON-encoded
@@ -258,7 +268,8 @@ export type LLMAdapterType =
   | 'anthropic'   // Direct Anthropic API
   | 'openai'      // Direct OpenAI API
   | 'ollama'      // Local Ollama
-  | 'agent-proxy' // Tap into the agent's own LLM (parasitic mode)
+  | 'agent-proxy' // DEPRECATED: always throws. Kept so existing builds compile.
+                  // It used to resolve a destination from ambient model keys.
   | 'custom';     // User-provided adapter
 
 /** Interface that LLM adapters must implement */

--- a/sdk/typescript/src/telemetry-egress-census.test.ts
+++ b/sdk/typescript/src/telemetry-egress-census.test.ts
@@ -36,6 +36,36 @@ const EXCLUDED: Record<string, string> = {
     'AIM client causal-denial relay. Own switch (telemetry.enabled + relay.enabled), ' +
     'default off. Exclusion is stated in README.md and in the first-run disclosure. ' +
     'Tracked for review as a joint DPO/CA question.',
+
+  // --- Caller-initiated functional clients -------------------------------------
+  //
+  // These are not observational channels. Each transmits only when the caller
+  // invokes it, to an endpoint the caller supplies, carrying the payload the
+  // caller passed in. The master opt-out governs data WE collect and send about
+  // the user; switching it on must not silently break the API calls the user
+  // asked the SDK to make. That is a different consent question, and answering it
+  // with isOptedOut() would be the wrong control.
+  //
+  // They are listed rather than filtered out so the census still SEES them: if one
+  // of these ever grows an observational side-channel, it stays in scope and the
+  // reason below stops being true.
+  'client/AIMClient.ts':
+    'The AIM API client. Caller-supplied base URL, caller-initiated requests. This is ' +
+    'the SDK performing the operation it was asked to perform.',
+  'a2a/A2AClient.ts':
+    'A2A protocol client. Caller-initiated messages to a peer agent the caller names.',
+  'auth/oauth.ts':
+    'OAuth token exchange against the issuer the caller configured. Required for the ' +
+    'authenticated calls the caller is making.',
+  'secrets/SecretsClient.ts':
+    'Secrets backend client. Caller-supplied endpoint, caller-initiated reads.',
+  'local/CrlCache.ts':
+    'Revocation list fetch. Security-critical input to a verification decision: ' +
+    'suppressing it would fail OPEN on revoked credentials, which is the opposite ' +
+    'of what an opt-out should do.',
+  'arp/proxy/forward.ts':
+    'ARP CLI proxy forwarder. Forwards the caller traffic it was explicitly started ' +
+    'to proxy, to the upstream the operator configured.',
 };
 
 /**
@@ -44,6 +74,16 @@ const EXCLUDED: Record<string, string> = {
  * asserted to still exist, so deleting it fails this test.
  */
 const GATED_AT_CALLSITE: Record<string, { site: string; guard: RegExp }> = {
+  'arp/intelligence/adapters.ts': {
+    site: 'arp/intelligence/coordinator.ts',
+    // L2 constructs an adapter only when the operator switched it on AND named a
+    // destination. Both halves matter: `enabled === true` (not `!== false`) so an
+    // absent value from a shallow-merged partial config means off, and an explicit
+    // `adapter` so no destination is ever chosen from ambient environment state.
+    // Deleting either half re-opens the default-on vendor egress this guard exists
+    // to prevent, and fails this test.
+    guard: /this\.config\.enabled\s*===\s*true\s*&&\s*this\.config\.adapter/,
+  },
   'arp/telemetry/gtin.ts': {
     site: 'arp/index.ts',
     // The forwarder is never constructed while opted out.
@@ -81,19 +121,47 @@ function stripComments(src: string): string {
  * this census exactly when it is hardest to notice by hand. Match any
  * fetch-shaped identifier, bare or as a member call.
  */
-const SENDER = /(^|[^A-Za-z0-9_$.])fetch[A-Za-z0-9_$]*\s*\(|\.\s*fetch[A-Za-z0-9_$]*\s*\(|\baxios\.|\bhttps?\.request\s*\(/;
+/**
+ * A module transmits if it calls fetch/axios, or calls `.request(` on anything.
+ *
+ * The trailing alternative is deliberately broad. The previous pattern required the
+ * literal `https.request(` or `http.request(`, and the L2 vendor adapter calls
+ * `mod.request(...)` where `const mod = useHttp ? nodeRequire('http') : https` — so
+ * aliasing the module through a variable made the biggest egress in the package
+ * invisible to its own census. Matching any `.request(` costs a few false positives,
+ * which are cheap to triage into EXCLUDED, and closes an evasion that was not
+ * deliberate but worked perfectly.
+ */
+const SENDER = /(^|[^A-Za-z0-9_$.])fetch[A-Za-z0-9_$]*\s*\(|\.\s*fetch[A-Za-z0-9_$]*\s*\(|\baxios\.|\.\s*request\s*\(/;
 
-/** Modules that actually transmit to the registry, as opposed to naming its URL. */
+/**
+ * Modules that must appear in the census, whatever the matcher is doing.
+ *
+ * These are positive controls. A census that stops seeing one of these has broken,
+ * and "no offenders" from a broken census reads exactly like a clean result.
+ * `arp/intelligence/adapters.ts` is here because it was invisible for two months.
+ */
+const MUST_BE_COUNTED = [
+  'arp/intelligence/adapters.ts',
+  'arp/telemetry/signature/emitter.ts',
+  'arp/telemetry/gtin.ts',
+];
+
+/**
+ * Modules that transmit anything off this process.
+ *
+ * The question this census asks used to be "what leaves for the OpenA2A registry".
+ * That framing is why the L2 vendor channel went uncounted: it addresses
+ * `api.anthropic.com`, so a registry-scoped filter could never see it, and widening
+ * the host list alone would not have helped because the send was also aliased. The
+ * question is now "what leaves this process", and the destination is a property to
+ * disclose rather than a condition for being counted.
+ */
 function egressModules(): string[] {
   const hits: string[] = [];
   for (const file of walk(SRC)) {
     const code = stripComments(readFileSync(file, 'utf-8'));
-    const sends = SENDER.test(code);
-    if (!sends) continue;
-    const reachesRegistry =
-      code.includes(REGISTRY_HOST) ||
-      /registryUrl|REGISTRY_URL|this\.endpoint/.test(code);
-    if (reachesRegistry) hits.push(relative(SRC, file));
+    if (SENDER.test(code)) hits.push(relative(SRC, file));
   }
   return hits.sort();
 }
@@ -104,6 +172,19 @@ describe('telemetry egress census', () => {
     // matcher breaks and the census returns nothing.
     const mods = egressModules();
     expect(mods.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('sees every module it is known to have missed before', () => {
+    // Named positive controls. The census was believed to pin the whole channel
+    // set while silently omitting the L2 vendor adapter, and nothing failed.
+    const mods = egressModules();
+    const missing = MUST_BE_COUNTED.filter(m => !mods.includes(m));
+    expect(
+      missing,
+      'The census no longer sees these modules, so it is not measuring what it claims:\n' +
+        missing.map(m => `  - ${m}`).join('\n') +
+        '\n\nFix the matcher rather than removing the entry.',
+    ).toEqual([]);
   });
 
   it('every registry egress module consults the master opt-out, or is a disclosed exclusion', () => {


### PR DESCRIPTION
## What was wrong

ARP shipped `intelligence: { enabled: true, adapter: 'agent-proxy' }` as its default, and `agent-proxy` chose an outbound destination by reading whichever model key happened to be exported: `ANTHROPIC_API_KEY`, else `OPENAI_API_KEY`, else a local Ollama. On any machine with one of those set — a developer laptop, a CI runner for an agent project — a default-configured ARP sent event content to that vendor, authenticated with the operator's own key and billed to their own account. The published README said nothing about it.

Reproduced against a real install of published `1.3.1`, with the HTTP layer stubbed so no socket opens and a synthetic key:

```
published default: {"enabled":true,"adapter":"agent-proxy",...}
outbound attempts: 1
  host: api.anthropic.com   path: /v1/messages
  header names: x-api-key, anthropic-version, content-type, Content-Length
  body bytes: 574
  body contains planted command line: true
```

A `critical` event bypasses batching, and the network monitor emits `critical` and is on by default, so that is the default path rather than an edge case.

**Affected: 1.0.0 through 1.3.1** — every published version, verified by reading `dist/arp/index.js` out of each tarball. `arp-guard@0.3.0` is **not** affected (7,021 bytes, zero vendor markers, against positive controls `function` 41 / `exports` 43).

## Why it survived a test that claimed to cover it

`telemetry-egress-census.test.ts` landed with the commit message "pin the whole channel set". It filtered on `api.oa2a.org`, so it could not see a channel addressed to `api.anthropic.com` — and could not see it a second time because the send is aliased (`const mod = useHttp ? nodeRequire('http') : https; mod.request(...)`), which the sender regex did not match. **Widening the host list alone would not have found it.**

## What changed

| | before | after |
|---|---|---|
| `intelligence.enabled` default | `true` | absent (off) |
| `intelligence.adapter` default | `'agent-proxy'` | none — must be named |
| constructor gate | `enabled !== false` | `enabled === true && adapter` |
| `shouldEscalateToL2` | `enabled === false` → stop | `enabled !== true` → stop |
| `createAdapter('agent-proxy')` | scans env for a key | throws |
| `event.data` to a remote adapter | `JSON.stringify` verbatim | allowlisted; rest → `<withheld: N chars, classes>` |

`enabled` is left **absent** rather than set to `false` deliberately: an explicit `false` is also a documented kill switch for the local behavioural twin (`buildRuntimeTwin`), so writing one would have disabled L1's risk signal for everyone as a side effect of an egress fix. An existing wiring test caught that, not review.

`'agent-proxy'` stays in the union so consumer builds still compile; it refuses at runtime. **That is the breaking change** for anyone who set it explicitly.

## Honest scope of the redaction

The allowlist covers `event.data`. It does **not** cover `event.description`, which every prompt builder sends verbatim. Prompt-interceptor descriptions carry only a pattern id and tool-authored text, but process-monitor descriptions embed up to 100 characters of the child command line — so a deliberately configured remote adapter still receives that much. This is asserted by a test (T6) rather than described, and stated in the CHANGELOG and README. It does not affect the default, under which L2 makes no outbound call at all.

## Verification

- Suite: **80 files, 1178 passed**, 36 skipped. `tsc --noEmit` clean. Build clean. Lint 0 errors (23 pre-existing warnings, none in changed files).
- `hackmyagent secure`: score 95, **201 files examined**, `measured: true`, 0 critical/high.
- Mutation results, recorded in the test header:

| mutation | outcome |
|---|---|
| restore `enabled: true, adapter: 'agent-proxy'` to `defaultConfig()` | killed (T0) |
| restore the env-scanning body of `createAdapter('agent-proxy')` | killed (T3) |
| restore the raw `Matched text: "..."` interpolation | killed (T5) |
| revert **both** L2 gates to `enabled !== false` | killed (T2c) |
| revert **either** gate alone | survives — the two are redundant |

The last row is stated rather than hidden: no test can attribute the property to one gate, so the pair is what is proven. Two assertions in the first draft of this suite were vacuous (an earlier condition answered first) and were rebuilt around fixtures that force the path.

## Still open, deliberately

Release sequencing for `arp-guard@0.4.0`, and the advisory this warrants, are release-owner decisions and are not part of this PR.
