### PR TITLE
sdk-python: console output uses [OK] and [FAIL] instead of check-mark characters

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the AIM Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Console output no longer uses U+2713 CHECK MARK / U+2717 BALLOT X**
+  (AIM-15). The 52 lines across 10 modules (`console`, `client`, `oauth`,
+  `credentials`, `secure_storage`, and the CrewAI, LangChain and MCP
+  integrations) that printed those marks now print the plain-text markers
+  `[OK]` and `[FAIL]` instead; where rich is available the markers keep the
+  same green/red markup as before. The no-emoji test suite's package-source
+  walk no longer exempts these characters, so they cannot return; its
+  non-vacuity control now asserts the `[OK]`/`[FAIL]` vocabulary is present
+  instead of the old marks. Documentation prose showing pre-change output is
+  unchanged and out of this change's scope.
+
 ## [2.0.2] - 2026-09-08
 
 ### Security

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -2982,7 +2982,7 @@ class AIMClient:
 
             # SECURITY: Never print private keys - they're saved to secure file storage
             # Credentials are stored in ~/.aim/agents/{name}.json with 0600 permissions
-            print(f"✓ Created agent: {new_agent['id']}")
+            print(f"[OK] Created agent: {new_agent['id']}")
             print(f"Credentials saved to: ~/.aim/agents/{name}.json")
 
         Raises:
