### PR TITLE
sdk-python: fix the five P2 findings from the 2.0.2 release test

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the AIM Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - Unreleased
+
+The five P2 findings from the 2.0.2 release test, re-measured at head and
+fixed as a batch.
+
+### Fixed
+
+- **`aim-sdk login` is bounded and fails fast on a dead URL.** The command now
+  probes the server before anything else: with an unreachable `--url` it exits
+  non-zero within the 5s probe bound, names the URL it could not reach, and
+  never opens a browser. After a successful browser open, the callback wait is
+  bounded by a 180s deadline; on expiry the command prints a timeout message
+  and exits non-zero. Previously there was no reachability check before
+  `webbrowser.open`, and the wait loop re-entered `handle_request()` after
+  every socket timeout, so "Waiting for authentication... (Ctrl+C to cancel)"
+  waited forever against a closed port.
+- **The README manual-mode example works as written.** `secure(name,
+  api_key=...)` requires `aim_url` — there is no default server URL and no
+  environment-variable fallback in `secure()` — but the README's manual-mode
+  one-liner omitted it, so pasting the documented line raised
+  `ConfigurationError`. The example now carries `aim_url=` beside `api_key=`
+  and the manual-mode prose states the requirement.
+- **The no-credentials error names the real fixes.** The `ConfigurationError`
+  raised when neither SDK credentials nor an `api_key` are present told a pip
+  user to "download SDK from dashboard ... or provide api_key parameter",
+  naming neither the `aim-sdk login` command (the README's own step for a pip
+  install) nor the fact that api_key mode also requires `aim_url`. It now
+  names both.
+- **The security log distinguishes "AIM was never asked" from "AIM said no",
+  and records unverified execution.** Every non-answer used to render as
+  `result: DENIED`: the `CAPABILITY_CHECK` event for a transport failure now
+  carries `result: UNAVAILABLE`, and for a 401 (`AuthenticationError`)
+  `result: UNVERIFIED`; only an actual policy denial renders `DENIED`. And
+  when the enforcement rule executes the wrapped function without a completed
+  verification (monitoring mode or the unresolved-mode transport window), an
+  `ACTION_EXECUTED` event with `result: EXECUTED_UNVERIFIED` now records that
+  the action ran — previously `ACTION_EXECUTED` was defined but emitted
+  nowhere, so the log showed a "denial" followed by nothing.
+- **No success line on a rejected capability registration.** The
+  `@perform_action` auto-registration path announced "Registered ..." whenever
+  `register_capability` returned without raising — including a 404's
+  `not_tracked` result and a 401 swallowed into an `error` result — so a
+  rejected registration printed a success line (on the 401 path, above the
+  failure warning). The wrapper now announces only a plain registered success;
+  `register_capability`'s own per-status output (granted, pending, warnings)
+  is unchanged, a granted registration is announced exactly once instead of
+  twice, and the 500 path still prints only a warning.
+
 ## [2.0.2] - 2026-09-08
 
 ### Security

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -277,10 +277,12 @@ are not part of this package -- see the module docstring for the boundary.
 
 ## Manual mode (no OAuth)
 
-For CI environments or pre-configured credentials, skip `aim-sdk login` and pass an API key:
+For CI environments or pre-configured credentials, skip `aim-sdk login` and pass an API key.
+API key mode always requires `aim_url` — there is no default server and no environment-variable
+fallback, so `secure()` raises `ConfigurationError` if `api_key` is passed without it:
 
 ```python
-agent = secure("my-agent", api_key="aim_abc123")
+agent = secure("my-agent", api_key="aim_abc123", aim_url="http://localhost:8080")
 ```
 
 Or supply full credentials:

--- a/sdk/python/aim_sdk/cli.py
+++ b/sdk/python/aim_sdk/cli.py
@@ -23,6 +23,7 @@ Security Design (RFC 8252 - OAuth for Native Apps):
 import argparse
 import sys
 import os
+import time
 import webbrowser
 import socket
 import secrets
@@ -52,6 +53,29 @@ __version__ = _get_version()
 
 # Default AIM Cloud URL
 DEFAULT_AIM_URL = "https://aim.opena2a.org"
+
+# Bounds for `aim-sdk login`. The pre-flight probe keeps a dead --url from
+# opening a browser at all; the callback deadline keeps "Waiting for
+# authentication..." from waiting forever (the wait loop re-entered
+# handle_request after every socket timeout, so the old per-request timeout
+# bounded nothing).
+LOGIN_PROBE_TIMEOUT_SECONDS = 5
+LOGIN_CALLBACK_TIMEOUT_SECONDS = 180
+
+
+def check_server_reachable(aim_url, timeout):
+    """
+    Pre-flight probe: is anything answering HTTP at aim_url?
+
+    Any HTTP response -- including an error status -- proves the server is
+    reachable; only a transport failure (refused, unroutable, timed out)
+    counts as unreachable.
+    """
+    try:
+        requests.get(aim_url, timeout=timeout, allow_redirects=False)
+        return True
+    except requests.RequestException:
+        return False
 
 
 def print_banner():
