### PR TITLE
test(sdk-python): read the newest release section, not the first heading, in the version changelog check

### DIFF
--- a/sdk/python/tests/test_detection_sdk_version_from_package.py
+++ b/sdk/python/tests/test_detection_sdk_version_from_package.py
@@ -243,11 +243,16 @@ def test_AIM_13_AC5_version_moved_past_2_0_2_and_changelog_names_the_fix():
     assert "version=version" in setup_text
 
     changelog = (PYTHON_SDK_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    headings = re.findall(r"^## \[(.+?)\]", changelog, flags=re.MULTILINE)
+    # Keep a Changelog keeps an ``[Unreleased]`` section above the newest release, so the
+    # newest RELEASE heading, not the first heading, must name the installed version, and
+    # the section read is that release's own, wherever it sits.
+    headings = [h for h in re.findall(r"^## \[(.+?)\]", changelog, flags=re.MULTILINE)
+                if h != "Unreleased"]
     assert headings, "CHANGELOG has no release headings"
     assert headings[0] == version
 
-    top_section = re.split(r"^## \[", changelog, flags=re.MULTILINE)[1]
+    sections = re.split(r"^## \[", changelog, flags=re.MULTILINE)[1:]
+    top_section = next(s for s in sections if s.startswith(version + "]"))
     assert "#464" in top_section
     assert "MCP detection" in top_section
     assert "installed package version" in top_section


### PR DESCRIPTION
## What

`test_AIM_13_AC5_version_moved_past_2_0_2_and_changelog_names_the_fix` asserted that the CHANGELOG's **first** heading equals `VERSION` and read the **first** section for the `#464` text. Keep a Changelog, which the file's preamble names as its format, keeps an `[Unreleased]` section above the newest release, so any entry documenting an unreleased change turned this test red until `VERSION` moved.

Measured on the three open sdk/python PRs (#471, #472, #473) after rebasing them onto `main`: each adds its entries under `## [Unreleased]` above `## [2.0.3] - 2026-09-09`, and each read `1 failed` on exactly this test.

## Change

One test file, +7/-2. The check now skips an `Unreleased` heading and reads the release's own section wherever it sits. It still requires the newest **release** heading to equal `VERSION` and that section to name the fix.

## Verification

- `pytest sdk/python`: 985 passed, 34 skipped at this head; the test file 11 passed at `main`.
- Red-proof: the old assertion fails on a changelog carrying an `[Unreleased]` section; the new one passes.
- Mutations, each turning the new test red: newest release heading not equal to `VERSION`; `#464` removed from the release section; `#464` present only in the Unreleased section; no release heading at all.
- The fixed assertions read true against the rebased changelogs of #471, #472 and #473.