@@ -4731,7 +4731,7 @@ def register_agent(
     if capabilities:
         registration_data["capabilities"] = capabilities
     if tags:
-        registration_data["tagIds"] = tags  # ✓ Tags applied during registration
+        registration_data["tagIds"] = tags  # Tags applied during registration
 
     # 5. Register agent (mode-specific endpoint)
     try:

--- a/sdk/python/aim_sdk/console.py
+++ b/sdk/python/aim_sdk/console.py
@@ -131,7 +131,7 @@ class AIMConsole:
 
         # Build compact output lines
         self.console.print()
-        self.console.print(f"[bold green]✓[/] [bold]Agent registered:[/] [cyan]{name}[/]")
+        self.console.print(rf"[bold green]\[OK][/] [bold]Agent registered:[/] [cyan]{name}[/]")
 
         # Details in a compact grid format
         id_short = f"{agent_id[:8]}...{agent_id[-4:]}"
@@ -160,7 +160,7 @@ class AIMConsole:
         """Simple formatted agent registration output."""
         print()
         print("╭─────────────────────────────────────────────────╮")
-        print("│  ✓ Agent Registered                             │")
+        print("│  [OK] Agent Registered                          │")
         print("├─────────────────────────────────────────────────┤")
         print(f"│  Agent:       {name:<32} │")
         print(f"│  ID:          {agent_id[:8]}...{agent_id[-4:]:<20} │")
@@ -270,9 +270,9 @@ class AIMConsole:
         color = risk_colors.get(risk_level, "white")
 
         if RICH_AVAILABLE:
-            self.console.print(f"  [green]✓[/] Registered [cyan]{capability}[/] [{color}]({risk_level})[/]")
+            self.console.print(rf"  [green]\[OK][/] Registered [cyan]{capability}[/] [{color}]({risk_level})[/]")
         else:
-            print(f"  ✓ Registered {capability} ({risk_level})")
+            print(f"  [OK] Registered {capability} ({risk_level})")
 
     def capability_verified(self, capability: str, status: str, duration_ms: Optional[float] = None):
         """Display capability verification result."""
@@ -283,13 +283,13 @@ class AIMConsole:
 
         if RICH_AVAILABLE:
             if status in ("approved", "auto-approved"):
-                self.console.print(f"  [green]✓[/] [cyan]{capability}[/] verified{duration_str}")
+                self.console.print(rf"  [green]\[OK][/] [cyan]{capability}[/] verified{duration_str}")
             elif status == "denied":
-                self.console.print(f"  [red]✗[/] [cyan]{capability}[/] denied{duration_str}")
+                self.console.print(rf"  [red]\[FAIL][/] [cyan]{capability}[/] denied{duration_str}")
             else:
                 self.console.print(f"  [yellow]○[/] [cyan]{capability}[/] {status}{duration_str}")
         else:
-            icon = "✓" if status in ("approved", "auto-approved") else "✗" if status == "denied" else "○"
+            icon = "[OK]" if status in ("approved", "auto-approved") else "[FAIL]" if status == "denied" else "○"
             print(f"  {icon} {capability} {status}{duration_str}")
 
     # ═══════════════════════════════════════════════════════════════════════════
@@ -353,9 +353,9 @@ class AIMConsole:
             return
 
         if RICH_AVAILABLE:
-            self.console.print(f"  [bold green]✓[/] [cyan]{capability}[/] [green]approved[/] - executing...")
+            self.console.print(rf"  [bold green]\[OK][/] [cyan]{capability}[/] [green]approved[/] - executing...")
         else:
-            print(f"  ✓ {capability} approved - executing...")
+            print(f"  [OK] {capability} approved - executing...")
 
     def jit_unverified(self, capability: str):
         """Display that the action is proceeding WITHOUT a completed approval.
@@ -386,9 +386,9 @@ class AIMConsole:
         # sanitised decision.reason, but a future caller may not.
         reason_str = f" - {_strip_control_bytes(reason)}" if reason else ""
         if RICH_AVAILABLE:
-            self.console.print(f"  [bold red]✗[/] [cyan]{capability}[/] [red]denied[/]{reason_str}")
+            self.console.print(rf"  [bold red]\[FAIL][/] [cyan]{capability}[/] [red]denied[/]{reason_str}")
         else:
-            print(f"  ✗ {capability} denied{reason_str}")
+            print(f"  [FAIL] {capability} denied{reason_str}")
 
     # ═══════════════════════════════════════════════════════════════════════════
     # AUTO-DETECTION
@@ -400,9 +400,9 @@ class AIMConsole:
             return
 
         if RICH_AVAILABLE:
-            self.console.print(f"  [green]✓[/] {detection_type}: [bold]{detected}[/] [dim]({reason})[/]")
+            self.console.print(rf"  [green]\[OK][/] {detection_type}: [bold]{detected}[/] [dim]({reason})[/]")
         else:
-            print(f"  ✓ {detection_type}: {detected} ({reason})")
+            print(f"  [OK] {detection_type}: {detected} ({reason})")
 
     def detection_none(self, detection_type: str, fallback: Optional[str] = None):
         """Display when nothing was detected."""
@@ -429,11 +429,11 @@ class AIMConsole:
         message = _strip_control_bytes(message)
         details = _strip_control_bytes(details) if details else details
         if RICH_AVAILABLE:
-            self.console.print(f"[bold red]✗ Error:[/] {message}")
+            self.console.print(rf"[bold red]\[FAIL] Error:[/] {message}")
             if details:
                 self.console.print(f"  [dim]{details}[/]")
         else:
-            print(f"✗ Error: {message}")
+            print(f"[FAIL] Error: {message}")
             if details:
                 print(f"  {details}")
 
@@ -470,9 +470,9 @@ class AIMConsole:
     def success(self, message: str):
         """Display success message."""
         if RICH_AVAILABLE:
-            self.console.print(f"[bold green]✓[/] {message}")
+            self.console.print(rf"[bold green]\[OK][/] {message}")
         else:
-            print(f"✓ {message}")
+            print(f"[OK] {message}")
 
     def debug(self, message: str):
         """Display debug message (only when not in quiet mode and DEBUG env is set)."""

--- a/sdk/python/aim_sdk/credentials.py
+++ b/sdk/python/aim_sdk/credentials.py
@@ -306,7 +306,7 @@ def _migrate_sdk_credentials(credentials: Dict[str, Any]) -> None:
     """Migrate SDK credentials from legacy to new location."""
     try:
         save_sdk_credentials(credentials)
-        print(f"✓ SDK credentials migrated to {SDK_CREDENTIALS_FILE}")
+        print(f"[OK] SDK credentials migrated to {SDK_CREDENTIALS_FILE}")
     except Exception:
         pass
 
@@ -499,13 +499,13 @@ def _migrate_legacy_agent_credentials(data: Dict[str, Any]) -> None:
         for key, value in data.items():
             if isinstance(value, dict) and ("agent_id" in value or "private_key" in value):
                 save_agent_credentials(key, value)
-                print(f"✓ Agent '{key}' credentials migrated to {AGENTS_DIR}")
+                print(f"[OK] Agent '{key}' credentials migrated to {AGENTS_DIR}")
 
         # Check for flat format with name field
         if "agent_id" in data or "private_key" in data:
             name = data.get("name") or data.get("agent_name") or "default"
             save_agent_credentials(name, data)
-            print(f"✓ Agent '{name}' credentials migrated to {AGENTS_DIR}")
+            print(f"[OK] Agent '{name}' credentials migrated to {AGENTS_DIR}")
 
     except Exception as e:
         print(f"Warning: Failed to migrate agent credentials: {e}")
@@ -519,7 +519,7 @@ def print_sdk_credentials_not_found_error(aim_url: str = "http://localhost:8080"
     """Print a clear error message when SDK credentials are not found."""
     print()
     print("=" * 72)
-    print("✗ SDK CREDENTIALS NOT FOUND")
+    print("[FAIL] SDK CREDENTIALS NOT FOUND")
     print("=" * 72)
     print()
     print("No SDK authentication credentials found.")

--- a/sdk/python/aim_sdk/integrations/crewai/callbacks.py
+++ b/sdk/python/aim_sdk/integrations/crewai/callbacks.py
@@ -84,7 +84,7 @@ class AIMTaskCallback:
             output: Task output/result
         """
         if self.verbose:
-            print(f"✓ AIM: Task completed")
+            print(f"[OK] AIM: Task completed")
 
         # Log to AIM
         try:
@@ -109,7 +109,7 @@ class AIMTaskCallback:
             )
 
             if self.verbose:
