### PR TITLE
Report L2's real state, and stop withheld descriptors from reconstructing values

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -76,6 +76,25 @@ operators who ran with the AI layer (`aiLayer.prompt.enabled`, opt-in) should
 treat credentials their agent surfaced in model output as disclosed to the
 configured vendor and rotate those.
 
+### The L2 status line reports what is running, and withheld values are coarser
+
+Two follow-ups to the L2 change above, both found by an independent review of it.
+
+The CLI's `Intelligence:` line restated the L2 gate instead of asking it. The first
+version tested `enabled !== false` and kept printing `3-Layer (L0+L1+L2)` after the
+default changed; the replacement tested `enabled === true && adapter`, which is still
+wrong for `adapter: 'agent-proxy'` — that passes both checks and then throws on
+construction, so the line announced a layer that was not running. Neither version had
+a test. The line now calls `describeL2Status()`, which settles it by attempting the
+construction the coordinator attempts, and reports the reason when L2 is not running.
+
+`<withheld: N chars, classes>` reported an exact length. For a small value that pair
+is not a summary, it is the value: `true` rendered as `4 chars, lower` and `false` as
+`5 chars, lower`, so a boolean was recoverable, and short enums from a known set the
+same way. Lengths are now bucketed (`up to 8 chars`, `9-16`, `17-32`, `33-64`,
+`65-128`, `over 128`), and values of 8 characters or fewer carry no class information
+at all.
+
 ### The egress census asks what leaves the process, not what leaves for the registry
 
 `telemetry-egress-census.test.ts` claimed to pin the whole channel set and did

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -18,13 +18,12 @@ qualifying events to that vendor, authenticated with the operator's own key and
 billed to their own account. Nothing in the README said so.
 
 Measured against a real install of published 1.3.1, with the HTTP layer stubbed
