### PR TITLE
Resolve js-yaml 4.3.2 in the TypeScript SDK lockfile (GHSA-2883-xcg3-v3hh)

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -15,6 +15,9 @@
         "fastify-plugin": "^6.0.0",
         "js-yaml": "^4.3.1"
       },
+      "bin": {
+        "aim-arp": "dist/arp/cli/aim-arp.js"
+      },
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/js-yaml": "^4.0.9",
@@ -3461,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

`sdk/typescript/package-lock.json` resolves js-yaml 4.3.2 instead of 4.3.1 (`npm audit fix --package-lock-only`). No source change.

## Why

The repository's unconditional dependency audit (`npm audit --package-lock-only --omit=dev --audit-level=high` in sdk/typescript) fails on every pull request while the lockfile resolves js-yaml 4.0.0 through 4.3.1 (GHSA-2883-xcg3-v3hh, published after main's last green run on 2026-09-06). Main carries 4.3.1, so every open PR, including the aim-sdk 2.0.2 security release (#458), is blocked by it.

## Checks

- `npm audit --package-lock-only --omit=dev --audit-level=high`: found 0 vulnerabilities, exit 0
- TypeScript SDK suite with the bumped lock: vitest green (exit 0)