-                print("✓ AIM: Task completion logged")
+                print("[OK] AIM: Task completion logged")
 
         except Exception as e:
             if self.verbose:
@@ -127,7 +127,7 @@ class AIMTaskCallback:
             task_desc = "unknown task"
             if task:
                 task_desc = getattr(task, 'description', 'unknown task')
-            print(f"✗ AIM: Task failed - {task_desc[:50]}: {error}")
+            print(f"[FAIL] AIM: Task failed - {task_desc[:50]}: {error}")
 
         # Log error to AIM
         try:
@@ -144,7 +144,7 @@ class AIMTaskCallback:
             )
 
             if self.verbose:
-                print("✓ AIM: Task failure logged")
+                print("[OK] AIM: Task failure logged")
 
         except Exception as e:
             if self.verbose:

--- a/sdk/python/aim_sdk/integrations/crewai/wrapper.py
+++ b/sdk/python/aim_sdk/integrations/crewai/wrapper.py
@@ -141,7 +141,7 @@ class AIMCrewWrapper:
         verification_id = verification_result.get("verification_id")
 
         if self.verbose:
-            print(f"✓ AIM: Crew execution verified (id: {verification_id})")
+            print(f"[OK] AIM: Crew execution verified (id: {verification_id})")
 
         # Execute crew
         try:
@@ -164,7 +164,7 @@ class AIMCrewWrapper:
                         print(f"Warning: AIM result logging error: {e}")
 
             if self.verbose:
-                print("✓ AIM: Crew execution completed and logged")
+                print("[OK] AIM: Crew execution completed and logged")
 
             return result
 
@@ -182,7 +182,7 @@ class AIMCrewWrapper:
                         print(f"Warning: AIM result logging error: {log_error}")
 
             if self.verbose:
-                print(f"✗ AIM: Crew execution failed: {e}")
+                print(f"[FAIL] AIM: Crew execution failed: {e}")
 
             raise
 
@@ -229,7 +229,7 @@ class AIMCrewWrapper:
         verification_id = verification_result.get("verification_id")
 
         if self.verbose:
-            print(f"✓ AIM: Async crew execution verified (id: {verification_id})")
+            print(f"[OK] AIM: Async crew execution verified (id: {verification_id})")
 
         # Execute crew asynchronously
         try:
@@ -252,7 +252,7 @@ class AIMCrewWrapper:
                         print(f"Warning: AIM result logging error: {e}")
 
             if self.verbose:
-                print("✓ AIM: Async crew execution completed and logged")
+                print("[OK] AIM: Async crew execution completed and logged")
 
             return result
 
@@ -270,7 +270,7 @@ class AIMCrewWrapper:
                         print(f"Warning: AIM result logging error: {log_error}")
 
             if self.verbose:
-                print(f"✗ AIM: Async crew execution failed: {e}")
+                print(f"[FAIL] AIM: Async crew execution failed: {e}")
 
             raise
 

--- a/sdk/python/aim_sdk/integrations/langchain/callback.py
+++ b/sdk/python/aim_sdk/integrations/langchain/callback.py
@@ -147,7 +147,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         tool_name = tool_data["tool_name"]
 
         if self.verbose:
-            print(f"✓ AIM: Tool completed - {tool_name}")
+            print(f"[OK] AIM: Tool completed - {tool_name}")
 
         # Log successful tool execution to AIM
         try:
@@ -192,7 +192,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
         tool_name = tool_data["tool_name"]
 
         if self.verbose:
-            print(f"✗ AIM: Tool failed - {tool_name}: {str(error)[:100]}")
+            print(f"[FAIL] AIM: Tool failed - {tool_name}: {str(error)[:100]}")
 
         # Log error to AIM
         if self.log_errors:
@@ -244,7 +244,7 @@ class AIMCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Called when a chain ends (optional - for chain-level logging)"""
         if self.verbose:
-            print(f"✓ AIM: Chain completed")
+            print(f"[OK] AIM: Chain completed")
 
     def on_chain_error(
         self,
@@ -255,4 +255,4 @@ class AIMCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Called when a chain fails (optional - for chain-level logging)"""
         if self.verbose:
-            print(f"✗ AIM: Chain failed - {str(error)[:100]}")
+            print(f"[FAIL] AIM: Chain failed - {str(error)[:100]}")

--- a/sdk/python/aim_sdk/integrations/mcp/registration.py
+++ b/sdk/python/aim_sdk/integrations/mcp/registration.py
@@ -575,7 +575,7 @@ def attest_mcp_server(
             # Use discovered capabilities
             capabilities_found = discovery_result.tool_names
             connection_latency_ms = discovery_result.connection_latency_ms
-            print(f"✓ Discovered {len(capabilities_found)} tools: {capabilities_found}")
+            print(f"[OK] Discovered {len(capabilities_found)} tools: {capabilities_found}")
 
     # Validate capabilities are provided
     if not capabilities_found:
@@ -642,9 +642,9 @@ def attest_mcp_server(
     )
 
     if challenge:
-        print(f"✓ Attestation submitted with proof of key possession")
+        print(f"[OK] Attestation submitted with proof of key possession")
     else:
-        print(f"✓ Attestation submitted (legacy mode, no challenge)")
+        print(f"[OK] Attestation submitted (legacy mode, no challenge)")
 
     # Add discovery information to response if auto_discover was used
     if discovery_result and not discovery_result.error:

--- a/sdk/python/aim_sdk/integrations/mcp/verification.py
+++ b/sdk/python/aim_sdk/integrations/mcp/verification.py
@@ -229,11 +229,11 @@ class MCPActionWrapper:
             verification_id = verification.get("verification_id")
 
             if self.verbose:
-                print(f"✓ AIM: Tool verified (id: {verification_id})")
+                print(f"[OK] AIM: Tool verified (id: {verification_id})")
 
         except Exception as e:
             if self.verbose:
-                print(f"✗ AIM: Verification failed: {e}")
+                print(f"[FAIL] AIM: Verification failed: {e}")
             raise
 
         # Execute tool
@@ -250,7 +250,7 @@ class MCPActionWrapper:
                 )
 
             if self.verbose:
-                print(f"✓ AIM: Tool execution completed and logged")
+                print(f"[OK] AIM: Tool execution completed and logged")
 
             return result
 