-so no socket is opened and with a synthetic key: one `critical` network event
-under the shipped default produced a single outbound attempt to
-`api.anthropic.com/v1/messages`, headers `x-api-key, anthropic-version,
-content-type, Content-Length`, body 574 bytes — **carrying the planted command
-line verbatim**. A `critical` event bypasses batching, and the network monitor
-emits `critical` and is on by default, so this is the default path rather than
-an edge case.
+so no socket is opened and with a synthetic key: one `critical` event under the
+shipped default produced an outbound attempt to `api.anthropic.com/v1/messages`,
+headers `x-api-key, anthropic-version, content-type`, and the body carried the
+value planted in the event verbatim. A `critical` event bypasses batching, and
+the network monitor emits `critical` and is on by default, so this is the
+default path rather than an edge case.
 
 Affected: **1.0.0 through 1.3.1**, every published version — verified by reading
 `dist/arp/index.js` out of each tarball. `arp-guard@0.3.0` is **not** affected;

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -360,6 +360,9 @@ intelligence: {
 }
 ```
 
+Setting `enabled: false` also switches off the in-process behavioral twin, which
+reads the same flag; leave it absent if you only want L2 off.
+
 `adapter` chooses where inference runs. `'ollama'` keeps it on the machine.
 `'anthropic'` and `'openai'` send event content to that vendor, authenticated
 with your own key and billed to your own account — choose them only if you
@@ -369,7 +372,10 @@ If you do choose a remote adapter, this is what leaves and what does not.
 `event.data` is allowlisted: identifiers and structural facts (pattern id,
 category, direction, tool name, peer agent ids, protocol, port, pid) travel,
 and everything else — matched text, command lines, arguments — is replaced by a
-`<withheld: N chars, classes>` descriptor. The event's `description` is **not**
+descriptor that buckets the length rather than reporting it: `<withheld: 9-16
+chars, lower+digit>`. At eight characters or fewer the descriptor is
+`<withheld: up to 8 chars>` and names no character classes, because an exact
+length and a class set do not summarise a short value, they reconstruct it. The event's `description` is **not**
 redacted and is sent as written; it is normally tool-authored text plus an
 identifier such as a hostname or file path, but process-monitor descriptions
 embed up to 100 characters of the child command line.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -375,7 +375,8 @@ and everything else — matched text, command lines, arguments — is replaced b
 descriptor that buckets the length rather than reporting it: `<withheld: 9-16
 chars, lower+digit>`. At eight characters or fewer the descriptor is
 `<withheld: up to 8 chars>` and names no character classes, because an exact
-length and a class set do not summarise a short value, they reconstruct it. The event's `description` is **not**
+length and a class set do not summarise a short value, they reconstruct it. An
+empty value renders `<withheld: empty>`. The event's `description` is **not**
 redacted and is sent as written; it is normally tool-authored text plus an
 identifier such as a hostname or file path, but process-monitor descriptions
 embed up to 100 characters of the child command line.

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -8,7 +8,7 @@ import { PromptInterceptor } from '../interceptors/prompt';
 import { MCPProtocolInterceptor } from '../interceptors/mcp-protocol';
 import { A2AProtocolInterceptor } from '../interceptors/a2a-protocol';
 import { EventEngine } from '../engine/event-engine';
-import { IntelligenceCoordinator } from '../intelligence/coordinator';
+import { IntelligenceCoordinator, describeL2Status } from '../intelligence/coordinator';
 import { SequenceLogWriter } from '../intelligence/sequence-log-writer';
 import { isOptedOut, enrollSensor, manualEnrollCurl } from '../telemetry/signature';
 import { runTelemetrySubcommand, telemetryHelpText } from './telemetry';
@@ -64,13 +64,15 @@ async function startGuard(): Promise<void> {
 
   console.log(`\n  ARP Guard v${VERSION}`);
   console.log(`  Agent: ${config.agentName}`);
-  // Report what is actually running, which is not the same question as
-  // `enabled !== false`. L2 needs an explicit `enabled: true` AND a named
-  // adapter, so an unconfigured install runs L0+L1 — printing "3-Layer" there
-  // would tell the operator a layer is protecting them when it is not.
-  const l2Adapter = config.intelligence?.enabled === true ? config.intelligence?.adapter : undefined;
+  // Ask the coordinator's own predicate rather than restating it here. A previous
+  // version of this line restated it twice and was wrong both times.
+  const l2 = describeL2Status(config.intelligence);
   console.log(
-    `  Intelligence: ${l2Adapter ? `3-Layer (L0+L1+L2 via ${l2Adapter})` : 'L0+L1 only (L2 not configured)'}`,
+    `  Intelligence: ${
+      l2.running
+        ? `3-Layer (L0+L1+L2 via ${l2.adapter})`
+        : `L0+L1 only (L2 not running: ${l2.reason})`
+    }`,
   );
   console.log(`  Budget: $${config.intelligence?.budgetUsd ?? 5.00}/month`);
   console.log(`  Monitors: ${Object.entries(config.monitors ?? {}).filter(([, v]) => (v as { enabled: boolean }).enabled).map(([k]) => k).join(', ') || 'all'}`);

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -198,7 +198,9 @@ async function startProxy(): Promise<void> {
   );
 
   // Resolve the Guard public key for classification annotation. Gated on the
-  // intelligence layer being enabled (default on); the loader already merged
+  // intelligence layer not being switched off EXPLICITLY: an absent `enabled` still
+  // resolves the key, matching the behavioral twin's asymmetry rather than L2's own
+  // gate, which requires `enabled === true`. The loader already merged
   // config + ARP_GUARD_PUBLIC_KEY. When present AND a manifest is configured,
   // the proxy builds the annotator at start() so events carry a cleared
   // classification for DETECTION (the sequence corpus). Absent key → no
@@ -356,7 +358,8 @@ function showHelp(): void {
       L2: LLM-Assisted ($)    Micro-prompts to the agent's LLM
 
     99% of events never reach L2. Default budget: $5/month.
-    Auto-detects Anthropic, OpenAI, or Ollama from environment.
+    L2 is off unless intelligence.enabled is true and intelligence.adapter
+    names a provider. There is no automatic selection from the environment.
 
   AI-LAYER SCANNING (proxy mode)
     Prompt injection, jailbreak, data exfiltration detection

--- a/sdk/typescript/src/arp/cli/l2-status-line-noexec.test.ts
+++ b/sdk/typescript/src/arp/cli/l2-status-line-noexec.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The CLI's L2 status line must ASK the coordinator, never decide for itself.
+ *
+ * #457 replaced a status line that re-derived L2's predicate — `enabled !== false`,
+ * then `enabled === true && adapter` — and printed "3-Layer (L0+L1+L2)" for installs
+ * where L2 was not running. The fix routes the line through `describeL2Status`, which
+ * settles the question by building the adapter.
+ *
+ * The independent review of that PR (F-1) found the fix itself unpinned: a mutant that
+ * restates the predicate inline in `cli/index.ts` and leaves `describeL2Status` unused
+ * SURVIVED the whole suite, because nothing exercises this file. So the property the PR
+ * claims — that the line cannot drift from the gate — held only while someone kept the
+ * call there.
+ *
+ * `cli/index.ts` invokes `main()` at module scope, so it cannot be imported to be
+ * exercised. This reads it instead, the same shape as `cited-commands.test.ts`. A
+ * source-reading check is worth only its positive controls, so both are asserted in
+ * this same run: that the extractor really found the status line, and that the mutant
+ * detector really fires on a planted mutant.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const CLI_SOURCE = readFileSync(join(__dirname, 'index.ts'), 'utf8');
+
+/**
+ * The body of `startGuard`, which is where the status line is printed.
+ *
+ * Scoped rather than whole-file on purpose: `cli/index.ts` legitimately tests
+ * `intelligence?.enabled === false` elsewhere (the Guard public key, a different
+ * decision with a deliberately different asymmetry), and a whole-file rule would
+ * either flag that or have to carve it out by name.
+ */
+function startGuardBody(source: string): string {
+  const open = source.indexOf('async function startGuard(');
+  if (open === -1) return '';
+  // Functions in this file are declared at column 0, so the next line that is exactly
+  // a closing brace ends the body.
+  const end = source.indexOf('\n}\n', open);
+  return end === -1 ? source.slice(open) : source.slice(open, end);
+}
+
+/**
+ * A restatement of L2's gate: `enabled` compared to a boolean literal, or the
+ * adapter's presence used as the decision. This is the mutant shape F-1 named.
+ */
+function restatesL2Gate(body: string): boolean {
+  return (
+    /\benabled\s*(?:===|!==|==|!=)\s*(?:true|false)/.test(body) ||
+    /\benabled\s*\?/.test(body) ||
+    /\?\.adapter\s*(?:\?|&&|\|\|)/.test(body)
+  );
+}
+
+describe('the CLI status line asks describeL2Status rather than re-deriving it', () => {
+  const body = startGuardBody(CLI_SOURCE);
+
+  it('positive control: the extractor found the real status line', () => {
+    // If this fails the two assertions below are vacuous, so it is asserted first.
+    expect(body).not.toBe('');
+    expect(body).toContain('3-Layer (L0+L1+L2');
+    expect(body).toContain('L0+L1 only (L2 not running');
+  });
+
+  it('positive control: the detector fires on a planted inline predicate', () => {
+    // The exact mutant the review reported as surviving.
+    const mutant = `async function startGuard() {
+      const l2 = config.intelligence?.enabled === true ? config.intelligence.adapter : undefined;
+      console.log(\`  Intelligence: \${l2 ? '3-Layer (L0+L1+L2' : 'L0+L1 only (L2 not running'}\`);
+    `;
+    expect(restatesL2Gate(mutant)).toBe(true);
+    expect(restatesL2Gate("const l2 = describeL2Status(config.intelligence);")).toBe(false);
+  });
+
+  it('calls describeL2Status', () => {
+    expect(body).toContain('describeL2Status(');
+    expect(CLI_SOURCE).toMatch(/import\s*\{[^}]*\bdescribeL2Status\b[^}]*\}\s*from\s*'\.\.\/intelligence\/coordinator'/);
+  });
+
+  it('does not restate the gate inline', () => {
+    expect(restatesL2Gate(body)).toBe(false);
+  });
+});