@@ -326,6 +350,16 @@ def login(args):
                 return 0
             print()
 
+    # Fail fast on an unreachable server: probing before the browser opens is
+    # what keeps a mistyped or dead --url from parking the user on a login
+    # page that will never call back.
+    if not check_server_reachable(aim_url, LOGIN_PROBE_TIMEOUT_SECONDS):
+        print(f"Error: could not reach the AIM server at {aim_url}")
+        print(f"(no HTTP response within {LOGIN_PROBE_TIMEOUT_SECONDS}s).")
+        print("Check the URL and your network, then retry. For a self-hosted")
+        print("server, pass it explicitly: aim-sdk login --url <your-aim-url>")
+        return 1
+
     # Generate PKCE pair
     code_verifier, code_challenge = generate_pkce_pair()
 
@@ -342,7 +376,10 @@ def login(args):
     PKCECallbackHandler.expected_state = state
 
     server = HTTPServer(('localhost', port), PKCECallbackHandler)
-    server.timeout = 120  # 2 minute timeout
+    # Per-handle_request poll interval, NOT the overall bound: the wait loop
+    # below re-enters handle_request after every timeout, so the real bound is
+    # the LOGIN_CALLBACK_TIMEOUT_SECONDS deadline it checks each iteration.
+    server.timeout = 1
 
     # Build authorization URL with PKCE parameters
     params = urllib.parse.urlencode({
@@ -359,14 +396,21 @@ def login(args):
     print(f"If the browser doesn't open, visit:")
     print(f"  {login_url}")
     print()
-    print("Waiting for authentication... (Ctrl+C to cancel)")
+    print(f"Waiting for authentication... (times out after "
+          f"{LOGIN_CALLBACK_TIMEOUT_SECONDS}s; Ctrl+C to cancel)")
 
     # Open browser
     webbrowser.open(login_url)
 
-    # Wait for callback (with timeout)
+    # Wait for callback, bounded by a deadline
+    deadline = time.monotonic() + LOGIN_CALLBACK_TIMEOUT_SECONDS
     try:
         while PKCECallbackHandler.authorization_code is None and PKCECallbackHandler.error is None:
+            if time.monotonic() >= deadline:
+                print(f"\nAuthentication timed out after "
+                      f"{LOGIN_CALLBACK_TIMEOUT_SECONDS}s: no browser callback "
+                      f"was received. Run aim-sdk login to try again.")
+                return 1
             server.handle_request()
     except KeyboardInterrupt:
         print("\n\nLogin cancelled.")

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -1229,24 +1229,34 @@ class AIMClient:
             )
 
         except (AuthenticationError, ActionDeniedError) as e:
+            # A rejected credential is not a policy denial: AIM never verified
+            # anything, so the check renders UNVERIFIED, distinguishable in the
+            # result field from an administrator's deny. An ActionDeniedError
+            # raised through here IS a denial and keeps the DENIED literal.
             security_logger.log_authorization(
                 AuthzEventType.CAPABILITY_CHECK,
                 action=capability,
                 resource=resource,
                 granted=False,
                 agent_id=self.agent_id,
-                error=str(e)
+                error=str(e),
+                result="UNVERIFIED" if isinstance(e, AuthenticationError) else None
             )
             raise
         except requests.exceptions.RequestException as e:
-            # Handle network errors (connection refused, timeout, etc.)
+            # Handle network errors (connection refused, timeout, etc.).
+            # AIM was never asked, so the event must not carry the policy-denial
+            # literal DENIED: a SOC reading DENIED for an action that then ran
+            # (the monitoring/unresolved leniency below) would chase a denial
+            # nobody issued. UNAVAILABLE states what happened: no answer.
             security_logger.log_authorization(
                 AuthzEventType.CAPABILITY_CHECK,
                 action=capability,
                 resource=resource,
                 granted=False,
                 agent_id=self.agent_id,
-                error=f"Network error: {type(e).__name__}: {str(e)}"
+                error=f"Network error: {type(e).__name__}: {str(e)}",
+                result="UNAVAILABLE"
             )
             console.warning(f"Network error during verification: {type(e).__name__}: {str(e)}")
             # THE transport allowlist. UNKNOWN is populated from the transport
@@ -1574,6 +1584,31 @@ class AIMClient:
             warnings.warn(verdict.pending_change, PendingEnforcementChange, stacklevel=3)
 
         return verdict, decision
+
+    def _log_unverified_execution(self, capability: str, resource: Optional[str],
+                                  decision: "VerificationDecision") -> None:
+        """
+        Record locally that an action is executing WITHOUT a completed
+        verification (the enforcement rule's monitoring / unresolved-mode
+        leniency). Without this event the security log showed only the failed
+        check -- rendered DENIED before AIM-14 -- and nothing recording that
+        the action then ran, so "AIM said no" and "AIM was never asked, and
+        the action executed anyway" were indistinguishable to a SOC. The
+        server-side log_capability_result call cannot cover this case: in the
+        unreachable-server scenario it fails on the same dead transport.
+        """
+        security_logger.log_authorization(
+            AuthzEventType.ACTION_EXECUTED,
+            action=capability,
+            resource=resource,
+            granted=False,
+            agent_id=self.agent_id,
+            result="EXECUTED_UNVERIFIED",
+            details={
+                "outcome": decision.outcome.value,
+                "reason": decision.reason,
+            }
+        )
 
     def verify_action(
         self,
@@ -3375,15 +3410,28 @@ class AIMClient:
                 # Auto-register capability on first use (if enabled)
                 if auto_register:
                     try:
-                        self.register_capability(
+                        registration = self.register_capability(
                             capability_type=cap,
                             description=f"Auto-registered by @perform_action decorator for {func.__name__}",
                             risk_level=detected_risk
                         )
-                        console.capability_registered(cap, detected_risk)
                     except Exception as e:
                         # Don't fail the action if registration fails - just log it
                         console.warning(f"Auto-registration of '{cap}' failed: {e}")
+                    else:
+                        # register_capability already spoke for every status it
+                        # resolves itself (granted prints, pending informs, a
+                        # swallowed rejection warns). Announce only the plain
+                        # "registered" success it stays silent on: a 404's
+                        # not_tracked and a 401's error dict return without
+                        # raising, and announcing those claimed a registration
+                        # the server had just rejected.
+                        if (
+                            isinstance(registration, dict)
+                            and registration.get("success")
+                            and registration.get("status") == "registered"
+                        ):
+                            console.capability_registered(cap, detected_risk)
 
                 # Build context with JIT access info
                 merged_context = context.copy() if context else {}
@@ -3410,6 +3458,9 @@ class AIMClient:
                 )
                 if verdict.blocked:
                     raise verdict.error
+                if decision.outcome is not Outcome.ALLOW:
+                    # Running without a completed verification: record it.
+                    self._log_unverified_execution(cap, resource, decision)
 
                 verification_id = decision.verification_id
 
@@ -3523,6 +3574,9 @@ class AIMClient:
                 )
                 if verdict.blocked:
                     raise verdict.error
+                if decision.outcome is not Outcome.ALLOW:
+                    # Running without a completed verification: record it.
+                    self._log_unverified_execution(action, resource, decision)
 
                 verification_id = decision.verification_id
 
@@ -3669,6 +3723,8 @@ class AIMClient:
                     console.jit_approved(action)
                 else:
                     console.jit_unverified(action)
+                    # Running without a completed verification: record it.
+                    self._log_unverified_execution(action, resource, decision)
                 verification_id = decision.verification_id
 
                 try:
@@ -4605,10 +4661,17 @@ def register_agent(
         console.info("Manual Mode: Using API key authentication")
 
     else:
-        # No authentication found
+        # No authentication found. Name the fixes that actually exist for a
+        # pip install: `aim-sdk login` (the README's own step), the dashboard
+        # SDK download, or api_key mode -- which also requires aim_url, so
+        # saying "provide api_key" alone sent users into the very
+        # ConfigurationError raised above.
         raise ConfigurationError(
             "No authentication credentials found.\n"
-            "Either download SDK from dashboard (OAuth mode) or provide api_key parameter (Manual mode)."
+            "Fix one of:\n"
+            "  - Run 'aim-sdk login' to authenticate this machine (works for pip installs), or\n"
+            "  - Download the SDK from the AIM dashboard (OAuth mode), or\n"
+            "  - Pass api_key= together with aim_url= (API key mode requires aim_url)."
         )
 
     # 2.5. Handle backward compatibility: merge talks_to into mcp_servers

--- a/sdk/python/aim_sdk/security_logging.py
+++ b/sdk/python/aim_sdk/security_logging.py
@@ -191,7 +191,8 @@ class SecurityEvent:
     # Action fields
     action: Optional[str] = None            # Action being performed
     resource: Optional[str] = None          # Resource being accessed
-    result: Optional[str] = None            # SUCCESS, FAILURE, DENIED
+    result: Optional[str] = None            # SUCCESS, FAILURE, GRANTED, DENIED,
+                                            # UNAVAILABLE, UNVERIFIED, EXECUTED_UNVERIFIED
 
     # Network fields
     source_ip: Optional[str] = None         # Client IP address
@@ -490,19 +491,31 @@ class SecurityLogger:
         granted: bool = True,
         agent_id: Optional[str] = None,
         details: Optional[Dict[str, Any]] = None,
-        error: Optional[str] = None
+        error: Optional[str] = None,
+        result: Optional[str] = None
     ):
-        """Log authorization events (capability checks, action execution)."""
+        """Log authorization events (capability checks, action execution).
+
+        ``result`` names what actually happened when the GRANTED/DENIED pair
+        derived from ``granted`` would misstate it. DENIED is the policy-denial
+        literal -- AIM answered no -- so a check that never got an answer must
+        not render as DENIED: callers pass UNAVAILABLE (transport failure, AIM
+        never reached), UNVERIFIED (credentials rejected before any decision),
+        or EXECUTED_UNVERIFIED (the enforcement rule ran the action without a
+        completed verification). Left unset, the historical mapping applies.
+        """
         severity = EventSeverity.INFO if granted else EventSeverity.WARNING
         if event_type == AuthzEventType.CAPABILITY_ESCALATION:
             severity = EventSeverity.WARNING
         elif event_type in [AuthzEventType.CAPABILITY_DENIED, AuthzEventType.ACTION_DENIED]:
             severity = EventSeverity.WARNING
 
+        result_value = result or ("GRANTED" if granted else "DENIED")
+
         message = f"Authorization {event_type.value}: {action}"
         if resource:
             message += f" on {resource}"
-        message += f" - {'GRANTED' if granted else 'DENIED'}"
+        message += f" - {result_value}"
 
         event = self._create_event(
             category=EventCategory.AUTHZ,
@@ -512,7 +525,7 @@ class SecurityLogger:
             agent_id=agent_id,
             action=action,
             resource=resource,
-            result="GRANTED" if granted else "DENIED",
+            result=result_value,
             details=details or {},
             error=error
         )

--- a/sdk/python/tests/test_release_202_p2_findings.py
+++ b/sdk/python/tests/test_release_202_p2_findings.py
@@ -1,0 +1,568 @@
+"""
+AIM-14 -- aim-sdk (Python): the five P2 findings from the 2.0.2 release test.
+
+AC1  `aim-sdk login` fails fast and bounded on an unreachable server: a dead
+     loopback port exits non-zero within a stated bound, names the URL, and
+     never opens a browser; after a successful browser open the callback wait
+     is bounded by a deadline and times out non-zero with a timeout message.
+AC2  The README manual-mode one-liner and the code agree in the same tree:
+     the manual-mode `secure(api_key=...)` example carries `aim_url=` and the
+     prose states the requirement the code actually enforces.
+AC3  The no-credentials ConfigurationError names the real fixes for a pip
+     user: the `aim-sdk login` command, and that api_key mode requires aim_url.
+AC4  The SOC-facing security log distinguishes "AIM was never asked" from
+     "AIM said no": an unreachable server writes a CAPABILITY_CHECK whose
+     result is not the policy-denial literal DENIED, and when the enforcement
+     rule executes the function unverified a security event records that the
+     action executed.
+AC5  A 401 on verification writes a check result distinguishable from the
+     DENIED literal that a server status "denied" produces.
+AC6  A rejected capability registration (404, 401; 500 stays warning-only)
+     prints no console line claiming the capability was registered.
+AC7  The tree's own record is coherent: CHANGELOG documents the batch under a
+     section newer than 2.0.2, the README passages match the delivered code,
+     and no test in this file performs network I/O beyond loopback.
+
+Every server below is a scripted loopback listener on 127.0.0.1; the "dead
+URL" is a loopback port held bound but never listening, so connects are
+refused. No test talks to anything beyond 127.0.0.1.
+"""
+
+import json
+import logging
+import re
+import socket
+import threading
+import time
+import types
+import uuid
+import warnings
+from pathlib import Path
+
+import pytest
+
+from aim_sdk import cli
+from aim_sdk import client as client_module
+from aim_sdk import security_logging
+from aim_sdk.client import AIMClient, register_agent
+from aim_sdk.decision import get_mode_cache
+from aim_sdk.exceptions import (
+    ActionDeniedError,
+    AuthenticationError,
+    ConfigurationError,
+)
+
+SDK_ROOT = Path(__file__).resolve().parent.parent
+README = SDK_ROOT / "README.md"
+CHANGELOG = SDK_ROOT / "CHANGELOG.md"
+
+
+# --------------------------------------------------------------------------- #
+# Loopback fixtures: a scripted HTTP listener, a refused port, an event spy.
+# --------------------------------------------------------------------------- #
+class LocalServer:
+    """Answers each request from handler(method, path) -> (status, headers, body)."""
+
+    def __init__(self, handler):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(16)
+        self.url = f"http://127.0.0.1:{self._sock.getsockname()[1]}"
+        self.request_lines = []
+        self._handler = handler
+        self._closing = threading.Event()
+        self._open = []
+        threading.Thread(target=self._accept, daemon=True).start()
+
+    def _accept(self):
+        while not self._closing.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            self._open.append(conn)
+            threading.Thread(target=self._serve, args=(conn,), daemon=True).start()
+
+    def _serve(self, conn):
+        try:
+            conn.settimeout(30)
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = conn.recv(65536)
+                if not chunk:
+                    return
+                data += chunk
+            head, _, body = data.partition(b"\r\n\r\n")
+            lines = head.decode("latin-1").split("\r\n")
+            self.request_lines.append(lines[0])
+            method, path = lines[0].split(" ")[0:2]
+            headers = {}
+            for line in lines[1:]:
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    headers[key.strip().lower()] = value.strip()
+            need = int(headers.get("content-length", "0"))
+            while len(body) < need:
+                chunk = conn.recv(65536)
+                if not chunk:
+                    break
+                body += chunk
+
+            status, extra_headers, payload = self._handler(method, path)
+            encoded = payload.encode("utf-8")
+            response_head = (
+                f"HTTP/1.1 {status} X\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(encoded)}\r\n"
+                f"Connection: close\r\n"
+            )
+            for key, value in extra_headers.items():
+                response_head += f"{key}: {value}\r\n"
+            conn.sendall(response_head.encode("latin-1") + b"\r\n" + encoded)
+            conn.close()
+        except OSError:
+            pass
+
+    def close(self):
+        self._closing.set()
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        for conn in self._open:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
+@pytest.fixture
+def server_factory():
+    servers = []
+
+    def start(handler):
+        server = LocalServer(handler)
+        servers.append(server)
+        return server
+
+    yield start
+    for server in servers:
+        server.close()
+
+
+@pytest.fixture
+def closed_port():
+    """A loopback port that refuses connections: bound, never listening,
+    and held for the duration of the test so nothing else can claim it."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    yield sock.getsockname()[1]
+    sock.close()
+
+
+class _EventCollector(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.events = []
+
+    def emit(self, record):
+        event = getattr(record, "security_event", None)
+        if event is not None:
+            self.events.append(event)
+
+
+@pytest.fixture
+def security_events():
+    logger = security_logging.security_logger._logger
+    collector = _EventCollector()
+    previous_level = logger.level
+    logger.addHandler(collector)
+    logger.setLevel(logging.DEBUG)
+    yield collector
+    logger.removeHandler(collector)
+    logger.setLevel(previous_level)
+
+
+@pytest.fixture(autouse=True)
+def clean_mode_cache():
+    get_mode_cache().clear()
+    yield
+    get_mode_cache().clear()
+
+
+def _api_key_client(url):
+    return AIMClient(
+        agent_id=str(uuid.uuid4()),
+        api_key="test-api-key",
+        aim_url=url,
+        auto_retry=False,
+    )
+
+
+def _no_stored_credentials(monkeypatch):
+    monkeypatch.setattr(client_module, "_load_credentials", lambda name: None)
+    monkeypatch.setattr(client_module, "load_sdk_credentials", lambda *a, **k: None)
+
+
+# --------------------------------------------------------------------------- #
+# AC1 -- login bounded and failing fast.
+# --------------------------------------------------------------------------- #
+def _login_args(url):
+    return types.SimpleNamespace(url=url, force=True)
+
+
+def _run_login_bounded(args, seconds):
+    """Run cli.login in a thread with a hard observation bound, so an
+    unbounded wait shows up as a failed assertion instead of a hung run."""
+    result = {}
+
+    def target():
+        result["rc"] = cli.login(args)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(seconds)
+    return (not thread.is_alive()), result.get("rc")
+
+
+def test_AIM_14_AC1_dead_url_exits_nonzero_fast_names_url_and_opens_no_browser(
+    monkeypatch, capsys, closed_port
+):
+    url = f"http://127.0.0.1:{closed_port}"
+    opened = []
+    monkeypatch.setattr(cli.webbrowser, "open", lambda *a, **k: opened.append(a) or True)
+    monkeypatch.setattr("aim_sdk.credentials.load_sdk_credentials", lambda *a, **k: None)
+
+    start = time.monotonic()
+    finished, rc = _run_login_bounded(_login_args(url), 15)
+    elapsed = time.monotonic() - start
+    out = capsys.readouterr().out
+
+    assert finished, "login must exit within a stated bound on an unreachable server"
+    assert rc != 0, "login must exit non-zero when the server is unreachable"
+    assert elapsed < 15, f"login took {elapsed:.1f}s against a refused loopback port"
+    assert url in out, "the failure output must name the unreachable URL"
+    assert opened == [], "webbrowser.open must not be called when the pre-flight probe fails"
+
+
+def test_AIM_14_AC1_callback_wait_is_bounded_and_times_out_nonzero(
+    monkeypatch, capsys, server_factory
+):
+    server = server_factory(lambda method, path: (200, {}, "{}"))
+    opened = []
+    monkeypatch.setattr(cli.webbrowser, "open", lambda *a, **k: opened.append(a) or True)
+    monkeypatch.setattr("aim_sdk.credentials.load_sdk_credentials", lambda *a, **k: None)
+    # Shrink the deadline so the green run is quick; at base the attribute does
+    # not exist and the wait re-enters handle_request forever.
+    monkeypatch.setattr(cli, "LOGIN_CALLBACK_TIMEOUT_SECONDS", 2, raising=False)
+
+    finished, rc = _run_login_bounded(_login_args(server.url), 15)
+    out = capsys.readouterr().out
+
+    assert finished, "the callback wait must be bounded by a deadline"
+    assert opened, "control: with a reachable server the browser open is reached"
+    assert rc != 0, "an expired callback wait must exit non-zero"
+    assert "timed out" in out.lower(), f"expected a timeout message, got: {out!r}"
+
+
+# --------------------------------------------------------------------------- #
+# AC2 -- README manual mode and the code agree in the same tree.
+# --------------------------------------------------------------------------- #
+def _manual_mode_section():
+    text = README.read_text(encoding="utf-8")
+    match = re.search(r"^## Manual mode.*?(?=^## )", text, re.M | re.S)
+    assert match, "README must keep its manual-mode section"
+    return match.group(0)
+
+
+def _prose_of(section):
+    """The section text outside fenced code blocks."""
+    parts = section.split("```")
+    return "\n".join(parts[0::2])
+
+
+def test_AIM_14_AC2_readme_manual_mode_example_carries_aim_url_and_states_it():
+    section = _manual_mode_section()
+    example_lines = [
+        line for line in section.splitlines()
+        if "secure(" in line and "api_key=" in line
+    ]
+    assert example_lines, "the manual-mode section must still show secure(api_key=...)"
+    for line in example_lines:
+        assert "aim_url=" in line, (
+            f"the manual-mode secure() example must carry aim_url= beside "
+            f"api_key= (the call raises without it): {line.strip()!r}"
+        )
+    assert "aim_url" in _prose_of(section), (
+        "the manual-mode prose must state that aim_url is required with api_key"
+    )
+
+
+def test_AIM_14_AC2_secure_with_api_key_and_no_aim_url_raises_the_documented_requirement(
+    monkeypatch,
+):
+    _no_stored_credentials(monkeypatch)
+    with pytest.raises(ConfigurationError) as excinfo:
+        register_agent("aim14-ac2-agent", api_key="aim_test_key")
+    assert "aim_url" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# AC3 -- the no-credentials error names the real fixes.
+# --------------------------------------------------------------------------- #
+def test_AIM_14_AC3_no_credentials_error_names_login_command_and_aim_url_requirement(
+    monkeypatch,
+):
+    _no_stored_credentials(monkeypatch)
+    with pytest.raises(ConfigurationError) as excinfo:
+        register_agent("aim14-ac3-agent")
+    message = str(excinfo.value)
+    assert "aim-sdk login" in message, (
+        f"the no-credentials error must name the aim-sdk login command "
+        f"(the README's own step for a pip install): {message!r}"
+    )
+    assert "api_key" in message and "aim_url" in message, (
+        f"the error must state that api_key mode also requires aim_url: {message!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# AC4 -- unreached is not DENIED, and an unverified run is recorded.
+# --------------------------------------------------------------------------- #
+def test_AIM_14_AC4_unreachable_check_is_not_denied_and_the_run_is_recorded(
+    closed_port, security_events
+):
+    client = _api_key_client(f"http://127.0.0.1:{closed_port}")
+    ran = []
+
+    @client.perform_action(capability="db:read", auto_register=False)
+    def guarded():
+        ran.append(True)
+        return "done"
+
+    with warnings.catch_warnings():
+        # The transport-plus-unknown-mode cell emits PendingEnforcementChange.
+        warnings.simplefilter("ignore")
+        assert guarded() == "done"
+    assert ran == [True], "control: the unverified action ran (monitoring-window cell)"
+
+    checks = [e for e in security_events.events if e.event_type == "CAPABILITY_CHECK"]
+    assert checks, "a CAPABILITY_CHECK authorization event must be written"
+    for event in checks:
+        assert event.result != "DENIED", (
+            "an unreachable AIM (connection refused) must not be recorded with "
+            "the policy-denial literal DENIED"
+        )
+    assert any(e.result == "UNAVAILABLE" for e in checks), (
+        f"the unreached check must carry an unreached/unverified result value, "
+        f"got: {[e.result for e in checks]}"
+    )
+
+    executed = [e for e in security_events.events if e.event_type == "ACTION_EXECUTED"]
+    assert executed, (
+        "when the enforcement rule executes the function unverified, a security "
+        "event must record that the action executed"
+    )
+    assert executed[0].action == "db:read"
+
+
+def test_AIM_14_AC4_unverified_require_approval_run_is_recorded(
+    closed_port, security_events, capsys
+):
+    client = _api_key_client(f"http://127.0.0.1:{closed_port}")
+
+    @client.require_approval(risk_level="high")
+    def sensitive():
+        return "ran"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert sensitive() == "ran"
+
+    executed = [e for e in security_events.events if e.event_type == "ACTION_EXECUTED"]
+    assert executed, (
+        "the console.jit_unverified path must write a security event recording "
+        "that the action executed"
+    )
+    assert executed[0].action == "sensitive"
+
+
+# --------------------------------------------------------------------------- #
+# AC5 -- a 401 on verification is not the policy-denial literal.
+# --------------------------------------------------------------------------- #
+def test_AIM_14_AC5_authentication_failure_result_is_distinguishable_from_denied(
+    server_factory, security_events
+):
+    server = server_factory(lambda method, path: (401, {}, '{"error":"bad key"}'))
+    client = _api_key_client(server.url)
+
+    with pytest.raises(AuthenticationError):
+        client.verify_capability("db:read")
+
+    checks = [e for e in security_events.events if e.event_type == "CAPABILITY_CHECK"]
+    assert checks, "the 401 must still write a CAPABILITY_CHECK event"
+    for event in checks:
+        assert event.result != "DENIED", (
+            "a 401 (AIM never verified anything) must be distinguishable in the "
+            "result field from an administrator's deny"
+        )
+
+
+def test_AIM_14_AC5_a_real_policy_denial_still_renders_denied(
+    server_factory, security_events
+):
+    body = json.dumps(
+        {"id": "ver-1", "status": "denied", "denialReason": "nope",
+         "enforcementMode": "strict"}
+    )
+    server = server_factory(lambda method, path: (200, {}, body))
+    client = _api_key_client(server.url)
+
+    with pytest.raises(ActionDeniedError):
+        client.verify_capability("db:read")
+
+    denials = [e for e in security_events.events if e.event_type == "CAPABILITY_DENIED"]
+    assert denials, "control: a server denial still writes CAPABILITY_DENIED"
+    assert all(e.result == "DENIED" for e in denials), (
+        "control: the policy-denial literal stays DENIED for a real denial"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# AC6 -- no success line on a rejected capability registration.
+# --------------------------------------------------------------------------- #
+def _registration_scenario(register_status, register_body):
+    approved = json.dumps(
+        {"id": "ver-ac6", "status": "approved", "enforcementMode": "monitoring"}
+    )
+
+    def handler(method, path):
+        if path.endswith("/capabilities/register"):
+            return (register_status, {}, register_body)
+        if path.endswith("/sdk-api/verifications"):
+            return (200, {}, approved)
+        return (200, {}, "{}")
+
+    return handler
+
+
+@pytest.mark.parametrize(
+    "register_status,register_body",
+    [(404, '{"error":"not found"}'), (401, '{"error":"bad key"}')],
+    ids=["404", "401"],
+)
+def test_AIM_14_AC6_rejected_registration_prints_no_registered_line(
+    server_factory, capsys, register_status, register_body
+):
+    server = server_factory(_registration_scenario(register_status, register_body))
+    client = _api_key_client(server.url)
+
+    @client.perform_action(capability="net:call")
+    def act():
+        return "ok"
+
+    assert act() == "ok"
+    out = capsys.readouterr().out
+    assert "Registered" not in out, (
+        f"a registration answered {register_status} must not print a console "
+        f"line claiming the capability was registered; got: {out!r}"
+    )
+
+
+def test_AIM_14_AC6_500_registration_path_still_prints_only_a_warning(
+    server_factory, capsys
+):
+    server = server_factory(_registration_scenario(500, '{"error":"boom"}'))
+    client = _api_key_client(server.url)
+
+    @client.perform_action(capability="net:call")
+    def act():
+        return "ok"
+
+    assert act() == "ok"
+    out = capsys.readouterr().out
+    assert "Registered" not in out, (
+        f"the 500 path must keep printing only a warning, no success line: {out!r}"
+    )
+
+
+def test_AIM_14_AC6_granted_registration_announces_exactly_once(
+    server_factory, capsys
+):
+    granted = json.dumps({"status": "granted", "message": "ok"})
+    server = server_factory(_registration_scenario(200, granted))
+    client = _api_key_client(server.url)
+
+    @client.perform_action(capability="net:call")
+    def act():
+        return "ok"
+
+    assert act() == "ok"
+    out = capsys.readouterr().out
+    announcements = [
+        line for line in out.splitlines()
+        if "Registered" in line and "net:call" in line
+    ]
+    assert len(announcements) == 1, (
+        f"a granted registration must be announced exactly once, got "
+        f"{len(announcements)}: {out!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# AC7 -- the tree's own record of the batch is coherent.
+# --------------------------------------------------------------------------- #
+def test_AIM_14_AC7_changelog_documents_the_batch_under_a_post_2_0_2_section():
+    text = CHANGELOG.read_text(encoding="utf-8")
+    headings = re.findall(r"^## \[(\d+)\.(\d+)\.(\d+)\]", text, re.M)
+    assert headings, "CHANGELOG must keep its versioned sections"
+    newest = tuple(int(part) for part in headings[0])
+    assert newest > (2, 0, 2), (
+        f"the batch must be documented under a section newer than 2.0.2; the "
+        f"newest section is {'.'.join(map(str, headings[0]))}"
+    )
+
+    assert "## [2.0.2] - 2026-09-08" in text, (
+        "adding the new section must not displace the 2.0.2 heading"
+    )
+
+    sections = re.split(r"^## \[", text, flags=re.M)
+    newest_section = sections[1]
+    for needle in (
+        "login",            # item 1: bounded, fail-fast login
+        "aim_url",          # items 2 and 3: the requirement, stated
+        "aim-sdk login",    # item 3: the error names the pip user's fix
+        "UNAVAILABLE",      # item 4: unreached is not DENIED
+        "ACTION_EXECUTED",  # item 4: the unverified run is recorded
+        "regist",           # item 5: no success line on a rejected registration
+    ):
+        assert needle in newest_section, (
+            f"the post-2.0.2 CHANGELOG section must document the batch; "
+            f"missing {needle!r}"
+        )
+
+
+def test_AIM_14_AC7_readme_credentials_guidance_matches_the_delivered_error(
+    monkeypatch,
+):
+    assert "aim-sdk login" in README.read_text(encoding="utf-8"), (
+        "the README must keep documenting aim-sdk login as the pip user's step"
+    )
+    _no_stored_credentials(monkeypatch)
+    with pytest.raises(ConfigurationError) as excinfo:
+        register_agent("aim14-ac7-agent")
+    assert "aim-sdk login" in str(excinfo.value), (
+        "the delivered error must name the same command the README documents"
+    )
+
+
+def test_AIM_14_AC7_this_file_touches_only_loopback():
+    source = Path(__file__).read_text(encoding="utf-8")
+    for host in re.findall(r"http://([\w\.\-:]+)", source):
+        assert host.startswith("127.0.0.1") or host.startswith("localhost"), (
+            f"non-loopback URL in this test file: {host}"
+        )
+    assert ("https" + "://") not in source, (
+        "no test added for this task may perform network I/O beyond loopback"
+    )


### PR DESCRIPTION
The five P2 findings from the 2.0.2 fresh-user release test, re-measured at head and fixed as one batch under a new `2.0.3 - Unreleased` changelog section.

- `aim-sdk login` probes the server before opening a browser: with an unreachable `--url` it exits non-zero inside the 5 s probe bound and names the URL; after a successful browser open the callback wait is bounded by a 180 s deadline and exits non-zero with a timeout message. Previously the wait loop re-entered the request handler after every socket timeout and waited forever against a closed port.
- The README manual-mode example carries the `aim_url` argument that `secure(name, api_key=...)` requires, and the error raised without it states the requirement; pasting the documented line no longer fails.
- The no-credentials error names the `aim-sdk login` command and the `aim_url` requirement instead of a bare failure.
- The security log distinguishes a server that was never asked from a server that said no: a `CAPABILITY_CHECK` for a transport failure renders `UNAVAILABLE` and one for a 401 renders `UNVERIFIED`, only a real policy denial renders `DENIED`, and an action that runs without a completed verification is recorded with an `ACTION_EXECUTED` event carrying `EXECUTED_UNVERIFIED`, an event that was defined but never emitted.
- A rejected registration prints no `registered` line; a granted registration announces itself exactly once; the 500 path still prints only a warning.

Six files: `aim_sdk/cli.py`, `aim_sdk/client.py`, `aim_sdk/security_logging.py`, the README, the CHANGELOG, and a loopback-only test file with sixteen cases, one or more per finding, that fail on the parent commit.

Verification on the branch with the requirements installed: `pytest sdk/python/tests` reports 990 passed and 34 skipped, exit 0. An independent review read every changed clause against the source and verified the changelog and README criteria; it could not execute the test file in its environment (no package registry reach), so the CI run on this pull request is the second execution of the suite.