### PR TITLE
sdk-ts: close eight open 1.3.1 release-test findings

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -109,6 +109,58 @@ the caller asked them to — the AIM client, A2A, OAuth, secrets, CRL fetch, the
 ARP proxy forwarder — are listed with the reason rather than filtered out, so
 they stay in scope if one ever grows an observational side-channel.
 
+### Fixed — 1.3.1 release-test P2 findings
+
+- **Token response shape**: `OAuthTokenManager` now reads both the RFC 6749
+  snake_case token response (`access_token`/`token_type`/`expires_in`) and the
+  historical camelCase form. Previously an RFC-shaped response produced
+  `Authorization: Bearer undefined`. A missing or unparseable expiry no longer
+  poisons the token cache into `NaN` (which silently forced a refetch on every
+  request); it falls back to a conservative 5 minutes, and a response with no
+  access token in either spelling raises `AuthenticationError` instead of
+  caching `undefined`.
+- **Typed `/oauth/token` errors**: a non-2xx from the token endpoint now
+  surfaces as the SDK's typed error family (429 → `RateLimitError`, 401 →
+  `AuthenticationError`, others → `AIMError` with `code` and `statusCode`)
+  instead of a bare `Error`, and the embedded response-body excerpt is capped
+  at 500 characters (a proxy's HTML error page ran to 2095).
+- **Retries claim removed**: the README advertised "Automatic Retries:
+  Built-in retry logic with exponential backoff", but no retry logic exists in
+  the SDK. The Features line now describes what the code does (typed errors,
+  `RateLimitError.retryAfter`); retry policy stays with the caller. Pinned by
+  `src/readme-claims.test.ts` so claim and code cannot diverge again.
+- **`Retry-After` honored**: `RateLimitError.retryAfter` now reflects the
+  server's `Retry-After` response header (seconds or HTTP-date) when present,
+  falling back to the body field then the 60s default only when absent.
+  Previously the header was never read, so `Retry-After: 7` yielded 60.
+- **Enforcement telemetry on wire 403**: a 403 from `POST /api/v1/verify` with
+  telemetry enabled now produces a correlated deny enforcement record, exactly
+  as the 200 `{actionAllowed: false}` path does. Previously the
+  `AuthorizationError` propagated before the recording hook could run, so the
+  403 path recorded nothing. (The allow-path half of this finding — an allowed
+  verify carrying a detection produces a record — was already fixed by the
+  post-1.3.1 correlation-joiner rework; it is now pinned by a test.)
+- **Network-error context**: a connection failure now names the request URL
+  and the underlying errno (e.g. `ECONNREFUSED`), unwrapped from the fetch
+  error's cause chain, with an explicit `baseUrl` too — not only when the
+  localhost default was in play. Previously an explicit-baseUrl failure read
+  just "Network error: fetch failed".
+- **Delegation lower bound**: `verifyDelegation`, `verifyDelegationChain` and
+  `checkDelegationTemporalValidity` now enforce BOTH bounds of the signed
+  window: an evaluation instant before `createdAt` is rejected as not yet
+  valid (lower bound inclusive; expiry stays exclusive). Previously
+  verify-at-epoch against a delegation created in 2026 returned `true`.
+- **GTIN registry destination**: `submitGTINEvent` resolves its registry URL
+  through the same chain as every other telemetry transport — explicit
+  `registryUrl`, else `OPENA2A_REGISTRY_URL`, else the default — instead of
+  hardcoding the production registry, which is how the release test's dummy
+  event reached production.
+- **Env-credential diagnostics**: `loadCredentialsFromEnv()` still returns
+  `null` when any of `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY`,
+  `AIM_ORGANIZATION_ID` is missing, but a PARTIAL environment now warns naming
+  the missing variable(s) instead of presenting exactly like a clean
+  environment. (The README half of this finding was already fixed by #451.)
+
 ## [1.3.1] - 2026-09-02
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -50,7 +50,7 @@ console.log(`Trust score: ${result.trustScore}`);
 - **OAuth 2.0**: Automatic token management with client credentials flow
 - **Express Middleware**: Easy integration with Express.js applications
 - **Fastify Plugin**: First-class support for Fastify applications
-- **Automatic Retries**: Built-in retry logic with exponential backoff
+- **Typed HTTP Errors**: Failures surface as a typed error family (`RateLimitError` carries the server's `Retry-After`); the SDK does not retry automatically — retry policy stays with the caller
 - **Local Credential Verification**: Verify signed ATX credentials offline against cached trust anchors, no per-action call to a central service
 - **Delegation Chains**: Create and verify Ed25519 delegation chains (cross-engine interop), with signature, identity, scope-narrowing, and expiry all enforced at verification time
 
@@ -89,7 +89,7 @@ app.get('/api/profile', (req, res) => {
 app.use(aimErrorHandler);
 ```
 
-The middleware authenticates to AIM as a registered agent. `apiKey` alone does not give it an identity: set `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY` and `AIM_ORGANIZATION_ID` in the environment (all four; `loadCredentialsFromEnv()` returns `null` when any is missing). Without them every verified route answers 401 and AIM is never contacted ([#449](https://github.com/opena2a-org/agent-identity-management/issues/449)). `aimErrorHandler` answers denial and authentication errors as JSON; other SDK errors, including an upstream 5xx, are passed to Express's default handler, which renders a stack trace outside `NODE_ENV=production` ([#450](https://github.com/opena2a-org/agent-identity-management/issues/450)).
+The middleware authenticates to AIM as a registered agent. `apiKey` alone does not give it an identity: set `AIM_AGENT_ID`, `AIM_PRIVATE_KEY`, `AIM_PUBLIC_KEY` and `AIM_ORGANIZATION_ID` in the environment (all four; `loadCredentialsFromEnv()` returns `null` when any is missing, and when only some are set it warns naming the missing variable(s)). Without them every verified route answers 401 and AIM is never contacted ([#449](https://github.com/opena2a-org/agent-identity-management/issues/449)). `aimErrorHandler` answers denial and authentication errors as JSON; other SDK errors, including an upstream 5xx, are passed to Express's default handler, which renders a stack trace outside `NODE_ENV=production` ([#450](https://github.com/opena2a-org/agent-identity-management/issues/450)).
 
 ## Fastify Integration
 
@@ -219,10 +219,11 @@ const { valid, results } = await verifyDelegationChain([d1, d2]);
 // scope narrowing, chain linkage, trust attenuation, AND temporal validity.
 ```
 
-`verifyDelegation` and `verifyDelegationChain` enforce the delegation's signed
-`createdAt`/`expiresAt` window. An expired delegation is rejected, and verification
-fails closed on a missing, unparseable, or inverted (`createdAt` after `expiresAt`)
-timestamp. A chain is evaluated against a single instant so every hop is judged by
+`verifyDelegation` and `verifyDelegationChain` enforce BOTH bounds of the
+delegation's signed `createdAt`/`expiresAt` window. An expired delegation is
+rejected, a delegation evaluated before its signed `createdAt` is rejected as
+not yet valid, and verification fails closed on a missing, unparseable, or
+inverted (`createdAt` after `expiresAt`) timestamp. A chain is evaluated against a single instant so every hop is judged by
 the same clock, and a child that outlives its parent is rejected even while the
 parent is still live (a delegate cannot hold authority in time beyond its
 delegator). When creating a sub-delegation, pass `parentExpiresAt` so the child's

--- a/sdk/typescript/src/arp/telemetry/gtin.registry-url.test.ts
+++ b/sdk/typescript/src/arp/telemetry/gtin.registry-url.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for submitGTINEvent destination resolution (AIM-11 item 8): the GTIN
+ * channel must resolve its registry URL through the same chain as every other
+ * signature-telemetry transport — explicit argument, else OPENA2A_REGISTRY_URL,
+ * else the default — instead of hardcoding the production registry.
+ *
+ * HARD RULE (AIM-11.AC9): these tests must never reach the production
+ * registry. Every request funnels through a guarding fetch stub that only
+ * forwards to 127.0.0.1; anything else is answered locally and recorded.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'http';
+import { submitGTINEvent, type GTINPayload } from './gtin';
+
+const PAYLOAD: GTINPayload = {
+  sensorToken: 'sensor-test-token',
+  eventType: 'unexpected_dns',
+  packageName: 'test-package',
+  packageVersion: '1.0.0',
+  daySinceInstall: 1,
+  runtimeEnv: 'node',
+  triggeredAt: '2026-09-09T00:00:00Z',
+};
+
+let server: Server;
+let loopbackBase: string;
+let received: Array<{ method: string | undefined; url: string | undefined; body: string }>;
+let attempted: string[];
+const realFetch = globalThis.fetch;
+const savedRegistryEnv = process.env.OPENA2A_REGISTRY_URL;
+
+beforeEach(async () => {
+  received = [];
+  attempted = [];
+
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      received.push({ method: req.method, url: req.url, body });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ eventId: 'evt-loopback-1' }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  loopbackBase = `http://127.0.0.1:${port}`;
+
+  // Guard: forward loopback requests to the real server; swallow anything else
+  // so a regression can NEVER produce non-loopback egress from this test.
+  vi.stubGlobal('fetch', ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    attempted.push(url);
+    if (url.startsWith('http://127.0.0.1:')) return realFetch(input, init);
+    return Promise.resolve(new Response('{}', { status: 599 }));
+  }) as typeof fetch);
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  if (savedRegistryEnv === undefined) delete process.env.OPENA2A_REGISTRY_URL;
+  else process.env.OPENA2A_REGISTRY_URL = savedRegistryEnv;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('submitGTINEvent registry URL resolution (item 8)', () => {
+  it('AIM-11.AC8 honours OPENA2A_REGISTRY_URL: the POST arrives at the loopback server', async () => {
+    process.env.OPENA2A_REGISTRY_URL = loopbackBase;
+
+    const result = await submitGTINEvent(PAYLOAD);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].method).toBe('POST');
+    expect(received[0].url).toBe('/api/v1/telemetry/runtime');
+    expect(JSON.parse(received[0].body).sensorToken).toBe('sensor-test-token');
+    expect(result.success).toBe(true);
+    expect(result.eventId).toBe('evt-loopback-1');
+  });
+
+  it('AIM-11.AC8 an explicit registryUrl argument wins over the environment', async () => {
+    process.env.OPENA2A_REGISTRY_URL = 'http://127.0.0.1:1'; // would be refused
+    const result = await submitGTINEvent(PAYLOAD, loopbackBase);
+
+    expect(received).toHaveLength(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('AIM-11.AC9 no request is addressed to api.oa2a.org or any non-loopback host', async () => {
+    process.env.OPENA2A_REGISTRY_URL = loopbackBase;
+    await submitGTINEvent(PAYLOAD);
+    await submitGTINEvent(PAYLOAD, loopbackBase);
+
+    for (const url of attempted) {
+      expect(url.startsWith('http://127.0.0.1:')).toBe(true);
+      expect(url).not.toContain('api.oa2a.org');
+    }
+  });
+});

--- a/sdk/typescript/src/arp/telemetry/gtin.ts
+++ b/sdk/typescript/src/arp/telemetry/gtin.ts
@@ -15,6 +15,7 @@ import { homedir, hostname, userInfo } from 'os';
 import { join } from 'path';
 import { ARPEvent, EventCategory } from '../types';
 import { VERSION } from '../index';
+import { resolveRegistryUrl } from './signature/config';
 
 // --- Types ---
 
@@ -260,14 +261,16 @@ export function isAnomalousEvent(event: ARPEvent): boolean {
 /**
  * Submit a single GTIN event to the OpenA2A Registry.
  *
- * POST to https://api.oa2a.org/api/v1/telemetry/runtime
+ * The destination resolves through the same chain as every other telemetry
+ * transport: explicit `registryUrl` argument, else `OPENA2A_REGISTRY_URL`,
+ * else the default registry. POST to <registry>/api/v1/telemetry/runtime.
  * Timeout: 10 seconds. Non-blocking: failures are logged as warnings, never crash.
  */
 export async function submitGTINEvent(
   payload: GTINPayload,
   registryUrl?: string,
 ): Promise<GTINSubmitResult> {
-  const baseUrl = registryUrl || 'https://api.oa2a.org';
+  const baseUrl = resolveRegistryUrl(registryUrl ? { registryUrl } : undefined);
   const url = `${baseUrl}/api/v1/telemetry/runtime`;
 
   try {

--- a/sdk/typescript/src/auth/oauth.token-handling.test.ts
+++ b/sdk/typescript/src/auth/oauth.token-handling.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for OAuth token-response parsing, typed /oauth/token errors, and
+ * env-credential diagnostics (AIM-11 items 1, 2 and 9).
+ *
+ * - The token endpoint may answer in RFC 6749 snake_case ({"access_token", ...})
+ *   or the SDK's historical camelCase; both must be read, and a missing expiry
+ *   must not poison the token cache into NaN.
+ * - A non-2xx from /oauth/token must surface as the SDK's typed error family
+ *   with the body excerpt capped, not as a bare Error carrying the raw body.
+ * - Partial AIM_* credential env must name the missing variable(s) instead of
+ *   the same silent null as a clean environment.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OAuthTokenManager, loadCredentialsFromEnv } from './oauth';
+import { AIMClient } from '../client/AIMClient';
+import { AIMError, AuthenticationError, RateLimitError } from '../exceptions';
+import { generateKeyPair, toBase64 } from '../crypto/ed25519';
+import type { AgentCredentials } from '../types';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const CRED_VARS = ['AIM_AGENT_ID', 'AIM_PRIVATE_KEY', 'AIM_PUBLIC_KEY', 'AIM_ORGANIZATION_ID'];
+
+async function realCredentials(agentId = 'agent-token-shape'): Promise<AgentCredentials> {
+  const { privateKey, publicKey } = await generateKeyPair();
+  return {
+    agentId,
+    privateKey: toBase64(privateKey),
+    publicKey: toBase64(publicKey),
+    organizationId: 'org-token-shape',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function mockTokenResponse(body: Record<string, unknown>): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+function mockApiOk(body: Record<string, unknown> = { id: 'agent-token-shape' }): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+/** Headers of the most recent fetch call. */
+function lastRequestHeaders(): Record<string, string> {
+  const call = mockFetch.mock.calls.at(-1);
+  return (call?.[1]?.headers ?? {}) as Record<string, string>;
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const name of ['AIM_BASE_URL', 'AIM_API_KEY', ...CRED_VARS]) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const [name, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('token response shapes (item 1)', () => {
+  it('AIM-11.AC1 RFC 6749 snake_case token response yields "Bearer <token>", never "Bearer undefined"', async () => {
+    const client = new AIMClient({ baseUrl: BASE_URL });
+    client.setCredentials(await realCredentials());
+
+    mockTokenResponse({ access_token: 'rfc-shaped-token', token_type: 'Bearer', expires_in: 3600 });
+    mockApiOk();
+
+    const agent = await client.getAgent();
+    expect(agent).not.toBeNull();
+
+    const headers = lastRequestHeaders();
+    expect(headers['Authorization']).toBe('Bearer rfc-shaped-token');
+    expect(headers['Authorization']).not.toContain('undefined');
+  });
+
+  it('AIM-11.AC1 camelCase token response keeps working', async () => {
+    const client = new AIMClient({ baseUrl: BASE_URL });
+    client.setCredentials(await realCredentials());
+
+    mockTokenResponse({ accessToken: 'camel-shaped-token', tokenType: 'Bearer', expiresIn: 3600 });
+    mockApiOk();
+
+    await client.getAgent();
+    expect(lastRequestHeaders()['Authorization']).toBe('Bearer camel-shaped-token');
+  });
+
+  it('AIM-11.AC1 expires_in drives the cache expiry for the RFC shape', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+
+    mockTokenResponse({ access_token: 'rfc-cached', token_type: 'Bearer', expires_in: 3600 });
+    await manager.getAccessToken();
+
+    expect(manager.hasValidToken()).toBe(true);
+    await manager.getAccessToken();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('AIM-11.AC1 a missing expiry must not poison the cache into NaN', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+
+    // No expiresIn/expires_in at all: the cache must still hold a real number,
+    // not NaN (which makes every validity check false and forces a refetch on
+    // every single request).
+    mockTokenResponse({ accessToken: 'no-expiry-token', tokenType: 'Bearer' });
+    const first = await manager.getAccessToken();
+    expect(first).toBe('no-expiry-token');
+
+    expect(manager.hasValidToken()).toBe(true);
+    await manager.getAccessToken();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('AIM-11.AC1 an unparseable expiry must not poison the cache into NaN', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+
+    mockTokenResponse({ access_token: 'weird-expiry-token', token_type: 'Bearer', expires_in: 'soon' });
+    await manager.getAccessToken();
+
+    expect(manager.hasValidToken()).toBe(true);
+    await manager.getAccessToken();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('typed /oauth/token errors (item 2)', () => {
+  function mockTokenFailure(status: number, body: string, headers?: Record<string, string>): void {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status,
+      headers: new Headers(headers ?? {}),
+      text: async () => body,
+    });
+  }
+
+  it('AIM-11.AC2 a 429 from /oauth/token surfaces as RateLimitError', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+    mockTokenFailure(429, JSON.stringify({ message: 'slow down' }), { 'Retry-After': '7' });
+
+    let caught: unknown;
+    try {
+      await manager.getAccessToken();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    expect((caught as RateLimitError).retryAfter).toBe(7);
+  });
+
+  it('AIM-11.AC2 a 401 from /oauth/token surfaces as AuthenticationError', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+    mockTokenFailure(401, JSON.stringify({ message: 'bad assertion' }));
+
+    let caught: unknown;
+    try {
+      await manager.getAccessToken();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AuthenticationError);
+    expect((caught as AuthenticationError).statusCode).toBe(401);
+  });
+
+  it('AIM-11.AC2 other statuses surface as an AIMError subclass with code and statusCode', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+    mockTokenFailure(503, 'upstream unavailable');
+
+    let caught: unknown;
+    try {
+      await manager.getAccessToken();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AIMError);
+    expect((caught as AIMError).statusCode).toBe(503);
+    expect((caught as AIMError).code).toBeTruthy();
+  });
+
+  it('AIM-11.AC2 the embedded response-body excerpt is capped at 500 characters', async () => {
+    const manager = new OAuthTokenManager(BASE_URL, await realCredentials());
+    // The release test observed a 2095-character HTML body embedded verbatim.
+    mockTokenFailure(502, 'x'.repeat(2095));
+
+    let caught: unknown;
+    try {
+      await manager.getAccessToken();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AIMError);
+    const message = (caught as AIMError).message;
+    expect(message).toContain('Failed to acquire token');
+    expect((message.match(/x/g) ?? []).length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('env-credential diagnostics (item 9, loader half)', () => {
+  it('AIM-11.AC10 a partial credential environment names the missing variables', async () => {
+    process.env.AIM_AGENT_ID = 'agent-partial';
+    process.env.AIM_PUBLIC_KEY = 'pk-partial';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const creds = loadCredentialsFromEnv();
+
+    expect(creds).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain('AIM_PRIVATE_KEY');
+    expect(message).toContain('AIM_ORGANIZATION_ID');
+  });
+
+  it('AIM-11.AC10 a clean environment stays silent and returns null', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(loadCredentialsFromEnv()).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('AIM-11.AC10 a complete environment still loads without warning', () => {
+    process.env.AIM_AGENT_ID = 'agent-full';
+    process.env.AIM_PRIVATE_KEY = 'sk-full';
+    process.env.AIM_PUBLIC_KEY = 'pk-full';
+    process.env.AIM_ORGANIZATION_ID = 'org-full';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const creds = loadCredentialsFromEnv();
+
+    expect(creds).not.toBeNull();
+    expect(creds!.agentId).toBe('agent-full');
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/typescript/src/auth/oauth.ts
+++ b/sdk/typescript/src/auth/oauth.ts
@@ -4,7 +4,7 @@
 
 import type { TokenResponse, AgentCredentials } from '../types';
 import { createRequestSignature, toBase64, fromBase64 } from '../crypto/ed25519';
-import { ConfigurationError } from '../exceptions';
+import { AuthenticationError, ConfigurationError, parseAPIError } from '../exceptions';
 
 /**
  * Token cache entry
@@ -126,19 +126,45 @@ export class OAuthTokenManager {
     }
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Failed to acquire token: ${response.status} ${error}`);
+      const raw = await response.text().catch(() => '');
+      // Cap the embedded body excerpt: a proxy's HTML error page can run to
+      // kilobytes, and the whole point of the message is the leading context.
+      const excerpt = raw.slice(0, 500);
+      let errorBody: Record<string, unknown> = {};
+      try {
+        errorBody = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        // Non-JSON body; the excerpt in the message is all we can carry.
+      }
+      throw parseAPIError(
+        response.status,
+        { ...errorBody, message: `Failed to acquire token: ${response.status} ${excerpt}` },
+        response.headers
+      );
     }
 
     const tokenResponse = (await response.json()) as TokenResponse;
+    // The server may answer in RFC 6749 snake_case ({"access_token", ...}) or
+    // the SDK's historical camelCase; accept both.
+    const accessToken = tokenResponse.accessToken ?? tokenResponse.access_token;
+    if (typeof accessToken !== 'string' || accessToken === '') {
+      throw new AuthenticationError(
+        'Token endpoint returned no access token (expected "access_token" or "accessToken" in the response)'
+      );
+    }
+    const expiresIn = Number(tokenResponse.expiresIn ?? tokenResponse.expires_in);
+    // A missing or unparseable expiry must not poison the cache into NaN
+    // (which makes every validity check false and forces a refetch per
+    // request); fall back to a conservative 5 minutes.
+    const expiresInSeconds = Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 300;
 
     // Cache the token
     this.cachedToken = {
-      accessToken: tokenResponse.accessToken,
-      expiresAt: Date.now() + tokenResponse.expiresIn * 1000,
+      accessToken,
+      expiresAt: Date.now() + expiresInSeconds * 1000,
     };
 
-    return tokenResponse.accessToken;
+    return accessToken;
   }
 
   /**
@@ -157,23 +183,40 @@ export class OAuthTokenManager {
 }
 
 /**
- * Load credentials from environment variables
+ * Load credentials from environment variables.
+ *
+ * All four of AIM_AGENT_ID, AIM_PRIVATE_KEY, AIM_PUBLIC_KEY and
+ * AIM_ORGANIZATION_ID are required. A clean environment (none set) returns
+ * null silently; a PARTIAL environment also returns null but warns naming the
+ * missing variable(s), so a one-variable typo does not present as the same
+ * "No credentials available" a clean environment does.
  */
 export function loadCredentialsFromEnv(): AgentCredentials | null {
-  const agentId = process.env.AIM_AGENT_ID;
-  const privateKey = process.env.AIM_PRIVATE_KEY;
-  const publicKey = process.env.AIM_PUBLIC_KEY;
-  const organizationId = process.env.AIM_ORGANIZATION_ID;
+  const vars = {
+    AIM_AGENT_ID: process.env.AIM_AGENT_ID,
+    AIM_PRIVATE_KEY: process.env.AIM_PRIVATE_KEY,
+    AIM_PUBLIC_KEY: process.env.AIM_PUBLIC_KEY,
+    AIM_ORGANIZATION_ID: process.env.AIM_ORGANIZATION_ID,
+  };
+  const missing = Object.keys(vars).filter((name) => !vars[name as keyof typeof vars]);
 
-  if (!agentId || !privateKey || !publicKey || !organizationId) {
+  if (missing.length === Object.keys(vars).length) {
+    return null;
+  }
+  if (missing.length > 0) {
+    console.warn(
+      `[AIM] Incomplete agent credentials in environment: missing ${missing.join(', ')} ` +
+        '(all of AIM_AGENT_ID, AIM_PRIVATE_KEY, AIM_PUBLIC_KEY, AIM_ORGANIZATION_ID are ' +
+        'required); loadCredentialsFromEnv() returns null.'
+    );
     return null;
   }
 
   return {
-    agentId,
-    privateKey,
-    publicKey,
-    organizationId,
+    agentId: vars.AIM_AGENT_ID!,
+    privateKey: vars.AIM_PRIVATE_KEY!,
+    publicKey: vars.AIM_PUBLIC_KEY!,
+    organizationId: vars.AIM_ORGANIZATION_ID!,
     createdAt: new Date().toISOString(),
   };
 }

--- a/sdk/typescript/src/client/AIMClient.network-context.test.ts
+++ b/sdk/typescript/src/client/AIMClient.network-context.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for connection-failure diagnostics with an EXPLICIT baseUrl
+ * (AIM-11 item 6): the NetworkError message must name the request URL and the
+ * underlying errno (unwrapped from the fetch error's cause chain), matching
+ * the diagnostic quality of the defaulted-baseUrl hint.
+ *
+ * Uses the real global fetch against a loopback port that is known to refuse
+ * connections — never a non-loopback host.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createServer } from 'net';
+import { AIMClient } from './AIMClient';
+import { NetworkError } from '../exceptions';
+
+/** Bind an ephemeral loopback port, then release it so connections are refused. */
+async function refusedLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+beforeEach(() => {
+  delete process.env.AIM_BASE_URL;
+  delete process.env.AIM_API_KEY;
+  delete process.env.AIM_AGENT_ID;
+  delete process.env.AIM_PRIVATE_KEY;
+  delete process.env.AIM_PUBLIC_KEY;
+  delete process.env.AIM_ORGANIZATION_ID;
+});
+
+describe('network-error context (item 6)', () => {
+  it('AIM-11.AC6 a refused connection with an explicit baseUrl names the URL and the errno', async () => {
+    const port = await refusedLoopbackPort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const client = new AIMClient({ baseUrl });
+
+    let caught: unknown;
+    try {
+      await client.registerAgent({ name: 'net-context-probe' });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(NetworkError);
+    const message = (caught as NetworkError).message;
+    expect(message).toContain(baseUrl);
+    expect(message).toContain('ECONNREFUSED');
+  });
+
+  it('AIM-11.AC6 the defaulted-baseUrl hint is preserved alongside the new context', async () => {
+    // No baseUrl option and no AIM_BASE_URL: the hint about the localhost
+    // default must still appear (the pre-existing diagnostic must not regress).
+    const client = new AIMClient();
+
+    let caught: unknown;
+    try {
+      await client.registerAgent({ name: 'net-context-default-probe' });
+    } catch (err) {
+      caught = err;
+    }
+
+    // Either the default port answers (unlikely in CI) or we get the hinted
+    // NetworkError; only assert when the connection actually failed.
+    if (caught instanceof NetworkError) {
+      expect(caught.message).toContain('baseUrl defaulted to');
+    }
+  });
+});

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -17,11 +17,13 @@ import { generateKeyPair, toBase64, createRequestSignature, fromBase64 } from '.
 import {
   AIMError,
   AuthenticationError,
+  AuthorizationError,
   ActionDeniedError,
   VerificationError,
   ConfigurationError,
   NetworkError,
   parseAPIError,
+  unwrapErrnoCode,
 } from '../exceptions';
 import { LocalVerifier } from '../local';
 import type { Atx } from '../local';
@@ -273,7 +275,7 @@ export class AIMClient {
 
       if (!response.ok) {
         const errorBody = await response.json().catch(() => ({}));
-        throw parseAPIError(response.status, errorBody);
+        throw parseAPIError(response.status, errorBody, response.headers);
       }
 
       // Handle empty responses
@@ -294,10 +296,18 @@ export class AIMClient {
         if (error.name === 'AbortError') {
           throw new NetworkError('Request timed out', error);
         }
+        // Name the target and the cause: Node's fetch reports connection
+        // failures as a bare "fetch failed" with the errno buried in the cause
+        // chain, which is useless without the URL it was aimed at.
+        const errnoCode = unwrapErrnoCode(error);
+        const causeSuffix = errnoCode ? ` [${errnoCode}]` : '';
         const hint = this.usedDefaultBaseUrl
           ? ` (baseUrl defaulted to ${DEFAULT_BASE_URL} — no baseUrl option or AIM_BASE_URL env var was set)`
           : '';
-        throw new NetworkError(`Network error: ${error.message}${hint}`, error);
+        throw new NetworkError(
+          `Network error: ${error.message} (${method} ${url})${causeSuffix}${hint}`,
+          error
+        );
       }
 
       throw new NetworkError('Unknown network error');
@@ -435,14 +445,34 @@ export class AIMClient {
     // best-effort. Minting/headers are skipped entirely when telemetry is off.
     const correlationId = this.telemetryEnabled ? mintCorrelationId() : undefined;
 
-    const result = await this.request<VerificationResult>(
-      'POST',
-      '/api/v1/verify',
-      payload,
-      false,
-      correlationHeaders(correlationId),
-      deadlineAt
-    );
+    let result: VerificationResult;
+    try {
+      result = await this.request<VerificationResult>(
+        'POST',
+        '/api/v1/verify',
+        payload,
+        false,
+        correlationHeaders(correlationId),
+        deadlineAt
+      );
+    } catch (error) {
+      // A wire 403 IS an enforcement deny — the server refused the action at
+      // the HTTP layer instead of answering 200 {actionAllowed:false}. Record
+      // it with the same correlation the in-band deny path gets.
+      if (correlationId && error instanceof AuthorizationError) {
+        this.recordVerificationTelemetry(correlationId, options, {
+          verified: false,
+          agentId: this.credentials.agentId,
+          agentName: '',
+          trustScore: 0,
+          riskLevel: options.riskLevel ?? RiskLevel.LOW,
+          actionAllowed: false,
+          denialReason: error.message,
+          timestamp: new Date().toISOString(),
+        });
+      }
+      throw error;
+    }
 
     // Record the enforcement outcome (allow OR deny) BEFORE the deny throw, so
     // the causal-denial case is captured. Never affects the result below.

--- a/sdk/typescript/src/client/AIMClient.wire-errors.test.ts
+++ b/sdk/typescript/src/client/AIMClient.wire-errors.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for wire-error handling on the verify path (AIM-11 items 4 and 5):
+ *
+ * - RateLimitError.retryAfter reflects the server's Retry-After header, falling
+ *   back to the body field then a default only when absent.
+ * - A wire 403 on /api/v1/verify with telemetry enabled produces a correlated
+ *   deny enforcement record exactly as the 200 {actionAllowed:false} path does;
+ *   an ALLOWED verify carrying a detection produces one too.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AIMClient } from './AIMClient';
+import { AuthorizationError, RateLimitError, parseAPIError } from '../exceptions';
+import { CorrelationJoiner, type CorrelatedRecord, type DetectionInput } from '../telemetry';
+import { generateKeyPair, toBase64 } from '../crypto/ed25519';
+import type { AgentCredentials, VerificationResult } from '../types';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+async function realCredentials(agentId = 'agent-wire-1'): Promise<AgentCredentials> {
+  const { privateKey, publicKey } = await generateKeyPair();
+  return {
+    agentId,
+    privateKey: toBase64(privateKey),
+    publicKey: toBase64(publicKey),
+    organizationId: 'org-wire',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function mockTokenOk(): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ accessToken: 'test-token', tokenType: 'Bearer', expiresIn: 3600 }),
+  });
+}
+
+function mockVerifyOk(overrides: Partial<VerificationResult> = {}): void {
+  const body: VerificationResult = {
+    verified: true,
+    agentId: 'agent-wire-1',
+    agentName: 'wire-agent',
+    trustScore: 0.9,
+    riskLevel: 'low' as VerificationResult['riskLevel'],
+    actionAllowed: true,
+    timestamp: '2026-09-09T00:00:00Z',
+    eventId: 'evt-wire',
+    ...overrides,
+  };
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+function mockVerifyFailure(
+  status: number,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>
+): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    headers: new Headers(headers ?? {}),
+    json: async () => body,
+  });
+}
+
+const SAMPLE_DETECTION: DetectionInput = {
+  injectionDetected: true,
+  attackClass: 'indirect',
+  techniqueId: 'T-2002',
+  techniqueSource: 'interim-mapping',
+  confidence: 0.84,
+  detector: 'nanomind-guard',
+  inputRef: 'sha256:abc',
+  detectedAt: '2026-09-09T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.AIM_BASE_URL;
+  delete process.env.AIM_API_KEY;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+describe('Retry-After (item 4)', () => {
+  it('AIM-11.AC4 a 429 with "Retry-After: 7" yields RateLimitError.retryAfter 7', async () => {
+    const client = new AIMClient();
+    client.setCredentials(await realCredentials());
+    mockTokenOk();
+    mockVerifyFailure(429, { message: 'rate limited' }, { 'Retry-After': '7' });
+
+    let caught: unknown;
+    try {
+      await client.verifyAction({ action: 'db:read', resource: 'users' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    expect((caught as RateLimitError).retryAfter).toBe(7);
+  });
+
+  it('AIM-11.AC4 falls back to the body retryAfter field when the header is absent', () => {
+    const err = parseAPIError(429, { retryAfter: 13 });
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfter).toBe(13);
+  });
+
+  it('AIM-11.AC4 falls back to the default only when both header and body are absent', () => {
+    const err = parseAPIError(429, {});
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfter).toBe(60);
+  });
+
+  it('AIM-11.AC4 the header wins over the body field when both are present', async () => {
+    const client = new AIMClient();
+    client.setCredentials(await realCredentials());
+    mockTokenOk();
+    mockVerifyFailure(429, { retryAfter: 999 }, { 'Retry-After': '7' });
+
+    let caught: unknown;
+    try {
+      await client.verifyAction({ action: 'db:read', resource: 'users' });
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as RateLimitError).retryAfter).toBe(7);
+  });
+});
+
+describe('telemetry on wire 403 (item 5)', () => {
+  it('AIM-11.AC5 a wire 403 on /api/v1/verify with telemetry enabled produces a correlated deny record', async () => {
+    const records: CorrelatedRecord[] = [];
+    const joiner = new CorrelationJoiner({ windowMs: 60_000, onRecord: (r) => records.push(r) });
+    const client = new AIMClient({ telemetry: { enabled: true, joiner } });
+    client.setCredentials(await realCredentials());
+    mockTokenOk();
+    mockVerifyFailure(403, { message: 'agent suspended' });
+
+    await expect(
+      client.verifyAction({ action: 'file:write', resource: '/etc/passwd' })
+    ).rejects.toThrow(AuthorizationError);
+
+    // The enforcement fact must have been ingested (buffered awaiting
+    // intent/detection) exactly as the 200 {actionAllowed:false} path buffers.
+    expect(joiner.pending).toBe(1);
+
+    // Force the window to expire so the record is emitted, and check the outcome.
+    joiner.flushExpired(Date.now() + 120_000);
+    expect(records).toHaveLength(1);
+    expect(records[0].enforcement.decision).toBe('deny');
+    expect(records[0].enforcement.outcome).toBe('DENY');
+    expect(records[0].enforcement.capability).toBe('file:write');
+  });
+
+  it('AIM-11.AC5 an allowed verify carrying a detection produces an enforcement record too', async () => {
+    const records: CorrelatedRecord[] = [];
+    const joiner = new CorrelationJoiner({ windowMs: 60_000, onRecord: (r) => records.push(r) });
+    const client = new AIMClient({ telemetry: { enabled: true, joiner } });
+    client.setCredentials(await realCredentials());
+    mockTokenOk();
+    mockVerifyOk({ actionAllowed: true });
+
+    await client.verifyAction({
+      action: 'file:read',
+      resource: '/data/report.json',
+      telemetry: { detection: SAMPLE_DETECTION },
+    });
+
+    expect(joiner.pending).toBe(1);
+    joiner.flushExpired(Date.now() + 120_000);
+    expect(records).toHaveLength(1);
+    expect(records[0].enforcement.decision).toBe('allow');
+    expect(records[0].detection?.techniqueId).toBe('T-2002');
+  });
+});

--- a/sdk/typescript/src/crypto/delegation.test.ts
+++ b/sdk/typescript/src/crypto/delegation.test.ts
@@ -848,3 +848,46 @@ describe('Trust attenuation through delegation hops', () => {
     expect(exported.chain[0].effectiveTrust).toBe(0.95);
   });
 });
+
+describe('Delegation temporal lower bound (AIM-11 item 7)', () => {
+  async function makeFutureWindow() {
+    const root = await generateKeyPair();
+    const agent = await generateKeyPair();
+    return createDelegation({
+      delegatorKeyPair: root,
+      delegatePublicKey: agent.publicKey,
+      scopes: ['search'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+    });
+  }
+
+  it('AIM-11.AC7 verifyDelegation at 1970-01-01 against a delegation created in 2026 returns false', async () => {
+    const d = await makeFutureWindow();
+    expect(await verifyDelegation(d, { verifyAt: '1970-01-01T00:00:00.000Z' })).toBe(false);
+  });
+
+  it('AIM-11.AC7 checkDelegationTemporalValidity refuses an instant before createdAt', async () => {
+    const d = await makeFutureWindow();
+    const res = checkDelegationTemporalValidity(d, '2025-12-31T23:59:59.000Z');
+    expect(res.valid).toBe(false);
+    expect(res.error).toMatch(/not yet valid|createdAt/i);
+  });
+
+  it('AIM-11.AC7 the chain variant refuses an evaluation instant before createdAt', async () => {
+    const d = await makeFutureWindow();
+    const result = await verifyDelegationChain([d], { verifyAt: '1970-01-01T00:00:00.000Z' });
+    expect(result.valid).toBe(false);
+    expect(result.results[0].temporalValid).toBe(false);
+  });
+
+  it('AIM-11.AC7 an instant inside the window still verifies', async () => {
+    const d = await makeFutureWindow();
+    expect(await verifyDelegation(d, { verifyAt: '2027-06-01T00:00:00.000Z' })).toBe(true);
+  });
+
+  it('AIM-11.AC7 the boundary instant createdAt itself is valid (inclusive lower bound)', async () => {
+    const d = await makeFutureWindow();
+    expect(checkDelegationTemporalValidity(d, '2026-01-01T00:00:00.000Z').valid).toBe(true);
+  });
+});

--- a/sdk/typescript/src/crypto/delegation.ts
+++ b/sdk/typescript/src/crypto/delegation.ts
@@ -319,8 +319,10 @@ function resolveVerifyAtMs(verifyAt?: Date | string): number {
  * Evaluate a delegation's signed temporal window (`createdAt`/`expiresAt`)
  * against an evaluation time. Fails closed: a missing or unparseable timestamp,
  * an inverted window (createdAt after expiresAt), or an unparseable evaluation
- * time all return `{ valid: false }`. The expiry bound is exclusive — a
- * delegation is valid strictly before `expiresAt`.
+ * time all return `{ valid: false }`. Both bounds are enforced: an evaluation
+ * instant before `createdAt` is not yet valid (lower bound inclusive), and the
+ * expiry bound is exclusive — a delegation is valid strictly before
+ * `expiresAt`.
  */
 export function checkDelegationTemporalValidity(
   delegation: Pick<Delegation, 'createdAt' | 'expiresAt'>,
@@ -344,6 +346,7 @@ function temporalAtMs(
   if (Number.isNaN(createdMs)) return { valid: false, error: 'Missing or unparseable createdAt timestamp' };
   if (Number.isNaN(expiresMs)) return { valid: false, error: 'Missing or unparseable expiresAt timestamp' };
   if (createdMs > expiresMs) return { valid: false, error: 'Invalid window: createdAt is after expiresAt' };
+  if (atMs < createdMs) return { valid: false, error: 'Delegation is not yet valid (before createdAt)' };
   if (atMs >= expiresMs) return { valid: false, error: 'Delegation has expired' };
   return { valid: true };
 }

--- a/sdk/typescript/src/exceptions.ts
+++ b/sdk/typescript/src/exceptions.ts
@@ -147,9 +147,52 @@ export class SecretsError extends AIMError {
 }
 
 /**
- * Parse API error response
+ * Minimal header lookup — satisfied by the fetch Headers class and by mocks.
  */
-export function parseAPIError(statusCode: number, body: unknown): AIMError {
+export interface HeaderLookup {
+  get(name: string): string | null;
+}
+
+/**
+ * Read the response's Retry-After header as seconds. Accepts the delay-seconds
+ * form and the HTTP-date form (converted to seconds from now); returns
+ * undefined when the header is absent or unparseable.
+ */
+function retryAfterSeconds(headers?: HeaderLookup): number | undefined {
+  const raw = headers?.get?.('retry-after')?.trim();
+  if (!raw) return undefined;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+  return undefined;
+}
+
+/**
+ * Walk an error's cause chain (including AggregateError members, where Node's
+ * fetch buries connection errno) for the first errno-style code.
+ */
+export function unwrapErrnoCode(error: unknown, seen = new Set<unknown>()): string | undefined {
+  let current: unknown = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const err = current as NodeJS.ErrnoException & { cause?: unknown; errors?: unknown[] };
+    if (typeof err.code === 'string' && err.code !== '') return err.code;
+    if (Array.isArray(err.errors)) {
+      for (const member of err.errors) {
+        const code = unwrapErrnoCode(member, seen);
+        if (code) return code;
+      }
+    }
+    current = err.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Parse API error response. When the response headers are supplied, a 429's
+ * Retry-After header takes precedence over the body's retryAfter field.
+ */
+export function parseAPIError(statusCode: number, body: unknown, headers?: HeaderLookup): AIMError {
   const errorBody = body as Record<string, unknown>;
   const message = (errorBody?.message ?? errorBody?.error ?? 'Unknown error') as string;
 
@@ -162,7 +205,7 @@ export function parseAPIError(statusCode: number, body: unknown): AIMError {
       return new NotFoundError('resource', message);
     case 429:
       return new RateLimitError(
-        (errorBody?.retryAfter as number) ?? 60,
+        retryAfterSeconds(headers) ?? (errorBody?.retryAfter as number) ?? 60,
         (errorBody?.limit as number) ?? 0,
         (errorBody?.remaining as number) ?? 0
       );

--- a/sdk/typescript/src/readme-claims.test.ts
+++ b/sdk/typescript/src/readme-claims.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins README/CHANGELOG claims to delivered behaviour (AIM-11 items 3, 7, and
+ * the release invariant).
+ *
+ * Item 3 resolution: the SDK implements no retry logic (measured: no retry
+ * loop, no `retries` config key), so the README must not claim automatic
+ * retries. If retries are ever implemented, rewrite the README and this pin
+ * together, in the same release — a public claim and the code must never
+ * disagree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..');
+const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8');
+const changelog = readFileSync(join(ROOT, 'CHANGELOG.md'), 'utf-8');
+const clientSrc = readFileSync(join(ROOT, 'src', 'client', 'AIMClient.ts'), 'utf-8');
+const typesSrc = readFileSync(join(ROOT, 'src', 'types', 'index.ts'), 'utf-8');
+
+describe('README claims match the code (item 3)', () => {
+  it('AIM-11.AC3 README does not claim automatic retries the client does not implement', () => {
+    // The delivered client has no retry loop and no retry configuration...
+    expect(clientSrc).not.toMatch(/exponential backoff/i);
+    expect(typesSrc).not.toMatch(/\bretries\??:/);
+    // ...so the README must not promise one.
+    expect(readme).not.toMatch(/Automatic Retries/);
+    expect(readme).not.toMatch(/Built-in retry logic/);
+  });
+});
+
+describe('README delegation window claim (item 7)', () => {
+  it('AIM-11.AC7 README documents the enforced not-yet-valid lower bound', () => {
+    expect(readme).toMatch(/not yet valid|before its signed .?createdAt|before `createdAt`/i);
+  });
+});
+
+describe('CHANGELOG release invariant (AIM-11)', () => {
+  it('AIM-11.AC11 the Unreleased section carries an entry per shipped P2 item', () => {
+    const unreleased = changelog.split(/^## \[Unreleased\]/m)[1]?.split(/^## \[/m)[0] ?? '';
+    // One recognizable marker per shipped item (1-9 of the release-test P2 set).
+    expect(unreleased).toMatch(/RFC 6749/); // item 1: token shape
+    expect(unreleased).toMatch(/\/oauth\/token/); // item 2: typed token errors
+    expect(unreleased).toMatch(/Automatic Retries|retry/i); // item 3: claim corrected
+    expect(unreleased).toMatch(/Retry-After/); // item 4
+    expect(unreleased).toMatch(/403/); // item 5: telemetry on wire 403
+    expect(unreleased).toMatch(/ECONNREFUSED|errno/); // item 6: network context
+    expect(unreleased).toMatch(/createdAt/); // item 7: delegation lower bound
+    expect(unreleased).toMatch(/OPENA2A_REGISTRY_URL/); // item 8: GTIN destination
+    expect(unreleased).toMatch(/AIM_AGENT_ID|missing variable/); // item 9: loader naming
+  });
+});

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -236,12 +236,20 @@ export interface AgentCredentials {
 }
 
 /**
- * OAuth token response
+ * OAuth token response. The server may answer in the SDK's historical
+ * camelCase or in the RFC 6749 snake_case wire form; both are read, and every
+ * field is optional at the type level because either spelling may be absent.
  */
 export interface TokenResponse {
-  accessToken: string;
-  tokenType: string;
-  expiresIn: number;
+  accessToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  /** RFC 6749 wire form of accessToken */
+  access_token?: string;
+  /** RFC 6749 wire form of tokenType */
+  token_type?: string;
+  /** RFC 6749 wire form of expiresIn */
+  expires_in?: number;
   scope?: string;
 }
 


### PR DESCRIPTION
Closes the eight findings still open from the TypeScript SDK 1.3.1 release test. Each fix was written red-first: the new test failed against the current code before the change and passes after it. 14 files, 926 insertions, 43 deletions.

- oauth: token responses are read in both RFC 6749 snake_case and camelCase; a missing or unparseable expiry no longer poisons the cache with NaN; non-2xx from /oauth/token surfaces as the typed error family with the body excerpt capped at 500 characters.
- exceptions: RateLimitError.retryAfter honours the Retry-After response header (seconds or HTTP-date); the body field, then 60 s, are fallbacks only.
- client: a wire 403 on /api/v1/verify records a correlated deny enforcement record before rethrowing; NetworkError names the request URL and the errno unwrapped from the fetch cause chain.
- delegation: the signed window's lower bound is enforced; an evaluation instant before createdAt is not yet valid, and the README's claim is now true.
- gtin: submitGTINEvent resolves its destination through resolveRegistryUrl (argument, OPENA2A_REGISTRY_URL, default) instead of a hardcoded production registry.
- oauth: a partial AIM_* credential environment warns naming the missing variables instead of returning the same silent null as a clean environment.
- README: the "Automatic Retries" claim is replaced by what the code does, pinned by a readme-claims test.
- CHANGELOG: one Unreleased entry per item.

Verification on the branch: full SDK vitest suite exit 0; tsc exit 0; static scan clean in scope. Against the base code the 12 new tests fail (3 delegation lower-bound cases, 9 token-handling cases), so each asserts the behaviour it was written for. Every new test binds 127.0.0.1 or stubs fetch; nothing reaches the network.