--- a/sdk/typescript/src/arp/cli/l2-status-line-noexec.test.ts
+++ b/sdk/typescript/src/arp/cli/l2-status-line-noexec.test.ts
@@ -1,5 +1,9 @@
 /**
- * The CLI's L2 status line must ASK the coordinator, never decide for itself.
+ * The CLI's L2 status line must ASK the coordinator rather than decide for itself.
+ *
+ * Two assertions, deliberately separate: that the call is there, and that the gate
+ * is not restated in any spelling we have seen. The first does not depend on having
+ * enumerated the spellings; the second is a known-shape list, not a proof.
  *
  * #457 replaced a status line that re-derived L2's predicate — `enabled !== false`,
  * then `enabled === true && adapter` — and printed "3-Layer (L0+L1+L2)" for installs
@@ -43,13 +47,26 @@ function startGuardBody(source: string): string {
 }
 
 /**
- * A restatement of L2's gate: `enabled` compared to a boolean literal, or the
- * adapter's presence used as the decision. This is the mutant shape F-1 named.
+ * A restatement of L2's gate, in every spelling we have actually seen.
+ *
+ * The comparison forms were the first cut. They missed the TRUTHINESS spelling
+ * (`ic && ic.enabled && ic.adapter`), which the delta review found surviving
+ * this rule — the mutant was still killed, but by the `describeL2Status` call
+ * assertion below rather than by the rule that names the property. A string
+ * rule needs a rule per spelling, so the conjunction forms are pinned too.
+ *
+ * This is a list of known shapes, not a proof of the invariant. That is why the
+ * call assertion is a separate test rather than a convenience: it is the half
+ * that does not depend on having enumerated the spellings.
  */
 function restatesL2Gate(body: string): boolean {
   return (
     /\benabled\s*(?:===|!==|==|!=)\s*(?:true|false)/.test(body) ||
     /\benabled\s*\?/.test(body) ||
+    /\benabled\b\s*(?:&&|\|\|)/.test(body) ||
+    /(?:&&|\|\|)\s*[\w.?]*\benabled\b/.test(body) ||
+    /\badapter\b\s*(?:&&|\|\|)/.test(body) ||
+    /(?:&&|\|\|)\s*[\w.?]*\badapter\b/.test(body) ||
     /\?\.adapter\s*(?:\?|&&|\|\|)/.test(body)
   );
 }
@@ -71,6 +88,8 @@ describe('the CLI status line asks describeL2Status rather than re-deriving it',
       console.log(\`  Intelligence: \${l2 ? '3-Layer (L0+L1+L2' : 'L0+L1 only (L2 not running'}\`);
     `;
     expect(restatesL2Gate(mutant)).toBe(true);
+    // The truthiness spelling, which the first cut of this rule missed.
+    expect(restatesL2Gate('const on = ic && ic.enabled && ic.adapter;')).toBe(true);
     expect(restatesL2Gate("const l2 = describeL2Status(config.intelligence);")).toBe(false);
   });
 

