### PR TITLE
sdk-python: fix the twelve P3 findings from the 2.0.2 release test

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to the AIM Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-09-09
+
+The twelve P3 findings from the 2.0.2 fresh-user release test, each fixed
+(none declined, none narrowed to a README note alone unless listed as such):
+
+### Fixed
+
+- **`AIM_SECURITY_LOG_STDOUT` accepts the same spellings as `AIM_STRICT_MODE`**
+  (item 1). `true`/`1`/`yes`/`on` install the stdout handler and
+  `false`/`0`/`no`/`off` do not, case-insensitively with surrounding
+  whitespace stripped, instead of an equality against the single literal
+  `"true"`. `AIM_SECURITY_LOGGING_ENABLED` parses with the same spellings
+  (still enabled by default). The README passage naming the variable now
+  enumerates the accepted true spellings.
+- **README's default-logging claim matches the installed handler** (item 2,
+  narrowed in the README). The package attaches a stderr handler at ERROR
+  level on import by design; the README no longer claims "under the SDK's own
+  defaults nothing is written" and instead states that ERROR-severity records
+  go to stderr and WARNING-severity records do not.
+- **`set_quiet` is exported and documented, and an unreachable verification
+  says each thing once** (item 3). `from aim_sdk import set_quiet` silences
+  the SDK's informational stdout output (info/warning/success lines,
+  registration banners, detection results); the README documents it. The
+  pending-enforcement-change sentence is emitted once, through the typed
+  `PendingEnforcementChange` warning, no longer duplicated onto stdout via
+  the console.
+- **A registration that cannot connect raises a typed, actionable error**
+  (item 4). `secure()` against an unreachable server raises
+  `ConfigurationError` naming the URL and the remedies (correct the URL,
+  start a server, `aim-sdk login --url`), with the `requests`/`urllib3`
+  chain suppressed (`raise ... from None`); a 401 on either registration
+  path raises `AuthenticationError`, the same class the verification path
+  raises for a 401.
+- **No request URL ever carries an absent identifier, and the result body is
+  camelCase** (item 5). `log_capability_result` returns without issuing a
+  request when `verification_id` is absent (the guard
+  `report_execution_status` already had), so the SDK never POSTs to
+  `/verifications/None/result`; its body now sends `resultSummary`/
+  `errorMessage`, the same key convention as the SDK's other write bodies.
+- **Every request to an AIM URL carries `User-Agent: AIM-Python-SDK/<version>`**
+  (item 6), including the agent-exists check, both registration requests,
+  MCP-server registration, and the cached-credential validation probe, which
+  previously went out under the `requests` default.
+- **The PyPI page is self-contained and the classifiers cover
+  `python_requires`** (item 7). Every README link that pointed outside the
+  packaged tree (`../../README.md`, `examples/`, `docs/`, sibling SDKs,
+  LICENSE) is now an absolute GitHub URL; the version pointer is
+  `aim_sdk.__version__` (resolvable from a wheel-only install) instead of
+  "see `VERSION` file"; classifiers now include 3.13 and 3.14 and
+  `python_requires` carries the matching `<3.15` upper bound.
+- **The login banner is rectangular** (item 8): all four lines of
+  `aim_sdk.cli.print_banner` are 61 columns, so the right border is a single
+  column.
+- **One public spelling of the security-logging entry point** (item 9).
+  `configure_security_logging` is now bound in `aim_sdk.security_logging`
+  itself (with `configure_from_environment` kept as a compatibility alias),
+  so both `from aim_sdk import configure_security_logging` and
+  `from aim_sdk.security_logging import configure_security_logging` work,
+  and the module docstring's usage block shows that spelling.
+- **An unreachable AIM costs a bounded, stated amount** (item 10). A refused
+  connection is no longer retried with 1+2+4s exponential backoff (~7s per
+  request); it fails on the first attempt. The README states the worst-case
+  cost of an unreachable server and how to change it (`timeout`,
+  `enforcement_timeout`, `max_retries`, `auto_retry`).
+- **A malformed 200 is named as malformed** (item 11). Both registration
+  paths agree that 200 and 201 are success; a success status whose body
+  lacks the agent's credentials (e.g. `200` with `{}`) raises
+  `ConfigurationError` saying the response was malformed or unexpected and
+  naming the statuses the SDK requires, instead of "Unknown error", and the
+  security event records `body_malformed`.
+- **`PolicyCache` is no longer exported from `aim_sdk`** (item 12). No
+  released AIM server serves the route it fetches, so it cannot answer a
+  check against any released backend; it is removed from `aim_sdk.__all__`
+  and the top-level namespace and remains importable from
+  `aim_sdk.auto_hooks` (unchanged behaviour) for the day a server registers
+  the route.
+
 ## [2.0.2] - 2026-09-08
 
 ### Security

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -4,9 +4,9 @@ Cryptographic identity, capability authorization, and audit trails for Python AI
 
 [![PyPI version](https://img.shields.io/pypi/v/aim-sdk.svg)](https://pypi.org/project/aim-sdk/)
 [![Python](https://img.shields.io/pypi/pyversions/aim-sdk.svg)](https://pypi.org/project/aim-sdk/)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../../LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/opena2a-org/agent-identity-management/blob/main/LICENSE)
 
-Part of [Agent Identity Management (AIM)](../../README.md). Managed hosting at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started); self-host via the [main README](../../README.md#install-aim-self-hosted).
+Part of [Agent Identity Management (AIM)](https://github.com/opena2a-org/agent-identity-management). Managed hosting at [aim.opena2a.org/get-started](https://aim.opena2a.org/get-started); self-host via the [main README](https://github.com/opena2a-org/agent-identity-management#install-aim-self-hosted).
 
 ## Upgrading to 2.0.0: a denied action now stops
 
@@ -68,13 +68,27 @@ After `secure()` registers the agent, the SDK installs no-op-on-failure hooks fo
 - OpenAI
 - Anthropic
 
-What the hooks record: with OpenAI, `chat.completions.create` calls, and with Anthropic, `messages.create` calls, each as one local security log event on the `aim.security` logger. That logger writes only where `AIM_SECURITY_LOG_FILE` or `AIM_SECURITY_LOG_STDOUT` points it, and it propagates to your root logger, so any handler attached there receives the event whatever level that logger is set to; under the SDK's own defaults nothing is written. With LangChain, a callback handler sends each tool run to AIM's verification route; with CrewAI, a task callback sends each task completion to it. Other client methods, including embeddings, are not recorded. The hooks never raise. A detected library whose hook cannot be installed is logged as a warning and left untouched; a recording failure inside an installed hook is swallowed and the wrapped call proceeds.
+What the hooks record: with OpenAI, `chat.completions.create` calls, and with Anthropic, `messages.create` calls, each as one local security log event on the `aim.security` logger. That logger writes where `AIM_SECURITY_LOG_FILE` or `AIM_SECURITY_LOG_STDOUT` points it — `AIM_SECURITY_LOG_STDOUT` accepts `true`, `1`, `yes`, or `on` to enable the stdout handler and `false`, `0`, `no`, or `off` (or unset) to leave it off, case-insensitively with surrounding whitespace stripped, the same spellings as `AIM_STRICT_MODE` — and it propagates to your root logger, so any handler attached there receives the event whatever level that logger is set to. Under the SDK's own defaults (no logging environment variable set, no handler of your own attached), ERROR-severity security records — for example a failed agent registration — are written to stderr as JSON; WARNING-severity records and below are not written anywhere. With LangChain, a callback handler sends each tool run to AIM's verification route; with CrewAI, a task callback sends each task completion to it. Other client methods, including embeddings, are not recorded. The hooks never raise. A detected library whose hook cannot be installed is logged as a warning and left untouched; a recording failure inside an installed hook is swallowed and the wrapped call proceeds.
 
 Disable: `secure("my-agent", auto_hooks=False)`. The parameter is keyword-only and defaults to `True`; before 2.0.2 it did not exist and this call raised `TypeError`.
 
+### Quieting SDK output
+
+`secure()` and auto-detection print progress lines to stdout. To silence them — in a library, a pipe, or any context where the SDK should not write to your streams:
+
+```python
+from aim_sdk import set_quiet
+
+set_quiet()        # suppress the SDK's informational stdout output
+agent = secure("my-agent", api_key="aim_abc123")
+set_quiet(False)   # restore
+```
+
+`set_quiet` suppresses registration banners, auto-detection results, and info/warning/success lines. Errors still print (they accompany raised exceptions), and the security log described above is governed by its own environment variables, not by `set_quiet`.
+
 ## Capability decorators
 
-`@agent.perform_action` signs each invocation, runs it through FGA on the server, and records the outcome. Risk level auto-detects from the capability string using two lookup tables in [`aim_sdk/risk_detector.py`](aim_sdk/risk_detector.py):
+`@agent.perform_action` signs each invocation, runs it through FGA on the server, and records the outcome. Risk level auto-detects from the capability string using two lookup tables in [`aim_sdk/risk_detector.py`](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/aim_sdk/risk_detector.py):
 
 - **Namespace prefix** maps `payment:`, `admin:`, `system:`, `billing:`, `finance:` to critical; `email:`, `notification:`, `sms:`, `user:`, `auth:`, `secret:`, `credential:` to high; `db:`, `database:`, `file:`, `storage:`, `cache:` to medium; `api:`, `weather:`, `search:`, `geocode:`, `translate:`, `time:`, `math:`, `util:` to low.
 - **Action suffix** maps `:read`, `:fetch`, `:get`, `:list`, `:query`, `:view`, `:check`, `:validate` to low; `:write`, `:update`, `:create`, `:modify`, `:save`, `:upload` to medium; `:delete`, `:send`, `:execute`, `:run`, `:invoke`, `:export`, `:transfer` to high; `:process`, `:refund`, `:charge`, `:approve`, `:drop`, `:truncate`, `:wipe`, `:terminate` to critical.
@@ -119,6 +133,10 @@ If the mode cannot be resolved either, a server that answered still blocks, whil
 > Before 2.0.0 this section was inverted, and so was the behaviour: the dashboard setting never reached the Python SDK, and the environment variable was the only lever that produced any enforcement at all. If you are upgrading from an earlier version, read [the 2.0.0 entry in CHANGELOG.md](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/CHANGELOG.md) before deploying.
 
 Everything the SDK enforces happens inside the agent's own process, so it is advisory with respect to that agent. It blocks denied actions for an honest operator and for a compromised agent that still routes through the SDK. It is not a control against a hostile operator.
+
+### Cost of an unreachable AIM
+
+A server that refuses connections — down, wrong port, wrong host — fails in a single connection attempt per request, with no retry and no backoff, so a decorated call against an unreachable AIM makes at most two fast connection attempts (the verification request plus one fire-and-forget status report) and returns control in well under a second on a local network. A server that accepts connections but never answers is bounded by the request timeout instead: up to `timeout` seconds per attempt (default 30; the enforcement path is further capped by `enforcement_timeout`, default 5.0s), and timeouts on non-enforcement routes retry up to `max_retries` times (default 3) with 1+2+4s backoff. Tighten or disable with `AIMClient(timeout=..., enforcement_timeout=..., max_retries=..., auto_retry=False)`.
 
 ## Capability declaration
 
@@ -301,18 +319,18 @@ def get_customer(customer_id): ...
 
 ## Examples
 
-Working examples in [`examples/`](examples/):
+Working examples in [`examples/`](https://github.com/opena2a-org/agent-identity-management/tree/main/sdk/python/examples):
 
 | Example | Shows |
 |---|---|
-| [`example.py`](examples/example.py) | Decorator-based verification, manual mode |
-| [`example_auto_detection.py`](examples/example_auto_detection.py) | Framework + MCP auto-discovery (no backend required) |
-| [`example_one_line_setup.py`](examples/example_one_line_setup.py) | Zero-config `secure()` flow (requires backend) |
+| [`example.py`](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/examples/example.py) | Decorator-based verification, manual mode |
+| [`example_auto_detection.py`](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/examples/example_auto_detection.py) | Framework + MCP auto-discovery (no backend required) |
+| [`example_one_line_setup.py`](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/examples/example_one_line_setup.py) | Zero-config `secure()` flow (requires backend) |
 
 Framework integration guides:
-- [LangChain](docs/LANGCHAIN_INTEGRATION.md)
-- [CrewAI](docs/CREWAI_INTEGRATION.md)
-- [MCP servers](docs/MCP_INTEGRATION.md)
+- [LangChain](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/docs/LANGCHAIN_INTEGRATION.md)
+- [CrewAI](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/docs/CREWAI_INTEGRATION.md)
+- [MCP servers](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/docs/MCP_INTEGRATION.md)
 
 ## Requirements
 
@@ -326,23 +344,25 @@ All install via `pip install aim-sdk`.
 
 ## Versioning
 
-[Semantic Versioning 2.0.0](https://semver.org/). Current: see `VERSION` file. The SDK and the backend platform are versioned and released independently — see [docs/VERSIONING.md](docs/VERSIONING.md#backend-api-compatibility).
+[Semantic Versioning 2.0.0](https://semver.org/). Current: `aim_sdk.__version__`, importable from any install:
 
 ```python
 import aim_sdk
 print(aim_sdk.__version__)
 ```
 
-See [CHANGELOG.md](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/CHANGELOG.md) for history, [docs/VERSIONING.md](docs/VERSIONING.md) for the support policy.
+The SDK and the backend platform are versioned and released independently — see [docs/VERSIONING.md](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/docs/VERSIONING.md#backend-api-compatibility).
+
+See [CHANGELOG.md](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/CHANGELOG.md) for history, [docs/VERSIONING.md](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/python/docs/VERSIONING.md) for the support policy.
 
 ## Related
 
-- [Java SDK](../java/README.md) — same API shape, AspectJ-based decoration
-- [TypeScript SDK](../typescript/README.md) — local-or-server mode
+- [Java SDK](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/java/README.md) — same API shape, AspectJ-based decoration
+- [TypeScript SDK](https://github.com/opena2a-org/agent-identity-management/blob/main/sdk/typescript/README.md) — local-or-server mode
 - [opena2a CLI](https://github.com/opena2a-org/opena2a) — codebase auditing, credential migration, runtime monitoring
-- [AIM backend](../../README.md) — server, dashboard, deployment
+- [AIM backend](https://github.com/opena2a-org/agent-identity-management) — server, dashboard, deployment
 - [aicomply](https://github.com/opena2a-org/aicomply) — content-compliance companion (`pip install aicomply`); `@guard_io`/`@guard_output` scan the PII, credentials, and regulated data an agent reads and emits, complementing AIM's `@agent.perform_action` capability checks (AIM authorizes the action; aicomply inspects the content)
 
 ## License
 
-Apache-2.0. See [LICENSE](../../LICENSE).
+Apache-2.0. See [LICENSE](https://github.com/opena2a-org/agent-identity-management/blob/main/LICENSE).

--- a/sdk/python/aim_sdk/__init__.py
+++ b/sdk/python/aim_sdk/__init__.py
@@ -119,7 +119,15 @@ from .isolation import (
     score_isolation,
     auto_detect_isolation,
 )
-from .auto_hooks import PolicyCache, activate_hooks
+# PolicyCache is deliberately NOT re-exported here: no released AIM server
+# serves the route it fetches, so it cannot answer a check against any released
+# backend (see its docstring in aim_sdk/auto_hooks.py). It remains importable
+# from aim_sdk.auto_hooks for the day a server registers the route.
+from .auto_hooks import activate_hooks
+
+# Console quieting: silences the SDK's informational stdout output
+# (registration banners, auto-detection results, info/warning lines).
+from .console import set_quiet
 
 # Credential management utilities
 from .credentials import (
@@ -137,7 +145,7 @@ from .security_logging import (
     SecurityLogger,
     SecurityEvent,
     security_logger,
-    configure_from_environment as configure_security_logging,
+    configure_security_logging,
     # Event types for custom logging
     EventCategory,
     EventSeverity,
@@ -233,8 +241,9 @@ __all__ = [
     "auto_detect_protocol",
     "AttestationCache",
     # Auto-hook activation
-    "PolicyCache",
     "activate_hooks",
+    # Console quieting
+    "set_quiet",
     # Credential management
     "load_sdk_credentials",
     "save_sdk_credentials",

--- a/sdk/python/aim_sdk/cli.py
+++ b/sdk/python/aim_sdk/cli.py
@@ -55,11 +55,11 @@ DEFAULT_AIM_URL = "https://aim.opena2a.org"
 
 
 def print_banner():
-    """Print AIM SDK banner."""
+    """Print AIM SDK banner. Every line is 61 columns wide so the ║ borders align."""
     print("""
 ╔═══════════════════════════════════════════════════════════╗
-║                     AIM SDK Login                          ║
-║         Agent Identity Management for AI Agents            ║
+║                       AIM SDK Login                       ║
+║          Agent Identity Management for AI Agents          ║
 ╚═══════════════════════════════════════════════════════════╝
 """)
 

--- a/sdk/python/aim_sdk/client.py
+++ b/sdk/python/aim_sdk/client.py
@@ -771,10 +771,11 @@ class AIMClient:
             raise VerificationError("Request timeout")
 
         except requests.exceptions.ConnectionError:
-            if self.auto_retry and retry_count < self.max_retries:
-                time.sleep(2 ** retry_count)
-                return self._make_request(method, endpoint, data, retry_count + 1, custom_headers)
-            raise VerificationError("Connection failed")
+            # No retry and no backoff here, unlike the timeout branch above: a
+            # refused or unroutable connection fails immediately and does not
+            # heal in a 1+2+4s sleep, so retrying it only made an unreachable
+            # AIM cost ~7s per request while returning the same error.
+            raise VerificationError(f"Connection failed: could not reach {self.aim_url}")
 
         except requests.exceptions.RequestException as e:
             raise VerificationError(f"Request failed: {e}")
@@ -1570,7 +1571,9 @@ class AIMClient:
         if verdict.warning:
             console.warning(verdict.warning)
         if verdict.pending_change:
-            console.warning(verdict.pending_change)
+            # One stream only: the typed warning (filterable, stderr). Printing
+            # the same sentence through console.warning as well made every
+            # unreachable-AIM verification say it twice, once per stream.
             warnings.warn(verdict.pending_change, PendingEnforcementChange, stacklevel=3)
 
         return verdict, decision
@@ -1910,6 +1913,12 @@ class AIMClient:
             result_summary: Brief summary of the result
             error_message: Error message if execution failed
         """
+        if not verification_id:
+            # Same guard as report_execution_status: with no id there is
+            # nothing to attach the result to, and interpolating the absent
+            # value built a literal /verifications/None/result URL.
+            return
+
         try:
             # Use direct HTTP call to avoid signature issues
             url = f"{self.aim_url}/api/v1/sdk-api/verifications/{verification_id}/result"
@@ -1938,9 +1947,11 @@ class AIMClient:
                 method="POST",
                 url=url,
                 json={
+                    # camelCase keys, the convention of every other write body
+                    # this SDK sends (strictMode/executedAt, displayName/agentType).
                     "result": "success" if success else "failure",
-                    "result_summary": result_summary,
-                    "error_message": error_message,
+                    "resultSummary": result_summary,
+                    "errorMessage": error_message,
                     "timestamp": datetime.now(timezone.utc).isoformat()
                 },
                 headers=headers,
@@ -4223,6 +4234,7 @@ def _validate_cached_credentials(
 
         headers = {
             "Content-Type": "application/json",
+            "User-Agent": f"AIM-Python-SDK/{__version__}",
             "X-SDK-Version": __version__,
         }
 
@@ -4546,7 +4558,10 @@ def register_agent(
                 # Register MCP servers even for cached credentials (user may have changed mcp_servers param)
                 if mcp_servers:
                     # Build headers for MCP registration
-                    _headers = {"Content-Type": "application/json"}
+                    _headers = {
+                        "Content-Type": "application/json",
+                        "User-Agent": f"AIM-Python-SDK/{__version__}",
+                    }
                     if api_key:
                         _headers["X-AIM-API-Key"] = api_key
                     # Split raw mcp_servers into names vs full definitions
@@ -4770,7 +4785,16 @@ def register_agent(
         return client
 
     except requests.RequestException as e:
-        raise ConfigurationError(f"Failed to connect to AIM server: {e}")
+        # `from None`: the requests/urllib3 chain beneath this adds host/port
+        # noise ("Max retries exceeded with url: ...") and no remedy; the
+        # remedy is in this message.
+        raise ConfigurationError(
+            f"Could not connect to the AIM server at {aim_url} "
+            f"({type(e).__name__}). Check that the URL is correct and that an "
+            f"AIM server is listening there: start one locally with "
+            f"'docker compose up', or pass aim_url= / run 'aim-sdk login "
+            f"--url <URL>' to point the SDK at your server."
+        ) from None
     except AIMError:
         # The inner helpers (_register_via_oauth / _register_via_api_key) already
         # raise typed, well-messaged errors (e.g. "Registration failed: <reason>").
@@ -4779,6 +4803,93 @@ def register_agent(
         raise
     except Exception as e:
         raise ConfigurationError(f"Registration failed: {e}")
+
+
+# The HTTP statuses BOTH registration endpoints treat as success. Before 2.0.3
+# the API-key path required exactly 201 while the OAuth path accepted 200 or
+# 201, so the same server answer registered on one path and failed on the other.
+REGISTRATION_SUCCESS_STATUSES = (200, 201)
+
+
+def _raise_registration_failure(response, name: str, registration_mode: str):
+    """
+    Turn a non-success registration response into a typed error.
+
+    A 401 raises AuthenticationError — the same class a 401 on the
+    verification path raises — and every other status ConfigurationError. A
+    body with no JSON 'error' field is reported as malformed, naming the
+    statuses the SDK requires, never as the literal "Unknown error".
+    """
+    try:
+        body = response.json()
+    except Exception:
+        body = None
+    error_msg = body.get("error") if isinstance(body, dict) else None
+    body_malformed = not error_msg
+    if body_malformed:
+        error_msg = (
+            f"the AIM server answered HTTP {response.status_code} with a malformed or "
+            f"unexpected body (no JSON 'error' field; the SDK requires HTTP 200 or 201 "
+            f"with the agent's credentials)"
+        )
+    security_logger.log_agent_event(
+        AgentEventType.AGENT_REGISTRATION_FAILED,
+        agent_name=name,
+        error=error_msg,
+        details={
+            "registration_mode": registration_mode,
+            "http_status": response.status_code,
+            "body_malformed": body_malformed,
+        }
+    )
+    if response.status_code == 401:
+        raise AuthenticationError(f"Registration failed: {error_msg}")
+    raise ConfigurationError(f"Registration failed: {error_msg}")
+
+
+def _parse_registration_body(response, name: str, registration_mode: str) -> Dict[str, Any]:
+    """
+    Parse a success-status registration response, raising a malformed-response
+    ConfigurationError (never a bare parse error) when the body is not a JSON
+    object.
+    """
+    try:
+        credentials = response.json()
+    except Exception:
+        credentials = None
+    if not isinstance(credentials, dict):
+        _log_malformed_registration_body(response, name, registration_mode, "not a JSON object")
+    return credentials
+
+
+def _require_registration_fields(credentials: Dict[str, Any], response, name: str,
+                                 registration_mode: str, required: List[str]):
+    """Reject a success-status body that lacks the fields the SDK needs."""
+    missing = [key for key in required if not credentials.get(key)]
+    if missing:
+        got = ", ".join(sorted(credentials)) if credentials else "an empty JSON object"
+        _log_malformed_registration_body(
+            response, name, registration_mode, f"missing {', '.join(missing)} (got {got})"
+        )
+
+
+def _log_malformed_registration_body(response, name: str, registration_mode: str, detail: str):
+    message = (
+        f"Registration failed: the AIM server answered HTTP {response.status_code} "
+        f"(a status the SDK accepts as success; it requires HTTP 200 or 201) but the "
+        f"response body was malformed or unexpected: {detail}."
+    )
+    security_logger.log_agent_event(
+        AgentEventType.AGENT_REGISTRATION_FAILED,
+        agent_name=name,
+        error=message,
+        details={
+            "registration_mode": registration_mode,
+            "http_status": response.status_code,
+            "body_malformed": True,
+        }
+    )
+    raise ConfigurationError(message)
 
 
 def _register_via_oauth(
@@ -4835,6 +4946,7 @@ def _register_via_oauth(
     # Set up headers for API calls
     headers = {
         "Content-Type": "application/json",
+        "User-Agent": f"AIM-Python-SDK/{__version__}",
         "Authorization": f"Bearer {access_token}"
     }
 
@@ -4956,24 +5068,16 @@ def _register_via_oauth(
         timeout=30
     )
 
-    if response.status_code not in [200, 201]:
-        error_msg = response.json().get("error", "Unknown error")
-        security_logger.log_agent_event(
-            AgentEventType.AGENT_REGISTRATION_FAILED,
-            agent_name=name,
-            error=error_msg,
-            details={
-                "registration_mode": "oauth",
-                "http_status": response.status_code
-            }
-        )
-        raise ConfigurationError(f"Registration failed: {error_msg}")
+    if response.status_code not in REGISTRATION_SUCCESS_STATUSES:
+        _raise_registration_failure(response, name, "oauth")
 
-    credentials = response.json()
+    credentials = _parse_registration_body(response, name, "oauth")
 
     # Backend returns 'id' but we need 'agent_id' for consistency
     if "id" in credentials and "agent_id" not in credentials:
         credentials["agent_id"] = credentials["id"]
+
+    _require_registration_fields(credentials, response, name, "oauth", ["agent_id"])
 
     # Add client-side generated private key to credentials (backend doesn't send it back)
     credentials["private_key"] = private_key_b64
@@ -5048,6 +5152,7 @@ def _register_via_api_key(
 
     headers = {
         "Content-Type": "application/json",
+        "User-Agent": f"AIM-Python-SDK/{__version__}",
         "X-AIM-API-Key": api_key
     }
 
@@ -5061,20 +5166,10 @@ def _register_via_api_key(
         timeout=30
     )
 
-    if response.status_code != 201:
-        error_msg = response.json().get("error", "Unknown error")
-        security_logger.log_agent_event(
-            AgentEventType.AGENT_REGISTRATION_FAILED,
-            agent_name=name,
-            error=error_msg,
-            details={
-                "registration_mode": "api_key",
-                "http_status": response.status_code
-            }
-        )
-        raise ConfigurationError(f"Registration failed: {error_msg}")
+    if response.status_code not in REGISTRATION_SUCCESS_STATUSES:
+        _raise_registration_failure(response, name, "api_key")
 
-    credentials = response.json()
+    credentials = _parse_registration_body(response, name, "api_key")
 
     # Map camelCase server response keys to snake_case for SDK consistency
     _camel_to_snake_map = {
@@ -5092,6 +5187,10 @@ def _register_via_api_key(
     # Backend may return 'id' instead of 'agent_id'
     if "id" in credentials and "agent_id" not in credentials:
         credentials["agent_id"] = credentials["id"]
+
+    _require_registration_fields(
+        credentials, response, name, "api_key", ["agent_id", "public_key", "private_key"]
+    )
 
     # Ensure aim_url is present in credentials
     if "aim_url" not in credentials:
@@ -5368,7 +5467,10 @@ def _register_single_mcp(
         json_body_str = json_module.dumps(mcp_data, sort_keys=True)
 
         # Build authentication headers
-        headers = {'Content-Type': 'application/json'}
+        headers = {
+            'Content-Type': 'application/json',
+            'User-Agent': f'AIM-Python-SDK/{__version__}',
+        }
         if client.signing_key and client.public_key:
             # Ed25519 signature authentication
             timestamp = str(int(time.time()))

--- a/sdk/python/aim_sdk/console.py
+++ b/sdk/python/aim_sdk/console.py
@@ -439,6 +439,9 @@ class AIMConsole:
 
     def warning(self, message: str):
         """Display warning message."""
+        if self.quiet:
+            return
+
         message = _strip_control_bytes(message)
         if RICH_AVAILABLE:
             self.console.print(f"[yellow]Warning:[/] {message}")
@@ -447,6 +450,9 @@ class AIMConsole:
 
     def info(self, message: str):
         """Display info message."""
+        if self.quiet:
+            return
+
         message = _strip_control_bytes(message)
         if RICH_AVAILABLE:
             self.console.print(f"{message}")
@@ -469,6 +475,9 @@ class AIMConsole:
 
     def success(self, message: str):
         """Display success message."""
+        if self.quiet:
+            return
+
         if RICH_AVAILABLE:
             self.console.print(f"[bold green]✓[/] {message}")
         else:
@@ -490,6 +499,13 @@ console = AIMConsole()
 
 
 def set_quiet(quiet: bool = True):
-    """Set quiet mode to suppress all output."""
+    """
+    Silence the SDK's informational console output.
+
+    With quiet engaged, registration banners, auto-detection results, and
+    info/warning/success lines are suppressed. Errors (``console.error``) stay
+    visible: they accompany raised exceptions and quiet mode is not a reason
+    to hide a failure. Also importable as ``from aim_sdk import set_quiet``.
+    """
     global console
     console.quiet = quiet

--- a/sdk/python/aim_sdk/security_logging.py
+++ b/sdk/python/aim_sdk/security_logging.py
@@ -35,6 +35,11 @@ Usage:
         details={"token_id": "xyz"}
     )
 
+    # Re-read the AIM_SECURITY_LOG_* environment variables (also importable
+    # as `from aim_sdk import configure_security_logging`)
+    from aim_sdk.security_logging import configure_security_logging
+    configure_security_logging()
+
     # For SIEM integration, enable JSON file logging
     security_logger.configure(
         log_file="/var/log/aim/security.log",
@@ -756,20 +761,48 @@ security_logger = SecurityLogger()
 # ENVIRONMENT-BASED CONFIGURATION
 # =============================================================================
 
-def configure_from_environment():
+def _env_flag(name: str, default: bool) -> bool:
+    """
+    Parse a boolean AIM_* environment variable with the same accepted
+    spellings as AIM_STRICT_MODE (strict_mode.TRUE_VALUES / FALSE_VALUES):
+    true/1/yes/on and false/0/no/off, case-insensitively, surrounding
+    whitespace stripped. Unset, empty, or unrecognised values resolve to
+    ``default``.
+    """
+    # Imported here, not at module top: strict_mode has no import-time side
+    # effects, but keeping the parser's home explicit at the one use site
+    # makes the shared-spelling contract easy to find.
+    from .strict_mode import TRUE_VALUES, FALSE_VALUES
+
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    return default
+
+
+def configure_security_logging():
     """
     Configure security logging from environment variables.
 
     Environment variables:
     - AIM_SECURITY_LOG_FILE: Path to security log file
     - AIM_SECURITY_LOG_LEVEL: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-    - AIM_SECURITY_LOG_STDOUT: Include stdout logging (true/false)
-    - AIM_SECURITY_LOGGING_ENABLED: Enable/disable security logging (true/false)
+    - AIM_SECURITY_LOG_STDOUT: Include stdout logging. Accepts the same
+      spellings as AIM_STRICT_MODE: true/1/yes/on enable it, false/0/no/off
+      (and unset) do not, case-insensitively with surrounding whitespace
+      stripped.
+    - AIM_SECURITY_LOGGING_ENABLED: Enable/disable security logging entirely
+      (same accepted spellings; default enabled)
     """
     log_file = os.environ.get("AIM_SECURITY_LOG_FILE")
     log_level = os.environ.get("AIM_SECURITY_LOG_LEVEL", "INFO")
-    include_stdout = os.environ.get("AIM_SECURITY_LOG_STDOUT", "false").lower() == "true"
-    enabled = os.environ.get("AIM_SECURITY_LOGGING_ENABLED", "true").lower() != "false"
+    include_stdout = _env_flag("AIM_SECURITY_LOG_STDOUT", default=False)
+    enabled = _env_flag("AIM_SECURITY_LOGGING_ENABLED", default=True)
 
     security_logger.configure(
         log_file=log_file,
@@ -779,5 +812,11 @@ def configure_from_environment():
     )
 
 
+# Backwards-compatible spelling: the function was published under this name
+# before 2.0.3 (aim_sdk re-exported it as configure_security_logging while the
+# module itself bound only configure_from_environment).
+configure_from_environment = configure_security_logging
+
+
 # Auto-configure from environment on import
-configure_from_environment()
+configure_security_logging()

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -36,8 +36,12 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
-    python_requires=">=3.8",
+    # Keep the upper bound in step with the classifier list above: every minor
+    # version this range admits must carry a classifier.
+    python_requires=">=3.8,<3.15",
     install_requires=[
         "requests>=2.28.0",
         "PyNaCl>=1.5.0",  # Ed25519 signing

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,434 @@
+"""
+Offline dependency shims for the test suite.
+
+Some CI/verification containers run this suite with no package index, so the
+SDK's third-party dependencies (`requests`, `PyNaCl`, `cryptography`, `PyJWT`)
+may be absent. When — and only when — a dependency is missing, this conftest
+installs a minimal functional stand-in into ``sys.modules`` before test
+collection imports ``aim_sdk``. When the real package is installed, nothing
+here runs and the suite behaves exactly as before.
+
+The `requests` stand-in is a real HTTP client over ``http.client`` with the
+same exception taxonomy, so tests against loopback fakes and closed loopback
+ports exercise genuine socket behaviour (a closed port raises
+``requests.exceptions.ConnectionError``, a silent server ``Timeout``).
+
+The `nacl`/`cryptography`/`jwt` stand-ins implement NO real cryptography —
+deterministic digests stand in for signatures, which is sufficient because the
+offline suite only ever talks to its own fakes, which do not verify
+signatures. They exist to satisfy imports and produce byte-shaped values.
+"""
+
+import base64
+import hashlib
+import importlib.machinery
+import importlib.util
+import json as _json
+import socket
+import sys
+import types
+import urllib.parse
+from pathlib import Path
+
+
+def _module(name):
+    mod = types.ModuleType(name)
+    # A real ModuleSpec so importlib.util.find_spec(name) keeps working after
+    # the shim is installed instead of raising ValueError.
+    mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+    sys.modules[name] = mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# requests
+# ---------------------------------------------------------------------------
+
+def _install_requests_shim():
+    requests = _module("requests")
+    exceptions = _module("requests.exceptions")
+    requests.exceptions = exceptions
+
+    class RequestException(IOError):
+        def __init__(self, *args, response=None, request=None):
+            super().__init__(*args)
+            self.response = response
+            self.request = request
+
+    class ConnectionError(RequestException):  # noqa: A001 - mirrors requests' name
+        pass
+
+    class Timeout(RequestException):
+        pass
+
+    class ConnectTimeout(ConnectionError, Timeout):
+        pass
+
+    class ReadTimeout(Timeout):
+        pass
+
+    class HTTPError(RequestException):
+        pass
+
+    class JSONDecodeError(ValueError, RequestException):
+        pass
+
+    class _Headers(dict):
+        """Case-insensitive header lookup, enough for .get()/[] access."""
+
+        def __init__(self, items=()):
+            super().__init__()
+            for k, v in dict(items).items():
+                self[k] = v
+
+        def __setitem__(self, key, value):
+            super().__setitem__(str(key).title(), value)
+
+        def __getitem__(self, key):
+            return super().__getitem__(str(key).title())
+
+        def __contains__(self, key):
+            return super().__contains__(str(key).title())
+
+        def get(self, key, default=None):
+            return super().get(str(key).title(), default)
+
+    class Response:
+        def __init__(self, status_code, headers, content, url):
+            self.status_code = status_code
+            self.headers = _Headers(headers)
+            self.content = content
+            self.url = url
+            self.reason = ""
+
+        @property
+        def text(self):
+            return self.content.decode("utf-8", errors="replace")
+
+        def json(self, **kwargs):
+            try:
+                return _json.loads(self.text)
+            except ValueError as exc:
+                raise JSONDecodeError(str(exc)) from None
+
+        @property
+        def ok(self):
+            return self.status_code < 400
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise HTTPError(
+                    f"{self.status_code} Error for url: {self.url}", response=self
+                )
+
+        def close(self):
+            pass
+
+    def _issue(method, url, params=None, data=None, json=None, headers=None,
+               timeout=None, **_ignored):
+        import http.client
+
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme not in ("http", "https"):
+            raise RequestException(f"Unsupported or missing URL scheme: {url!r}")
+        host = parsed.hostname or ""
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+
+        path = parsed.path or "/"
+        query = parsed.query
+        if params:
+            extra = urllib.parse.urlencode(params)
+            query = f"{query}&{extra}" if query else extra
+        if query:
+            path = f"{path}?{query}"
+
+        send_headers = _Headers(headers or {})
+        body = None
+        if json is not None:
+            body = _json.dumps(json).encode("utf-8")
+            send_headers.setdefault("Content-Type", "application/json")
+        elif data is not None:
+            body = data.encode("utf-8") if isinstance(data, str) else data
+
+        if parsed.scheme == "https":
+            conn = http.client.HTTPSConnection(host, port, timeout=timeout)
+        else:
+            conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        try:
+            try:
+                conn.request(method.upper(), path, body=body, headers=dict(send_headers))
+                raw = conn.getresponse()
+                content = raw.read()
+                return Response(raw.status, dict(raw.getheaders()), content, url)
+            except socket.timeout as exc:
+                raise Timeout(f"timed out: {exc}") from None
+            except (ConnectionRefusedError, ConnectionResetError, BrokenPipeError,
+                    socket.gaierror, OSError) as exc:
+                raise ConnectionError(
+                    f"Connection error for url {url}: {exc}"
+                ) from None
+        finally:
+            conn.close()
+
+    class Session:
+        def __init__(self):
+            self.headers = _Headers()
+
+        def request(self, method, url=None, **kwargs):
+            merged = _Headers(self.headers)
+            for k, v in _Headers(kwargs.pop("headers", None) or {}).items():
+                merged[k] = v
+            return _issue(method, url, headers=merged, **kwargs)
+
+        def get(self, url, **kwargs):
+            return self.request("GET", url, **kwargs)
+
+        def post(self, url, **kwargs):
+            return self.request("POST", url, **kwargs)
+
+        def put(self, url, **kwargs):
+            return self.request("PUT", url, **kwargs)
+
+        def delete(self, url, **kwargs):
+            return self.request("DELETE", url, **kwargs)
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+
+    def request(method, url, **kwargs):
+        return _issue(method, url, **kwargs)
+
+    def get(url, **kwargs):
+        return _issue("GET", url, **kwargs)
+
+    def post(url, **kwargs):
+        return _issue("POST", url, **kwargs)
+
+    def put(url, **kwargs):
+        return _issue("PUT", url, **kwargs)
+
+    def delete(url, **kwargs):
+        return _issue("DELETE", url, **kwargs)
+
+    for cls in (RequestException, ConnectionError, Timeout, ConnectTimeout,
+                ReadTimeout, HTTPError, JSONDecodeError):
+        setattr(exceptions, cls.__name__, cls)
+        setattr(requests, cls.__name__, cls)
+    requests.Response = Response
+    requests.Session = Session
+    requests.request = request
+    requests.get = get
+    requests.post = post
+    requests.put = put
+    requests.delete = delete
+    requests.__version__ = "0.0.0-offline-shim"
+
+
+# ---------------------------------------------------------------------------
+# nacl (PyNaCl)
+# ---------------------------------------------------------------------------
+
+def _install_nacl_shim():
+    nacl = _module("nacl")
+    signing = _module("nacl.signing")
+    encoding = _module("nacl.encoding")
+    bindings = _module("nacl.bindings")
+    nacl_exceptions = _module("nacl.exceptions")
+    nacl.signing = signing
+    nacl.encoding = encoding
+    nacl.bindings = bindings
+    nacl.exceptions = nacl_exceptions
+
+    class RawEncoder:
+        @staticmethod
+        def encode(data):
+            return data
+
+        @staticmethod
+        def decode(data):
+            return data
+
+    class Base64Encoder:
+        @staticmethod
+        def encode(data):
+            return base64.b64encode(data)
+
+        @staticmethod
+        def decode(data):
+            return base64.b64decode(data)
+
+    class BadSignatureError(Exception):
+        pass
+
+    class _SignedMessage(bytes):
+        signature = b""
+        message = b""
+
+    class VerifyKey:
+        def __init__(self, key, encoder=RawEncoder):
+            self._key = encoder.decode(key)
+
+        def encode(self, encoder=RawEncoder):
+            return encoder.encode(self._key)
+
+        def __bytes__(self):
+            return self._key
+
+        def verify(self, smessage, signature=None, encoder=RawEncoder):
+            # NOT cryptographic verification; accepts anything. Offline fakes
+            # never depend on rejecting a signature.
+            return encoder.decode(smessage) if signature is None else smessage
+
+    class SigningKey:
+        def __init__(self, seed, encoder=RawEncoder):
+            seed = encoder.decode(seed)
+            if len(seed) != 32:
+                raise ValueError("SigningKey seed must be 32 bytes")
+            self._seed = seed
+            self.verify_key = VerifyKey(hashlib.sha256(b"vk" + seed).digest())
+
+        @classmethod
+        def generate(cls):
+            import secrets as _secrets
+            return cls(_secrets.token_bytes(32))
+
+        def sign(self, message, encoder=RawEncoder):
+            sig = hashlib.sha512(self._seed + bytes(message)).digest()  # 64 bytes
+            signed = _SignedMessage(encoder.encode(sig + bytes(message)))
+            signed.signature = sig
+            signed.message = bytes(message)
+            return signed
+
+        def encode(self, encoder=RawEncoder):
+            return encoder.encode(self._seed)
+
+        def __bytes__(self):
+            return self._seed
+
+    signing.SigningKey = SigningKey
+    signing.VerifyKey = VerifyKey
+    encoding.RawEncoder = RawEncoder
+    encoding.Base64Encoder = Base64Encoder
+    encoding.HexEncoder = RawEncoder
+    nacl_exceptions.BadSignatureError = BadSignatureError
+    bindings.crypto_sign_ed25519_pk_to_curve25519 = lambda pk: pk
+
+
+# ---------------------------------------------------------------------------
+# cryptography (only the names aim_sdk.secrets imports at module level)
+# ---------------------------------------------------------------------------
+
+def _install_cryptography_shim():
+    crypto = _module("cryptography")
+    hazmat = _module("cryptography.hazmat")
+    primitives = _module("cryptography.hazmat.primitives")
+    asymmetric = _module("cryptography.hazmat.primitives.asymmetric")
+    x25519 = _module("cryptography.hazmat.primitives.asymmetric.x25519")
+    ciphers = _module("cryptography.hazmat.primitives.ciphers")
+    aead = _module("cryptography.hazmat.primitives.ciphers.aead")
+    crypto.hazmat = hazmat
+    hazmat.primitives = primitives
+    primitives.asymmetric = asymmetric
+    asymmetric.x25519 = x25519
+    primitives.ciphers = ciphers
+    ciphers.aead = aead
+
+    class _Unusable:
+        def __init__(self, *a, **k):
+            raise NotImplementedError(
+                "cryptography is not installed; this offline shim satisfies "
+                "imports only"
+            )
+
+        @classmethod
+        def generate(cls, *a, **k):
+            raise NotImplementedError("cryptography is not installed")
+
+        from_private_bytes = from_public_bytes = generate
+
+    x25519.X25519PrivateKey = type("X25519PrivateKey", (_Unusable,), {})
+    x25519.X25519PublicKey = type("X25519PublicKey", (_Unusable,), {})
+    aead.ChaCha20Poly1305 = type("ChaCha20Poly1305", (_Unusable,), {})
+
+    fernet = _module("cryptography.fernet")
+    crypto.fernet = fernet
+    fernet.Fernet = type("Fernet", (_Unusable,), {})
+
+
+# ---------------------------------------------------------------------------
+# jwt (PyJWT; aim_sdk.oauth uses jwt.decode + jwt.exceptions.DecodeError)
+# ---------------------------------------------------------------------------
+
+def _install_jwt_shim():
+    jwt = _module("jwt")
+    jwt_exceptions = _module("jwt.exceptions")
+    jwt.exceptions = jwt_exceptions
+
+    class DecodeError(Exception):
+        pass
+
+    class ExpiredSignatureError(DecodeError):
+        pass
+
+    def decode(token, key=None, algorithms=None, options=None, **kwargs):
+        # Parse the payload without verification (options passed by the SDK
+        # disable verification anyway; offline fakes sign nothing).
+        try:
+            payload_b64 = token.split(".")[1]
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            return _json.loads(base64.urlsafe_b64decode(payload_b64))
+        except Exception as exc:
+            raise DecodeError(str(exc)) from None
+
+    jwt.decode = decode
+    jwt.DecodeError = DecodeError
+    jwt.ExpiredSignatureError = ExpiredSignatureError
+    jwt_exceptions.DecodeError = DecodeError
+    jwt_exceptions.ExpiredSignatureError = ExpiredSignatureError
+
+
+_MISSING = {
+    name
+    for name in ("requests", "nacl", "cryptography", "jwt", "responses")
+    if importlib.util.find_spec(name) is None
+}
+
+for _name, _installer in (
+    ("requests", _install_requests_shim),
+    ("nacl", _install_nacl_shim),
+    ("cryptography", _install_cryptography_shim),
+    ("jwt", _install_jwt_shim),
+):
+    if _name in _MISSING:
+        _installer()
+
+
+# ---------------------------------------------------------------------------
+# Collection: skip test modules whose real dependency is absent
+# ---------------------------------------------------------------------------
+# The shims satisfy what aim_sdk itself imports. A few test modules import
+# more than the shims provide (the `responses` mocking library, or deep
+# cryptography submodules like ...asymmetric.ed25519). When the real package
+# is installed these run exactly as before; when it is absent they cannot
+# even be collected, so they are excluded rather than erroring the run.
+
+collect_ignore = []
+_UNSHIMMED_MARKERS = []
+if "responses" in _MISSING:
+    _UNSHIMMED_MARKERS.append("import responses")
+if "cryptography" in _MISSING:
+    _UNSHIMMED_MARKERS.append("cryptography.hazmat.primitives.asymmetric.ed25519")
+    # Real key-exchange/AEAD tests: the shim satisfies imports only.
+    _UNSHIMMED_MARKERS.append("cryptography.hazmat.primitives.asymmetric.x25519")
+
+if _UNSHIMMED_MARKERS:
+    for _test_file in Path(__file__).parent.glob("test_*.py"):
+        _source = _test_file.read_text(encoding="utf-8", errors="replace")
+        if any(marker in _source for marker in _UNSHIMMED_MARKERS):
+            collect_ignore.append(_test_file.name)

--- a/sdk/python/tests/test_aim16_p3_release_findings.py
+++ b/sdk/python/tests/test_aim16_p3_release_findings.py
@@ -1,0 +1,788 @@
+"""
+AIM-16 -- the twelve P3 findings from the 2.0.2 fresh-user release test,
+re-measured at head. One test (or parametrized group) per acceptance
+criterion; every leaf test name carries its criterion id as the first token.
+
+Everything here runs offline: HTTP goes only to loopback fakes started by the
+tests themselves, or to a loopback port that was bound and closed so it
+refuses connections. No test opens a socket to any address outside loopback
+(test_AIM_16_AC13 asserts that over this file's own source).
+"""
+
+import io
+import json
+import logging
+import re
+import socket
+import sys
+import threading
+import time
+import warnings
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+import aim_sdk
+import aim_sdk.client as client_module
+import aim_sdk.security_logging as security_logging_module
+from aim_sdk import AIMClient
+from aim_sdk.console import console, set_quiet
+from aim_sdk.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+)
+
+AgentEventType = security_logging_module.AgentEventType
+security_logger = security_logging_module.security_logger
+# getattr with the old spelling as fallback, so at the base commit each
+# criterion fails its own test instead of erroring this module's collection;
+# AC9 asserts the strict import inside its test body.
+configure_security_logging = getattr(
+    security_logging_module,
+    "configure_security_logging",
+    security_logging_module.configure_from_environment,
+)
+
+SDK_DIR = Path(__file__).resolve().parent.parent
+README = (SDK_DIR / "README.md").read_text(encoding="utf-8")
+CHANGELOG = (SDK_DIR / "CHANGELOG.md").read_text(encoding="utf-8")
+SETUP_PY = (SDK_DIR / "setup.py").read_text(encoding="utf-8")
+
+LOG_ENV_VARS = (
+    "AIM_SECURITY_LOG_FILE",
+    "AIM_SECURITY_LOG_LEVEL",
+    "AIM_SECURITY_LOG_STDOUT",
+    "AIM_SECURITY_LOGGING_ENABLED",
+)
+
+
+# ---------------------------------------------------------------------------
+# Loopback fixtures
+# ---------------------------------------------------------------------------
+
+class _FakeAIM:
+    """A loopback AIM fake: canned JSON answers, captured requests."""
+
+    def __init__(self, routes):
+        self.routes = routes  # {(METHOD, path): (status, body_dict)}
+        self.requests = []    # [(method, path, headers_dict, body_bytes)]
+        fake = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _serve(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                fake.requests.append(
+                    (self.command, self.path, dict(self.headers.items()), body)
+                )
+                status, payload = fake.routes.get(
+                    (self.command, self.path), (404, {"error": "not found"})
+                )
+                data = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            do_GET = do_POST = do_PUT = do_DELETE = _serve
+
+            def log_message(self, *args):
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def header(self, index, name):
+        headers = self.requests[index][2]
+        for key, value in headers.items():
+            if key.lower() == name.lower():
+                return value
+        return None
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+@pytest.fixture
+def fake_aim_factory():
+    servers = []
+
+    def factory(routes):
+        server = _FakeAIM(routes)
+        servers.append(server)
+        return server
+
+    yield factory
+    for server in servers:
+        server.close()
+
+
+@pytest.fixture
+def closed_port_url():
+    """A loopback URL nothing listens on: bound, learned, closed."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture
+def clean_logging_env(monkeypatch):
+    """Clear the AIM logging env vars; restore the import-time config after."""
+    for var in LOG_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield monkeypatch
+    for var in LOG_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    configure_security_logging()
+
+
+@pytest.fixture
+def isolated_home(monkeypatch, tmp_path):
+    """
+    A fresh HOME so credential files never touch the real user profile.
+
+    aim_sdk.credentials resolves its paths at import time, so patching the
+    HOME environment variable alone is not enough: the module constants must
+    be repointed too.
+    """
+    import aim_sdk.credentials as credentials_module
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    aim_dir = tmp_path / ".aim"
+    monkeypatch.setattr(credentials_module, "AIM_DIR", aim_dir)
+    monkeypatch.setattr(
+        credentials_module, "SDK_CREDENTIALS_FILE", aim_dir / "sdk_credentials.json"
+    )
+    monkeypatch.setattr(credentials_module, "AGENTS_DIR", aim_dir / "agents")
+    monkeypatch.setattr(
+        credentials_module, "LEGACY_CREDENTIALS_FILE", aim_dir / "credentials.json"
+    )
+    return tmp_path
+
+
+def _keypair():
+    """A consistent (public_b64, private_b64) pair from whichever nacl is loaded."""
+    import base64
+    from nacl.signing import SigningKey
+
+    sk = SigningKey.generate()
+    priv = base64.b64encode(bytes(sk)).decode()
+    pub = base64.b64encode(bytes(sk.verify_key)).decode()
+    return pub, priv
+
+
+def _stdout_handlers():
+    return [
+        h for h in security_logger._logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        and h.stream is sys.stdout
+    ]
+
+
+def _api_key_client(url, **kwargs):
+    return AIMClient(
+        agent_id="aim16-agent",
+        api_key="aim_test_key",
+        aim_url=url,
+        telemetry={"enabled": False},
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- the two boolean env vars agree on their accepted spellings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spelling", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_AIM_16_AC1_true_spellings_install_the_stdout_handler(clean_logging_env, spelling):
+    clean_logging_env.setenv("AIM_SECURITY_LOG_STDOUT", spelling)
+    configure_security_logging()
+    assert _stdout_handlers(), (
+        f"AIM_SECURITY_LOG_STDOUT={spelling!r} must install the stdout handler, "
+        f"the same spellings AIM_STRICT_MODE accepts"
+    )
+
+
+@pytest.mark.parametrize("spelling", ["false", "0", "no", "off", "OFF", " No "])
+def test_AIM_16_AC1_false_spellings_install_no_stdout_handler(clean_logging_env, spelling):
+    clean_logging_env.setenv("AIM_SECURITY_LOG_STDOUT", spelling)
+    configure_security_logging()
+    assert not _stdout_handlers()
+
+
+def test_AIM_16_AC1_unset_installs_no_stdout_handler(clean_logging_env):
+    configure_security_logging()
+    assert not _stdout_handlers()
+
+
+def test_AIM_16_AC1_spellings_match_strict_mode_sets():
+    from aim_sdk.strict_mode import TRUE_VALUES, FALSE_VALUES
+
+    assert TRUE_VALUES == frozenset({"true", "1", "yes", "on"})
+    assert FALSE_VALUES == frozenset({"false", "0", "no", "off"})
+
+
+def test_AIM_16_AC1_readme_passage_enumerates_the_true_spellings():
+    passages = [
+        line for line in README.splitlines() if "AIM_SECURITY_LOG_STDOUT" in line
+    ]
+    assert passages, "README must name AIM_SECURITY_LOG_STDOUT"
+    passage = "\n".join(passages)
+    for spelling in ("`true`", "`1`", "`yes`", "`on`"):
+        assert spelling in passage, (
+            f"the README passage naming AIM_SECURITY_LOG_STDOUT must enumerate "
+            f"the accepted true spellings; missing {spelling}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- the README default-logging claim matches the installed handler
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC2_error_records_reach_stderr_under_defaults(clean_logging_env, capsys):
+    configure_security_logging()
+    security_logger.log_agent_event(
+        AgentEventType.AGENT_REGISTRATION_FAILED,
+        agent_name="aim16",
+        error="server said no",
+    )
+    captured = capsys.readouterr()
+    assert "AGENT_REGISTRATION_FAILED" in captured.err, (
+        "an ERROR-severity security record goes to stderr under the SDK's defaults"
+    )
+    assert captured.out == "", "nothing goes to stdout under the defaults"
+
+
+def test_AIM_16_AC2_warning_records_are_not_written_under_defaults(clean_logging_env, capsys):
+    configure_security_logging()
+    security_logger.warning("routine warning, nobody's business")
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+def test_AIM_16_AC2_readme_states_the_default_stderr_behaviour():
+    assert "under the SDK's own defaults nothing is written" not in README, (
+        "the README claim contradicted the unconditional stderr handler"
+    )
+    assert re.search(r"ERROR-severity[^.]*stderr", README), (
+        "the README default-behaviour passage must state that ERROR-severity "
+        "records go to stderr"
+    )
+    assert re.search(r"WARNING-severity[^.]*not written", README), (
+        "the README must state that WARNING-severity records are not written"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- silenceable chatter; each unreachable verification says a thing once
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC3_set_quiet_is_importable_and_documented():
+    assert "set_quiet" in aim_sdk.__all__
+    from aim_sdk import set_quiet as imported  # noqa: F401
+    assert "set_quiet" in README, "the README must name the silencer"
+
+
+def test_AIM_16_AC3_quiet_secure_api_key_mode_prints_nothing(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    pub, priv = _keypair()
+    fake = fake_aim_factory({
+        ("POST", "/api/v1/public/agents/register"): (201, {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "agentId": "11111111-1111-1111-1111-111111111111",
+            "publicKey": pub,
+            "privateKey": priv,
+            "aimUrl": "unused",
+            "trustScore": 80,
+        }),
+    })
+    set_quiet(True)
+    try:
+        agent = aim_sdk.secure(
+            "aim16-quiet-agent", aim_url=fake.url, api_key="aim_test_key"
+        )
+    finally:
+        set_quiet(False)
+    assert isinstance(agent, AIMClient)
+    captured = capsys.readouterr()
+    assert captured.out == "", (
+        f"quiet mode must silence secure()'s stdout chatter, got: {captured.out!r}"
+    )
+
+
+def test_AIM_16_AC3_quiet_auto_detection_pass_prints_nothing(capsys):
+    set_quiet(True)
+    try:
+        console.info("API Key Mode: Using API key authentication")
+        console.detection_result("Agent Type", "langchain", "langchain imported")
+        console.detection_none("Agent Type", fallback="ai_agent")
+        console.detection_none("Capabilities")
+        console.warning("noise")
+        console.success("done")
+    finally:
+        set_quiet(False)
+    assert capsys.readouterr().out == ""
+
+
+def test_AIM_16_AC3_unreachable_verification_emits_pending_change_on_one_stream(
+    closed_port_url, clean_logging_env, capsys
+):
+    client = _api_key_client(closed_port_url, timeout=2)
+
+    @client.perform_action(capability="util:noop")
+    def action():
+        return "ran"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = action()
+
+    assert result == "ran"
+    pending = [
+        w for w in caught
+        if issubclass(w.category, aim_sdk.PendingEnforcementChange)
+    ]
+    assert len(pending) == 1, (
+        f"exactly one PendingEnforcementChange warning, got {len(pending)}"
+    )
+    sentence = str(pending[0].message)
+    captured = capsys.readouterr()
+    assert sentence not in captured.out, (
+        "the enforcement-mode sentence must not be duplicated onto stdout; it "
+        "is emitted once, through the typed warning"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- typed actionable registration error; one class per HTTP condition
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC4_unreachable_registration_raises_actionable_untangled_error(
+    closed_port_url, isolated_home, clean_logging_env, capsys
+):
+    with pytest.raises(ConfigurationError) as excinfo:
+        aim_sdk.secure(
+            "aim16-noserver-agent", aim_url=closed_port_url, api_key="aim_test_key"
+        )
+    message = str(excinfo.value)
+    assert closed_port_url in message, "the message names the URL to correct"
+    assert "docker compose up" in message or "aim-sdk login" in message, (
+        "the message names a command that starts or points at a server"
+    )
+    assert "Max retries exceeded" not in message
+    assert excinfo.value.__suppress_context__ is True, (
+        "raise ... from None: the requests/urllib3 chain must not be re-printed "
+        "as implicit context"
+    )
+    assert excinfo.value.__cause__ is None
+
+
+def test_AIM_16_AC4_registration_401_and_verification_401_raise_the_same_class(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    fake = fake_aim_factory({
+        ("POST", "/api/v1/public/agents/register"): (401, {"error": "bad api key"}),
+        ("POST", "/api/v1/sdk-api/some-route"): (401, {"error": "bad creds"}),
+    })
+
+    with pytest.raises(AuthenticationError) as reg_excinfo:
+        aim_sdk.secure(
+            "aim16-badkey-agent", aim_url=fake.url, api_key="aim_wrong_key"
+        )
+
+    client = _api_key_client(fake.url, auto_retry=False)
+    with pytest.raises(AuthenticationError) as verify_excinfo:
+        client._make_request("POST", "/api/v1/sdk-api/some-route", {"x": 1})
+
+    assert type(reg_excinfo.value) is type(verify_excinfo.value), (
+        "a 401 answered to registration and a 401 answered to verification "
+        "must raise the same exception class"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- no absent identifier in a URL; one case convention per body
+# ---------------------------------------------------------------------------
+
+def _recording_session(client):
+    calls = []
+
+    def record(method=None, url=None, **kwargs):
+        calls.append({"method": method, "url": url, **kwargs})
+        raise AssertionError("no response wired; test only records the attempt")
+
+    client.session.request = record
+    return calls
+
+
+@pytest.mark.parametrize("absent", [None, ""])
+def test_AIM_16_AC5_absent_verification_id_issues_no_request(closed_port_url, absent):
+    client = _api_key_client(closed_port_url)
+    calls = _recording_session(client)
+    client.log_capability_result(absent, True, result_summary="fine")
+    assert calls == [], (
+        "log_capability_result must return without any HTTP request when "
+        "verification_id is absent -- never POST to /verifications/None/result"
+    )
+
+
+def test_AIM_16_AC5_result_body_uses_the_camel_case_convention(closed_port_url):
+    client = _api_key_client(closed_port_url)
+    calls = []
+
+    class _Ok:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {}
+
+    def record(method=None, url=None, **kwargs):
+        calls.append({"method": method, "url": url, **kwargs})
+        return _Ok()
+
+    client.session.request = record
+    client.log_capability_result(
+        "vid-123", False, result_summary="s", error_message="boom"
+    )
+    assert len(calls) == 1
+    assert "/verifications/vid-123/result" in calls[0]["url"]
+    assert "/None/" not in calls[0]["url"]
+    body = calls[0]["json"]
+    assert "resultSummary" in body and "errorMessage" in body, (
+        "the result body uses the same camelCase convention as strictMode/"
+        "executedAt and displayName/agentType"
+    )
+    assert "result_summary" not in body and "error_message" not in body
+
+
+# ---------------------------------------------------------------------------
+# AC6 -- an SDK User-Agent on every request to an AIM URL
+# ---------------------------------------------------------------------------
+
+EXPECTED_UA = f"AIM-Python-SDK/{aim_sdk.__version__}"
+
+
+def test_AIM_16_AC6_api_key_registration_carries_the_sdk_user_agent(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    pub, priv = _keypair()
+    fake = fake_aim_factory({
+        ("POST", "/api/v1/public/agents/register"): (201, {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "publicKey": pub,
+            "privateKey": priv,
+            "trustScore": 80,
+        }),
+    })
+    aim_sdk.secure("aim16-ua-agent", aim_url=fake.url, api_key="aim_test_key")
+    assert fake.requests, "the registration request must have been issued"
+    assert fake.header(0, "User-Agent") == EXPECTED_UA
+
+
+def test_AIM_16_AC6_oauth_check_and_registration_carry_the_sdk_user_agent(
+    fake_aim_factory, isolated_home, clean_logging_env, monkeypatch, capsys
+):
+    name = "aim16-oauth-agent"
+    fake = fake_aim_factory({
+        ("GET", f"/api/v1/sdk-api/agents/{name}"): (404, {"error": "no such agent"}),
+        ("POST", "/api/v1/agents"): (201, {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "trustScore": 80,
+        }),
+    })
+
+    class _StubTokenManager:
+        credentials = {}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_access_token(self, **kwargs):
+            return "stub-access-token"
+
+    monkeypatch.setattr(client_module, "OAuthTokenManager", _StubTokenManager)
+    client_module._register_via_oauth(
+        name=name,
+        aim_url=fake.url,
+        sdk_creds={},
+        registration_data={"name": name, "displayName": name, "agentType": "ai_agent"},
+        sdk_token_id=None,
+        mcp_server_names=[],
+        mcp_full_definitions=[],
+    )
+    assert len(fake.requests) >= 2, "agent-exists check plus registration"
+    for index, request in enumerate(fake.requests):
+        assert fake.header(index, "User-Agent") == EXPECTED_UA, (
+            f"request {request[0]} {request[1]} reached the server without the "
+            f"SDK User-Agent"
+        )
+
+
+def test_AIM_16_AC6_mcp_registration_carries_the_sdk_user_agent(
+    fake_aim_factory, clean_logging_env, capsys
+):
+    agent_id = "44444444-4444-4444-4444-444444444444"
+    fake = fake_aim_factory({
+        ("POST", f"/api/v1/sdk-api/agents/{agent_id}/mcp-servers"): (
+            201, {"id": "mcp-1"},
+        ),
+    })
+    client = _api_key_client(fake.url)
+    result = client_module._register_single_mcp(
+        client,
+        fake.url,
+        {},
+        {"name": "aim16-mcp", "description": "d"},
+        agent_id,
+        {},
+    )
+    assert result["success"] is True
+    assert fake.requests
+    assert fake.header(0, "User-Agent") == EXPECTED_UA
+
+
+def test_AIM_16_AC6_credential_validation_probe_carries_the_sdk_user_agent(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    agent_id = "55555555-5555-5555-5555-555555555555"
+    fake = fake_aim_factory({
+        ("GET", f"/api/v1/agents/{agent_id}"): (200, {"id": agent_id}),
+    })
+    ok, error = client_module._validate_cached_credentials(
+        agent_id, fake.url, "aim16-agent", api_key="aim_test_key"
+    )
+    assert ok is True and error is None
+    assert fake.header(0, "User-Agent") == EXPECTED_UA
+
+
+# ---------------------------------------------------------------------------
+# AC7 -- a PyPI-resolvable README; classifiers cover python_requires
+# ---------------------------------------------------------------------------
+
+PACKAGED_ROOT_FILES = {"README.md", "CHANGELOG.md", "LICENSE", "VERSION"}
+
+
+def test_AIM_16_AC7_no_readme_link_targets_a_path_outside_the_packaged_tree():
+    offenders = []
+    for target in re.findall(r"\]\(([^)\s]+)\)", README):
+        if target.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        path = target.split("#")[0]
+        if not path:
+            continue
+        if path.startswith("../") or "/../" in path:
+            offenders.append(target)
+        elif not (path in PACKAGED_ROOT_FILES or path.startswith("aim_sdk/")):
+            offenders.append(target)
+    assert offenders == [], (
+        f"README links must resolve for a PyPI reader; these target paths "
+        f"outside the packaged tree: {offenders}"
+    )
+
+
+def test_AIM_16_AC7_version_pointer_resolves_for_a_wheel_only_install():
+    assert "see `VERSION` file" not in README, (
+        "no VERSION file exists after a wheel install"
+    )
+    assert "aim_sdk.__version__" in README
+
+
+def test_AIM_16_AC7_classifiers_cover_every_minor_python_requires_admits():
+    classifier_minors = {
+        int(m) for m in re.findall(
+            r"Programming Language :: Python :: 3\.(\d+)", SETUP_PY
+        )
+    }
+    match = re.search(r"python_requires\s*=\s*[\"']([^\"']+)[\"']", SETUP_PY)
+    assert match, "setup.py must declare python_requires"
+    spec = match.group(1).replace(" ", "")
+    lower = re.search(r">=3\.(\d+)", spec)
+    upper = re.search(r"<3\.(\d+)", spec)
+    assert lower, f"python_requires has no lower bound: {spec}"
+    assert upper, (
+        f"python_requires must carry an upper bound matching the classifier "
+        f"list (or the classifiers cannot cover it): {spec}"
+    )
+    admitted = set(range(int(lower.group(1)), int(upper.group(1))))
+    missing = admitted - classifier_minors
+    assert missing == set(), (
+        f"python_requires {spec} admits 3.{sorted(missing)} with no matching "
+        f"'Programming Language :: Python :: 3.x' classifier"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC8 -- the login banner is rectangular
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC8_banner_lines_all_share_one_display_width(capsys):
+    from aim_sdk.cli import print_banner
+
+    print_banner()
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert lines, "the banner prints something"
+    widths = {len(line) for line in lines}
+    assert len(widths) == 1, (
+        f"every banner line must be the same width so the right border is a "
+        f"single column; got widths {sorted(widths)} over {lines!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC9 -- one importable spelling of configure_security_logging
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC9_the_public_spelling_is_importable_from_both_paths():
+    from aim_sdk import configure_security_logging as from_package
+    from aim_sdk.security_logging import configure_security_logging as from_module
+
+    assert from_package is from_module
+
+
+def test_AIM_16_AC9_module_docstring_usage_block_shows_the_public_spelling():
+    import aim_sdk.security_logging as security_logging_module
+
+    docstring = security_logging_module.__doc__ or ""
+    assert "Usage:" in docstring
+    usage_block = docstring.split("Usage:", 1)[1]
+    assert "configure_security_logging" in usage_block
+
+
+# ---------------------------------------------------------------------------
+# AC10 -- a bounded, stated unreachable-AIM cost
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC10_decorated_call_returns_fast_when_aim_refuses_connections(
+    closed_port_url, clean_logging_env, capsys
+):
+    client = _api_key_client(closed_port_url, timeout=5)
+
+    @client.perform_action(capability="util:noop")
+    def action():
+        return 42
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        start = time.monotonic()
+        result = action()
+        elapsed = time.monotonic() - start
+
+    assert result == 42
+    assert elapsed < 3.0, (
+        f"a decorated call against a closed loopback port took {elapsed:.2f}s; "
+        f"the README's stated budget is well under a second (was ~7s of "
+        f"exponential backoff at base)"
+    )
+
+
+def test_AIM_16_AC10_readme_states_the_unreachable_cost_and_the_lever():
+    assert "Cost of an unreachable AIM" in README
+    section = README.split("Cost of an unreachable AIM", 1)[1].split("##", 1)[0]
+    assert "single connection attempt" in section
+    for lever in ("timeout", "max_retries", "auto_retry"):
+        assert lever in section, f"the README must say how to change the cost ({lever})"
+
+
+# ---------------------------------------------------------------------------
+# AC11 -- a malformed 200 is named as malformed; paths agree on success
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC11_a_200_with_an_empty_body_is_reported_as_malformed(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    fake = fake_aim_factory({
+        ("POST", "/api/v1/public/agents/register"): (200, {}),
+    })
+    with pytest.raises(ConfigurationError) as excinfo:
+        aim_sdk.secure(
+            "aim16-empty200-agent", aim_url=fake.url, api_key="aim_test_key"
+        )
+    message = str(excinfo.value)
+    assert "Unknown error" not in message
+    assert "malformed" in message or "unexpected" in message
+    assert "200" in message and "201" in message, (
+        "the error names the statuses the SDK requires"
+    )
+
+
+def test_AIM_16_AC11_both_registration_paths_accept_200_and_201(
+    fake_aim_factory, isolated_home, clean_logging_env, capsys
+):
+    # The OAuth path accepted 200 at base; the API-key path required exactly
+    # 201. A well-formed 200 must now register on the API-key path too.
+    pub, priv = _keypair()
+    fake = fake_aim_factory({
+        ("POST", "/api/v1/public/agents/register"): (200, {
+            "id": "66666666-6666-6666-6666-666666666666",
+            "publicKey": pub,
+            "privateKey": priv,
+            "trustScore": 80,
+        }),
+    })
+    agent = aim_sdk.secure(
+        "aim16-status200-agent", aim_url=fake.url, api_key="aim_test_key"
+    )
+    assert isinstance(agent, AIMClient)
+    assert client_module.REGISTRATION_SUCCESS_STATUSES == (200, 201)
+
+
+# ---------------------------------------------------------------------------
+# AC12 -- PolicyCache's public status matches its documented reachability
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC12_policycache_is_absent_from_the_public_namespace():
+    assert "PolicyCache" not in aim_sdk.__all__, (
+        "no released AIM server serves the route PolicyCache fetches; it must "
+        "not be offered as public API"
+    )
+    assert not hasattr(aim_sdk, "PolicyCache")
+
+
+def test_AIM_16_AC12_policycache_stays_importable_from_its_module():
+    from aim_sdk.auto_hooks import PolicyCache  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# AC13 -- the tree's own record of the batch is coherent
+# ---------------------------------------------------------------------------
+
+def test_AIM_16_AC13_changelog_carries_a_release_newer_than_2_0_2():
+    headings = re.findall(r"^## \[(\d+)\.(\d+)\.(\d+)\]", CHANGELOG, re.MULTILINE)
+    assert headings, "the changelog has release headings"
+    newest = tuple(int(part) for part in headings[0])
+    assert newest > (2, 0, 2), (
+        f"the newest changelog section must be for a release after 2.0.2, "
+        f"got {newest}"
+    )
+
+
+def test_AIM_16_AC13_the_new_section_names_all_twelve_dispositions():
+    newest_section = re.sub(r"\s+", " ", CHANGELOG.split("## [", 2)[1])
+    for item in range(1, 13):
+        assert re.search(rf"\(item {item}[,)]", newest_section), (
+            f"the release section must name the disposition of item {item} "
+            f"of the twelve"
+        )
+
+
+def test_AIM_16_AC13_these_tests_touch_only_loopback_addresses():
+    source = Path(__file__).read_text(encoding="utf-8")
+    for host in re.findall(r"https?://([^/\s\"')]+)", source):
+        hostname = host.split(":")[0]
+        assert hostname in ("127.0.0.1", "localhost"), (
+            f"AIM-16 tests must not reference any non-loopback address: {host}"
+        )

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -387,7 +387,7 @@ class TestLogActionResult:
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body["result"] == "success"
-        assert request_body["result_summary"] == "Operation completed successfully"
+        assert request_body["resultSummary"] == "Operation completed successfully"
 
     @responses.activate
     def test_log_failure(self, aim_client):
@@ -408,7 +408,7 @@ class TestLogActionResult:
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body["result"] == "failure"
-        assert request_body["error_message"] == "Database connection failed"
+        assert request_body["errorMessage"] == "Database connection failed"
 
     @responses.activate
     def test_log_ignores_errors(self, aim_client):
@@ -543,7 +543,7 @@ class TestPerformActionDecorator:
         assert len(responses.calls) == 3  # Auto-registration + Verification + logging
         log_request = json.loads(responses.calls[2].request.body)
         assert log_request["result"] == "failure"
-        assert "Database connection failed" in log_request["error_message"]
+        assert "Database connection failed" in log_request["errorMessage"]
 
 
 class TestContextManager:


### PR DESCRIPTION
The twelve P3 findings from the 2.0.2 fresh-user release test, re-measured at head and fixed as one batch under a `2.0.3` changelog section.

- `AIM_SECURITY_LOG_STDOUT` and `AIM_SECURITY_LOG_ENABLED` accept the same true/false spellings as `AIM_STRICT_MODE`, through one shared set, and the README enumerates them.
- The README's default-logging claim matches the installed handler: ERROR to stderr, WARNING nowhere, under defaults.
- `set_quiet` is exported and documented and silences the informational stdout lines; the pending-enforcement sentence is emitted once, through the typed warning.
- A registration that cannot connect raises a typed, actionable `ConfigurationError` instead of a bare failure; a malformed 200 is named as malformed on both registration paths.
- No request URL carries an absent identifier (the log-result call returns early without a verification id, as the execution-status call already did), and the log-result body uses the same camelCase keys as every other payload (`resultSummary`, `errorMessage`); the three pre-existing tests that pinned the snake_case keys are re-pinned.
- Every request to an AIM URL carries `User-Agent: AIM-Python-SDK/<version>`.
- An unreachable AIM costs a bounded, stated amount per decorated call; the PyPI page is self-contained with classifiers covering the supported versions; the login banner is rectangular; there is one public spelling of the security-logging entry point; `PolicyCache` is no longer re-exported from `aim_sdk` because no released server serves the route it fetches.

Files: `aim_sdk/__init__.py`, `cli.py`, `client.py`, `console.py`, `security_logging.py`, `setup.py`, the README, the CHANGELOG, `tests/test_client.py` (three assertions), a criterion test file with 46 cases (32 red on the parent commit), and a new `tests/conftest.py`.

About that conftest: it installs stdlib-backed stand-ins for `requests`, `PyNaCl`, `cryptography` and `PyJWT` into `sys.modules` only when the real package is absent, so the suite can run in a container with no package index. The `requests` stand-in is a real HTTP client over `http.client`; the crypto stand-ins implement no cryptography and exist to satisfy imports against the suite's own fakes. With the real packages installed nothing in it runs. It is a test-only file; if the project would rather not carry it, dropping it changes no test outcome where the dependencies are installed, and the reviewer should say so.

Verification: with the requirements installed, `pytest sdk/python/tests` reports 1020 passed and 34 skipped, exit 0. An independent review executed every criterion at this head (964 passed under the offline stand-ins) and confirmed each was red on the parent commit.