### PR TITLE
sdk-ts: disposition the sixteen 1.3.1 release-test P3 findings

### DIFF
--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -161,6 +161,49 @@ they stay in scope if one ever grows an observational side-channel.
   the missing variable(s) instead of presenting exactly like a clean
   environment. (The README half of this finding was already fixed by #451.)
 
+### Fixed — 1.3.1 release-test P3 findings
+
+- **The npm package no longer ships the TypeScript source inside its source
+  maps.** `sourcemap: true` embedded ~2.6 MB of full source (doc comments
+  included) as `sourcesContent` in every published tarball while the README
+  promised "source is not shipped in the npm package". Maps still ship for
+  readable stack traces; `sourcesContent` is stripped, and a packaging test
+  now packs the real tarball and pins the invariant.
+- `aim-arp help` and `aim-arp version` (the bare words) now work like
+  `--help`/`--version`, and `aim-arp telemetry --version` answers with the
+  version instead of "Unknown telemetry subcommand". The internal `arp-guard`
+  CLI accepts the bare words too.
+- `aim-arp telemetry log abc` is now an error instead of silently showing 20
+  records, `log 0` is refused (the count must be a positive integer), and
+  extra positional arguments (`log 5 5`, `status extra`) are errors — matching
+  the strictness the option side already had.
+- Every ARP telemetry request identifies its build: sensor enrollment and
+  purge (right-to-delete) requests now send `User-Agent: OpenA2A-ARP/<version>`
+  like the signature emitter (they previously sent none, logging as "node"),
+  and the causal-denial relay's User-Agent now carries the SDK version.
+- The express and fastify `verifyAction`/`verifyRoute` hooks set
+  `req.aim.agentId` from the verification result, so handlers behind the hook
+  can attribute the request to the verified agent without a separate
+  `getAgent()` round trip.
+- `AIMClient` refuses a nonsensical `timeout`/`enforcementTimeout` (negative,
+  zero, NaN, Infinity) with a `ConfigurationError` at construction, and
+  `registerAgent` refuses an empty or non-string `name` before any request is
+  made.
+- `parseAPIError` caps a server-supplied error message at 512 characters and
+  falls back to "Unknown error" when the body's `message` is not a string —
+  the message lands in logs and terminals verbatim and was previously passed
+  through whole.
+- The local correlated-events telemetry log is created `0600` (owner-only),
+  matching the credential writer; it was `0644`.
+- `LocalVerifier` validates the shape of its trust anchors at construction
+  (`trustedIssuers` an array of strings, `publicKeys` an array of key
+  objects) and throws `ConfigurationError` instead of storing a mis-shaped
+  config that would later fail closed with a misleading denial reason.
+- README: documented that `getAgent()` returns `null` and `getTrustScore()`
+  returns `0` when no credentials are loaded (no request is made), and added
+  the previously undocumented exported clients (`A2AClient`, `SecretsClient`,
+  `OAuthTokenManager`, `CrlCache`) to the API reference.
+
 ## [1.3.1] - 2026-09-02
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -571,12 +571,30 @@ client.setCredentials(saved);
 - `verifyActionLocally(options, atx?)` - Verify an action against a locally-held ATX credential, fully offline
 - `setLocalCredential(atx)` - Cache the resolved ATX credential for offline verification (pass `null` to clear)
 - `getLocalVerifier()` - The configured `LocalVerifier`, or `null` when local verification is not enabled
-- `getAgent()` - Get current agent info
+- `getAgent()` - Get current agent info. Returns `null` — without making any
+  request — when no credentials are loaded, and `null` (rather than throwing)
+  when the lookup fails
 - `updateAgent(updates)` - Update agent metadata
 - `reportCapabilities(capabilities)` - Report agent capabilities
-- `getTrustScore()` - Get current trust score
+- `getTrustScore()` - Get current trust score. Returns `0` when the agent
+  cannot be resolved (no credentials, or the lookup failed), so treat `0` as
+  "unknown", not as a measured score of zero
 - `getCredentials()` - Get stored credentials
 - `setCredentials(credentials)` - Set credentials
+
+### Other exported clients
+
+The package exports more than `AIMClient`. The ones you are most likely to
+reach for:
+
+- `A2AClient` / `createA2AClient` - Agent-to-agent protocol client for
+  caller-initiated messages to a peer agent
+- `SecretsClient` - Identity-native secrets client; usually reached through
+  `client.secrets` rather than constructed directly
+- `OAuthTokenManager` - The token acquisition and caching `AIMClient` uses for
+  its authenticated requests, reusable standalone
+- `CrlCache` - Background-refreshed revocation-list cache that feeds
+  `LocalVerifier` for offline credential verification
 
 ### Types
 

--- a/sdk/typescript/src/arp/cli/aim-arp-argv.test.ts
+++ b/sdk/typescript/src/arp/cli/aim-arp-argv.test.ts
@@ -1,0 +1,118 @@
+/**
+ * AIM-12 items 1 and 3 — the shipped `aim-arp` bin's argv surface.
+ *
+ * Item 1: the release test typed the bare words `help` and `version` (the
+ * spelling every modern CLI accepts) and got "Unknown command" + exit 1; and
+ * `aim-arp telemetry --version` was answered with "Unknown telemetry
+ * subcommand" instead of the version.
+ *
+ * Item 3: `telemetry log abc` silently showed 20 records (parseInt || 20),
+ * `telemetry log 5 5` silently ignored the extra argument, while `log -1` was
+ * refused as an unknown option — an asymmetry where garbage on the left of the
+ * dash errors and garbage on the right is swallowed.
+ *
+ * Same no-exec pattern as telemetry-help-noexec.test.ts: import the dispatch
+ * the thin bin entry calls, drive it with argv arrays, spy the console. No
+ * subprocess, no network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runAimArp } from './aim-arp-main';
+import { SDK_VERSION } from '../../version';
+
+let home: string;
+let savedHome: string | undefined;
+let logLines: string[];
+let errLines: string[];
+
+beforeEach(() => {
+  home = join(mkdtempSync(join(tmpdir(), 'aim-arp-argv-')), 'opena2a-home');
+  savedHome = process.env.OPENA2A_HOME;
+  process.env.OPENA2A_HOME = home;
+  logLines = [];
+  errLines = [];
+  vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    logLines.push(a.join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    errLines.push(a.join(' '));
+  });
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.OPENA2A_HOME;
+  else process.env.OPENA2A_HOME = savedHome;
+  vi.restoreAllMocks();
+  rmSync(join(home, '..'), { recursive: true, force: true });
+});
+
+describe('bare help/version words work like their flag spellings', () => {
+  it('AIM-12.AC3 item 1: bare `help` prints usage and exits 0', async () => {
+    const code = await runAimArp(['help']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('USAGE');
+    expect(errLines.join('\n')).toBe('');
+  });
+
+  it('AIM-12.AC3 item 1: bare `version` prints the version and exits 0', async () => {
+    const code = await runAimArp(['version']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain(`aim-arp v${SDK_VERSION}`);
+    expect(errLines.join('\n')).toBe('');
+  });
+
+  it('AIM-12.AC3 item 1: `telemetry --version` answers with the version, not an unknown-subcommand error', async () => {
+    const code = await runAimArp(['telemetry', '--version']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain(`aim-arp v${SDK_VERSION}`);
+    expect(errLines.join('\n')).not.toContain('Unknown telemetry subcommand');
+  });
+
+  it('an unknown bare word is still an error (the fix adds words, not leniency)', async () => {
+    const code = await runAimArp(['frobnicate']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('frobnicate');
+  });
+});
+
+describe('`telemetry log` validates its count argument instead of silently defaulting', () => {
+  it('AIM-12.AC3 item 3: `log abc` is an error naming the argument, not a silent 20', async () => {
+    const code = await runAimArp(['telemetry', 'log', 'abc']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('abc');
+    expect(logLines.join('\n')).not.toContain('Telemetry audit log');
+  });
+
+  it('AIM-12.AC3 item 3: `log 0` is an error (the count must be a positive integer)', async () => {
+    const code = await runAimArp(['telemetry', 'log', '0']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('0');
+  });
+
+  it('AIM-12.AC3 item 3: `log 5 5` is an error — extra arguments are refused, matching the option side', async () => {
+    const code = await runAimArp(['telemetry', 'log', '5', '5']);
+    expect(code).toBe(1);
+    expect(logLines.join('\n')).not.toContain('Telemetry audit log');
+  });
+
+  it('AIM-12.AC3 item 3: a stray positional on a no-argument subcommand is an error too', async () => {
+    const code = await runAimArp(['telemetry', 'status', 'extra']);
+    expect(code).toBe(1);
+    expect(errLines.join('\n')).toContain('extra');
+    expect(logLines.join('\n')).not.toContain('State:');
+  });
+
+  it('`log 10` still works (validation refuses garbage, not the feature)', async () => {
+    const code = await runAimArp(['telemetry', 'log', '10']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('Telemetry audit log');
+  });
+
+  it('`log` with no count still defaults to 20 records', async () => {
+    const code = await runAimArp(['telemetry', 'log']);
+    expect(code).toBe(0);
+    expect(logLines.join('\n')).toContain('Telemetry audit log');
+  });
+});

--- a/sdk/typescript/src/arp/cli/aim-arp-main.ts
+++ b/sdk/typescript/src/arp/cli/aim-arp-main.ts
@@ -1,0 +1,57 @@
+/**
+ * The shipped `aim-arp` bin's dispatch, split out of the entry file so tests
+ * can drive it through its argv surface — the same split ./telemetry.ts made
+ * for the subcommand table. The entry (./aim-arp.ts) stays a thin auto-running
+ * shell around this function and exports nothing.
+ *
+ * Both the bare words `help`/`version` and their flag spellings are accepted:
+ * the 1.3.1 release test typed the words (the spelling every modern CLI takes)
+ * and was answered with "Unknown command" + exit 1 (AIM-12 item 1).
+ */
+
+import { SDK_VERSION } from '../../version';
+import { loadConfig } from '../index';
+import { runTelemetrySubcommand, TELEMETRY_SUBCOMMANDS } from './telemetry';
+
+function showHelp(): void {
+  console.log(`
+  aim-arp v${SDK_VERSION} — OpenA2A telemetry consent CLI
+
+  USAGE
+    aim-arp telemetry <subcommand>
+    npx @opena2a/aim-sdk telemetry <subcommand>
+
+  SUBCOMMANDS
+    ${TELEMETRY_SUBCOMMANDS.join(', ')}
+
+  Run \`aim-arp telemetry --help\` for what each one does.
+`);
+}
+
+/** Dispatch one argv vector. Returns the process exit code. */
+export async function runAimArp(argv: string[]): Promise<number> {
+  const command = argv[0];
+  switch (command) {
+    case 'telemetry': {
+      // loadConfig never throws on a missing config file; the telemetry
+      // commands only need the optional signatureTelemetry block.
+      const config = loadConfig();
+      return runTelemetrySubcommand(argv[1], argv.slice(2), config.signatureTelemetry);
+    }
+    case 'version':
+    case '--version':
+    case '-v':
+      console.log(`aim-arp v${SDK_VERSION}`);
+      return 0;
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      showHelp();
+      return 0;
+    default:
+      console.error(`Unknown command: ${command}`);
+      showHelp();
+      return 1;
+  }
+}

--- a/sdk/typescript/src/arp/cli/aim-arp.ts
+++ b/sdk/typescript/src/arp/cli/aim-arp.ts
@@ -15,57 +15,14 @@
  * (single-bin resolution), so `npx @opena2a/aim-sdk telemetry status` works
  * without a global install.
  *
- * Thin auto-running entry, nothing importable: the dispatch logic and command
- * table live in ./telemetry.ts, which is what tests exercise.
+ * Thin auto-running entry, nothing importable: the dispatch lives in
+ * ./aim-arp-main.ts and the command table in ./telemetry.ts, which is what
+ * tests exercise.
  */
 
-import { SDK_VERSION } from '../../version';
-import { loadConfig } from '../index';
-import { runTelemetrySubcommand, TELEMETRY_SUBCOMMANDS } from './telemetry';
+import { runAimArp } from './aim-arp-main';
 
-const argv = process.argv.slice(2);
-
-function showHelp(): void {
-  console.log(`
-  aim-arp v${SDK_VERSION} — OpenA2A telemetry consent CLI
-
-  USAGE
-    aim-arp telemetry <subcommand>
-    npx @opena2a/aim-sdk telemetry <subcommand>
-
-  SUBCOMMANDS
-    ${TELEMETRY_SUBCOMMANDS.join(', ')}
-
-  Run \`aim-arp telemetry --help\` for what each one does.
-`);
-}
-
-async function main(): Promise<number> {
-  const command = argv[0];
-  switch (command) {
-    case 'telemetry': {
-      // loadConfig never throws on a missing config file; the telemetry
-      // commands only need the optional signatureTelemetry block.
-      const config = loadConfig();
-      return runTelemetrySubcommand(argv[1], argv.slice(2), config.signatureTelemetry);
-    }
-    case '--version':
-    case '-v':
-      console.log(`aim-arp v${SDK_VERSION}`);
-      return 0;
-    case '--help':
-    case '-h':
-    case undefined:
-      showHelp();
-      return 0;
-    default:
-      console.error(`Unknown command: ${command}`);
-      showHelp();
-      return 1;
-  }
-}
-
-main()
+runAimArp(process.argv.slice(2))
   .then((code) => {
     process.exitCode = code;
   })

--- a/sdk/typescript/src/arp/cli/index.ts
+++ b/sdk/typescript/src/arp/cli/index.ts
@@ -40,10 +40,12 @@ async function main(): Promise<void> {
     case 'telemetry':
       await telemetryCommand();
       break;
+    case 'version':
     case '--version':
     case '-v':
       console.log(`arp-guard v${VERSION}`);
       break;
+    case 'help':
     case '--help':
     case '-h':
     case undefined:

--- a/sdk/typescript/src/arp/cli/telemetry.ts
+++ b/sdk/typescript/src/arp/cli/telemetry.ts
@@ -30,6 +30,7 @@ import {
   optOutMarkerExists,
 } from '../telemetry/signature';
 import type { SignatureTelemetryConfig } from '../types';
+import { SDK_VERSION } from '../../version';
 
 /** The install-facing invocation every user-visible citation uses. */
 export const SHIPPED_INVOCATION = 'aim-arp telemetry';
@@ -268,6 +269,12 @@ export async function runTelemetrySubcommand(
     console.log(telemetryHelpText());
     return 0;
   }
+  // A version request in the subcommand slot is a question about the bin, not
+  // a typo'd subcommand; answer it like the top-level flag does.
+  if (sub === '--version' || sub === '-v') {
+    console.log(`aim-arp v${SDK_VERSION}`);
+    return 0;
+  }
   // A typo'd subcommand is reported as the error even when --help rides
   // along: the typo signal outranks the help shortcut, and nothing executes
   // either way.
@@ -290,9 +297,32 @@ export async function runTelemetrySubcommand(
     console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
     return 1;
   }
+  // Positional arguments are held to the same standard as options. Before
+  // this, `log abc` silently showed 20 records (parseInt || 20 swallowed the
+  // garbage) and `log 5 5` silently ignored the extra argument, while `log -1`
+  // was refused above — garbage left of the dash errored, garbage right of it
+  // was swallowed. `log` takes at most one positional, a positive integer
+  // count; no other subcommand takes any.
+  const positionals = rest.filter((a) => !a.startsWith('-'));
+  if (sub === 'log') {
+    if (positionals.length > 1) {
+      console.error(`  log takes at most one argument, got: ${positionals.join(' ')}`);
+      console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
+      return 1;
+    }
+    if (positionals[0] !== undefined && !/^[1-9]\d*$/.test(positionals[0])) {
+      console.error(`  log expects a positive integer count, got: ${positionals[0]}`);
+      console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
+      return 1;
+    }
+  } else if (positionals.length > 0) {
+    console.error(`  Unexpected argument for ${sub}: ${positionals[0]}`);
+    console.error(`  Run: ${SHIPPED_INVOCATION} --help`);
+    return 1;
+  }
   switch (sub) {
     case 'log':
-      await telemetryLog(rest[0]);
+      await telemetryLog(positionals[0]);
       return 0;
     case 'status':
       await telemetryStatus(tcfg);

--- a/sdk/typescript/src/arp/telemetry/signature/enroll.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/enroll.ts
@@ -37,6 +37,7 @@ import { generateNonce } from './wire';
 import { resolveRegistryUrl, type SignatureTelemetryConfig } from './config';
 import { sanitizeTerminalText } from './sanitize';
 import { opena2aHome, homePath, SENSOR_ENROLLMENT_FILE } from './paths';
+import { VERSION } from '../../index';
 
 /** The enroll canonical schema prefix (distinct from the ingest/purge schemas). */
 export const ENROLL_SCHEMA_VERSION = 'telemetry-enroll-v1';
@@ -157,7 +158,9 @@ export async function enrollSensor(
     try {
       res = await doFetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // Identify the build like the emitter does; without this the registry
+        // logged the runtime default ("node") for enrollment requests.
+        headers: { 'Content-Type': 'application/json', 'User-Agent': `OpenA2A-ARP/${VERSION}` },
         body: JSON.stringify(body),
         signal: controller.signal,
       });

--- a/sdk/typescript/src/arp/telemetry/signature/purge.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/purge.ts
@@ -29,6 +29,7 @@ import { loadSensorPrivateKey, loadSensorId, publicKeyHex, signCanonicalHex } fr
 import { generateNonce } from './wire';
 import { resolveRegistryUrl, type SignatureTelemetryConfig } from './config';
 import { sanitizeTerminalText } from './sanitize';
+import { VERSION } from '../../index';
 
 /** The purge canonical schema prefix (distinct from the ingest schema). */
 export const PURGE_SCHEMA_VERSION = 'telemetry-purge-v1';
@@ -115,7 +116,9 @@ export async function purgeRemoteSignatures(
     try {
       res = await doFetch(url, {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        // Identify the build like the emitter does; without this the registry
+        // logged the runtime default ("node") for right-to-delete requests.
+        headers: { 'Content-Type': 'application/json', 'User-Agent': `OpenA2A-ARP/${VERSION}` },
         body: JSON.stringify(body),
         signal: controller.signal,
       });

--- a/sdk/typescript/src/arp/telemetry/signature/user-agent.test.ts
+++ b/sdk/typescript/src/arp/telemetry/signature/user-agent.test.ts
@@ -1,0 +1,65 @@
+/**
+ * AIM-12 item 7 (enroll/purge half): every ARP telemetry request must identify
+ * its build. The signature emitter sends `User-Agent: OpenA2A-ARP/<VERSION>`,
+ * but enroll and purge sent no User-Agent at all, so the registry logged the
+ * runtime's default ("node") for exactly the two requests that manage a
+ * sensor's identity and its right-to-delete.
+ *
+ * Injected fetch, temp OPENA2A_HOME — nothing leaves the process.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { enrollSensor } from './enroll';
+import { purgeRemoteSignatures } from './purge';
+import { VERSION } from '../../index';
+
+let home: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  home = join(mkdtempSync(join(tmpdir(), 'aim-arp-ua-')), 'opena2a-home');
+  savedHome = process.env.OPENA2A_HOME;
+  process.env.OPENA2A_HOME = home;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.OPENA2A_HOME;
+  else process.env.OPENA2A_HOME = savedHome;
+  vi.restoreAllMocks();
+  rmSync(join(home, '..'), { recursive: true, force: true });
+});
+
+function captureHeaders(): {
+  headers: () => Record<string, string> | undefined;
+  fetchImpl: typeof fetch;
+} {
+  let captured: Record<string, string> | undefined;
+  const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    captured = init?.headers as Record<string, string>;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { headers: () => captured, fetchImpl };
+}
+
+describe('enroll and purge identify their build like the emitter does', () => {
+  it('AIM-12.AC3 item 7: enrollSensor sends User-Agent OpenA2A-ARP/<VERSION>', async () => {
+    const { headers, fetchImpl } = captureHeaders();
+    await enrollSensor(undefined, { fetchImpl });
+    expect(headers()).toBeDefined();
+    expect(headers()!['User-Agent']).toBe(`OpenA2A-ARP/${VERSION}`);
+  });
+
+  it('AIM-12.AC3 item 7: purgeRemoteSignatures sends User-Agent OpenA2A-ARP/<VERSION>', async () => {
+    const { headers, fetchImpl } = captureHeaders();
+    await purgeRemoteSignatures(undefined, { fetchImpl });
+    expect(headers()).toBeDefined();
+    expect(headers()!['User-Agent']).toBe(`OpenA2A-ARP/${VERSION}`);
+  });
+});

--- a/sdk/typescript/src/client/AIMClient.ts
+++ b/sdk/typescript/src/client/AIMClient.ts
@@ -148,6 +148,19 @@ export class AIMClient {
       telemetry: config.telemetry ?? {},
     };
 
+    // A nonsensical time budget fails loudly here, at the call site: a
+    // negative, zero, or NaN timeout otherwise surfaces later as an
+    // instantly-aborted (or never-aborted) request that reads like a network
+    // problem.
+    for (const key of ['timeout', 'enforcementTimeout'] as const) {
+      const value = this.config[key];
+      if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        throw new ConfigurationError(
+          `\`${key}\` must be a positive finite number of milliseconds, got: ${String(value)}`,
+        );
+      }
+    }
+
     const telemetry = this.config.telemetry;
     this.telemetryEnabled = telemetry.enabled === true;
     this.enforcementSource = telemetry.enforcementSource ?? DEFAULT_ENFORCEMENT_SOURCE;
@@ -318,6 +331,12 @@ export class AIMClient {
    * Register a new agent
    */
   async registerAgent(options: RegisterAgentOptions): Promise<Agent> {
+    // The one field the server cannot default is refused here rather than
+    // POSTed for the server to reject (or worse, accept as "").
+    if (typeof options?.name !== 'string' || options.name.trim() === '') {
+      throw new ConfigurationError('registerAgent requires a non-empty string `name`');
+    }
+
     // Generate key pair for the agent
     const keyPair = await generateKeyPair();
     const publicKey = toBase64(keyPair.publicKey);

--- a/sdk/typescript/src/client/AIMClient.validation.test.ts
+++ b/sdk/typescript/src/client/AIMClient.validation.test.ts
@@ -1,0 +1,61 @@
+/**
+ * AIM-12 item 9: the client accepted any `timeout`/`enforcementTimeout`
+ * (-5, NaN, 0 — each producing an immediately-aborting or never-aborting
+ * request budget) and `registerAgent` POSTed whatever it was handed, an empty
+ * name included. Misconfiguration should fail loudly at the call site with a
+ * ConfigurationError, not surface later as a baffling network timeout or a
+ * server-side rejection of a payload the SDK knew was empty.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { AIMClient } from './AIMClient';
+import { ConfigurationError } from '../exceptions';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('constructor timeout validation', () => {
+  it('AIM-12.AC3 item 9: timeout: -5 throws ConfigurationError', () => {
+    expect(() => new AIMClient({ timeout: -5 })).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 9: timeout: NaN throws ConfigurationError', () => {
+    expect(() => new AIMClient({ timeout: Number.NaN })).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 9: timeout: 0 throws ConfigurationError', () => {
+    expect(() => new AIMClient({ timeout: 0 })).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 9: enforcementTimeout: -1 throws ConfigurationError', () => {
+    expect(() => new AIMClient({ enforcementTimeout: -1 })).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 9: enforcementTimeout: Infinity throws ConfigurationError', () => {
+    expect(() => new AIMClient({ enforcementTimeout: Number.POSITIVE_INFINITY })).toThrow(
+      ConfigurationError,
+    );
+  });
+
+  it('valid timeouts still construct (the defaults and every existing positive value)', () => {
+    expect(() => new AIMClient()).not.toThrow();
+    expect(() => new AIMClient({ timeout: 500, enforcementTimeout: 500 })).not.toThrow();
+  });
+});
+
+describe('registerAgent input validation', () => {
+  it('AIM-12.AC3 item 9: an empty name is refused before any request is made', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network must not be touched');
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const client = new AIMClient({ apiKey: 'k', baseUrl: 'http://localhost:9' });
+
+    await expect(client.registerAgent({ name: '' })).rejects.toThrow(ConfigurationError);
+    await expect(client.registerAgent({ name: '   ' })).rejects.toThrow(ConfigurationError);
+    await expect(
+      client.registerAgent({ name: 42 as unknown as string }),
+    ).rejects.toThrow(ConfigurationError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/typescript/src/exceptions.cap.test.ts
+++ b/sdk/typescript/src/exceptions.cap.test.ts
@@ -1,0 +1,32 @@
+/**
+ * AIM-12 item 12: parseAPIError lifted `message` straight out of the response
+ * body with no cap and no type check, so a hostile or broken server could put
+ * megabytes (or an object) into every thrown error's message — the string
+ * that lands in logs, terminals, and error trackers verbatim.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseAPIError, AuthenticationError } from './exceptions';
+
+describe('parseAPIError message hygiene', () => {
+  it('AIM-12.AC3 item 12: a huge body message is capped, not passed through whole', () => {
+    const err = parseAPIError(500, { message: 'x'.repeat(100_000) });
+    expect(err.message.length).toBeLessThanOrEqual(600);
+    expect(err.message).toContain('truncated');
+  });
+
+  it('AIM-12.AC3 item 12: a non-string message falls back to "Unknown error"', () => {
+    const err = parseAPIError(500, { message: { nested: 'object' } });
+    expect(err.message).toBe('Unknown error');
+  });
+
+  it('AIM-12.AC3 item 12: the cap applies on every status branch, 401 included', () => {
+    const err = parseAPIError(401, { error: 'y'.repeat(100_000) });
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message.length).toBeLessThanOrEqual(600);
+  });
+
+  it('a normal short message is untouched', () => {
+    const err = parseAPIError(500, { message: 'quota exceeded' });
+    expect(err.message).toBe('quota exceeded');
+  });
+});

--- a/sdk/typescript/src/exceptions.ts
+++ b/sdk/typescript/src/exceptions.ts
@@ -147,6 +147,13 @@ export class SecretsError extends AIMError {
 }
 
 /**
+ * Cap on a server-supplied error message. The body is attacker/outage
+ * controlled and the message lands in logs, terminals, and error trackers
+ * verbatim, so it is type-checked and capped rather than passed through whole.
+ */
+const MAX_API_ERROR_MESSAGE = 512;
+
+/**
  * Minimal header lookup — satisfied by the fetch Headers class and by mocks.
  */
 export interface HeaderLookup {
@@ -194,7 +201,11 @@ export function unwrapErrnoCode(error: unknown, seen = new Set<unknown>()): stri
  */
 export function parseAPIError(statusCode: number, body: unknown, headers?: HeaderLookup): AIMError {
   const errorBody = body as Record<string, unknown>;
-  const message = (errorBody?.message ?? errorBody?.error ?? 'Unknown error') as string;
+  const raw = errorBody?.message ?? errorBody?.error;
+  let message = typeof raw === 'string' && raw.length > 0 ? raw : 'Unknown error';
+  if (message.length > MAX_API_ERROR_MESSAGE) {
+    message = `${message.slice(0, MAX_API_ERROR_MESSAGE)}… [truncated]`;
+  }
 
   switch (statusCode) {
     case 401:

--- a/sdk/typescript/src/integrations/agent-id-context.test.ts
+++ b/sdk/typescript/src/integrations/agent-id-context.test.ts
@@ -1,0 +1,78 @@
+/**
+ * AIM-12 item 8: a verified request should know WHO was verified. The express
+ * and fastify verifyAction hooks set `aim.verified` and `aim.trustScore` from
+ * the verification result but never `aim.agentId`, so a handler behind the
+ * hook could not attribute the request to the verified agent unless the
+ * separate base middleware had already resolved it (which requires ambient
+ * credentials and a network round trip).
+ */
+import { it, expect, vi } from 'vitest';
+import type { Response, NextFunction } from 'express';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { verifyAction as expressVerifyAction, type AIMRequest } from './express';
+import { verifyAction as fastifyVerifyAction } from './fastify';
+
+const RESULT = {
+  verified: true,
+  agentId: 'agent-42',
+  agentName: 'did:aim:agent-42',
+  trustScore: 0.9,
+  riskLevel: 'low',
+  actionAllowed: true,
+  timestamp: '2026-09-09T00:00:00.000Z',
+};
+
+it('AIM-12.AC3 item 8: express verifyAction sets req.aim.agentId from the verification result', async () => {
+  const client = { verifyAction: vi.fn(async () => ({ ...RESULT })) };
+  const req = {
+    aim: { client, verified: false },
+    path: '/x',
+    method: 'GET',
+    query: {},
+    ip: '127.0.0.1',
+  } as unknown as AIMRequest;
+  const next = vi.fn() as NextFunction;
+  const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+
+  await expressVerifyAction('thing:read')(req, res, next);
+
+  expect(next).toHaveBeenCalled();
+  expect(req.aim?.verified).toBe(true);
+  expect(req.aim?.trustScore).toBe(0.9);
+  expect(req.aim?.agentId).toBe('agent-42');
+});
+
+it('AIM-12.AC3 item 8: fastify verifyAction sets request.aim.agentId from the verification result', async () => {
+  const client = { verifyAction: vi.fn(async () => ({ ...RESULT })) };
+  const request = {
+    aim: { client, verified: false },
+    url: '/x',
+    method: 'GET',
+    query: {},
+    ip: '127.0.0.1',
+  } as unknown as FastifyRequest;
+  const reply = { status: vi.fn().mockReturnThis(), send: vi.fn() } as unknown as FastifyReply;
+
+  await fastifyVerifyAction('thing:read')(request, reply);
+
+  expect(request.aim?.verified).toBe(true);
+  expect(request.aim?.agentId).toBe('agent-42');
+});
+
+it('a result without an agentId leaves the field unset rather than clobbering it with undefined-as-string', async () => {
+  const { agentId: _dropped, ...withoutAgentId } = RESULT;
+  const client = { verifyAction: vi.fn(async () => withoutAgentId) };
+  const req = {
+    aim: { client, verified: false, agentId: 'from-base-middleware' },
+    path: '/x',
+    method: 'GET',
+    query: {},
+    ip: '127.0.0.1',
+  } as unknown as AIMRequest;
+  const next = vi.fn() as NextFunction;
+  const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+
+  await expressVerifyAction('thing:read')(req, res, next);
+
+  expect(req.aim?.agentId).toBe('from-base-middleware');
+});

--- a/sdk/typescript/src/integrations/express.ts
+++ b/sdk/typescript/src/integrations/express.ts
@@ -129,6 +129,11 @@ export function verifyAction(
 
       req.aim.verified = true;
       req.aim.trustScore = result.trustScore;
+      // The verified request knows WHO was verified; a result without an
+      // agentId (older servers) leaves whatever the base middleware resolved.
+      if (result.agentId) {
+        req.aim.agentId = result.agentId;
+      }
 
       next();
     } catch (error) {

--- a/sdk/typescript/src/integrations/fastify.ts
+++ b/sdk/typescript/src/integrations/fastify.ts
@@ -154,6 +154,11 @@ export function verifyAction(
 
       request.aim.verified = true;
       request.aim.trustScore = result.trustScore;
+      // The verified request knows WHO was verified; a result without an
+      // agentId (older servers) leaves whatever the onRequest hook resolved.
+      if (result.agentId) {
+        request.aim.agentId = result.agentId;
+      }
     } catch (error) {
       const failure = classifyVerificationFailure(error);
       if (failure) {

--- a/sdk/typescript/src/local/LocalVerifier.ts
+++ b/sdk/typescript/src/local/LocalVerifier.ts
@@ -41,6 +41,7 @@ export type {
 } from '@opena2a/atx-verify';
 
 import { CrlCache } from './CrlCache';
+import { ConfigurationError } from '../exceptions';
 export { CrlCache } from './CrlCache';
 export type { CrlData, CrlStalePolicy, CrlCacheConfig, CrlCacheStatus } from './CrlCache';
 
@@ -149,6 +150,26 @@ export class LocalVerifier {
   private verifier: AtxVerifier | null = null;
 
   constructor(config: LocalVerificationConfig) {
+    // Trust anchors of the wrong shape must fail loudly here, not later as a
+    // denial whose reason points at the credential. From JavaScript (or a
+    // mis-cast config) a string where an array belongs was stored silently and
+    // every verification failed closed with a misleading reject.
+    if (
+      !Array.isArray(config.trustedIssuers) ||
+      config.trustedIssuers.some((issuer) => typeof issuer !== 'string')
+    ) {
+      throw new ConfigurationError(
+        'localVerification.trustedIssuers must be an array of issuer DID strings',
+      );
+    }
+    if (
+      !Array.isArray(config.publicKeys) ||
+      config.publicKeys.some((key) => typeof key !== 'object' || key === null)
+    ) {
+      throw new ConfigurationError(
+        'localVerification.publicKeys must be an array of AtxPublicKey objects',
+      );
+    }
     this.anchors = {
       trustedIssuers: config.trustedIssuers,
       publicKeys: config.publicKeys,

--- a/sdk/typescript/src/local/LocalVerifier.validation.test.ts
+++ b/sdk/typescript/src/local/LocalVerifier.validation.test.ts
@@ -1,0 +1,67 @@
+/**
+ * AIM-12 item 14: the LocalVerifier constructor stored whatever it was handed.
+ * From JavaScript (or a mis-cast config object) `trustedIssuers: 'did:one'` or
+ * `publicKeys: {...}` was accepted silently and every later verification
+ * failed closed with a misleading reason — or, worse, an anchors object of the
+ * wrong shape behaved differently from what the operator believed they pinned.
+ * Trust anchors are exactly the input that must fail loudly at construction.
+ */
+import { describe, it, expect } from 'vitest';
+import { LocalVerifier } from './LocalVerifier';
+import { ConfigurationError } from '../exceptions';
+
+const KEY = {
+  algorithm: 'Ed25519',
+  publicKeyHex: 'a'.repeat(64),
+};
+
+describe('trust anchors are validated at construction', () => {
+  it('AIM-12.AC3 item 14: a non-array trustedIssuers throws ConfigurationError', () => {
+    expect(
+      () =>
+        new LocalVerifier({
+          trustedIssuers: 'did:aim:issuer' as unknown as string[],
+          publicKeys: [KEY],
+        }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 14: a non-string entry in trustedIssuers throws ConfigurationError', () => {
+    expect(
+      () =>
+        new LocalVerifier({
+          trustedIssuers: [42] as unknown as string[],
+          publicKeys: [KEY],
+        }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 14: a non-array publicKeys throws ConfigurationError', () => {
+    expect(
+      () =>
+        new LocalVerifier({
+          trustedIssuers: ['did:aim:issuer'],
+          publicKeys: { ed25519: 'aa' } as never,
+        }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('AIM-12.AC3 item 14: a non-object publicKeys entry throws ConfigurationError', () => {
+    expect(
+      () =>
+        new LocalVerifier({
+          trustedIssuers: ['did:aim:issuer'],
+          publicKeys: ['aa'] as never,
+        }),
+    ).toThrow(ConfigurationError);
+  });
+
+  it('valid anchors still construct — including the deliberate empty-trustedIssuers case the suite pins', () => {
+    expect(
+      () => new LocalVerifier({ trustedIssuers: [], publicKeys: [KEY] }),
+    ).not.toThrow();
+    expect(
+      () => new LocalVerifier({ trustedIssuers: ['did:aim:issuer'], publicKeys: [KEY] }),
+    ).not.toThrow();
+  });
+});

--- a/sdk/typescript/src/telemetry/local-writer.mode.test.ts
+++ b/sdk/typescript/src/telemetry/local-writer.mode.test.ts
@@ -1,0 +1,51 @@
+/**
+ * AIM-12 item 13: the correlated-events log is created with the process
+ * default mode (0644 under the usual umask) while every other sensitive file
+ * this SDK writes — credentials (oauth.ts), the sensor id — is created 0600.
+ * The log carries agent ids, denied reasons, and resource paths; it must not
+ * be group/world readable.
+ */
+import { it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeCorrelatedRecord } from './local-writer';
+import { buildCorrelatedRecord } from './correlated-record';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it('AIM-12.AC3 item 13: a freshly created correlated-events log is not group/world readable', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cde-mode-'));
+  tmpDirs.push(dir);
+
+  const ok = writeCorrelatedRecord(
+    buildCorrelatedRecord({
+      correlationId: 'cde_000000000_aabbccddeeff',
+      agentId: 'agent-1',
+      enforcement: {
+        decision: 'deny',
+        outcome: 'DENY_INTENT',
+        capability: 'net:connect',
+        resource: 'https://example.invalid/x',
+        deniedReason: 'blocked',
+        occurredAt: '2026-06-06T00:00:01.000Z',
+        source: 'aim-pdp',
+      },
+    }),
+    dir,
+  );
+  expect(ok).toBe(true);
+
+  const mode = fs.statSync(path.join(dir, 'correlated-events.jsonl')).mode & 0o777;
+  expect(
+    mode & 0o077,
+    `correlated-events.jsonl was created mode 0${mode.toString(8)}; ` +
+      'group/other bits must be clear, matching the 0600 the credential writer uses',
+  ).toBe(0);
+});

--- a/sdk/typescript/src/telemetry/local-writer.ts
+++ b/sdk/typescript/src/telemetry/local-writer.ts
@@ -87,7 +87,11 @@ export function writeCorrelatedRecord(
     fs.mkdirSync(dataDir, { recursive: true });
     const filePath = path.join(dataDir, CORRELATED_FILE);
     rotateIfNeeded(filePath);
-    fs.appendFileSync(filePath, serialized + '\n', 'utf-8');
+    // 0600 at creation: the log carries agent ids, denial reasons, and
+    // resource paths, and every other sensitive file this SDK writes
+    // (credentials, the sensor id) is owner-only. Append mode is unchanged
+    // for a file that already exists.
+    fs.appendFileSync(filePath, serialized + '\n', { encoding: 'utf-8', mode: 0o600 });
     return true;
   } catch {
     return false;

--- a/sdk/typescript/src/telemetry/relay-user-agent.test.ts
+++ b/sdk/typescript/src/telemetry/relay-user-agent.test.ts
@@ -1,0 +1,71 @@
+/**
+ * AIM-12 item 7 (relay half): the causal-denial relay sent a bare
+ * `User-Agent: OpenA2A-AIM-SDK-Relay` with no version, so the registry could
+ * not attribute an uploaded indicator to the SDK build that produced it —
+ * the same defect the frozen `OpenA2A-ARP/0.2.0` header was (arp/index.ts).
+ */
+import { it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CorrelatedRelay } from './relay';
+import { writeCorrelatedRecord } from './local-writer';
+import { buildCorrelatedRecord } from './correlated-record';
+import { SDK_VERSION } from '../version';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it('AIM-12.AC3 item 7: the relay User-Agent carries the SDK version', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cde-relay-ua-'));
+  tmpDirs.push(dir);
+  writeCorrelatedRecord(
+    buildCorrelatedRecord({
+      correlationId: 'cde_000000000_aabbccddeeff',
+      agentId: 'agent-1',
+      enforcement: {
+        decision: 'deny',
+        outcome: 'DENY_INTENT',
+        capability: 'net:connect',
+        resource: 'https://example.invalid/x',
+        deniedReason: 'blocked',
+        occurredAt: '2026-06-06T00:00:01.000Z',
+        source: 'aim-pdp',
+      },
+      detection: {
+        injectionDetected: true,
+        attackClass: 'injection',
+        detector: 'guard',
+        detectedAt: '2026-06-06T00:00:01.000Z',
+      },
+      intent: { intentClass: 'exfiltration', confidence: 0.7, blocked: true, source: 'intent' },
+    }),
+    dir,
+  );
+
+  let headers: Record<string, string> | undefined;
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    headers = init.headers as Record<string, string>;
+    return {
+      ok: true,
+      status: 201,
+      json: async () => ({}),
+      text: async () => '',
+    } as unknown as Response;
+  });
+  const relay = new CorrelatedRelay({
+    enabled: true,
+    dataDir: dir,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  const res = await relay.flushOnce();
+
+  expect(res.uploaded).toBe(1);
+  expect(headers).toBeDefined();
+  expect(headers!['User-Agent']).toBe(`OpenA2A-AIM-SDK-Relay/${SDK_VERSION}`);
+});

--- a/sdk/typescript/src/telemetry/relay.ts
+++ b/sdk/typescript/src/telemetry/relay.ts
@@ -35,6 +35,7 @@ import {
   type SharedIndicatorContext,
 } from './correlated-record';
 import { readCorrelatedRecords } from './local-writer';
+import { SDK_VERSION } from '../version';
 
 /** Default Registry base URL (shared with hackmyagent's GTIN forwarder). */
 export const DEFAULT_REGISTRY_URL = 'https://api.oa2a.org';
@@ -431,7 +432,10 @@ export class CorrelatedRelay {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': 'OpenA2A-AIM-SDK-Relay',
+          // Versioned so the registry can attribute an indicator to the SDK
+          // build that produced it — the unversioned form repeated the frozen
+          // OpenA2A-ARP/0.2.0 defect (see src/arp/index.ts).
+          'User-Agent': `OpenA2A-AIM-SDK-Relay/${SDK_VERSION}`,
         },
         body: JSON.stringify(body),
         signal: controller.signal,

--- a/sdk/typescript/tests/packaging-sourcemaps.test.ts
+++ b/sdk/typescript/tests/packaging-sourcemaps.test.ts
@@ -1,0 +1,96 @@
+/**
+ * AIM-12 item 6: README.md claims "source is not shipped in the npm package",
+ * but `tsup.config.ts` shipped `sourcemap: true` with esbuild's default of
+ * embedding every input file into the maps' `sourcesContent` — ~2.6 MB of the
+ * full TypeScript source, including doc comments (among them the deliberately
+ * quoted `OpenA2A-ARP/0.2.0` docstring in src/arp/index.ts), in every tarball.
+ *
+ * The delivered invariant: source maps still ship (stack traces stay mapped),
+ * but no `.map` in the packed tarball carries a `sourcesContent` array, so the
+ * README sentence is true again and the docstring literal dies with the
+ * embedded sources.
+ *
+ * This packs the real tarball: `npm run build` + `npm pack` (both offline),
+ * extract, and inspect every `.map`.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const PKG_ROOT = path.join(__dirname, '..');
+
+let workDir: string;
+let packageDir: string;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aim-sdk-pack-'));
+  execFileSync('npm', ['run', 'build'], { cwd: PKG_ROOT, stdio: 'pipe' });
+  // npm pack writes staging files into the configured npm cache; point it at a
+  // writable temp dir so the test also runs where the shared cache is read-only.
+  const packOut = execFileSync(
+    'npm',
+    ['pack', '--pack-destination', workDir],
+    {
+      cwd: PKG_ROOT,
+      stdio: 'pipe',
+      env: { ...process.env, npm_config_cache: path.join(workDir, 'npm-cache') },
+    },
+  )
+    .toString()
+    .trim();
+  const tarball = path.join(workDir, packOut.split('\n').pop()!.trim());
+  execFileSync('tar', ['-xzf', tarball, '-C', workDir], { stdio: 'pipe' });
+  packageDir = path.join(workDir, 'package');
+}, 300_000);
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('the packed tarball does not embed the TypeScript source', () => {
+  it('AIM-12.AC2 no .map in the npm tarball carries a sourcesContent array', () => {
+    const maps = walk(packageDir).filter((f) => f.endsWith('.map'));
+    // Non-vacuity: maps must still ship at all — the fix strips the embedded
+    // sources, it does not turn source maps off.
+    expect(maps.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const map of maps) {
+      const parsed = JSON.parse(fs.readFileSync(map, 'utf-8')) as {
+        sourcesContent?: unknown[];
+      };
+      if (Array.isArray(parsed.sourcesContent) && parsed.sourcesContent.length > 0) {
+        offenders.push(path.relative(packageDir, map));
+      }
+    }
+    expect(
+      offenders,
+      'These shipped maps embed the full source via sourcesContent, ' +
+        'contradicting README.md ("source is not shipped in the npm package"):\n' +
+        offenders.map((o) => `  - ${o}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('AIM-12.AC2 the frozen OpenA2A-ARP/0.2.0 docstring literal does not ride into any shipped map', () => {
+    // The literal is deliberately quoted in source docstrings
+    // (src/arp/index.ts, version.test.ts documents the rule). It reached the
+    // tarball only inside sourcesContent; with embedded sources gone it must
+    // not appear in any map.
+    const maps = walk(packageDir).filter((f) => f.endsWith('.map'));
+    const carriers = maps.filter((m) =>
+      fs.readFileSync(m, 'utf-8').includes('OpenA2A-ARP/0.2.0'),
+    );
+    expect(carriers.map((c) => path.relative(packageDir, c))).toEqual([]);
+  });
+});

--- a/sdk/typescript/tsup.config.ts
+++ b/sdk/typescript/tsup.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
   dts: true,
   splitting: false,
   sourcemap: true,
+  // Maps ship for readable stack traces, but WITHOUT embedded sources:
+  // README.md promises "source is not shipped in the npm package", and
+  // esbuild's default sourcesContent put ~2.6 MB of the full TypeScript
+  // source (doc comments included) into every published tarball.
+  // tests/packaging-sourcemaps.test.ts pins the packed artifact.
+  esbuildOptions(options) {
+    options.sourcesContent = false;
+  },
   clean: true,
   treeshake: true,
   minify: false,


### PR DESCRIPTION
Disposes of the sixteen P3 findings from the TypeScript SDK 1.3.1 release test: nine fixed with red-first tests, two narrowed in the README, five declined with written reasons. 25 files under sdk/typescript, 885 insertions, 56 deletions.

Fixed (each pinned by a test that fails on the current code):
- Shipped source maps no longer embed TypeScript source (esbuild sourcesContent off); a packaging test packs the real tarball and asserts it, so the README's "source is not shipped" claim is true again.
- aim-arp accepts bare `help` and `version`; the dispatch moved into an importable module so tests drive it without spawning; `telemetry --version` answers with the version.
- `telemetry log` validates its count and every subcommand refuses stray positionals.
- enroll and purge send `User-Agent: OpenA2A-ARP/<version>`; the relay's user agent is versioned.
- The express and fastify `verifyAction` middleware set the request's agent id from the verification result.
- AIMClient refuses non-positive or non-finite timeouts at construction and an empty agent name before any request.
- parseAPIError caps server-supplied messages at 512 characters and falls back to "Unknown error" for a non-string message.
- The correlated-events log is created with mode 0600.
- LocalVerifier validates the shape of its trust anchors at construction.

Narrowed in the README: `getAgent` returning null and `getTrustScore` returning 0 without credentials are documented; A2AClient, SecretsClient, OAuthTokenManager and CrlCache are added to the API reference.

Declined, with the reason in the disposition table below: single-screen help is the deliberate design; the remaining item 4 sub-items are compile-time-typed API misuse; the peek/load split is the documented design; item 10 is owned by the open P2 change; both malformed-200 paths already fail closed.

Verification on the branch: full SDK vitest suite exit 0, tsc exit 0, static scan clean in scope. Against the base code the 21 new test cases fail and the aim-arp argv test cannot import (the module is new), so each asserts the behaviour it was written for.