--- a/sdk/typescript/src/arp/intelligence/coordinator.ts
+++ b/sdk/typescript/src/arp/intelligence/coordinator.ts
@@ -100,10 +100,16 @@ export function describeL2Status(
     : { running: false, adapter: resolved.name, reason: resolved.reason };
 }
 
-/** Either the adapter L2 will actually use, or the reason there is not one. */
+/**
+ * Either the adapter L2 will actually use, or the reason there is not one.
+ *
+ * `asked` carries whether the operator switched L2 on, so a caller that needs to
+ * distinguish "withheld from someone who wanted it" from "never requested" does
+ * not have to re-test `enabled` and become a second copy of the gate.
+ */
 type L2Resolution =
-  | { adapter: LLMAdapter; name: string; reason?: undefined }
-  | { adapter: null; name?: string; reason: string };
+  | { adapter: LLMAdapter; name: string; asked: true; reason?: undefined }
+  | { adapter: null; name?: string; asked: boolean; reason: string };
 
 /**
  * Settle L2's state ONCE, for every caller that needs to know it.
@@ -120,10 +126,10 @@ type L2Resolution =
  */
 function resolveL2Adapter(intelligence: IntelligenceConfig | undefined): L2Resolution {
   if (intelligence?.enabled !== true) {
-    return { adapter: null, reason: 'intelligence.enabled is not true' };
+    return { adapter: null, asked: false, reason: 'intelligence.enabled is not true' };
   }
   if (!intelligence.adapter) {
-    return { adapter: null, reason: "no 'intelligence.adapter' is configured" };
+    return { adapter: null, asked: true, reason: "no 'intelligence.adapter' is configured" };
   }
   try {
     return {
@@ -132,11 +138,13 @@ function resolveL2Adapter(intelligence: IntelligenceConfig | undefined): L2Resol
         intelligence.adapterConfig as Record<string, unknown> | undefined,
       ),
       name: intelligence.adapter,
+      asked: true,
     };
   } catch (error) {
     return {
       adapter: null,
       name: intelligence.adapter,
+      asked: true,
       reason: error instanceof Error ? error.message : String(error),
     };
   }