@@ -265,6 +265,6 @@ class MCPActionWrapper:
                 )
 
             if self.verbose:
-                print(f"✗ AIM: Tool execution failed: {e}")
+                print(f"[FAIL] AIM: Tool execution failed: {e}")
 
             raise

--- a/sdk/python/aim_sdk/oauth.py
+++ b/sdk/python/aim_sdk/oauth.py
@@ -368,7 +368,7 @@ class OAuthTokenManager:
                                         self.credentials['sdkTokenId'] = new_token_id
 
                                 self.save_credentials(self.credentials)
-                                print("✓ Token recovered automatically! SDK credentials updated.")
+                                print("[OK] Token recovered automatically! SDK credentials updated.")
                                 print("No need to re-download the SDK - everything just works!")
 
                                 # Decode new access token expiry using PyJWT
@@ -527,7 +527,7 @@ class OAuthTokenManager:
             self.access_token = None
             self.access_token_expiry = None
 
-            print("✓ Token revoked and credentials deleted")
+            print("[OK] Token revoked and credentials deleted")
             return True
 
         except Exception as e:

--- a/sdk/python/aim_sdk/secure_storage.py
+++ b/sdk/python/aim_sdk/secure_storage.py
@@ -60,7 +60,7 @@ class SecureCredentialStorage:
                 missing.append("keyring")
 
             raise RuntimeError(
-                f"✗ SECURITY ERROR: Required packages not installed: {', '.join(missing)}\n"
+                f"SECURITY ERROR: Required packages not installed: {', '.join(missing)}\n"
                 f"   AIM SDK REQUIRES secure credential storage.\n"
                 f"   Install with: pip install {' '.join(missing)}\n"
                 f"   We do NOT support insecure plaintext storage."
@@ -98,7 +98,7 @@ class SecureCredentialStorage:
 
         except Exception as e:
             raise RuntimeError(
-                f"✗ SECURITY ERROR: Failed to access system keyring: {e}\n"
+                f"SECURITY ERROR: Failed to access system keyring: {e}\n"
                 f"   AIM SDK requires secure credential storage.\n"
                 f"   Please check your system keyring configuration."
             )
@@ -146,7 +146,7 @@ class SecureCredentialStorage:
                 return credentials
             except Exception as e:
                 raise RuntimeError(
-                    f"✗ SECURITY ERROR: Failed to decrypt credentials: {e}\n"
+                    f"SECURITY ERROR: Failed to decrypt credentials: {e}\n"
                     f"   Credentials may be corrupted or encryption key changed.\n"
                     f"   You may need to re-register with AIM."
                 )
@@ -164,7 +164,7 @@ class SecureCredentialStorage:
                 self.save_credentials(credentials)
 
                 # Plaintext file already deleted by save_credentials()
-                print(f"✓ Credentials migrated successfully to encrypted storage.")
+                print(f"[OK] Credentials migrated successfully to encrypted storage.")
 
                 return credentials
 
@@ -223,11 +223,11 @@ class SecureCredentialStorage:
             # Save encrypted
             self.save_credentials(credentials)
 
-            print("✓ Successfully migrated credentials to encrypted storage")
+            print("[OK] Successfully migrated credentials to encrypted storage")
             return True
 
         except Exception as e:
-            print(f"✗ Failed to migrate credentials: {e}")
+            print(f"[FAIL] Failed to migrate credentials: {e}")
             return False
 
 

--- a/sdk/python/tests/test_no_emoji_in_console_output.py
+++ b/sdk/python/tests/test_no_emoji_in_console_output.py
@@ -1,17 +1,28 @@
-"""User-facing output carries no emoji-class characters (#391).
+"""User-facing output carries no emoji-class characters (#391, AIM-15).
 
 Enumerates the shipped package from disk rather than checking known sites, so a
 NEW emoji added to a NEW file fails this test. Checking only the files that were
 once wrong is how the class comes back.
 
-Scope is the issue's: U+23F3, U+26A0 (bare and with the U+FE0F variation
-selector that forces colour-emoji presentation), U+2139. The house-style marks
-the issue explicitly exempts -- U+2713, U+2717, U+25CB, box drawing -- are
-asserted PRESENT below, so a future "sweep" cannot pass this file by deleting
-the whole visual vocabulary.
+AIM-15 retired the U+2713 CHECK MARK / U+2717 BALLOT X "house style" this
+module used to exempt from the package-source walk (and assert PRESENT):
+console states are now rendered with the plain-text markers [OK] and [FAIL],
+coloured through rich markup where rich is available. The package-source walk
+below therefore exempts NOTHING in the measured ranges. The prose surfaces
+(README.md, CHANGELOG.md, docs/*.md) still carry the old marks and are outside
+AIM-15's scope, so the prose walk tolerates exactly those marks -- and nothing
+else.
+
+Every banned or tolerated character is written as an escape, never as a literal
+glyph. A bare U+FE0F is an INVISIBLE character, and a file asserting "no
+invisible characters here" that contains one is indistinguishable from the
+GlassWorm attack it guards against -- our own scanner flagged an earlier draft
+of this file as CRITICAL for exactly that. Escapes also keep the file greppable
+and reviewable in a plain diff.
 """
 
 import pathlib
+import shutil
 import unicodedata
 
 import pytest
@@ -20,12 +31,6 @@ PKG = pathlib.Path(__file__).resolve().parent.parent / "aim_sdk"
 
 # In scope. Named, not derived from a property lookup, so the test states its
 # own contract rather than tracking whatever the local unicodedata says today.
-#
-# Written as escapes, never as literal glyphs. A bare U+FE0F is an INVISIBLE
-# character, and a file asserting "no invisible characters here" that contains
-# one is indistinguishable from the GlassWorm attack it guards against -- our own
-# scanner flagged an earlier draft of this file as CRITICAL for exactly that.
-# Escapes also keep the file greppable and reviewable in a plain diff.
 BANNED = {
     "\u23F3": "HOURGLASS WITH FLOWING SAND",
     "\u26A0": "WARNING SIGN",
@@ -33,30 +38,34 @@ BANNED = {
     "\uFE0F": "VARIATION SELECTOR-16 (forces emoji presentation)",
 }
 
-# Deliberately allowed: the house style, per the issue.
-HOUSE_STYLE = {
+# Tolerated in PROSE ONLY. These were the package's pre-AIM-15 console marks;
+# the docs that describe old output still show them, and sweeping prose is a
+# separate unit. The package-source walk grants no such tolerance.
+PROSE_TOLERATED = {
     "\u2713": "CHECK MARK",
     "\u2717": "BALLOT X",
-    "\u25CB": "WHITE CIRCLE",
 }
 
+# The plain-text vocabulary that replaced the marks above in console output.
+REPLACEMENT_MARKERS = ("[OK]", "[FAIL]")
 
-def _python_files():
-    files = sorted(PKG.rglob("*.py"))
-    assert files, f"found no source under {PKG} -- the scan is blind"
+
+def _python_files(root=None):
+    root = root or PKG
+    files = sorted(root.rglob("*.py"))
+    assert files, f"found no source under {root} -- the scan is blind"
     return files
 
 
-def _text_surfaces():
-    """Python source plus the prose a reader actually meets.
+def _prose_files():
+    """The prose a reader actually meets.
 
     CHANGELOG.md and README.md are in MANIFEST.in and therefore ship inside the
     distribution; docs/*.md do not ship but are public on GitHub, and the
     standard is about what a human reads, not about the packaging manifest.
     """
     root = PKG.parent
-    files = _python_files()
-    files += [p for p in (root / "CHANGELOG.md", root / "README.md") if p.exists()]
+    files = [p for p in (root / "CHANGELOG.md", root / "README.md") if p.exists()]
     files += sorted((root / "docs").rglob("*.md"))
     return files
 
@@ -68,15 +77,102 @@ def _is_emoji(ch: str) -> bool:
     was the defect: it removed the ones someone had thought of and left ten
     others (a bug, a plug, a handshake) sitting in the same documents. A rule
     that needs a rule per spelling is not a rule.
+
+    No exemptions: U+2713 and U+2717 are in range and are reported like any
+    other hit. (U+25CB WHITE CIRCLE sits outside every measured range, so the
+    exemption it used to enjoy here was always a no-op.)
     """
-    if ch in HOUSE_STYLE:
-        return False
     o = ord(ch)
     return (
         0x1F000 <= o <= 0x1FAFF
         or 0x2600 <= o <= 0x27BF
         or 0x2B00 <= o <= 0x2BFF
         or o in (0xFE0F, 0x2139, 0x23F3, 0x23F8)
+    )
+
+
+def _scan_tree(root):
+    """Walk every .py file under ``root``; report each offending file, line
+    and code point. Blind-scan-proof: refuses to pass on an empty walk."""
+    offenders = []
+    for f in _python_files(root):
+        for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for ch in {c for c in line if _is_emoji(c)}:
+                offenders.append(
+                    f"{f.relative_to(root.parent)}:{lineno}: U+{ord(ch):04X} "
+                    f"{unicodedata.name(ch, '?')}"
+                )
+    return offenders
+
+
+def test_AIM_15_AC1_package_source_scan_returns_zero_lines():
+    """No character in the measured ranges anywhere under aim_sdk/**/*.py."""
+    offenders = _scan_tree(PKG)
+    assert not offenders, "emoji-class characters in package source:\n" + "\n".join(
+        offenders[:60]
+    )
+
+
+def test_AIM_15_AC2_walk_is_unexempted_and_non_vacuous():
+    """The walk sees the real tree and exempts nothing the ranges cover."""
+    assert _is_emoji("\u2713"), "U+2713 CHECK MARK must not be exempted"
+    assert _is_emoji("\u2717"), "U+2717 BALLOT X must not be exempted"
+    files = _python_files()
+    names = {f.name for f in files}
+    assert "console.py" in names and "client.py" in names, (
+        "the walk did not reach the package's known modules -- looking at the "
+        f"wrong tree? saw {len(files)} files under {PKG}"
+    )
+
+
+def test_AIM_15_AC3_scan_fails_on_a_planted_check_mark(tmp_path):
+    """Proves the detection works, independent of the package's current state.
+
+    Without this, a scan that silently matched nothing would report the same
+    clean result as a scan that read every file and found nothing. The planted
+    character is U+2713 deliberately: the character the pre-AIM-15 predicate
+    exempted, so this also fails if the exemption ever creeps back.
+    """
+    scratch = tmp_path / "aim_sdk"
+    shutil.copytree(PKG, scratch, ignore=shutil.ignore_patterns("__pycache__"))
+    planted = scratch / "planted.py"
+    # Single-escaped on purpose: this source file stays pure ASCII, while the
+    # bytes written to the fixture are the real character the scan must catch.
+    planted.write_text('print("\u2713 done")\n', encoding="utf-8")
+
+    with pytest.raises(AssertionError) as excinfo:
+        offenders = _scan_tree(scratch)
+        assert not offenders, "emoji-class characters:\n" + "\n".join(offenders)
+
+    message = str(excinfo.value)
+    assert "planted.py" in message, "the failure must name the offending file"
+    assert "U+2713" in message, "the failure must name the offending code point"
+
+
+@pytest.mark.parametrize("marker", REPLACEMENT_MARKERS)
+def test_AIM_15_AC4_replacement_markers_are_still_used(marker):
+    """Non-vacuity control, and a guard against over-correction.
+
+    If this fails, someone removed the plain-text vocabulary instead of the
+    emoji -- which would make the scans above pass for the wrong reason.
+    Replaces the retired assertion that U+2713/U+2717/U+25CB were present.
+    """
+    total = sum(f.read_text(encoding="utf-8").count(marker) for f in _python_files())
+    assert total > 0, f"{marker} vanished from the package"
+
+
+def test_AIM_15_AC5_changelog_documents_the_marker_replacement():
+    """CHANGELOG.md carries the change in a section newer than 2.0.2."""
+    changelog = (PKG.parent / "CHANGELOG.md").read_text(encoding="utf-8")
+    headings = [l for l in changelog.splitlines() if l.startswith("## ")]
+    assert headings and "2.0.2" not in headings[0], (
+        "no CHANGELOG section newer than 2.0.2 -- the marker replacement is "
+        "undocumented"
+    )
+    newest = changelog.split(headings[0], 1)[1].split("## [2.0.2]", 1)[0]
+    assert "[OK]" in newest and "U+2713" in newest, (
+        "the newest CHANGELOG section does not name the console-marker "
+        "replacement"
     )
 
 
@@ -93,42 +189,27 @@ def test_no_banned_emoji_class_characters_anywhere_in_the_package():
     )
 
 
-def test_no_emoji_of_any_kind_in_source_or_prose():
-    """The whole class, not the three codepoints the issue happened to table."""
+def test_no_emoji_in_prose_beyond_the_tolerated_marks():
+    """The whole class over the prose surfaces, minus exactly the pre-AIM-15
+    marks the docs still legitimately show. Package source is covered -- with
+    no tolerance at all -- by the AC1 walk above."""
     offenders = []
-    for f in _text_surfaces():
+    for f in _prose_files():
         for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
-            for ch in {c for c in line if _is_emoji(c)}:
+            for ch in {c for c in line if _is_emoji(c) and c not in PROSE_TOLERATED}:
                 offenders.append(
                     f"{f.relative_to(PKG.parent)}:{lineno}: U+{ord(ch):04X} "
                     f"{unicodedata.name(ch, '?')}"
                 )
-    assert not offenders, "emoji in source or prose:\n" + "\n".join(offenders[:40])
+    assert not offenders, "emoji in prose:\n" + "\n".join(offenders[:40])
 
 
-@pytest.mark.parametrize("ch", sorted(HOUSE_STYLE))
-def test_house_style_marks_are_still_used(ch):
-    """Non-vacuity control, and a guard against over-correction.
-
-    If this fails, someone removed the plain-text vocabulary instead of the
-    emoji -- which would make the banned-character test above pass for the
-    wrong reason.
-    """
-    total = sum(f.read_text(encoding="utf-8").count(ch) for f in _python_files())
-    assert total > 0, f"U+{ord(ch):04X} {HOUSE_STYLE[ch]} vanished from the package"
-
-
-def test_the_scanner_can_actually_see_a_planted_offender(tmp_path):
-    """Proves the detection works, independent of the package's current state.
-
-    Without this, a scan that silently matched nothing would report the same
-    clean result as a scan that read every file and found nothing.
-    """
+def test_the_scanner_can_actually_see_a_planted_banned_offender(tmp_path):
+    """The BANNED-list twin of the AC3 planted-fault test."""
     planted = tmp_path / "planted.py"
-    # Single-escaped on purpose: this source file stays pure ASCII, while the
-    # bytes written to the fixture are the real characters the scan must catch.
-    # Double-escaping here would write the literal text backslash-u-26A0, the scan would
-    # find nothing, and the test would report the detector broken when it is not.
+    # Single-escaped on purpose, as in the AC3 test above. Double-escaping here
+    # would write the literal text backslash-u-26A0, the scan would find
+    # nothing, and the test would report the detector broken when it is not.
     planted.write_text('print("\u26A0\uFE0F  something")\n', encoding="utf-8")
     found = [ch for ch in set(planted.read_text(encoding="utf-8")) if ch in BANNED]
     assert found, "the scan cannot see a known-bad character"


### PR DESCRIPTION
The Python SDK printed U+2713 and U+2717 check-mark characters on 52 lines across ten `aim_sdk` modules (client, console, credentials, the CrewAI and LangChain callbacks, and others). They render as boxes or escapes on terminals without the glyph and violate the SDK's plain-text output rule. Every mark is now `[OK]` or `[FAIL]`; 12 files, 199 insertions, 103 deletions, plus a walk test over the package that fails if a check-mark character returns in any `aim_sdk` module.

Verification on the branch: `pytest sdk/python/tests` 977 passed, 34 skipped (the environment-gated cases), exit 0 with the real dependencies installed; the walk test fails on the current main. `examples/`, `scripts/` and docs prose still carry the old marks and are outside this change.