### PR TITLE
ci: pin atx-conformance at the 21-fixture suite and vendor the untrusted-chain-authority fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
       # Pinned suite ref. Bump deliberately when the suite grows; the vendored
       # Java fixture copies must be refreshed in the same PR or the drift gate
       # below fails.
-      ATX_CONFORMANCE_REF: f4d40a4e33ac15946e90683ad1f1c59122559407
+      ATX_CONFORMANCE_REF: d2b8376daaec47046e54a3035178d706a5edec1d
     steps:
       - uses: actions/checkout@v4
 

--- a/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
+++ b/sdk/java/src/test/java/org/opena2a/aim/atx/LocalAtxVerifierConformanceTest.java
@@ -56,6 +56,7 @@ class LocalAtxVerifierConformanceTest {
             "v1_1-tampered-capabilities.json,      REJECT, SIGNATURE_INVALID",
             "v1_1-tampered-declared-purpose.json,  REJECT, SIGNATURE_INVALID",
             "v1_1-cross-issuer-key.json,           REJECT, SIGNATURE_INVALID",
+            "v1_1-untrusted-chain-authority.json,  REJECT, SIGNATURE_INVALID",
             "v1_1-declared-purpose-empty-whitespace.json, ACCEPT, ",
             "v1_1-declared-purpose-array-injected.json,   REJECT, SIGNATURE_INVALID",
             "v1_1-declared-purpose-string-injected.json,  REJECT, SIGNATURE_INVALID",

--- a/sdk/java/src/test/resources/atx-fixtures/baseline-valid-hybrid.json
+++ b/sdk/java/src/test/resources/atx-fixtures/baseline-valid-hybrid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
   "name": "atx-v1/baseline-valid-hybrid",
-  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. NOTE: the current opena2a-registry/pkg/atcverify verifier verifies Ed25519 only and silently ignores ML-DSA-65 signatures; the conformance Go verifier in ../verifiers/go DOES verify both, per spec.",
+  "description": "An ATX v1.0 credential carrying both an Ed25519 signature and an ML-DSA-65 signature over the same canonical payload. This is the hybrid signing path the ATX v1.0 spec mandates. A spec-conformant verifier MUST verify BOTH signatures and ACCEPT only when both are valid. The ML-DSA-65 signature value is a raw FIPS 204 ML-DSA-65 signature (3309 bytes decoded) over the same canonical bytes as the Ed25519 signature; no container or combined-blob framing is used.",
   "spec": [
     {
       "id": "ATX",

--- a/sdk/java/src/test/resources/atx-fixtures/malformed-schema.json
+++ b/sdk/java/src/test/resources/atx-fixtures/malformed-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
   "name": "atx-v1/malformed-schema",
-  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed using ATCVersion=\"1.0\" canonical bytes because the production canonicalPayload function hardcodes \"1.0\" in the canonical string regardless of the credential's atcVersion field. This is itself a discrepancy worth noting in the reconciliation log; the conformance fixture intentionally still produces a syntactically reasonable file so verifiers can demonstrate they reject on schema-version alone.",
+  "description": "An ATX whose atcVersion claims a version (2.0) that is not the v1.0 supported by this conformance suite. Verifier MUST REJECT at step 1 (schema-version check) with an unsupported-version reason. NOTE: the signature is computed over v1.0 canonical bytes, whose eleventh field is the literal \"1.0\" independent of the credential's atcVersion field; the fixture is otherwise well formed so that a verifier can demonstrate it rejects on the schema-version check alone.",
   "spec": [
     {
       "id": "ATX",

--- a/sdk/java/src/test/resources/atx-fixtures/v1_1-untrusted-chain-authority.json
+++ b/sdk/java/src/test/resources/atx-fixtures/v1_1-untrusted-chain-authority.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://atx.opena2a.org/schemas/fixture-v1.json",
-  "name": "atx-v1_1/cross-issuer-key",
-  "description": "An ATX v1.1 credential issued by the primary authority but signed by a different trusted authority's key (partner.example). The secondary authority is trusted and its key is configured, and the signature is valid over JCS(TBS), but the secondary is neither the issuer nor present in the signed issuerChain. A spec-conformant verifier binds each signature to a key controlled by the issuer, or by an authority that is both named in the signed issuerChain and in the verifier's trusted issuers, and MUST REJECT with a signature-validation reason.",
+  "name": "atx-v1_1/untrusted-chain-authority",
+  "description": "An ATX v1.1 credential whose issuerDid is the primary authority (did:opena2a:authority:opena2a.org) and whose signed issuerChain names the primary authority and an untrusted authority (did:opena2a:authority:attacker.example). It carries one Ed25519 signature made ONLY by the untrusted authority's key over JCS(TBS), so the chain that names the signer is inside the signed bytes. The verifier trusts only the primary authority as an issuer, but the untrusted key is present in its configured public keys under a DID-URL keyId. A verifier that derives the eligible signing authorities from the credential's own issuerChain wrongly ACCEPTs: the chain names the signer's DID and the signer's key is configured. That chain is signed by the very key whose eligibility is in question, so it cannot vouch for that key. A signature verifies only against a key resolved for an authority the verifier trusts for this credential: the issuerDid, or an authority that is both named in the signed issuerChain and in the verifier's trusted issuers. A chain DID that is not a trusted issuer contributes no eligible key, so no configured key verifies the signature and the verifier MUST REJECT with a signature-validation reason.",
   "spec": [
     {
       "id": "ATX",
@@ -33,18 +33,17 @@
       "keyId": "did:opena2a:authority:opena2a.org#key-1"
     },
     {
-      "role": "issuer-secondary",
-      "path": "vectors/issuer-secondary.json",
+      "role": "issuer-untrusted",
+      "path": "vectors/issuer-untrusted.json",
       "algorithm": "Ed25519",
-      "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
-      "keyId": "did:opena2a:authority:partner.example#key-1"
+      "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+      "keyId": "did:opena2a:authority:attacker.example#key-1"
     }
   ],
   "verifierState": {
     "clockRfc3339": "2026-05-24T00:00:00Z",
     "trustedIssuers": [
-      "did:opena2a:authority:opena2a.org",
-      "did:opena2a:authority:partner.example"
+      "did:opena2a:authority:opena2a.org"
     ],
     "publicKeys": [
       {
@@ -69,11 +68,11 @@
         "keyId": "did:opena2a:authority:opena2a.org#key-3"
       },
       {
-        "role": "issuer-secondary",
-        "path": "vectors/issuer-secondary.json",
+        "role": "issuer-untrusted",
+        "path": "vectors/issuer-untrusted.json",
         "algorithm": "Ed25519",
-        "publicKeyHex": "2043fa51c3d9e4a21a535ccb38bdc4fb56083737d22059d69475e7e43c47f582",
-        "keyId": "did:opena2a:authority:partner.example#key-1"
+        "publicKeyHex": "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+        "keyId": "did:opena2a:authority:attacker.example#key-1"
       }
     ]
   },
@@ -116,14 +115,14 @@
     "expiresAt": "2099-12-31T23:59:59Z",
     "issuerDid": "did:opena2a:authority:opena2a.org",
     "issuerChain": [
-      "did:opena2a:authority:opena2a.org-root",
-      "did:opena2a:authority:opena2a.org"
+      "did:opena2a:authority:opena2a.org",
+      "did:opena2a:authority:attacker.example"
     ],
     "signatures": [
       {
-        "keyId": "did:opena2a:authority:partner.example#key-1",
+        "keyId": "did:opena2a:authority:attacker.example#key-1",
         "algorithm": "Ed25519",
-        "value": "VIoRLMLXWSQJosyTSMpnORfH1oMv9pfWYoehAwyASHRJ03cL7MuErJ/0vu7jziGur8meBaleSNP3D3ETLTXmBw=="
+        "value": "wckUCFwBI1XfltoMx2NOXK2JhfOHvl4M8plQ/p47e+AKKKdfGiZ/PoQ4dOrGC1b787J1CTZ96/OC9y4PhYc0CQ=="
       }
     ],
     "revoked": false,


### PR DESCRIPTION
## What

Bumps `ATX_CONFORMANCE_REF` from f4d40a4e (20 fixtures) to d2b8376 (21). Every vendored Java fixture copy is refreshed to that ref byte-for-byte, as the drift gate requires: `v1_1-untrusted-chain-authority.json` is added and pinned `REJECT`/`SIGNATURE_INVALID` in `LocalAtxVerifierConformanceTest`; `v1_1-cross-issuer-key.json`, `baseline-valid-hybrid.json` and `malformed-schema.json` pick up the suite's revised descriptions (credential bytes and verdicts unchanged).

Stacked on the Java SDK fix branch (the PR titled "Java SDK: an untrusted issuerChain authority cannot sign for a trusted issuer"); merge that first. The previous verifier accepts fixture 21, so this pin only goes green with the fix in.

## Proof

Local run at this ref: 21 of 21 fixtures produce the pinned verdict; `cmp` of all 21 vendored files against the suite at d2b8376 reports no drift in either direction.

This touches `.github/workflows/ci.yml`, so it needs the gate-file approval.