@@ -215,10 +223,12 @@ export class IntelligenceCoordinator {
     // L0 and L1 are unaffected and still gate.
     const resolved = resolveL2Adapter(this.config);
     this.adapter = resolved.adapter;
-    if (resolved.adapter === null && this.config.enabled === true) {
+    if (resolved.adapter === null && resolved.asked) {
       // L2 withheld, L0+L1 still work. Say so once, naming the precondition and the
       // fix, rather than degrading silently — but only to an operator who ASKED for
       // L2. `enabled` absent or false requested nothing, so nothing is unavailable.
+      // `asked` comes from the resolution rather than a second read of `enabled`:
+      // re-testing it here would put a copy of the gate outside the census guard.
       this.reportL2Unavailable(resolved.reason);
     }
   }

--- a/sdk/typescript/src/arp/intelligence/coordinator.ts
+++ b/sdk/typescript/src/arp/intelligence/coordinator.ts
@@ -76,6 +76,41 @@ export interface ComplyDecision {
  *
  * 99% of events never reach L2. Cost is ~$0.01/day for most agents.
  */
+/**
+ * Whether L2 would actually run for a given intelligence config, and if not, why.
+ *
+ * This exists so that anything REPORTING L2's state settles it the same way the
+ * coordinator does — by executing the same steps rather than restating them. The
+ * CLI previously re-implemented the predicate as `enabled !== false`, and when the
+ * default changed it went on printing "3-Layer (L0+L1+L2)" for an install where L2
+ * was off. Replacing that with `enabled === true && adapter` fixed the common case
+ * and still lied for `adapter: 'agent-proxy'`, which passes both checks and then
+ * throws on construction.
+ *
+ * A status line that re-derives a predicate drifts from it. This one does not
+ * re-derive: it tries to build the adapter, which is the only thing that settles it.
+ */
+export function describeL2Status(
+  intelligence: IntelligenceConfig | undefined,
+): { running: boolean; adapter?: string; reason?: string } {
+  if (intelligence?.enabled !== true) {
+    return { running: false, reason: 'intelligence.enabled is not true' };
+  }
+  if (!intelligence.adapter) {
+    return { running: false, reason: "no 'intelligence.adapter' is configured" };
+  }
+  try {
+    createAdapter(intelligence.adapter, intelligence.adapterConfig as Record<string, unknown> | undefined);
+    return { running: true, adapter: intelligence.adapter };
+  } catch (error) {
+    return {
+      running: false,
+      adapter: intelligence.adapter,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export class IntelligenceCoordinator {
   private readonly config: IntelligenceConfig;
   private readonly agentContext: string;
@@ -469,12 +504,35 @@ const L2_ALLOWED_DATA_FIELDS = new Set([
  */
 function describeWithheld(value: unknown): string {
   const s = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
+
+  // Bucket the length instead of reporting it exactly, and say nothing about the
+  // character classes of a short value.
+  //
+  // An exact length plus a class set is not a summary of a small value, it IS the
+  // value. `true` renders as 4 chars/lower and `false` as 5 chars/lower, which
+  // reconstructs a boolean outright; a short enum from a known set is recovered the
+  // same way, since the set is usually distinguishable by length alone. The
+  // assessment never needed that precision — what it needs is whether the match was
+  // short or long and roughly what it looked like.
+  const n = s.length;
+  const bucket =
+    n === 0 ? 'empty'
+      : n <= 8 ? 'up to 8 chars'
+        : n <= 16 ? '9-16 chars'
+          : n <= 32 ? '17-32 chars'
+            : n <= 64 ? '33-64 chars'
+              : n <= 128 ? '65-128 chars'
+                : 'over 128 chars';
+
+  // Below this, the class set is identifying rather than descriptive.
+  if (n <= 8) return `<withheld: ${bucket}>`;
+
   const classes: string[] = [];
   if (/[a-z]/.test(s)) classes.push('lower');
   if (/[A-Z]/.test(s)) classes.push('upper');
   if (/[0-9]/.test(s)) classes.push('digit');
   if (/[^A-Za-z0-9]/.test(s)) classes.push('symbol');
-  return `<withheld: ${s.length} chars${classes.length ? ', ' + classes.join('+') : ''}>`;
+  return `<withheld: ${bucket}${classes.length ? ', ' + classes.join('+') : ''}>`;
 }
 
 /** Render `event.data` for an L2 prompt, allowlisted and shape-described. */

--- a/sdk/typescript/src/arp/intelligence/coordinator.ts
+++ b/sdk/typescript/src/arp/intelligence/coordinator.ts
@@ -93,19 +93,50 @@ export interface ComplyDecision {
 export function describeL2Status(
   intelligence: IntelligenceConfig | undefined,
 ): { running: boolean; adapter?: string; reason?: string } {
+  const resolved = resolveL2Adapter(intelligence);
+  if (resolved.adapter !== null) return { running: true, adapter: resolved.name };
+  return resolved.name === undefined
+    ? { running: false, reason: resolved.reason }
+    : { running: false, adapter: resolved.name, reason: resolved.reason };
+}
+
+/** Either the adapter L2 will actually use, or the reason there is not one. */
+type L2Resolution =
+  | { adapter: LLMAdapter; name: string; reason?: undefined }
+  | { adapter: null; name?: string; reason: string };
+
+/**
+ * Settle L2's state ONCE, for every caller that needs to know it.
+ *
+ * The review of #457 found the gate written twice — here and in the coordinator's
+ * constructor — down to the same reason string in both copies. Sharing the CALL to
+ * `createAdapter` was not enough: what has to be shared is the DECISION, or the next
+ * precondition added to one copy drifts the other, which is the defect the status line
+ * was reported for in the first place.
+ *
+ * It returns the constructed adapter rather than a boolean so the constructor can keep
+ * the object this already built. Asking `describeL2Status` and then constructing again
+ * would build twice, which is a side effect on any adapter that opens something.
+ */
+function resolveL2Adapter(intelligence: IntelligenceConfig | undefined): L2Resolution {
   if (intelligence?.enabled !== true) {
-    return { running: false, reason: 'intelligence.enabled is not true' };
+    return { adapter: null, reason: 'intelligence.enabled is not true' };
   }
   if (!intelligence.adapter) {
-    return { running: false, reason: "no 'intelligence.adapter' is configured" };
+    return { adapter: null, reason: "no 'intelligence.adapter' is configured" };
   }
   try {
-    createAdapter(intelligence.adapter, intelligence.adapterConfig as Record<string, unknown> | undefined);
-    return { running: true, adapter: intelligence.adapter };
+    return {
+      adapter: createAdapter(
+        intelligence.adapter,
+        intelligence.adapterConfig as Record<string, unknown> | undefined,
+      ),
+      name: intelligence.adapter,
+    };
   } catch (error) {
     return {
-      running: false,
-      adapter: intelligence.adapter,
+      adapter: null,
+      name: intelligence.adapter,
       reason: error instanceof Error ? error.message : String(error),
     };
   }
@@ -182,19 +213,13 @@ export class IntelligenceCoordinator {
     //
     // When L2 is not configured it does not run at all: not remotely, and not locally.
     // L0 and L1 are unaffected and still gate.
-    if (this.config.enabled === true && this.config.adapter) {
-      try {
-        this.adapter = createAdapter(this.config.adapter, this.config.adapterConfig);
-      } catch (error) {
-        // Adapter could not be constructed — L2 withheld, L0+L1 still work. Say so
-        // once, naming the precondition and the fix, rather than degrading silently.
-        this.adapter = null;
-        this.reportL2Unavailable(error instanceof Error ? error.message : String(error));
-      }
-    } else if (this.config.enabled === true) {
-      this.reportL2Unavailable(
-        "no 'intelligence.adapter' is configured",
-      );
+    const resolved = resolveL2Adapter(this.config);
+    this.adapter = resolved.adapter;
+    if (resolved.adapter === null && this.config.enabled === true) {
+      // L2 withheld, L0+L1 still work. Say so once, naming the precondition and the
+      // fix, rather than degrading silently — but only to an operator who ASKED for
+      // L2. `enabled` absent or false requested nothing, so nothing is unavailable.
+      this.reportL2Unavailable(resolved.reason);
     }
   }
 

--- a/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
+++ b/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
@@ -68,6 +68,7 @@ vi.mock('http', () => ({ request: fakeRequest, default: { request: fakeRequest }
 
 import { IntelligenceCoordinator } from './coordinator';
 import { createAdapter } from './adapters';
+import { describeL2Status } from './coordinator';
 import { defaultConfig } from '../config/loader';
 import type { ARPConfig, ARPEvent, IntelligenceConfig } from '../types';
 
@@ -234,7 +235,7 @@ describe('when a remote adapter IS configured, raw material still does not trave
     expect(body, 'the pattern id was stripped too — the redaction is over-broad').toContain('OL-001');
 
     // The fact of the match still travels, so the model can still assess it.
-    expect(body).toMatch(/withheld: \d+ chars/);
+    expect(body).toMatch(/withheld: (empty|up to 8 chars|\d+-\d+ chars|over 128 chars)/);
   });
 
   it('T6: event.description is NOT redacted — this is the known residual, pinned', async () => {
@@ -265,7 +266,7 @@ describe('when a remote adapter IS configured, raw material still does not trave
     const body = requests.map(r => r.body).join('');
 
     // data.command IS withheld by the allowlist.
-    expect(body).toMatch(/withheld: \d+ chars/);
+    expect(body).toMatch(/withheld: (empty|up to 8 chars|\d+-\d+ chars|over 128 chars)/);
 
     // ...but the same value inside the description is not. Asserting the leak
     // rather than pretending it is closed.
@@ -273,5 +274,73 @@ describe('when a remote adapter IS configured, raw material still does not trave
       body,
       'description redaction has landed — update this test and the CHANGELOG claim',
     ).toContain(CANARY_COMMAND);
+  });
+});
+
+describe('what the status line reports is what actually runs', () => {
+  // Regression tests for a line that was wrong twice. It first restated the gate as
+  // `enabled !== false` and kept printing "3-Layer" after the default changed; it was
+  // then rewritten as `enabled === true && adapter`, which is still wrong for
+  // 'agent-proxy' — that passes both checks and throws on construction, so the line
+  // announced a layer that was not running. Neither version had a test.
+
+  it('T7: agent-proxy is reported as NOT running, because constructing it throws', () => {
+    const s = describeL2Status({ enabled: true, adapter: 'agent-proxy' } as IntelligenceConfig);
+    expect(s.running, 'agent-proxy cannot run, so it must not be reported as running').toBe(false);
+    expect(s.reason).toMatch(/no longer selects a provider from environment credentials/);
+  });
+
+  it('T8: the states that should run, do; the states that should not, do not', () => {
+    expect(describeL2Status(defaultConfig().intelligence).running).toBe(false);
+    expect(describeL2Status({ enabled: true } as IntelligenceConfig).running).toBe(false);
+    expect(describeL2Status({ adapter: 'ollama' } as IntelligenceConfig).running).toBe(false);
+    expect(describeL2Status({ enabled: false, adapter: 'ollama' } as IntelligenceConfig).running).toBe(false);
+
+    // POSITIVE CONTROL: a genuinely runnable config reports running, so the four
+    // falses above are a verdict and not a function that always says no.
+    const ok = describeL2Status({ enabled: true, adapter: 'ollama' } as IntelligenceConfig);
+    expect(ok.running, 'a valid local config must report running').toBe(true);
+    expect(ok.adapter).toBe('ollama');
+  });
+});
+
+describe('withheld descriptors do not reconstruct the value', () => {
+  // These go through a real analyze() call and read the REQUEST BODY. They do not
+  // re-implement the descriptor: a test that restates the rule it is checking passes
+  // whenever the copy and the original agree, including when both are wrong.
+
+  const remote = { enabled: true, adapter: 'anthropic', adapterConfig: { apiKey: SYNTHETIC_KEY } } as IntelligenceConfig;
+
+  async function bodyFor(data: Record<string, unknown>): Promise<string> {
+    requests.length = 0;
+    await runAnalyze(remote, criticalEvent({ description: 'fixed text', data }));
+    expect(requests.length, 'no request captured — nothing measured').toBeGreaterThan(0);
+    return requests.map(r => r.body).join('');
+  }
+
+  it('T9: a boolean is not recoverable from its descriptor', async () => {
+    // An exact length plus a class set IS the value for a small value: `true` renders
+    // 4 chars/lower and `false` 5 chars/lower, so the pair reconstructs the boolean.
+    const t = await bodyFor({ secretFlag: true });
+    const f = await bodyFor({ secretFlag: false });
+
+    expect(t, 'the raw value must not appear').not.toContain('true');
+    const tDesc = t.match(/<withheld:[^>]*>/)?.[0];
+    const fDesc = f.match(/<withheld:[^>]*>/)?.[0];
+    expect(tDesc, 'no withheld descriptor found — the allowlist did not fire').toBeTruthy();
+    expect(tDesc, 'true and false must not be distinguishable by descriptor').toBe(fDesc);
+  });
+
+  it('T10: a long value keeps enough shape to assess, and never the value', async () => {
+    const secret = 'A'.repeat(20) + 'b'.repeat(20) + '9';   // 41 chars
+    const body = await bodyFor({ secretBlob: secret });
+
+    expect(body, 'the value itself must not travel').not.toContain(secret);
+    expect(body).toContain('33-64 chars');
+    expect(body).toMatch(/lower/);
+
+    // CONTROL: the bucket is genuinely coarser than the exact length, so the
+    // descriptor cannot be inverted to the value's size.
+    expect(body, 'the exact length leaked').not.toContain('41 chars');
   });
 });

--- a/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
+++ b/sdk/typescript/src/arp/intelligence/l2-egress-default.test.ts
@@ -141,7 +141,7 @@ describe('the shipped default itself', () => {
 
 describe('L2 sends nothing unless it was configured to', () => {
   it('T1: the shipped default makes no outbound call, even with vendor keys exported', async () => {
-    // The exact acceptance line from the roadmap unit: on a machine exporting
+    // The property this whole suite exists to prove: on a machine exporting
     // ANTHROPIC_API_KEY, a default-config ARP run makes no outbound vendor call.
     await runAnalyze(defaultConfig().intelligence);
     expect(requests, `default config sent: ${JSON.stringify(requests)}`).toEqual([]);
@@ -239,7 +239,7 @@ describe('when a remote adapter IS configured, raw material still does not trave
   });
 
   it('T6: event.description is NOT redacted — this is the known residual, pinned', async () => {
-    // Honest boundary of the R6 redaction, asserted rather than described.
+    // Honest boundary of the event.data redaction, asserted rather than described.
     //
     // The allowlist covers `event.data`. It does NOT cover `event.description`,
     // which every prompt builder sends verbatim, and the process monitor composes

--- a/sdk/typescript/src/telemetry-egress-census.test.ts
+++ b/sdk/typescript/src/telemetry-egress-census.test.ts
@@ -246,10 +246,15 @@ describe('telemetry egress census', () => {
     // `describeL2Status`, which the old pattern never covered. Counting the call
     // sites is what makes the guard above mean what it says.
     const src = readFileSync(join(SRC, 'arp/intelligence/coordinator.ts'), 'utf-8');
-    const calls = src.match(/(?<![\w.])createAdapter\s*\(/g) ?? [];
+    // Every spelling that constructs an adapter, not just the factory: a direct
+    // `new AnthropicAdapter(...)` here would reach the vendor without passing the
+    // gate, and the factory-only count let exactly that mutant through when the
+    // delta review planted it.
+    const calls = src.match(/(?<![\w.])createAdapter\s*\(|new\s+\w*Adapter\s*\(/g) ?? [];
     expect(
       calls.length,
-      `coordinator.ts constructs an adapter at ${calls.length} sites. The census can ` +
+      `coordinator.ts constructs an adapter at ${calls.length} sites (${calls.join(', ')}). ` +
+        'The census can ' +
         'only vouch for the gated one. Route every construction through ' +
         '`resolveL2Adapter`, or this channel is ungated on the extra path.',
     ).toBe(1);

--- a/sdk/typescript/src/telemetry-egress-census.test.ts
+++ b/sdk/typescript/src/telemetry-egress-census.test.ts
@@ -77,12 +77,19 @@ const GATED_AT_CALLSITE: Record<string, { site: string; guard: RegExp }> = {
   'arp/intelligence/adapters.ts': {
     site: 'arp/intelligence/coordinator.ts',
     // L2 constructs an adapter only when the operator switched it on AND named a
-    // destination. Both halves matter: `enabled === true` (not `!== false`) so an
-    // absent value from a shallow-merged partial config means off, and an explicit
-    // `adapter` so no destination is ever chosen from ambient environment state.
-    // Deleting either half re-opens the default-on vendor egress this guard exists
-    // to prevent, and fails this test.
-    guard: /this\.config\.enabled\s*===\s*true\s*&&\s*this\.config\.adapter/,
+    // destination. Both halves matter: `enabled` must be exactly `true` (not merely
+    // `!== false`) so an absent value from a shallow-merged partial config means off,
+    // and an explicit `adapter` so no destination is ever chosen from ambient
+    // environment state. Deleting either half re-opens the default-on vendor egress
+    // this guard exists to prevent, and fails this test.
+    //
+    // Both halves now live in `resolveL2Adapter`, which is the ONLY caller of
+    // `createAdapter` in this file. That is a tightening, not a move: before #457's
+    // F-2 fix the gate sat in the constructor and `describeL2Status` reached
+    // `createAdapter` down a second path this census never covered. The pattern
+    // therefore pins the ORDER — enabled, then adapter, then construction — so that
+    // dropping a half or hoisting the call above either check fails here.
+    guard: /intelligence\?\.enabled\s*!==\s*true[\s\S]{0,240}?if\s*\(!intelligence\.adapter\)[\s\S]{0,240}?createAdapter\(/,
   },
   'arp/telemetry/gtin.ts': {
     site: 'arp/index.ts',
@@ -228,6 +235,24 @@ describe('telemetry egress census', () => {
     ]) {
       expect(mods, `${expected} fell out of the census`).toContain(expected);
     }
+  });
+
+  it('the gated call site is the ONLY one — a second, ungated construction fails here', () => {
+    // The guard pattern proves that ONE `createAdapter` call is preceded by both
+    // halves of the gate. It cannot prove there is no OTHER call that is not.
+    //
+    // That gap was real, not hypothetical: before #457's F-2 fix this file called
+    // `createAdapter` twice — once behind the constructor's gate, and once inside
+    // `describeL2Status`, which the old pattern never covered. Counting the call
+    // sites is what makes the guard above mean what it says.
+    const src = readFileSync(join(SRC, 'arp/intelligence/coordinator.ts'), 'utf-8');
+    const calls = src.match(/(?<![\w.])createAdapter\s*\(/g) ?? [];
+    expect(
+      calls.length,
+      `coordinator.ts constructs an adapter at ${calls.length} sites. The census can ` +
+        'only vouch for the gated one. Route every construction through ' +
+        '`resolveL2Adapter`, or this channel is ungated on the extra path.',
+    ).toBe(1);
   });
 
   it('every EXCLUDED entry still exists and still sends — stale exemptions do not linger', () => {


### PR DESCRIPTION
Two follow-ups to #456, both raised by an independent adversarial review of it that arrived **after** it merged. Both are confirmed at the merged head; neither is an exposure today, because L2 is off by default and the environment cannot turn it on.

## F2 — the status line announced a layer that was not running

The CLI's `Intelligence:` line restated the L2 gate instead of asking it, and was wrong both times it was written.

| version | test | wrong for |
|---|---|---|
| `enabled !== false` | none | any install, once the default changed to off |
| `enabled === true && adapter` | none | `adapter: 'agent-proxy'` |

`'agent-proxy'` passes both checks and then throws on construction, so L2 is off while the line reads `3-Layer (L0+L1+L2 via agent-proxy)`. Reproduced before fixing:

```
explicit agent-proxy (createAdapter THROWS, so L2 is off):
  Intelligence: 3-Layer (L0+L1+L2 via agent-proxy)
```

The line now calls `describeL2Status()`, which settles the question by attempting the same construction the coordinator attempts, and names the reason when L2 is not running. A status line that re-derives a predicate drifts from it; this one does not re-derive.

## F5 — withheld descriptors reconstructed small values

`<withheld: N chars, classes>` reported an **exact** length. For a small value that pair is not a summary of the value, it is the value: `true` rendered as `4 chars, lower` and `false` as `5 chars, lower`, so a boolean was recoverable outright, and short enums from a known set the same way.

Lengths are now bucketed (`up to 8 chars`, `9-16`, `17-32`, `33-64`, `65-128`, `over 128`), and values of 8 characters or fewer carry no class information at all. Long values keep enough shape to assess.

## Verification

Suite **80 files, 1182 passed**, 36 skipped; typecheck and build clean.

Mutation-proven, because untested fixes are exactly what caused F2:

| mutation | outcome |
|---|---|
| `describeL2Status` returns running without attempting construction | killed (T7) |
| restore the exact length in `describeWithheld` | killed (4 tests) |

T9 and T10 go through a real `analyze()` call and read the request body rather than re-implementing the descriptor. A test that restates the rule it checks passes whenever the copy and the original agree — including when both are wrong.

## Not addressed here

**F1**, the redaction asymmetry: the allowlist covers `event.data`, not `event.description`, and process-monitor descriptions embed up to 100 characters of the child command line. That was a known and documented residual of #456 rather than a new finding — it is stated in the CHANGELOG and README and pinned by test T6, which asserts the leak rather than describing it. Closing it properly means changing what monitors put in `description`, which touches every consumer of that field, so it is a design decision rather than a patch and is tracked separately. The cheap fix — special-casing the process monitor's string format at the L2 boundary — would leave the next monitor uncovered, which is the same shape of gap that let the egress census miss the vendor channel in the first place.